### PR TITLE
hard-code CAC authentication route for login

### DIFF
--- a/templates/login.html.to
+++ b/templates/login.html.to
@@ -14,12 +14,12 @@
 <main class="usa-grid-full usa-section login-area" id="main-content">
 
   <img class="logo-img" src="/static/img/logo-alt.png" alt="Defense Digital Service Logo">
-  
+
   <h1 class="usa-display">JEDI</h1>
 
-  <a class="usa-button" href='{{ reverse_url('home') }}'><span>Sign In with CAC</span></a>
+  <a class="usa-button" href='https://cac.atat.codes'><span>Sign In with CAC</span></a>
   <button class="usa-button" disabled>Sign In via MFA</button>
-  
+
 </main>
 
 </body>


### PR DESCRIPTION
Verrry small PR.

This hard-codes the location of the CAC authentication URL for now. Once atst has config management, the value can be configurable.

When both this and my [open PR](https://github.com/dod-ccpo/authnid/pull/3) in authnid are deployed, we'll see a CAC auth prompt when the user clicks "Sign In with CAC". If the user selects a valid cert, they'll be redirected to the atst home page. If they don't, they'll get a standin page from authnid with a link that will take them to atst anyway (for now!).