### PR TITLE
Use python 3.6 for pipenv

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -7,6 +7,7 @@ set -e
 cd "$(dirname "${0}")/.."
 
 # Install Python dependencies
+pipenv --python 3.6
 pipenv install --dev
 
 # Install uswds node module and dependencies


### PR DESCRIPTION
This PR updates bootstrap to create a virtual environment using Python 3.6