### PR TITLE
Basic authentication

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -7,7 +7,6 @@ name = "pypi"
 tornado = "==5.0.2"
 webassets = "==0.12.1"
 Unipath = "==1.1"
-requests = "*"
 
 [dev-packages]
 pytest = "==3.6.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68a0d5093979093899f0f86faa82eb55f90f9a67a16b11a5701ea85096e72ee8"
+            "sha256": "391e254ddb902877afca9c07aa2306710ce6d1e207b029c1a8b5dc0115ee99a5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,35 +16,6 @@
         ]
     },
     "default": {
-        "certifi": {
-            "hashes": [
-                "sha256:13e698f54293db9f89122b0581843a782ad0934a4fe0172d2a980ba77fc61bb7",
-                "sha256:9fa520c1bacfb634fa7af20a76bcbd3d5fb390481724c597da32c719a7dca4b0"
-            ],
-            "version": "==2018.4.16"
-        },
-        "chardet": {
-            "hashes": [
-                "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae",
-                "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
-            ],
-            "version": "==3.0.4"
-        },
-        "idna": {
-            "hashes": [
-                "sha256:2c6a5de3089009e3da7c5dde64a141dbc8551d5b7f6cf4ed7c2568d0cc520a8f",
-                "sha256:8c7309c718f94b3a625cb648ace320157ad16ff131ae0af362c9f21b80ef6ec4"
-            ],
-            "version": "==2.6"
-        },
-        "requests": {
-            "hashes": [
-                "sha256:6a1b267aa90cac58ac3a765d067950e7dbbf75b1da07e895d1f594193a40a38b",
-                "sha256:9c443e7324ba5b85070c4a818ade28bfabedf16ea10206da1132edaa6dda237e"
-            ],
-            "index": "pypi",
-            "version": "==2.18.4"
-        },
         "tornado": {
             "hashes": [
                 "sha256:1b83d5c10550f2653380b4c77331d6f8850f287c4f67d7ce1e1c639d9222fbc7",
@@ -63,13 +34,6 @@
             ],
             "index": "pypi",
             "version": "==1.1"
-        },
-        "urllib3": {
-            "hashes": [
-                "sha256:06330f386d6e4b195fbfc736b297f58c5a892e4440e54d294d7004e3a9bbea1b",
-                "sha256:cc44da8e1145637334317feebd728bd869a35285b93cbb4cca2577da7e62db4f"
-            ],
-            "version": "==1.22"
         },
         "webassets": {
             "hashes": [

--- a/atst/api_client.py
+++ b/atst/api_client.py
@@ -33,7 +33,7 @@ class ApiClient(object):
             kwargs['body'] = dumps(kwargs['json'])
             del kwargs['json']
             headers = kwargs.get('headers', {})
-            headers['Content-Type'] = 'application-json'
+            headers['Content-Type'] = 'application/json'
             kwargs['headers'] = headers
 
         response = yield self.client.fetch(url, method=method, **kwargs)

--- a/atst/app.py
+++ b/atst/app.py
@@ -4,6 +4,7 @@ import tornado.web
 from tornado.web import url
 
 from atst.handlers.main import MainHandler
+from atst.handlers.home import Home
 from atst.handlers.login import Login
 from atst.handlers.workspace import Workspace
 from atst.handlers.request import Request
@@ -20,7 +21,7 @@ def make_app(config):
     authnid_client = ApiClient(config["default"]["AUTHNID_BASE_URL"])
 
     routes = [
-        url(r"/", Login, {"page": "login"}, name="main"),
+        url(r"/", Home, {"page": "login"}, name="main"),
         url(r"/login", Login, {"page": "login"}, name="login"),
         url(r"/home", MainHandler, {"page": "home"}, name="home"),
         url(
@@ -47,7 +48,7 @@ def make_app(config):
 
     app = tornado.web.Application(
         routes,
-        login_url="/login",
+        login_url="/",
         template_path = home.child('templates'),
         static_path   = home.child('static'),
         cookie_secret=config["default"]["COOKIE_SECRET"],

--- a/atst/app.py
+++ b/atst/app.py
@@ -17,6 +17,7 @@ ENV = os.getenv("TORNADO_ENV", "dev")
 def make_app(config):
 
     authz_client = ApiClient(config["default"]["AUTHZ_BASE_URL"])
+    authnid_client = ApiClient(config["default"]["AUTHNID_BASE_URL"])
 
     routes = [
         url(r"/", Login, {"page": "login"}, name="main"),
@@ -52,6 +53,7 @@ def make_app(config):
         cookie_secret=config["default"]["COOKIE_SECRET"],
         debug=config['default'].getboolean('DEBUG')
     )
+    app.authnid_client = authnid_client
     return app
 
 

--- a/atst/app.py
+++ b/atst/app.py
@@ -4,6 +4,7 @@ import tornado.web
 from tornado.web import url
 
 from atst.handlers.main import MainHandler
+from atst.handlers.login import Login
 from atst.handlers.workspace import Workspace
 from atst.handlers.request import Request
 from atst.handlers.request_new import RequestNew
@@ -16,7 +17,8 @@ def make_app(config):
     authz_client = ApiClient(config['default']['AUTHZ_BASE_URL'])
 
     app = tornado.web.Application([
-            url( r"/",           MainHandler, {'page': 'login'},      name='login' ),
+            url( r"/",           Login, {'page': 'login'},      name='main' ),
+            url( r"/login",      Login, {'page': 'login'},      name='login' ),
             url( r"/home",       MainHandler, {'page': 'home'},       name='home' ),
             url( r"/workspaces",
                  Workspace,

--- a/atst/app.py
+++ b/atst/app.py
@@ -8,29 +8,39 @@ from atst.handlers.login import Login
 from atst.handlers.workspace import Workspace
 from atst.handlers.request import Request
 from atst.handlers.request_new import RequestNew
+from atst.handlers.dev import Dev
 from atst.home import home
 from atst.api_client import ApiClient
 
+
+routes = [
+    url(r"/", Login, {"page": "login"}, name="main"),
+    url(r"/login", Login, {"page": "login"}, name="login"),
+    url(r"/home", MainHandler, {"page": "home"}, name="home"),
+    url(r"/workspaces", Workspace, {"page": "workspaces"}, name="workspaces"),
+    url(r"/requests", Request, {"page": "requests"}, name="requests"),
+    url(r"/requests/new", RequestNew, {"page": "requests_new"}, name="request_new"),
+    url(
+        r"/requests/new/([0-9])",
+        RequestNew,
+        {"page": "requests_new"},
+        name="request_form",
+    ),
+    url(r"/users", MainHandler, {"page": "users"}, name="users"),
+    url(r"/reports", MainHandler, {"page": "reports"}, name="reports"),
+    url(r"/calculator", MainHandler, {"page": "calculator"}, name="calculator"),
+]
+
+env = os.getenv("TORNADO_ENV", "development")
+if not env == "production":
+    routes += [url(r"/login-dev", Dev, {"action": "login"}, name="dev-login")]
 
 def make_app(config):
 
     authz_client = ApiClient(config['default']['AUTHZ_BASE_URL'])
 
-    app = tornado.web.Application([
-            url( r"/",           Login, {'page': 'login'},      name='main' ),
-            url( r"/login",      Login, {'page': 'login'},      name='login' ),
-            url( r"/home",       MainHandler, {'page': 'home'},       name='home' ),
-            url( r"/workspaces",
-                 Workspace,
-                 {'page': 'workspaces', 'authz_client': authz_client},
-                 name='workspaces'),
-            url( r"/requests",   Request,     {'page': 'requests'},   name='requests' ),
-            url( r"/requests/new",         RequestNew, {'page': 'requests_new'},   name='request_new' ),
-            url( r"/requests/new/([0-9])", RequestNew, {'page': 'requests_new'},   name='request_form' ),
-            url( r"/users",      MainHandler, {'page': 'users'},      name='users' ),
-            url( r"/reports",    MainHandler, {'page': 'reports'},    name='reports' ),
-            url( r"/calculator", MainHandler, {'page': 'calculator'}, name='calculator' ),
-        ],
+    app = tornado.web.Application(
+        routes,
         template_path = home.child('templates'),
         static_path   = home.child('static'),
         debug=config['default'].getboolean('DEBUG')

--- a/atst/app.py
+++ b/atst/app.py
@@ -12,51 +12,55 @@ from atst.handlers.dev import Dev
 from atst.home import home
 from atst.api_client import ApiClient
 
-
-routes = [
-    url(r"/", Login, {"page": "login"}, name="main"),
-    url(r"/login", Login, {"page": "login"}, name="login"),
-    url(r"/home", MainHandler, {"page": "home"}, name="home"),
-    url(r"/workspaces", Workspace, {"page": "workspaces"}, name="workspaces"),
-    url(r"/requests", Request, {"page": "requests"}, name="requests"),
-    url(r"/requests/new", RequestNew, {"page": "requests_new"}, name="request_new"),
-    url(
-        r"/requests/new/([0-9])",
-        RequestNew,
-        {"page": "requests_new"},
-        name="request_form",
-    ),
-    url(r"/users", MainHandler, {"page": "users"}, name="users"),
-    url(r"/reports", MainHandler, {"page": "reports"}, name="reports"),
-    url(r"/calculator", MainHandler, {"page": "calculator"}, name="calculator"),
-]
-
-env = os.getenv("TORNADO_ENV", "development")
-if not env == "production":
-    routes += [url(r"/login-dev", Dev, {"action": "login"}, name="dev-login")]
+ENV = os.getenv("TORNADO_ENV", "dev")
 
 def make_app(config):
 
-    authz_client = ApiClient(config['default']['AUTHZ_BASE_URL'])
+    authz_client = ApiClient(config["default"]["AUTHZ_BASE_URL"])
+
+    routes = [
+        url(r"/", Login, {"page": "login"}, name="main"),
+        url(r"/login", Login, {"page": "login"}, name="login"),
+        url(r"/home", MainHandler, {"page": "home"}, name="home"),
+        url(
+            r"/workspaces",
+            Workspace,
+            {"page": "workspaces", "authz_client": authz_client},
+            name="workspaces",
+        ),
+        url(r"/requests", Request, {"page": "requests"}, name="requests"),
+        url(r"/requests/new", RequestNew, {"page": "requests_new"}, name="request_new"),
+        url(
+            r"/requests/new/([0-9])",
+            RequestNew,
+            {"page": "requests_new"},
+            name="request_form",
+        ),
+        url(r"/users", MainHandler, {"page": "users"}, name="users"),
+        url(r"/reports", MainHandler, {"page": "reports"}, name="reports"),
+        url(r"/calculator", MainHandler, {"page": "calculator"}, name="calculator"),
+    ]
+
+    if not ENV == "production":
+        routes += [url(r"/login-dev", Dev, {"action": "login"}, name="dev-login")]
 
     app = tornado.web.Application(
         routes,
+        login_url="/login",
         template_path = home.child('templates'),
         static_path   = home.child('static'),
+        cookie_secret=config["default"]["COOKIE_SECRET"],
         debug=config['default'].getboolean('DEBUG')
     )
     return app
 
 
 def make_config():
-    BASE_CONFIG_FILENAME = os.path.join(
-        os.path.dirname(__file__),
-        '../config/base.ini',
-    )
+    BASE_CONFIG_FILENAME = os.path.join(os.path.dirname(__file__), "../config/base.ini")
     ENV_CONFIG_FILENAME = os.path.join(
         os.path.dirname(__file__),
-        '../config/',
-        '{}.ini'.format(os.getenv('TORNADO_ENV', 'dev').lower())
+        "../config/",
+        "{}.ini".format(ENV.lower()),
     )
     config = ConfigParser()
 

--- a/atst/app.py
+++ b/atst/app.py
@@ -15,6 +15,7 @@ from atst.api_client import ApiClient
 
 ENV = os.getenv("TORNADO_ENV", "dev")
 
+
 def make_app(config):
 
     authz_client = ApiClient(config["default"]["AUTHZ_BASE_URL"])
@@ -22,7 +23,12 @@ def make_app(config):
 
     routes = [
         url(r"/", Home, {"page": "login"}, name="main"),
-        url(r"/login", Login, {"page": "login"}, name="login"),
+        url(
+            r"/login",
+            Login,
+            {"authnid_client": authnid_client},
+            name="login",
+        ),
         url(r"/home", MainHandler, {"page": "home"}, name="home"),
         url(
             r"/workspaces",
@@ -54,16 +60,18 @@ def make_app(config):
         cookie_secret=config["default"]["COOKIE_SECRET"],
         debug=config['default'].getboolean('DEBUG')
     )
-    app.authnid_client = authnid_client
     return app
 
 
 def make_config():
-    BASE_CONFIG_FILENAME = os.path.join(os.path.dirname(__file__), "../config/base.ini")
+    BASE_CONFIG_FILENAME = os.path.join(
+        os.path.dirname(__file__),
+        "../config/base.ini"
+    )
     ENV_CONFIG_FILENAME = os.path.join(
         os.path.dirname(__file__),
         "../config/",
-        "{}.ini".format(ENV.lower()),
+        "{}.ini".format(ENV.lower())
     )
     config = ConfigParser()
 

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -1,5 +1,4 @@
 import os
-import functools
 from webassets import Environment, Bundle
 import tornado.web
 from atst.home import home

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -20,19 +20,6 @@ helpers = {
     'assets': assets
 }
 
-def authenticated(method):
-    @functools.wraps(method)
-    def wrapper(self, *args, **kwargs):
-        if not self.current_user:
-            if self.request.method in ("GET", "HEAD"):
-                url = self.get_login_url()
-                self.redirect(url)
-                return
-            else:
-                raise tornado.web.HTTPError(403)
-        return method(self, *args, **kwargs)
-    return wrapper
-
 class BaseHandler(tornado.web.RequestHandler):
 
     def get_template_namespace(self):

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -22,17 +22,9 @@ helpers = {
 
 def authenticated(method):
     @functools.wraps(method)
-    @tornado.gen.coroutine
     def wrapper(self, *args, **kwargs):
         if not self.current_user:
-            if self.get_cookie('bearer-token'):
-                bearer_token = self.get_cookie('bearer-token')
-                valid = yield validate_login_token(self.application.authnid_client, bearer_token)
-                if valid:
-                    self._start_session()
-                else:
-                    raise NotImplementedError
-            elif self.request.method in ("GET", "HEAD"):
+            if self.request.method in ("GET", "HEAD"):
                 url = self.get_login_url()
                 self.redirect(url)
                 return
@@ -40,17 +32,6 @@ def authenticated(method):
                 raise tornado.web.HTTPError(403)
         return method(self, *args, **kwargs)
     return wrapper
-
-@tornado.gen.coroutine
-def validate_login_token(client, token):
-    try:
-        response = yield client.post('/api/v1/validate', raise_error=False, json={"token": token})
-        return response.code == 200
-    except tornado.httpclient.HTTPError as error:
-        if error.response.code == 401:
-            return False
-        else:
-            raise error
 
 class BaseHandler(tornado.web.RequestHandler):
 

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -56,5 +56,6 @@ class BaseHandler(tornado.web.RequestHandler):
         else:
             False
 
+    # this is a temporary implementation until we have real sessions
     def _start_session(self):
         self.set_secure_cookie('atst', 'valid-user-session')

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -1,4 +1,4 @@
-from atst.handler import BaseHandler, authenticated
+from atst.handler import BaseHandler
 
 class Dev(BaseHandler):
     def initialize(self, action):

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -1,0 +1,13 @@
+from atst.handler import BaseHandler, authenticated
+
+class Dev(BaseHandler):
+    def initialize(self, action):
+        self.action = action
+
+    def get(self):
+        if self.action == 'login':
+            self._login()
+
+    def _login(self):
+        self._start_session()
+        self.redirect("/home")

--- a/atst/handlers/home.py
+++ b/atst/handlers/home.py
@@ -1,0 +1,10 @@
+import tornado
+from atst.handler import BaseHandler
+
+class Home(BaseHandler):
+
+    def initialize(self, page):
+        self.page = page
+
+    def get(self):
+        self.render( '%s.html.to' % self.page, page = self.page )

--- a/atst/handlers/login.py
+++ b/atst/handlers/login.py
@@ -1,10 +1,37 @@
 import tornado
 from atst.handler import BaseHandler
 
+
 class Login(BaseHandler):
 
     def initialize(self, page):
         self.page = page
 
+    @tornado.gen.coroutine
     def get(self):
-        self.render( '%s.html.to' % self.page, page = self.page )
+        token = self.get_query_argument("bearer-token")
+        if token:
+            valid = yield self._validate_login_token(token)
+            if valid:
+                self._start_session()
+                self.redirect("/home")
+                return
+
+        url = self.get_login_url()
+        self.redirect(url)
+        return
+
+    @tornado.gen.coroutine
+    def _validate_login_token(self, token):
+        try:
+            response = yield self.application.authnid_client.post(
+                "/api/v1/validate", json={"token": token}
+            )
+            return response.code == 200
+
+        except tornado.httpclient.HTTPError as error:
+            if error.response.code == 401:
+                return False
+
+            else:
+                raise error

--- a/atst/handlers/login.py
+++ b/atst/handlers/login.py
@@ -4,8 +4,8 @@ from atst.handler import BaseHandler
 
 class Login(BaseHandler):
 
-    def initialize(self, page):
-        self.page = page
+    def initialize(self, authnid_client):
+        self.authnid_client = authnid_client
 
     @tornado.gen.coroutine
     def get(self):
@@ -24,7 +24,7 @@ class Login(BaseHandler):
     @tornado.gen.coroutine
     def _validate_login_token(self, token):
         try:
-            response = yield self.application.authnid_client.post(
+            response = yield self.authnid_client.post(
                 "/api/v1/validate", json={"token": token}
             )
             return response.code == 200

--- a/atst/handlers/login.py
+++ b/atst/handlers/login.py
@@ -1,11 +1,10 @@
-import atst
-from atst.handler import BaseHandler, authenticated
+import tornado
+from atst.handler import BaseHandler
 
-class MainHandler(BaseHandler):
+class Login(BaseHandler):
 
     def initialize(self, page):
         self.page = page
 
-    @authenticated
     def get(self):
         self.render( '%s.html.to' % self.page, page = self.page )

--- a/atst/handlers/main.py
+++ b/atst/handlers/main.py
@@ -1,11 +1,12 @@
 import atst
-from atst.handler import BaseHandler, authenticated
+import tornado
+from atst.handler import BaseHandler
 
 class MainHandler(BaseHandler):
 
     def initialize(self, page):
         self.page = page
 
-    @authenticated
+    @tornado.web.authenticated
     def get(self):
         self.render( '%s.html.to' % self.page, page = self.page )

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -1,4 +1,5 @@
-from atst.handler import BaseHandler, authenticated
+import tornado
+from atst.handler import BaseHandler
 
 mock_requests = [
         {
@@ -31,6 +32,6 @@ class Request(BaseHandler):
     def initialize(self, page):
         self.page = page
 
-    @authenticated
+    @tornado.web.authenticated
     def get(self):
         self.render('requests.html.to', page = self.page, requests = mock_requests )

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -1,4 +1,4 @@
-from atst.handler import BaseHandler
+from atst.handler import BaseHandler, authenticated
 
 mock_requests = [
         {
@@ -31,5 +31,6 @@ class Request(BaseHandler):
     def initialize(self, page):
         self.page = page
 
+    @authenticated
     def get(self):
         self.render('requests.html.to', page = self.page, requests = mock_requests )

--- a/atst/handlers/request_new.py
+++ b/atst/handlers/request_new.py
@@ -1,4 +1,5 @@
-from atst.handler import BaseHandler, authenticated
+import tornado
+from atst.handler import BaseHandler
 
 class RequestNew(BaseHandler):
     screens = [
@@ -22,7 +23,7 @@ class RequestNew(BaseHandler):
     def initialize(self, page):
         self.page = page
 
-    @authenticated
+    @tornado.web.authenticated
     def get(self, screen = 1):
         self.render( 'requests/screen-%d.html.to' % int(screen),
                     page = self.page,

--- a/atst/handlers/request_new.py
+++ b/atst/handlers/request_new.py
@@ -1,4 +1,4 @@
-from atst.handler import BaseHandler
+from atst.handler import BaseHandler, authenticated
 
 class RequestNew(BaseHandler):
     screens = [
@@ -22,6 +22,7 @@ class RequestNew(BaseHandler):
     def initialize(self, page):
         self.page = page
 
+    @authenticated
     def get(self, screen = 1):
         self.render( 'requests/screen-%d.html.to' % int(screen),
                     page = self.page,

--- a/atst/handlers/workspace.py
+++ b/atst/handlers/workspace.py
@@ -1,5 +1,4 @@
-from atst.handler import BaseHandler
-import requests
+from atst.handler import BaseHandler, authenticated
 import tornado.gen
 
 mock_workspaces = [
@@ -13,8 +12,6 @@ mock_workspaces = [
     }
 ]
 
-session = requests.Session()
-
 class Workspace(BaseHandler):
 
     def initialize(self, page, authz_client):
@@ -22,5 +19,6 @@ class Workspace(BaseHandler):
         self.authz_client = authz_client
 
     @tornado.gen.coroutine
+    @authenticated
     def get(self):
         self.render( 'workspaces.html.to', page = self.page, workspaces = mock_workspaces )

--- a/atst/handlers/workspace.py
+++ b/atst/handlers/workspace.py
@@ -1,4 +1,5 @@
-from atst.handler import BaseHandler, authenticated
+from atst.handler import BaseHandler
+import tornado
 import tornado.gen
 
 mock_workspaces = [
@@ -19,6 +20,6 @@ class Workspace(BaseHandler):
         self.authz_client = authz_client
 
     @tornado.gen.coroutine
-    @authenticated
+    @tornado.web.authenticated
     def get(self):
         self.render( 'workspaces.html.to', page = self.page, workspaces = mock_workspaces )

--- a/config/base.ini
+++ b/config/base.ini
@@ -3,3 +3,4 @@ ENVIRONMENT = dev
 DEBUG = true
 AUTHZ_BASE_URL = http://localhost
 PORT = 8000
+COOKIE_SECRET = some-secret-please-replace

--- a/config/base.ini
+++ b/config/base.ini
@@ -1,6 +1,7 @@
 [default]
+PORT=8000
 ENVIRONMENT = dev
 DEBUG = true
 AUTHZ_BASE_URL = http://localhost
-PORT = 8000
+AUTHNID_BASE_URL= http://localhost
 COOKIE_SECRET = some-secret-please-replace

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,4 @@
+import re
 import pytest
 import tornado.web
 from concurrent.futures import ThreadPoolExecutor
@@ -15,9 +16,10 @@ def test_redirects_when_not_logged_in(http_client, base_url):
     response = yield http_client.fetch(
         base_url + "/home", raise_error=False, follow_redirects=False
     )
+    location = response.headers['Location']
     assert response.code == 302
     assert response.error
-    assert response.headers["Location"] == "/"
+    assert re.match('/\??', location)
 
 
 @pytest.mark.gen_test

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,34 @@
+import pytest
+import tornado.web
+
+
+@pytest.mark.gen_test
+def test_redirects_when_not_logged_in(http_client, base_url):
+    response = yield http_client.fetch(
+        base_url + "/home", raise_error=False, follow_redirects=False
+    )
+    assert response.code == 302
+    assert response.error
+    assert response.headers["Location"] == "/login"
+
+
+@pytest.mark.gen_test
+def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
+    monkeypatch.setattr("atst.handler.validate_login_token", lambda t: True)
+    response = yield http_client.fetch(
+        base_url + "/home", headers={"Cookie": "bearer-token=anything"}
+    )
+    assert response.headers['Set-Cookie'].startswith('atst')
+    assert response.code == 200
+    assert not response.error
+
+
+@pytest.mark.gen_test
+@pytest.mark.skip(reason="need to work out auth error user paths")
+def test_login_with_invalid_bearer_token(monkeypatch, http_client, base_url):
+    monkeypatch.setattr("atst.handler.validate_login_token", lambda t: False)
+    response = yield http_client.fetch(
+        base_url + "/home",
+        raise_error=False,
+        headers={"Cookie": "bearer-token=anything"},
+    )

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -11,7 +11,6 @@ def test_redirects_when_not_logged_in(http_client, base_url):
     assert response.error
     assert response.headers["Location"] == "/login"
 
-
 @pytest.mark.gen_test
 def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
     monkeypatch.setattr("atst.handler.validate_login_token", lambda t: True)
@@ -22,6 +21,14 @@ def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
     assert response.code == 200
     assert not response.error
 
+@pytest.mark.gen_test
+def test_login_with_via_dev_endpoint(app, monkeypatch, http_client, base_url):
+    response = yield http_client.fetch(
+        base_url + "/login-dev", raise_error=False, follow_redirects=False
+    )
+    assert response.headers['Set-Cookie'].startswith('atst')
+    assert response.code == 302
+    assert response.headers["Location"] == "/home"
 
 @pytest.mark.gen_test
 @pytest.mark.skip(reason="need to work out auth error user paths")

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,13 +4,6 @@ import tornado.web
 from concurrent.futures import ThreadPoolExecutor
 
 
-class MockApiResponse():
-
-    def __init__(self, code, json):
-        self.code = code
-        self.json = json
-
-
 @pytest.mark.gen_test
 def test_redirects_when_not_logged_in(http_client, base_url):
     response = yield http_client.fetch(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,7 +1,6 @@
 import pytest
 import tornado.web
 from concurrent.futures import ThreadPoolExecutor
-from atst.handler import validate_login_token
 
 
 class MockApiResponse():
@@ -12,49 +11,30 @@ class MockApiResponse():
 
 
 @pytest.mark.gen_test
-def test_successful_validate_login_token(monkeypatch, app):
-    monkeypatch.setattr(
-        "atst.api_client.ApiClient.get",
-        lambda x,
-        y,
-        json=None: MockApiResponse(200, {"status": "success"}),
-    )
-    assert validate_login_token(app.authnid_client, "abc-123")
-
-
-@pytest.mark.gen_test
-def test_unsuccessful_validate_login_token(monkeypatch, app):
-    monkeypatch.setattr(
-        "atst.api_client.ApiClient.get",
-        lambda x,y,json=None: MockApiResponse(401, {"status": "error"}),
-    )
-    valid = yield validate_login_token(app.authnid_client, "abc-123")
-    assert not valid
-
-
-@pytest.mark.gen_test
 def test_redirects_when_not_logged_in(http_client, base_url):
     response = yield http_client.fetch(
         base_url + "/home", raise_error=False, follow_redirects=False
     )
     assert response.code == 302
     assert response.error
-    assert response.headers["Location"] == "/login"
+    assert response.headers["Location"] == "/"
 
 
 @pytest.mark.gen_test
 def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
     with ThreadPoolExecutor(max_workers=1) as executor:
         monkeypatch.setattr(
-            "atst.handler.validate_login_token",
+            "atst.handlers.login.Login._validate_login_token",
             lambda c,t: executor.submit(lambda: True),
         )
         response = yield http_client.fetch(
-            base_url + "/home", headers={"Cookie": "bearer-token=anything"}
+            base_url + "/login?bearer-token=abc-123",
+            follow_redirects=False,
+            raise_error=False
         )
         assert response.headers["Set-Cookie"].startswith("atst")
-        assert response.code == 200
-        assert not response.error
+        assert response.headers['Location'] == '/home'
+        assert response.code == 302
 
 
 @pytest.mark.gen_test

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -33,7 +33,7 @@ def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
 
 
 @pytest.mark.gen_test
-def test_login_with_via_dev_endpoint(app, monkeypatch, http_client, base_url):
+def test_login_via_dev_endpoint(app, http_client, base_url):
     response = yield http_client.fetch(
         base_url + "/login-dev", raise_error=False, follow_redirects=False
     )
@@ -44,8 +44,7 @@ def test_login_with_via_dev_endpoint(app, monkeypatch, http_client, base_url):
 
 @pytest.mark.gen_test
 @pytest.mark.skip(reason="need to work out auth error user paths")
-def test_login_with_invalid_bearer_token(monkeypatch, http_client, base_url):
-    monkeypatch.setattr("atst.handler.validate_login_token", lambda t: False)
+def test_login_with_invalid_bearer_token(http_client, base_url):
     response = yield http_client.fetch(
         base_url + "/home",
         raise_error=False,


### PR DESCRIPTION
This adds a basic integration with authnid and protects internal routes within the app. The happy path workflow is:

- User visits ATST home/login screen
- User clicks "Sign in with CAC"
- User gets certificate prompt, etc.
- If successfully authenticated in authnid, they are redirected to ATST `/login?bearer-token=[token]`
- ATST validates the bearer token with authnid and, if valid, creates a session for the user

Right now the ATST session is just a dummy cookie. Session management will be its own story.

**Note** you don't actually have to authenticate when the server is running in development. You can either visit `/login-dev` or click the Monty Python gif. This route is only available in dev and test environments.