### PR TITLE
ensure we clear session cookies

### DIFF
--- a/atst/handler.py
+++ b/atst/handler.py
@@ -23,6 +23,7 @@ class BaseHandler(tornado.web.RequestHandler):
             try:
                 session = self.application.sessions.get_session(cookie)
             except SessionNotFoundError:
+                self.clear_cookie("atat")
                 return None
         else:
             return None

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,6 +26,9 @@ def test_redirects_when_session_does_not_exist(monkeypatch, http_client, base_ur
         base_url + "/home", raise_error=False, follow_redirects=False
     )
     location = response.headers["Location"]
+    cookie = response.headers._dict.get('Set-Cookie')
+    # should clear session cookie
+    assert 'atat=""' in cookie
     assert response.code == 302
     assert response.error
     assert re.match("/\??", location)


### PR DESCRIPTION
If a user's session has expired in the session store, we should also clear the cookie.