### PR TITLE
Request form fixes

### DIFF
--- a/atst/forms/org.py
+++ b/atst/forms/org.py
@@ -11,8 +11,7 @@ class OrgForm(Form):
     fname_request = StringField("First Name", validators=[Required()])
     lname_request = StringField("Last Name", validators=[Required()])
 
-    email_request = EmailField(
-        "Email (associated with your CAC)", validators=[Required(), Email()]
+    email_request = EmailField("Email Address", validators=[Required(), Email()])
     )
 
     phone_number = TelField("Phone Number", validators=[Required(), Length(min=7)])

--- a/atst/forms/org.py
+++ b/atst/forms/org.py
@@ -1,10 +1,10 @@
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.fields import RadioField, StringField
-from wtforms.validators import Required, Length, Email
+from wtforms.validators import Required, Email
 from wtforms_tornado import Form
 import pendulum
 from .fields import DateField
-from .validators import DateRange
+from .validators import DateRange, PhoneNumber
 
 
 class OrgForm(Form):
@@ -12,9 +12,8 @@ class OrgForm(Form):
     lname_request = StringField("Last Name", validators=[Required()])
 
     email_request = EmailField("Email Address", validators=[Required(), Email()])
-    )
 
-    phone_number = TelField("Phone Number", validators=[Required(), Length(min=7)])
+    phone_number = TelField("Phone Number", validators=[Required(), PhoneNumber()])
 
     service_branch = StringField("Service Branch or Agency", validators=[Required()])
 

--- a/atst/forms/org.py
+++ b/atst/forms/org.py
@@ -27,7 +27,15 @@ class OrgForm(Form):
         validators=[Required()],
     )
 
-    designation = StringField("Designation of Person", validators=[Required()])
+    designation = RadioField(
+        "Designation of Person",
+        choices=[
+            ("military", "Military"),
+            ("civilian", "Civilian"),
+            ("contractor", "Contractor"),
+        ],
+        validators=[Required()],
+    )
 
     date_latest_training = DateField(
         "Latest Information Assurance (IA) Training completion date.",

--- a/atst/forms/validators.py
+++ b/atst/forms/validators.py
@@ -1,3 +1,4 @@
+import re
 from wtforms.validators import ValidationError
 import pendulum
 
@@ -27,3 +28,16 @@ def IsNumber(message="Please enter a valid number."):
             raise ValidationError(message)
 
     return _is_number
+
+
+def PhoneNumber(message="Please enter a valid 5 or 10 digit phone number."):
+    def _is_phone_number(form, field):
+        digits = re.sub(r"\D", "", field.data)
+        if len(digits) not in [5, 10]:
+            raise ValidationError(message)
+
+        match = re.match(r"[\d\-\(\) ]+", field.data)
+        if not match or match.group() != field.data:
+            raise ValidationError(message)
+
+    return _is_phone_number

--- a/templates/requests/screen-2.html.to
+++ b/templates/requests/screen-2.html.to
@@ -61,13 +61,15 @@
 {% end %}
 </fieldset>
 
-{{ f.designation.label }}
-{{ f.designation }}
+<fieldset class="usa-fieldset-inputs">
+  {{ f.designation.label }}
+  {{ f.designation(class_="usa-unstyled-list") }}
 {% for e in f.designation.errors %}
   <div class="usa-input-error-message">
     {{ e }}
   </div>
 {% end %}
+</fieldset>
 
 {{ f.date_latest_training.label }}
 {{ f.date_latest_training }}


### PR DESCRIPTION
Fixing three issues in the "Information About You" section of the JEDI request form.

1. Designation of person is now a radio widget rather than a text field.
2. The email field label no longer mentions that it should be associated with the user's CAC.
3. Added a simple phone number validation, which accepts either 5 or 10 digit numbers along with standard symbols.