### PR TITLE
turn off service SSL cert validation by default for development

### DIFF
--- a/atst/api_client.py
+++ b/atst/api_client.py
@@ -5,9 +5,10 @@ from json import dumps, loads
 
 class ApiClient(object):
 
-    def __init__(self, base_url):
+    def __init__(self, base_url, validate_cert=True):
         self.base_url = base_url
         self.client = AsyncHTTPClient()
+        self.validate_cert = validate_cert
 
     @tornado.gen.coroutine
     def get(self, path, **kwargs):
@@ -35,6 +36,8 @@ class ApiClient(object):
             headers = kwargs.get('headers', {})
             headers['Content-Type'] = 'application/json'
             kwargs['headers'] = headers
+        if not 'validate_cert' in kwargs:
+            kwargs['validate_cert'] = self.validate_cert
 
         response = yield self.client.fetch(url, method=method, **kwargs)
         return self.adapt_response(response)

--- a/atst/app.py
+++ b/atst/app.py
@@ -69,10 +69,12 @@ def make_app(config, deps, **kwargs):
 
 
 def make_deps(config):
+    # we do not want to do SSL verify services in test and development
+    validate_cert = ENV == 'production'
     return {
-        'authz_client': ApiClient(config["default"]["AUTHZ_BASE_URL"]),
-        'authnid_client': ApiClient(config["default"]["AUTHNID_BASE_URL"]),
-        'requests_client': ApiClient(config["default"]["REQUESTS_QUEUE_BASE_URL"])
+        'authz_client': ApiClient(config["default"]["AUTHZ_BASE_URL"], validate_cert=validate_cert),
+        'authnid_client': ApiClient(config["default"]["AUTHNID_BASE_URL"], validate_cert=validate_cert),
+        'requests_client': ApiClient(config["default"]["REQUESTS_QUEUE_BASE_URL"], validate_cert=validate_cert)
     }
 
 


### PR DESCRIPTION
When we use the Tornado HTTP client, it will validate the server cert for HTTPS requests. Our development cert for `authnid` is self-signed, and so this throws an error. Rather than pass around CAs for local development, this PR allows us to configure out API client to disregard that validation by default in any environment besides production.