### PR TITLE
CIbuild and publish

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,27 @@
+# Files to exclude from COPY and ADD commands when 
+# building a docker image from this directory
+
+# Exclude Docker build related files
+Dockerfile
+.dockerignore
+
+# Exclude the git directory and gitignore file
+.git
+.gitignore
+
+# Skip any existing logs
+log/*
+
+# Skip LICENSE, README, etc.
+LICENSE
+*.md
+
+# Skip pipenv/virtualenv related things
+.envrc
+.venv
+
+# Skip ansible-container stuff
+ansible*
+container.yml
+meta.yml
+requirements.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,6 @@ before_deploy:
 
 deploy:
   provider: script
-  script: echo "Hi there"
+  script: echo "** Image push only for now... stay tuned! **"
   on:
-    all_branches: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,5 @@ before_deploy:
 deploy:
   provider: script
   script: echo "Hi there"
+  on:
+    all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,16 @@ env:
 
 before_install:
   - docker login -u $ATAT_DOCKER_REGISTRY_USERNAME -p $ATAT_DOCKER_REGISTRY_PASSWORD $ATAT_DOCKER_REGISTRY_URL
-  - docker build --tag "$TESTER_IMAGE_NAME" . -f docker/tester/Dockerfile
+  - docker build --tag "${TESTER_IMAGE_NAME}" . -f docker/tester/Dockerfile
 
 script:
-  - docker run "$TESTER_IMAGE_NAME"
+  - docker run "${TESTER_IMAGE_NAME}"
 
 before_deploy:
-  - docker build --tag "$PROD_IMAGE_NAME" . -f docker/prod/Dockerfile
+  - docker build --tag "${PROD_IMAGE_NAME}" . -f docker/prod/Dockerfile
   - remote_image_name="${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${git_sha}"
   - git_sha="$(git rev-parse --short HEAD)"
-  - docker tag "$PROD_IMAGE_NAME" "${remote_image_name}"
+  - docker tag "${PROD_IMAGE_NAME}" "${remote_image_name}"
   - docker images
   - docker push "${remote_image_name}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,26 @@
+sudo: required
 language: python
-python:
-  - "3.6"
+python: "3.6"
+services: docker
+env:
+  - TESTER_IMAGE_NAME=atst-tester
+  - PROD_IMAGE_NAME=atst-prod
+
 before_install:
-  - pip install pipenv
-  - pipenv install --dev --skip-lock
-  - gem install sass
-  - npm install
+  - docker login -u "$ATAT_DOCKER_REGISTRY_USERNAME" -p "$ATAT_DOCKER_REGISTRY_PASSWORD" "$ATAT_DOCKER_REGISTRY_URL"
+  - docker build --tag "$TESTER_IMAGE_NAME" . -f docker/tester/Dockerfile
+
 script:
-  - python -m pytest
+  - docker run "$TESTER_IMAGE_NAME"
+
+before_deploy:
+  - docker build --tag "$PROD_IMAGE_NAME" . -f docker/prod/Dockerfile
+  - remote_image_name="${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${git_sha}"
+  - git_sha="$(git rev-parse --short HEAD)"
+  - docker tag "$PROD_IMAGE_NAME" "${remote_image_name}"
+  - docker images
+  - docker push "${remote_image_name}"
+
+deploy:
+  provider: script
+  script: echo "Hi there"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ language: python
 python: "3.6"
 services: docker
 env:
-  - TESTER_IMAGE_NAME=atst-tester
-  - PROD_IMAGE_NAME=atst-prod
+  global:
+    - TESTER_IMAGE_NAME=atst-tester
+    - PROD_IMAGE_NAME=atst-prod
 
 before_install:
-  - docker login -u "$ATAT_DOCKER_REGISTRY_USERNAME" -p "$ATAT_DOCKER_REGISTRY_PASSWORD" "$ATAT_DOCKER_REGISTRY_URL"
+  - docker login -u $ATAT_DOCKER_REGISTRY_USERNAME -p $ATAT_DOCKER_REGISTRY_PASSWORD $ATAT_DOCKER_REGISTRY_URL
   - docker build --tag "$TESTER_IMAGE_NAME" . -f docker/tester/Dockerfile
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ script:
 
 before_deploy:
   - docker build --tag "${PROD_IMAGE_NAME}" . -f docker/prod/Dockerfile
-  - remote_image_name="${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${git_sha}"
   - git_sha="$(git rev-parse --short HEAD)"
+  - remote_image_name="${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${git_sha}"
   - docker tag "${PROD_IMAGE_NAME}" "${remote_image_name}"
   - docker images
   - docker push "${remote_image_name}"

--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pendulum = "*"
 redis = "*"
 
 [dev-packages]
+bandit = "*"
 pytest = "==3.6.0"
 pytest-tornado = "==0.5.0"
 ipython = "*"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,0 +1,40 @@
+FROM python:3.6.5-alpine
+
+# Overridable default config
+ARG APP_USER=atst
+ARG APP_GROUP=atat
+ARG APP_DIR=/opt/atat/atst
+ARG APP_PORT=8000
+ARG SITE_PACKAGES_DIR=/usr/local/lib/python3.6/site-packages
+
+ENV APP_DIR "${APP_DIR}"
+ENV SKIP_PIPENV true
+
+# Copy installed python packages from the tester image
+COPY --from=atst-tester:latest "${SITE_PACKAGES_DIR}" "${SITE_PACKAGES_DIR}"
+
+# Copy the app directory contents from the tester image (includes node modules)
+COPY --from=atst-tester:latest "${APP_DIR}" "${APP_DIR}"
+
+# Set working dir
+WORKDIR ${APP_DIR}
+
+# Add required system packages and app user
+RUN set -x ; \
+  script/alpine_setup "${APP_USER}" "${APP_GROUP}"
+
+# Update file ownership
+RUN set -x ; \
+  chown -R atst:atat "${APP_DIR}"
+
+# Set port to open
+EXPOSE "${APP_PORT}"
+
+# Run as the unprivileged APP user
+USER "${APP_USER}"
+
+# Use dumb-init for proper signal handling
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command is to launch the server
+CMD ["bash", "-c", "${APP_DIR}/script/server"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -13,9 +13,6 @@ ENV SKIP_PIPENV true
 # Set port to open
 EXPOSE "${APP_PORT}"
 
-# Run as the unprivileged APP user
-USER "${APP_USER}"
-
 # Use dumb-init for proper signal handling
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
@@ -38,3 +35,6 @@ RUN set -x ; \
 # Update file ownership
 RUN set -x ; \
   chown -R atst:atat "${APP_DIR}"
+
+# Run as the unprivileged APP user
+USER "${APP_USER}"

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -10,6 +10,18 @@ ARG SITE_PACKAGES_DIR=/usr/local/lib/python3.6/site-packages
 ENV APP_DIR "${APP_DIR}"
 ENV SKIP_PIPENV true
 
+# Set port to open
+EXPOSE "${APP_PORT}"
+
+# Run as the unprivileged APP user
+USER "${APP_USER}"
+
+# Use dumb-init for proper signal handling
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command is to launch the server
+CMD ["bash", "-c", "${APP_DIR}/script/server"]
+
 # Copy installed python packages from the tester image
 COPY --from=atst-tester:latest "${SITE_PACKAGES_DIR}" "${SITE_PACKAGES_DIR}"
 
@@ -26,15 +38,3 @@ RUN set -x ; \
 # Update file ownership
 RUN set -x ; \
   chown -R atst:atat "${APP_DIR}"
-
-# Set port to open
-EXPOSE "${APP_PORT}"
-
-# Run as the unprivileged APP user
-USER "${APP_USER}"
-
-# Use dumb-init for proper signal handling
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
-# Default command is to launch the server
-CMD ["bash", "-c", "${APP_DIR}/script/server"]

--- a/docker/prod/Dockerfile
+++ b/docker/prod/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.6.5-alpine
 
+### Very low chance of changing
+###############################
 # Overridable default config
 ARG APP_USER=atst
 ARG APP_GROUP=atat
@@ -7,6 +9,8 @@ ARG APP_DIR=/opt/atat/atst
 ARG APP_PORT=8000
 ARG SITE_PACKAGES_DIR=/usr/local/lib/python3.6/site-packages
 
+ENV APP_USER "${APP_USER}"
+ENV APP_GROUP "${APP_GROUP}"
 ENV APP_DIR "${APP_DIR}"
 ENV SKIP_PIPENV true
 
@@ -19,6 +23,8 @@ ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 # Default command is to launch the server
 CMD ["bash", "-c", "${APP_DIR}/script/server"]
 
+### Items that will change almost every build
+#############################################
 # Copy installed python packages from the tester image
 COPY --from=atst-tester:latest "${SITE_PACKAGES_DIR}" "${SITE_PACKAGES_DIR}"
 
@@ -34,7 +40,7 @@ RUN set -x ; \
 
 # Update file ownership
 RUN set -x ; \
-  chown -R atst:atat "${APP_DIR}"
+  for subdir in $(find . -type d -maxdepth 1 | grep -Ee '.[^/]' | grep -Fve 'node_modules'); do chown atst:atat -R ${subdir}; done
 
 # Run as the unprivileged APP user
 USER "${APP_USER}"

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -7,6 +7,12 @@ ARG CIBUILD=true
 
 ENV SKIP_PIPENV true
 
+# Use dumb-init for proper signal handling
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command is to run all the tests
+CMD ["${APP_DIR}/script/cibuild"]
+
 # Create application directory
 RUN set -x ; \
   mkdir -p ${APP_DIR}
@@ -25,8 +31,3 @@ RUN set -x ; \
 RUN set -x ; \
   script/setup
 
-# Use dumb-init for proper signal handling
-ENTRYPOINT ["/usr/bin/dumb-init", "--"]
-
-# Default command is to run all the tests
-CMD ["${APP_DIR}/script/cibuild"]

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.atat.codes:443/atat-app-builder:latest
 
+### Very low chance of changing
+###############################
 ARG APP_USER=atst
 ARG APP_GROUP=atat
 ARG APP_DIR=/opt/atat/atst
@@ -21,14 +23,18 @@ RUN set -x ; \
 # Set working dir
 WORKDIR ${APP_DIR}
 
-# Copy app and module files
-COPY . .
+# Copy over alpine setup script
+COPY script/alpine_setup ./script/
 
 # Add required system packages and app user
 RUN set -x ; \
   script/alpine_setup "${APP_USER}" "${APP_GROUP}"
 
+### Items that will change almost every build
+#############################################
+# Copy over the rest of the app source
+COPY . .
+
 # Install app dependencies
 RUN set -x ; \
   script/setup
-

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -1,0 +1,32 @@
+FROM atat-app-builder-builder:latest as app-builder
+
+ARG APP_USER=atst
+ARG APP_GROUP=atat
+ARG APP_DIR=/opt/atat/atst
+ARG CIBUILD=true
+
+ENV SKIP_PIPENV true
+
+# Create application directory
+RUN set -x ; \
+  mkdir -p ${APP_DIR}
+
+# Set working dir
+WORKDIR ${APP_DIR}
+
+# Copy app and module files
+COPY . .
+
+# Add required system packages and app user
+RUN set -x ; \
+  script/alpine_setup "${APP_USER}" "${APP_GROUP}"
+
+# Install app dependencies
+RUN set -x ; \
+  script/setup
+
+# Use dumb-init for proper signal handling
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+
+# Default command is to run all the tests
+CMD ["${APP_DIR}/script/cibuild"]

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -11,7 +11,7 @@ ENV SKIP_PIPENV true
 ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 
 # Default command is to run all the tests
-CMD ["${APP_DIR}/script/cibuild"]
+CMD ["bash", "-c", "${APP_DIR}/script/cibuild"]
 
 # Create application directory
 RUN set -x ; \

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -1,4 +1,4 @@
-FROM atat-app-builder-builder:latest as app-builder
+FROM registry.atat.codes:443/atat-app-builder:latest
 
 ARG APP_USER=atst
 ARG APP_GROUP=atat

--- a/docker/tester/Dockerfile
+++ b/docker/tester/Dockerfile
@@ -5,6 +5,7 @@ ARG APP_GROUP=atat
 ARG APP_DIR=/opt/atat/atst
 ARG CIBUILD=true
 
+ENV APP_DIR "${APP_DIR}"
 ENV SKIP_PIPENV true
 
 # Use dumb-init for proper signal handling

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -19,5 +19,3 @@ apk add bash
 
 addgroup -g 8000 -S "${APP_GROUP}"
 adduser -u 8010 -D -S -G "${APP_GROUP}" "${APP_USER}"
-
-echo 'gem: --no-document' > ~/.gemrc

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -17,7 +17,7 @@ apk upgrade
 
 apk add bash
 
-addgroup -g 8000 -S ${APP_GROUP}
-adduser -u 8010 -D -S -G ${APP_GROUP} ${APP_USER}
+addgroup -g 8000 -S "${APP_GROUP}"
+adduser -u 8010 -D -S -G "${APP_GROUP}" "${APP_USER}"
 
 echo 'gem: --no-document' > ~/.gemrc

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# script/alpine_setup: Adds all the system packages, directors, users, etc.
+#                      required to run the application on Alpine
+
+# If a command fails, exit the script
+set -e
+
+# Ensure we are in the app root directory (not the /script directory)
+cd "$(dirname "${0}")/.."
+
+APP_USER=${1}
+APP_GROUP=${2}
+
+apk update
+apk upgrade
+
+apk add bash
+
+addgroup -g 8000 -S ${APP_GROUP}
+adduser -u 8010 -D -S -G ${APP_GROUP} ${APP_USER}
+
+echo 'gem: --no-document' > ~/.gemrc

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -16,6 +16,7 @@ apk update
 apk upgrade
 
 apk add bash
+apk add dumb-init
 
 addgroup -g 8000 -S "${APP_GROUP}"
 adduser -u 8010 -D -S -G "${APP_GROUP}" "${APP_USER}"

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -28,5 +28,9 @@ pipenv install ${PIPENV_INSTALL_FLAGS}
 # Install uswds node module and dependencies
 npm install
 
+# Relink uswds fonts into the /static directory
+rm -f ./static/fonts
+ln -s ../node_modules/uswds/src/fonts ./static/fonts
+
 # Precompile assets for deployment
 ${WEBASSETS_CMD} -m atst.assets build

--- a/script/cibuild
+++ b/script/cibuild
@@ -10,3 +10,6 @@ cd "$(dirname "${0}")/.."
 
 # Run lint/style checks and unit tests
 script/test
+
+# Run static code analysis security check (exluding the tests subdir)
+bandit -r . -x tests

--- a/script/cibuild
+++ b/script/cibuild
@@ -11,5 +11,6 @@ cd "$(dirname "${0}")/.."
 # Run lint/style checks and unit tests
 script/test
 
-# Run static code analysis security check (exluding the tests subdir)
-bandit -r . -x tests
+# Run static code analysis security checks
+# (excluding the tests and node_modules subdirs)
+bandit -r . -x node_modules,tests

--- a/script/cibuild
+++ b/script/cibuild
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# script/cibuild: Run CI related checks and tests
+
+# If a command fails, exit the script
+set -e
+
+# Ensure we are in the app root directory (not the /script directory)
+cd "$(dirname "${0}")/.."
+
+# Run lint/style checks and unit tests
+script/test

--- a/script/setup
+++ b/script/setup
@@ -23,7 +23,3 @@ fi
 
 # Install application dependencies
 script/bootstrap
-
-# Symlink uswds fonts into the /static directory
-rm -f ./static/fonts
-ln -s ../node_modules/uswds/src/fonts ./static/fonts


### PR DESCRIPTION
First whack at building and testing ATST in a docker image, and then creating a production ready image to push to our private container repository.

- Add docker files for creating tester and production ready images
- Add script/cibuild which the tester container runs by default
- Minor tweak to script/setup and script/bootstrap (move font symlink step to after npm install)
- Update Travis config to build and test in docker, and then push passing master images to our repo