### PR TITLE
Add missing fields to financial verification step

### DIFF
--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -15,8 +15,8 @@ class FinancialForm(Form):
         "Unique Item Identifier (UII)s related to your application(s) if you already have them."
     )
 
-    pe_id = NewlineListField(
-        "Program Element (PE) Numbers related to your request"
+    pe_id = StringField(
+        "Program Element (PE) Number related to your request"
     )
 
     fname_co = StringField("Contracting Officer First Name", validators=[Required()])

--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -19,6 +19,10 @@ class FinancialForm(Form):
         "Program Element (PE) Number related to your request"
     )
 
+    treasury_code = StringField("Please provide your Program Treasury Code")
+
+    ba_code = StringField("Please provide your Program BA Code")
+
     fname_co = StringField("Contracting Officer First Name", validators=[Required()])
     lname_co = StringField("Contracting Officer Last Name", validators=[Required()])
 

--- a/templates/requests/screen-5.html.to
+++ b/templates/requests/screen-5.html.to
@@ -35,6 +35,21 @@
   </div>
 {% end %}
 
+{{ f.treasury_code.label }}
+{{ f.treasury_code(placeholder="Example: 1200") }}
+{% for e in f.treasury_code.errors %}
+  <div class="usa-input-error-message">
+    {{ e }}
+  </div>
+{% end %}
+
+{{ f.ba_code.label }}
+{{ f.ba_code(placeholder="Example: 02") }}
+{% for e in f.ba_code.errors %}
+  <div class="usa-input-error-message">
+    {{ e }}
+  </div>
+{% end %}
 
 <!-- KO Information -->
 


### PR DESCRIPTION
Adds the treasury code and ba code fields to the financial verification step and makes the PE number a simple string input instead of a multi-line input.

![image](https://user-images.githubusercontent.com/40774582/42655339-d267902c-85e9-11e8-9b1d-b1ec747237c2.png)
