### PR TITLE
do not redirect in get_current_user

### DIFF
--- a/atst/handler.py
+++ b/atst/handler.py
@@ -23,7 +23,7 @@ class BaseHandler(tornado.web.RequestHandler):
             try:
                 session = self.application.sessions.get_session(cookie)
             except SessionNotFoundError:
-                return self.redirect("/login")
+                return None
         else:
             return None
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -20,6 +20,18 @@ def test_redirects_when_not_logged_in(http_client, base_url):
 
 
 @pytest.mark.gen_test
+def test_redirects_when_session_does_not_exist(monkeypatch, http_client, base_url):
+    monkeypatch.setattr("atst.handlers.main.MainHandler.get_secure_cookie", lambda s,c: 'stale cookie!')
+    response = yield http_client.fetch(
+        base_url + "/home", raise_error=False, follow_redirects=False
+    )
+    location = response.headers["Location"]
+    assert response.code == 302
+    assert response.error
+    assert re.match("/\??", location)
+
+
+@pytest.mark.gen_test
 def test_login_with_valid_bearer_token(app, monkeypatch, http_client, base_url):
     monkeypatch.setattr("atst.handlers.login.Login._fetch_user_info", _fetch_user_info)
     response = yield http_client.fetch(


### PR DESCRIPTION
This is a small bug fix. The `get_current_user` method used in authentication should only return user data or a falsey value. If the method returns a falsey value, Tornado knows to redirect the user to the `login_url` we define when we initialize the app (currently the root route). 