### PR TITLE
Removed requirements.txt in favor of Pipenv

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-source .venv/bin/activate
+layout virtualenv $(pipenv --venv)

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ scss/assets
 .venv/
 __pycache__
 *.pyc
+.cache/
 
 # Ignore static/fonts for now, since it is just symlink
 static/fonts

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "3.6"
 before_install:
+  - pipenv install --dev
   - gem install sass
   - npm install
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
   - "3.6"
 before_install:
-  - pipenv install --dev
+  - pip install pipenv
+  - pipenv install --dev --skip-lock
   - gem install sass
   - npm install
 script:

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,16 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+tornado = "==5.0.2"
+webassets = "==0.12.1"
+Unipath = "==1.1"
+
+[dev-packages]
+pytest = "==3.6.0"
+pytest-tornado = "==0.5.0"
+
+[requires]
+python_version = "3.6"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,119 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "8d3125836797aa0d47e617fde767493efeb5d912980e2a0ba7f5740fbab8c35c"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.6"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "tornado": {
+            "hashes": [
+                "sha256:1b83d5c10550f2653380b4c77331d6f8850f287c4f67d7ce1e1c639d9222fbc7",
+                "sha256:408d129e9d13d3c55aa73f8084aa97d5f90ed84132e38d6932e63a67d5bec563",
+                "sha256:88ce0282cce70df9045e515f578c78f1ebc35dcabe1d70f800c3583ebda7f5f5",
+                "sha256:ba9fbb249ac5390bff8a1d6aa4b844fd400701069bda7d2e380dfe2217895101",
+                "sha256:c050089173c2e9272244bccfb6a8615fb9e53b79420a5551acfa76094ecc3111"
+            ],
+            "index": "pypi",
+            "version": "==5.0.2"
+        },
+        "unipath": {
+            "hashes": [
+                "sha256:09839adcc72e8a24d4f76d63656f30b5a1f721fc40c9bcd79d8c67bdd8b47dae",
+                "sha256:e6257e508d8abbfb6ddd8ec357e33589f1f48b1599127f23b017124d90b0fff7"
+            ],
+            "index": "pypi",
+            "version": "==1.1"
+        },
+        "webassets": {
+            "hashes": [
+                "sha256:e7d9c8887343123fd5b32309b33167428cb1318cdda97ece12d0907fd69d38db"
+            ],
+            "index": "pypi",
+            "version": "==0.12.1"
+        }
+    },
+    "develop": {
+        "atomicwrites": {
+            "hashes": [
+                "sha256:240831ea22da9ab882b551b31d4225591e5e447a68c5e188db5b89ca1d487585",
+                "sha256:a24da68318b08ac9c9c45029f4a10371ab5b20e4226738e150e6e7c571630ae6"
+            ],
+            "version": "==1.1.5"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:4b90b09eeeb9b88c35bc642cbac057e45a5fd85367b985bd2809c62b7b939265",
+                "sha256:e0d0eb91441a3b53dab4d9b743eafc1ac44476296a2053b6ca3af0b139faf87b"
+            ],
+            "version": "==18.1.0"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:2b6b9893337bfd9166bee6a62c2b0c9fe7735dcf85948b387ec8cba30e85d8e8",
+                "sha256:6703844a52d3588f951883005efcf555e49566a48afd4db4e965d69b883980d3",
+                "sha256:a18d870ef2ffca2b8463c0070ad17b5978056f403fb64e3f15fe62a52db21cc0"
+            ],
+            "version": "==4.2.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:7f8ae7f5bdf75671a718d2daf0a64b7885f74510bcd98b1a0bb420eb9a9d0cff",
+                "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
+                "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
+            ],
+            "version": "==0.6.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
+                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+            ],
+            "version": "==1.5.3"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:39555d023af3200d004d09e51b4dd9fdd828baa863cded3fd6ba2f29f757ae2d",
+                "sha256:c76e93f3145a44812955e8d46cdd302d8a45fbfc7bf22be24fe231f9d8d8853a"
+            ],
+            "index": "pypi",
+            "version": "==3.6.0"
+        },
+        "pytest-tornado": {
+            "hashes": [
+                "sha256:214fc59d06fb81696fce3028b56dff522168ac1cfc784cfc0077b7b1e425b4cd",
+                "sha256:687c1f9c0f5bda7808c1e53c14bbebfe4fb9452e34cc95b440e598d4724265e0"
+            ],
+            "index": "pypi",
+            "version": "==0.5.0"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
+        "tornado": {
+            "hashes": [
+                "sha256:1b83d5c10550f2653380b4c77331d6f8850f287c4f67d7ce1e1c639d9222fbc7",
+                "sha256:408d129e9d13d3c55aa73f8084aa97d5f90ed84132e38d6932e63a67d5bec563",
+                "sha256:88ce0282cce70df9045e515f578c78f1ebc35dcabe1d70f800c3583ebda7f5f5",
+                "sha256:ba9fbb249ac5390bff8a1d6aa4b844fd400701069bda7d2e380dfe2217895101",
+                "sha256:c050089173c2e9272244bccfb6a8615fb9e53b79420a5551acfa76094ecc3111"
+            ],
+            "index": "pypi",
+            "version": "==5.0.2"
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,13 +7,11 @@
 
     script/setup
 
-The setup script will create a new Python virtual environment for the application to use. All of the scripts will activate this virutal envirnment automatically, but you can also manually activate it like this:
+The setup script installs pipenv, which is what this application uses to manage its dependences and virtualenv. Instead of the classic `requirements.txt` file, pipenv uses a Pipfile and Pipfile.lock, making it more similar to other modern package managers like yarn or mix.
 
-    source .venv/bin/activate
+To enter the virtualenv manually (a la `source .venv/bin/activate`):
 
-When you are done, type
-
-    deactivate
+    pipenv shell
 
 If you want to automatically load the virtual environment whenever you enter the project directory, take a look at [direnv](https://direnv.net/).  An `.envrc` file is included in this repository.  direnv will activate and deactivate virtualenvs for you when you enter and leave the directory.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-tornado==5.0.2
-webassets==0.12.1
-pytest==3.6.0
-pytest-tornado==0.5.0
-Unipath==1.1

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -6,11 +6,8 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-# Activate virtual environment
-source .venv/bin/activate
-
 # Install Python dependencies
-pip install -r requirements.txt
+pipenv install --dev
 
 # Install uswds node module and dependencies
 npm install

--- a/script/server
+++ b/script/server
@@ -6,8 +6,5 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-# Activate virtual environment
-source .venv/bin/activate
-
 # Launch the app
-python3 app.py ${@}
+pipenv run python app.py ${@}

--- a/script/setup
+++ b/script/setup
@@ -7,14 +7,7 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install virtualenv
-pip install virtualenv
-
-# Create and activate virtual environment
-python3 -m venv .venv
-source .venv/bin/activate
-
-# Install/update pip
-pip install --upgrade pip
+pip install pipenv
 
 # Update npm
 npm install -g npm

--- a/script/test
+++ b/script/test
@@ -6,8 +6,5 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-# Activate virtual environment
-source .venv/bin/activate
-
 # Run unit tests
-python3 -m pytest
+pipenv run python -m pytest

--- a/script/update
+++ b/script/update
@@ -6,8 +6,5 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-# Activate virtual environment
-source .venv/bin/activate
-
 # Update dependencies
 script/bootstrap


### PR DESCRIPTION
I converted this repo over from pip and requirements.txt to `pipenv`, at Brian's request. This involves a couple new files and a few tweaks to the scripts.

The justification for using pipenv is that it's now the recommended way of handling python dependencies, according to [python.org](https://packaging.python.org/tutorials/managing-dependencies/#managing-dependencies). It has dev packages and a lock file, similar to `yarn` and `mix`. It's also a pretty nice developer experience in my opinion.