### PR TITLE
Make using a pipenv environment optional

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -9,13 +9,24 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
+if [ -z "${CIBUILD+xxxx}" ]; then
+  CMD_PREFIX='pipenv run '
+fi
+PIP_CMD="${CMD_PREFIX}pip"
+WEBASSETS_CMD="${CMD_PREFIX}webassets"
+
+PIPENV_INSTALL_FLAGS='--dev'
+if ${CIBUILD}; then
+  PIPENV_INSTALL_FLAGS+=' --system --ignore-pipfile'
+fi
+
 # Install Python dependencies
 pipenv --python 3.6
-pipenv run pip install --upgrade pip
-pipenv install --dev
+${PIP_CMD} install --upgrade pip
+pipenv install ${PIPENV_INSTALL_FLAGS}
 
 # Install uswds node module and dependencies
 npm install
 
 # Precompile assets for deployment
-pipenv run webassets -m atst.assets build
+${WEBASSETS_CMD} -m atst.assets build

--- a/script/server
+++ b/script/server
@@ -14,8 +14,13 @@ set -e
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
+if [ -z "${SKIP_PIPENV+xxxx}" ]; then
+  CMD_PREFIX='pipenv run '
+fi
+PYTHON_CMD="${CMD_PREFIX}python"
+
 # Launch the app
-pipenv run python app.py ${@} &
+${PYTHON_CMD} app.py ${@} &
 child=$!
 
 wait $child

--- a/script/setup
+++ b/script/setup
@@ -12,9 +12,6 @@ cd "$(dirname "${0}")/.."
 # Install virtualenv
 pip install pipenv
 
-# Update npm
-npm install -g npm
-
 if ! type sass > /dev/null; then
   if type gem > /dev/null; then
     echo 'installing a sass compiler...'

--- a/script/test
+++ b/script/test
@@ -1,12 +1,23 @@
 #!/bin/bash
 
+# script/test: Run static code checks and unit tests
+
 # If a command fails, exit the script
 set -e
 
 # Ensure we are in the app root directory (not the /script directory)
 cd "$(dirname "${0}")/.."
 
-pipenv run pylint app.py atst/ tests/
+if [ -z "${SKIP_PIPENV+xxxx}" ]; then
+  CMD_PREFIX='pipenv run '
+fi
+PYLINT_CMD="${CMD_PREFIX}pylint"
+PYTHON_CMD="${CMD_PREFIX}python"
+
+# Run lint check
+echo "Running lint..."
+${PYLINT_CMD} app.py atst/ tests/
 
 # Run unit tests
-pipenv run python -m pytest -s $*
+echo "Running unit tests..."
+${PYTHON_CMD} -m pytest -s $*


### PR DESCRIPTION
Moving virtual environments between systems is problematic... and unnecessary when creating container images. These modifications allow the ability to install app dependencies into the system python, and use that instead of a virtual environment.