### PR TITLE
Add workspaces blank screen

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -18,6 +18,7 @@ def make_app(config):
     app = tornado.web.Application([
             url( r"/",           MainHandler, {'page': 'login'},      name='login' ),
             url( r"/home",       MainHandler, {'page': 'home'},       name='home' ),
+            url( r"/workspaces/blank",       MainHandler, {'page': 'workspaces_blank'},       name='workspaces_blank' ),
             url( r"/workspaces",
                  Workspace,
                  {'page': 'workspaces', 'authz_client': authz_client},

--- a/scss/components/_empty_state.scss
+++ b/scss/components/_empty_state.scss
@@ -1,0 +1,15 @@
+.empty-state {
+  text-align: center;
+  padding-top: 10rem;
+  
+  p {
+    font-family: $font-sans;
+    font-weight: 300;
+    line-height: 10rem;
+    font-size: 44px;
+    line-height: 5rem;
+    margin: 0 auto;
+    padding-bottom: 2rem;
+    max-width: 40%;
+  }
+}

--- a/templates/workspaces_blank.html.to
+++ b/templates/workspaces_blank.html.to
@@ -1,0 +1,12 @@
+{% extends "base.html.to" %}
+
+{% block content %}
+
+<div class="usa-width-one-whole empty-state">
+  <p>There are currently no JEDI workspaces</p>
+  <a href="" class="usa-button">New Workspace</a>
+</div>
+
+
+{% end %}
+


### PR DESCRIPTION
This PR adds an empty state blank screen for workspaces.

This screen should be displayed for users that have no workspaces in their accounts.

![screen shot 2018-06-12 at 15 48 30](https://user-images.githubusercontent.com/38014252/41313844-04a0f3e2-6e59-11e8-86a7-75b3d44f3d11.png)
