### PR TITLE
install sass if it is not already present

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -12,6 +12,15 @@ pip install pipenv
 # Update npm
 npm install -g npm
 
+if ! type sass > /dev/null; then
+  if type gem > /dev/null; then
+    echo 'installing a sass compiler...'
+    gem install sass
+  else
+    echo 'Could not install a sass compiler. Please install a version of sass.'
+  fi
+fi
+
 # Install application dependencies
 script/bootstrap
 


### PR DESCRIPTION
Resolves issue #31 . If a system-wide sass binary can't be found, it will install one. I don't know if anyone has strong feelings about which sass compiler to use or whether to install it system-wide, but `webassets` looks for a `sass` bin in the system path by default. If we want to do something more nuanced we should be setting the `SASS_BIN` env var. More info: https://webassets.readthedocs.io/en/latest/builtin_filters.html#sass