### PR TITLE
Include more real data in requests listing

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ tornado = "==5.0.2"
 webassets = "==0.12.1"
 Unipath = "==1.1"
 wtforms-tornado = "*"
+pendulum = "*"
 
 [dev-packages]
 pytest = "==3.6.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "357ba55027d4ffbb2cbc2d9bd034c1995407b3ac87f27a54d3f26c543019e5c6"
+            "sha256": "5f91978d61968a720e4edc404ea36123ff96d857c1d7ff865f5aaef9b133db37"
         },
         "pipfile-spec": 6,
         "requires": {

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "4792f21af3f461ea6eb1c7c2f7387a545cb5cfaedaf5f27694e16b6ba0a042fd"
+            "sha256": "357ba55027d4ffbb2cbc2d9bd034c1995407b3ac87f27a54d3f26c543019e5c6"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,6 +16,43 @@
         ]
     },
     "default": {
+        "pendulum": {
+            "hashes": [
+                "sha256:0643d45824e6789b88187728337dfa6075a0233f6976c2abefba00d064156309",
+                "sha256:3cc271195d8054bec06f54ff7d56ea6c2e2b5ad5dd6b532d787b34d2cabe6a65",
+                "sha256:544e44d8a92954e5ef4db4fa8b662d3282f2ac7b7c2cbf4227dc193ba78b9e1e",
+                "sha256:846478ab5f7480b3d850a09e44fe03830d448633c84f0b1066615ff6c34293aa",
+                "sha256:8bb523f759daeecfc0649369f198cbeb27a6608347354f4f847d21d579003db6",
+                "sha256:a449142063100f1b3c1119453c7569667c9ba79897305a1c50ca83a8c790f1e4",
+                "sha256:b7ff156b3d7cccbdeeb63465578d9a4e6f57d463f6ff6d4474254208d08f8353",
+                "sha256:d8822a592bbc16576c44ec4625bff9187ed9b649d47714e4905a55adc5b25339",
+                "sha256:dd45c7b349faab69714df9835cdf8bf8bce50bf6fc471419d3b23ba33e1915a5",
+                "sha256:fac088b637b5db5a047a0e89194d8c3c9e9e9ce1665089240003bb7c05b92536"
+            ],
+            "index": "pypi",
+            "version": "==2.0.2"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
+                "sha256:e27001de32f627c22380a688bcc43ce83504a7bc5da472209b4c70f02829f0b8"
+            ],
+            "version": "==2.7.3"
+        },
+        "pytzdata": {
+            "hashes": [
+                "sha256:1d936da41ee06216d89fdc7ead1ee9a5da2811a8787515a976b646e110c3f622",
+                "sha256:e4ef42e82b0b493c5849eed98b5ab49d6767caf982127e9a33167f1153b36cc5"
+            ],
+            "version": "==2018.5"
+        },
+        "six": {
+            "hashes": [
+                "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9",
+                "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"
+            ],
+            "version": "==1.11.0"
+        },
         "tornado": {
             "hashes": [
                 "sha256:1b83d5c10550f2653380b4c77331d6f8850f287c4f67d7ce1e1c639d9222fbc7",

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -22,10 +22,15 @@ class BaseHandler(tornado.web.RequestHandler):
         return ns
 
     def get_current_user(self):
-        if self.get_secure_cookie("atst"):
-            return "9cb348f0-8102-4962-88c4-dac8180c904c"
+        if self.get_secure_cookie('atst'):
+            return {
+                'id': '9cb348f0-8102-4962-88c4-dac8180c904c',
+                'email': 'fake.user@mail.com',
+                'first_name': 'Fake',
+                'last_name': 'User'
+            }
         else:
-            return False
+            return None
 
     # this is a temporary implementation until we have real sessions
     def _start_session(self):

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -22,12 +22,12 @@ class BaseHandler(tornado.web.RequestHandler):
         return ns
 
     def get_current_user(self):
-        if self.get_secure_cookie('atst'):
+        if self.get_secure_cookie("atst"):
             return {
-                'id': '9cb348f0-8102-4962-88c4-dac8180c904c',
-                'email': 'fake.user@mail.com',
-                'first_name': 'Fake',
-                'last_name': 'User'
+                "id": "9cb348f0-8102-4962-88c4-dac8180c904c",
+                "email": "fake.user@mail.com",
+                "first_name": "Fake",
+                "last_name": "User",
             }
         else:
             return None

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -3,17 +3,18 @@ import pendulum
 
 from atst.handler import BaseHandler
 
+
 def map_request(user, request):
-    time_created = pendulum.parse(request['time_created'])
+    time_created = pendulum.parse(request["time_created"])
     is_new = time_created.add(days=1) > pendulum.now()
 
     return {
-        'order_id': request['id'],
-        'is_new': is_new,
-        'status': request['status'],
-        'app_count': 1,
-        'date': time_created.format('M/DD/YYYY'),
-        'full_name': '{} {}'.format(user['first_name'], user['last_name'])
+        "order_id": request["id"],
+        "is_new": is_new,
+        "status": request["status"],
+        "app_count": 1,
+        "date": time_created.format("M/DD/YYYY"),
+        "full_name": "{} {}".format(user["first_name"], user["last_name"]),
     }
 
 
@@ -27,7 +28,8 @@ class Request(BaseHandler):
     def get(self):
         user = self.get_current_user()
         response = yield self.requests_client.get(
-            '/users/{}/requests'.format(user['id']))
-        requests = response.json['requests']
+            "/users/{}/requests".format(user["id"])
+        )
+        requests = response.json["requests"]
         mapped_requests = [map_request(user, request) for request in requests]
-        self.render('requests.html.to', page=self.page, requests=mapped_requests)
+        self.render("requests.html.to", page=self.page, requests=mapped_requests)

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -3,34 +3,6 @@ import pendulum
 
 from atst.handler import BaseHandler
 
-mock_requests = [
-    {
-        "order_id": 36552612,
-        "date": "5/17/2018",
-        "is_new": True,
-        "full_name": "Friedrich Straat",
-        "app_count": 2,
-        "status": "Pending",
-    },
-    {
-        "order_id": 87362910,
-        "date": "10/2/2017",
-        "is_new": False,
-        "full_name": "Pietro Quirinis",
-        "app_count": 1,
-        "status": "Complete",
-    },
-    {
-        "order_id": 29938172,
-        "date": "1/7/2017",
-        "is_new": False,
-        "full_name": "Marina Borsetti",
-        "app_count": 1,
-        "status": "Denied",
-    },
-]
-
-
 def map_request(user, request):
     time_created = pendulum.parse(request['time_created'])
     is_new = time_created.add(days=1) > pendulum.now()
@@ -40,7 +12,6 @@ def map_request(user, request):
         'is_new': is_new,
         'status': request['status'],
         'app_count': 1,
-        'is_new': False,
         'date': time_created.format('M/DD/YYYY'),
         'full_name': '{} {}'.format(user['first_name'], user['last_name'])
     }

