### PR TITLE
Session management

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -9,6 +9,7 @@ webassets = "==0.12.1"
 Unipath = "==1.1"
 wtforms-tornado = "*"
 pendulum = "*"
+redis = "*"
 
 [dev-packages]
 pytest = "==3.6.0"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "5f91978d61968a720e4edc404ea36123ff96d857c1d7ff865f5aaef9b133db37"
+            "sha256": "e424765acd32453d13c35cade0b4d0cb57cac5742ac020f32352411f15df71c5"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -45,6 +45,14 @@
                 "sha256:e4ef42e82b0b493c5849eed98b5ab49d6767caf982127e9a33167f1153b36cc5"
             ],
             "version": "==2018.5"
+        },
+        "redis": {
+            "hashes": [
+                "sha256:8a1900a9f2a0a44ecf6e8b5eb3e967a9909dfed219ad66df094f27f7d6f330fb",
+                "sha256:a22ca993cea2962dbb588f9f30d0015ac4afcc45bee27d3978c0dbe9e97c6c0f"
+            ],
+            "index": "pypi",
+            "version": "==2.10.6"
         },
         "six": {
             "hashes": [
@@ -293,10 +301,10 @@
         },
         "py": {
             "hashes": [
-                "sha256:29c9fab495d7528e80ba1e343b958684f4ace687327e6f789a94bf3d1915f881",
-                "sha256:983f77f3331356039fdd792e9220b7b8ee1aa6bd2b25f567a963ff1de5a64f6a"
+                "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
+                "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "version": "==1.5.3"
+            "version": "==1.5.4"
         },
         "pygments": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ To enter the virtualenv manually (a la `source .venv/bin/activate`):
 
 If you want to automatically load the virtual environment whenever you enter the project directory, take a look at [direnv](https://direnv.net/).  An `.envrc` file is included in this repository.  direnv will activate and deactivate virtualenvs for you when you enter and leave the directory.
 
+Additionally, ATST requires a redis instance for session management. Have redis installed and running. By default, ATST will try to connect to a redis instance running on localhost on its default port, 6379.
+
 ## Running (development)
 
 To start the app and watch for changes:

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -2,13 +2,10 @@ from atst.handler import BaseHandler
 
 
 class Dev(BaseHandler):
-    def initialize(self, action):
+    def initialize(self, action, sessions):
         self.action = action
+        self.sessions = sessions
 
     def get(self):
-        if self.action == "login":
-            self._login()
-
-    def _login(self):
-        self._start_session()
-        self.redirect("/home")
+        user = {"id": "164497f6-c1ea-4f42-a5ef-101da278c012"}
+        self.login(user)

--- a/atst/sessions.py
+++ b/atst/sessions.py
@@ -1,0 +1,71 @@
+from uuid import uuid4
+import json
+from redis import exceptions
+
+
+class SessionStorageError(Exception):
+    pass
+
+
+class SessionNotFoundError(Exception):
+    pass
+
+
+class Sessions(object):
+    def start_session(self, user):
+        raise NotImplementedError()
+
+    def get_session(self, session_id):
+        raise NotImplementedError()
+
+    def generate_session_id(self):
+        return str(uuid4())
+
+    def build_session_dict(self, user=None):
+        return {"user": user or {}}
+
+
+class DictSessions(Sessions):
+    def __init__(self):
+        self.sessions = {}
+
+    def start_session(self, user):
+        session_id = self.generate_session_id()
+        self.sessions[session_id] = self.build_session_dict(user=user)
+        return session_id
+
+    def get_session(self, session_id):
+        try:
+            session = self.sessions[session_id]
+        except KeyError:
+            raise SessionNotFoundError
+
+        return session
+
+
+class RedisSessions(Sessions):
+    def __init__(self, redis, ttl_seconds):
+        self.redis = redis
+        self.ttl_seconds = ttl_seconds
+
+    def start_session(self, user):
+        session_id = self.generate_session_id()
+        session_dict = self.build_session_dict(user=user)
+        session_serialized = json.dumps(session_dict)
+        try:
+            self.redis.setex(session_id, self.ttl_seconds, session_serialized)
+        except exceptions.ConnectionError:
+            raise SessionStorageError
+        return session_id
+
+    def get_session(self, session_id):
+        try:
+            session_serialized = self.redis.get(session_id)
+        except exceptions.ConnectionError:
+            raise
+
+        if session_serialized:
+            self.redis.expire(session_id, self.ttl_seconds)
+            return json.loads(session_serialized)
+        else:
+            raise SessionNotFoundError

--- a/config/base.ini
+++ b/config/base.ini
@@ -8,3 +8,5 @@ COOKIE_SECRET = some-secret-please-replace
 SECRET = change_me_into_something_secret
 CAC_URL = https://localhost:8001
 REQUESTS_QUEUE_BASE_URL = http://localhost:8003
+REDIS_URI = redis://localhost:6379
+SESSION_TTL_SECONDS = 3600

--- a/config/base.ini
+++ b/config/base.ini
@@ -9,4 +9,4 @@ SECRET = change_me_into_something_secret
 CAC_URL = https://localhost:8001
 REQUESTS_QUEUE_BASE_URL = http://localhost:8003
 REDIS_URI = redis://localhost:6379
-SESSION_TTL_SECONDS = 3600
+SESSION_TTL_SECONDS = 600

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,7 @@ import pytest
 
 from atst.app import make_app, make_deps, make_config
 from tests.mocks import MockApiClient, MockRequestsClient
+from atst.sessions import DictSessions
 
 
 @pytest.fixture
@@ -10,6 +11,7 @@ def app():
         "authz_client": MockApiClient("authz"),
         "requests_client": MockRequestsClient("requests"),
         "authnid_client": MockApiClient("authnid"),
+        "sessions": DictSessions(),
     }
 
     config = make_config()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -4,7 +4,9 @@ import tornado.web
 import tornado.gen
 
 MOCK_USER = {"user": {"id": "438567dd-25fa-4d83-a8cc-8aa8366cb24a"}}
-
+@tornado.gen.coroutine
+def _fetch_user_info(c, t):
+    return MOCK_USER
 
 @pytest.mark.gen_test
 def test_redirects_when_not_logged_in(http_client, base_url):
@@ -19,10 +21,6 @@ def test_redirects_when_not_logged_in(http_client, base_url):
 
 @pytest.mark.gen_test
 def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
-    @tornado.gen.coroutine
-    def _fetch_user_info(c, t):
-        return MOCK_USER
-
     monkeypatch.setattr("atst.handlers.login.Login._fetch_user_info", _fetch_user_info)
     response = yield http_client.fetch(
         base_url + "/login?bearer-token=abc-123",
@@ -52,3 +50,14 @@ def test_login_with_invalid_bearer_token(http_client, base_url):
         raise_error=False,
         headers={"Cookie": "bearer-token=anything"},
     )
+
+@pytest.mark.gen_test
+def test_valid_login_creates_session(app, monkeypatch, http_client, base_url):
+    monkeypatch.setattr("atst.handlers.login.Login._fetch_user_info", _fetch_user_info)
+    assert len(app.sessions.sessions) == 0
+    yield http_client.fetch(
+        base_url + "/login?bearer-token=abc-123",
+        follow_redirects=False,
+        raise_error=False,
+    )
+    assert len(app.sessions.sessions) == 1

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,6 +3,8 @@ import pytest
 import tornado.web
 import tornado.gen
 
+MOCK_USER = {"user": {"id": "438567dd-25fa-4d83-a8cc-8aa8366cb24a"}}
+
 
 @pytest.mark.gen_test
 def test_redirects_when_not_logged_in(http_client, base_url):
@@ -18,18 +20,16 @@ def test_redirects_when_not_logged_in(http_client, base_url):
 @pytest.mark.gen_test
 def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
     @tornado.gen.coroutine
-    def _validate_login_token(c, t):
-        return True
+    def _fetch_user_info(c, t):
+        return MOCK_USER
 
-    monkeypatch.setattr(
-        "atst.handlers.login.Login._validate_login_token", _validate_login_token
-    )
+    monkeypatch.setattr("atst.handlers.login.Login._fetch_user_info", _fetch_user_info)
     response = yield http_client.fetch(
         base_url + "/login?bearer-token=abc-123",
         follow_redirects=False,
         raise_error=False,
     )
-    assert response.headers["Set-Cookie"].startswith("atst")
+    assert response.headers["Set-Cookie"].startswith("atat")
     assert response.headers["Location"] == "/home"
     assert response.code == 302
 
@@ -39,7 +39,7 @@ def test_login_via_dev_endpoint(app, http_client, base_url):
     response = yield http_client.fetch(
         base_url + "/login-dev", raise_error=False, follow_redirects=False
     )
-    assert response.headers["Set-Cookie"].startswith("atst")
+    assert response.headers["Set-Cookie"].startswith("atat")
     assert response.code == 302
     assert response.headers["Location"] == "/home"
 


### PR DESCRIPTION
This was mostly @richard-dds , I'm just tying off the PR.

This adds session management to ATST using Redis. Session management is simple:

- When a user logs in with a valid bearer-token, ATST validates the token against authnid. If the token is valid, authnid will send back JSON user data.
- ATST creates a random UUID for the session ID. We add the session ID to Redis and set its value to the JSON user data.
- We set the session ID as a secure cookie on the client side.
- TTL for the session is configurable and set to an hour by default right now. Every time the user takes an action on a protected route in ATST, the TTL for their session is bumped to 60 minutes again. If they're inactive for an hour, they'll get the boot.