### PR TITLE
Fix debug kwarg so that tornado server will autoreload properly

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -31,7 +31,7 @@ def make_app(config):
         ],
         template_path = home.child('templates'),
         static_path   = home.child('static'),
-        DEBUG=config['default']['DEBUG']
+        debug=config['default'].getboolean('DEBUG')
     )
     return app
 


### PR DESCRIPTION
Realized that the `DEBUG` kwarg needed to be named `debug` for tornado to recognize it properly.