### PR TITLE
Fix mock login for development

### DIFF
--- a/atst/handler.py
+++ b/atst/handler.py
@@ -23,7 +23,7 @@ class BaseHandler(tornado.web.RequestHandler):
             try:
                 session = self.application.sessions.get_session(cookie)
             except SessionNotFoundError:
-                self.redirect("/login")
+                return self.redirect("/login")
         else:
             return None
 

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -7,5 +7,9 @@ class Dev(BaseHandler):
         self.sessions = sessions
 
     def get(self):
-        user = {"id": "164497f6-c1ea-4f42-a5ef-101da278c012"}
+        user = {
+            "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
+            "first_name": "Test",
+            "last_name": "User"
+        }
         self.login(user)


### PR DESCRIPTION
The mock user was missing the name fields which are used elsewhere in the app.