### PR TITLE
Fix for broken layout breakpoint

### DIFF
--- a/scss/elements/_panels.scss
+++ b/scss/elements/_panels.scss
@@ -47,6 +47,9 @@
 
   @include media($medium-screen) {
     @include margin(($site-margins * 2) null);
+  }
+
+  @include media($large-screen) {
     flex-wrap: nowrap;
   }
 

--- a/scss/sections/_sidenav.scss
+++ b/scss/sections/_sidenav.scss
@@ -79,6 +79,10 @@
   > ul {
     @include panel-margin;
 
+    &:last-child {
+      margin: 0;
+    }
+
     > li {
       &:last-child {
         > .sidenav__link {


### PR DESCRIPTION
Fixes an issue where the panels would not wrap correctly between breakpoints.

| Before | After |
| -- | -- |
| ![breakpoint_broken](https://user-images.githubusercontent.com/40467269/42634580-9388743a-85b1-11e8-8bf4-3d78308d6b14.gif) | ![breakpoint_fixed](https://user-images.githubusercontent.com/40467269/42634587-985dc276-85b1-11e8-8c9f-ebf6e74204b9.gif) |

Also, fixes a small issue with sidenav panel having double bottom-margin.