--- a/atst/handlers/request_new.py
+++ b/atst/handlers/request_new.py
@@ -85,7 +85,10 @@ class RequestNew(BaseHandler):
 
     @tornado.gen.coroutine
     def create_or_update_request(self, form_data, request_id=None):
-        request_data = {"creator_id": self.get_current_user(), "request": form_data}
+        request_data = {
+            'creator_id': self.get_current_user()['id'],
+            'request': form_data
+        }
         if request_id:
             response = yield self.requests_client.patch(
                 "/requests/{}".format(request_id), json=request_data

--- a/atst/handlers/request_new.py
+++ b/atst/handlers/request_new.py
@@ -86,8 +86,8 @@ class RequestNew(BaseHandler):
     @tornado.gen.coroutine
     def create_or_update_request(self, form_data, request_id=None):
         request_data = {
-            'creator_id': self.get_current_user()['id'],
-            'request': form_data
+            "creator_id": self.get_current_user()["id"],
+            "request": form_data,
         }
         if request_id:
             response = yield self.requests_client.patch(

--- a/tests/handlers/test_request_new.py
+++ b/tests/handlers/test_request_new.py
@@ -1,21 +1,23 @@
 import re
 import pytest
 
-ERROR_CLASS = 'usa-input-error-message'
+ERROR_CLASS = "usa-input-error-message"
 MOCK_USER = {
-    'id': '9cb348f0-8102-4962-88c4-dac8180c904c',
-    'email': 'fake.user@mail.com',
-    'first_name': 'Fake',
-    'last_name': 'User'
+    "id": "9cb348f0-8102-4962-88c4-dac8180c904c",
+    "email": "fake.user@mail.com",
+    "first_name": "Fake",
+    "last_name": "User",
 }
 
 
 @pytest.mark.gen_test
 def test_submit_invalid_request_form(monkeypatch, http_client, base_url):
     monkeypatch.setattr(
-        'atst.handlers.request_new.RequestNew.get_current_user',
-        lambda s: MOCK_USER)
-    monkeypatch.setattr('atst.handlers.request_new.RequestNew.check_xsrf_cookie', lambda s: True)
+        "atst.handlers.request_new.RequestNew.get_current_user", lambda s: MOCK_USER
+    )
+    monkeypatch.setattr(
+        "atst.handlers.request_new.RequestNew.check_xsrf_cookie", lambda s: True
+    )
     # this just needs to send a known invalid form value
     response = yield http_client.fetch(
         base_url + "/requests/new",
@@ -30,10 +32,12 @@ def test_submit_invalid_request_form(monkeypatch, http_client, base_url):
 @pytest.mark.gen_test
 def test_submit_valid_request_form(monkeypatch, http_client, base_url):
     monkeypatch.setattr(
-        'atst.handlers.request_new.RequestNew.get_current_user',
-        lambda s: MOCK_USER)
-    monkeypatch.setattr('atst.handlers.request_new.RequestNew.check_xsrf_cookie', lambda s: True)
-    monkeypatch.setattr('atst.forms.request.RequestForm.validate', lambda s: True)
+        "atst.handlers.request_new.RequestNew.get_current_user", lambda s: MOCK_USER
+    )
+    monkeypatch.setattr(
+        "atst.handlers.request_new.RequestNew.check_xsrf_cookie", lambda s: True
+    )
+    monkeypatch.setattr("atst.forms.request.RequestForm.validate", lambda s: True)
 
     # this just needs to send a known invalid form value
     response = yield http_client.fetch(

--- a/tests/handlers/test_request_new.py
+++ b/tests/handlers/test_request_new.py
@@ -1,17 +1,21 @@
 import re
 import pytest
 
-ERROR_CLASS = "usa-input-error-message"
+ERROR_CLASS = 'usa-input-error-message'
+MOCK_USER = {
+    'id': '9cb348f0-8102-4962-88c4-dac8180c904c',
+    'email': 'fake.user@mail.com',
+    'first_name': 'Fake',
+    'last_name': 'User'
+}
 
 
 @pytest.mark.gen_test
 def test_submit_invalid_request_form(monkeypatch, http_client, base_url):
     monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.get_current_user", lambda s: True
-    )
-    monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.check_xsrf_cookie", lambda s: True
-    )
+        'atst.handlers.request_new.RequestNew.get_current_user',
+        lambda s: MOCK_USER)
+    monkeypatch.setattr('atst.handlers.request_new.RequestNew.check_xsrf_cookie', lambda s: True)
     # this just needs to send a known invalid form value
     response = yield http_client.fetch(
         base_url + "/requests/new",
@@ -26,12 +30,10 @@ def test_submit_invalid_request_form(monkeypatch, http_client, base_url):
 @pytest.mark.gen_test
 def test_submit_valid_request_form(monkeypatch, http_client, base_url):
     monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.get_current_user", lambda s: True
-    )
-    monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.check_xsrf_cookie", lambda s: True
-    )
-    monkeypatch.setattr("atst.forms.request.RequestForm.validate", lambda s: True)
+        'atst.handlers.request_new.RequestNew.get_current_user',
+        lambda s: MOCK_USER)
+    monkeypatch.setattr('atst.handlers.request_new.RequestNew.check_xsrf_cookie', lambda s: True)
+    monkeypatch.setattr('atst.forms.request.RequestForm.validate', lambda s: True)
 
     # this just needs to send a known invalid form value
     response = yield http_client.fetch(


### PR DESCRIPTION
Use the new `status` attribute of the requests api, as well as the actual datetime of the request.