### PR TITLE
Styles for block lists and tables

### DIFF
--- a/scss/atat.scss
+++ b/scss/atat.scss
@@ -7,8 +7,9 @@
 @import 'elements/typography';
 @import 'elements/inputs';
 @import 'elements/buttons';
-@import 'elements/tables';
 @import 'elements/panels';
+@import 'elements/block_lists';
+@import 'elements/tables';
 
 @import 'components/site_action';
 @import 'components/empty_state';

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -26,8 +26,10 @@
   border-top: 0;
   border-bottom: 1px dashed $color-gray-light;
 
-  &li:last-child {
-    border-bottom-style: solid;
+  @at-root li#{&} {
+    &:last-child {
+      border-bottom-style: solid;
+    }
   }
 }
 

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -1,0 +1,49 @@
+@mixin block-list {
+  @include panel-margin;
+
+  > ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+}
+
+@mixin block-list-header {
+  @include panel-base;
+  @include panel-theme-default;
+  padding: $gap * 2;
+}
+
+@mixin block-list__title {
+  @include h4;
+  margin: 0;
+}
+
+@mixin block-list-item {
+  @include panel-base;
+  margin: 0;
+  padding: $gap * 2;
+  border-top: 0;
+  border-bottom: 1px dashed $color-gray-light;
+
+  &li:last-child {
+    border-bottom-style: solid;
+  }
+}
+
+
+.block-list {
+  @include block-list;
+}
+
+.block-list__header {
+  @include block-list-header;
+}
+
+.block-list__title {
+  @include block-list__title;
+}
+
+.block-list__item {
+  @include block-list-item;
+}

--- a/scss/elements/_panels.scss
+++ b/scss/elements/_panels.scss
@@ -19,6 +19,9 @@
 }
 
 @mixin panel-margin {
+  margin-top: 0;
+  margin-left: 0;
+  margin-right: 0;
   margin-bottom: $site-margins-mobile * 2;
 
   @include media($medium-screen) {

--- a/scss/elements/_panels.scss
+++ b/scss/elements/_panels.scss
@@ -9,6 +9,8 @@
   border-bottom-width: 1px;
   border-top-style: solid;
   border-bottom-style: solid;
+  border-left: 0;
+  border-right: 0;
 }
 
 @mixin panel-theme-default {
@@ -29,9 +31,14 @@
   @include panel-theme-default;
   @include panel-margin;
 
-  &__content {
-    padding-left: $gap*4;
-    padding-right: $gap*4;
+  .panel__content {
+    margin: ($gap * 2) 0;
+    padding: 0 ($gap * 2);
+
+    @include media($medium-screen) {
+      margin: ($gap * 4) 0;
+      padding: 0 ($gap * 4);
+    }
   }
 }
 

--- a/scss/elements/_tables.scss
+++ b/scss/elements/_tables.scss
@@ -6,9 +6,14 @@
 
 table {
   @include panel-margin;
-  margin-top: 0;
+  min-width: 100%;
 
   tr {
+    th,
+    td {
+      white-space: nowrap;
+    }
+
     th {
       @include block-list-header;
     }
@@ -23,8 +28,16 @@ table {
       }
     }
 
-    .align-right {
+    .table-cell--align-right {
       text-align: right;
+    }
+
+    .table-cell--shrink {
+      width: 1%;
+    }
+
+    .table-cell--expand {
+      width: 100%;
     }
   }
 }

--- a/scss/elements/_tables.scss
+++ b/scss/elements/_tables.scss
@@ -3,3 +3,28 @@
  * @see https://designsystem.digital.gov/components/tables/
  * @source https://github.com/uswds/uswds/blob/develop/src/stylesheets/elements/_table.scss
  */
+
+table {
+  @include panel-margin;
+  margin-top: 0;
+
+  tr {
+    th {
+      @include block-list-header;
+    }
+
+    td {
+      @include block-list-item;
+    }
+
+    &:last-child {
+      td {
+        border-bottom-style: solid;
+      }
+    }
+
+    .align-right {
+      text-align: right;
+    }
+  }
+}

--- a/templates/styleguide.html.to
+++ b/templates/styleguide.html.to
@@ -24,7 +24,7 @@
 {% end %}
 
 {% block content %}
-<div class='col'> 
+<div class='col'>
   <div class='panel'>
     <p>This is a panel</p>
   </div>
@@ -33,16 +33,6 @@
 <div class='col col--grow'>
   <div class='panel'>
     <div class='panel__content'>
-
-      <div class="panel__heading">
-        <h1>Panel Heading H1</h1>
-        <h2>Panel Heading H2</h2>
-        <h3>Panel Heading H3</h3>
-        <h4>Panel Heading H4</h4>
-        <h5>Panel Heading H5</h5>
-        <h6>Panel Heading H6</h6>
-      </div>
-
       <em>This is a panel content</em>
       <h1>Heading H1</h1>
       <h2>Heading H2</h2>
@@ -57,7 +47,7 @@
         <div class='col col--grow'>col 1</div>
         <div class='col col--grow'>col 2</div>
         <div class='col col--grow'>col 3</div>
-        <div class='col col--grow'>col 4</div>        
+        <div class='col col--grow'>col 4</div>
       </div>
       <hr>
       <div class='row'>
@@ -80,5 +70,48 @@
   <div class='panel'>
     Another panel without padding
   </div>
+
+  <section class='block-list'>
+    <header class='block-list__header'>
+      <h3 class='block-list__title'>A Block List</h3>
+    </header>
+    <ul>
+      <li class='block-list__item'>Block List Item</li>
+      <li class='block-list__item'>Block List Item</li>
+      <li class='block-list__item'>Block List Item</li>
+      <li class='block-list__item'>Block List Item</li>
+      <li class='block-list__item'>Block List Item</li>
+    </ul>
+  </section>
+
+  <table>
+    <thead>
+      <tr>
+        <th>Table Heading</th>
+        <th class='align-right'>Table Heading</th>
+        <th>Table Heading</th>
+      </tr>
+    </thead>
+
+    <tbody>
+      <tr>
+        <td>Table Cell</td>
+        <td class='align-right'>1,234.56</td>
+        <td>Table Cell</td>
+      </tr>
+
+      <tr>
+        <td>Table Cell</td>
+        <td class='align-right'>1,231,253.43</td>
+        <td>Table Cell</td>
+      </tr>
+
+      <tr>
+        <td>Table Cell</td>
+        <td class='align-right'>564.54</td>
+        <td>Table Cell</td>
+      </tr>
+    </tbody>
+  </table>
 </div>
 {% end %}

--- a/templates/styleguide.html.to
+++ b/templates/styleguide.html.to
@@ -84,32 +84,36 @@
     </ul>
   </section>
 
-  <table>
+  <table class='col--grow'>
     <thead>
       <tr>
-        <th>Table Heading</th>
-        <th class='align-right'>Table Heading</th>
-        <th>Table Heading</th>
+        <th class='table-cell--expand'>Expanded Column</th>
+        <th>Normal Column</th>
+        <th class='table-cell--align-right'>Right Aligned</th>
+        <th class='table-cell--shrink'>Shrunk</th>
       </tr>
     </thead>
 
     <tbody>
       <tr>
+        <td class='table-cell--expand'>Table Cell</td>
         <td>Table Cell</td>
-        <td class='align-right'>1,234.56</td>
-        <td>Table Cell</td>
+        <td class='table-cell--align-right'>1,234.56</td>
+        <td class='table-cell--shrink'>Table Cell</td>
       </tr>
 
       <tr>
+        <td class='table-cell--expand'>Table Cell</td>
         <td>Table Cell</td>
-        <td class='align-right'>1,231,253.43</td>
-        <td>Table Cell</td>
+        <td class='table-cell--align-right'>1,231,253.43</td>
+        <td class='table-cell--shrink'>Table Cell</td>
       </tr>
 
       <tr>
+        <td class='table-cell--expand'>Table Cell</td>
         <td>Table Cell</td>
-        <td class='align-right'>564.54</td>
-        <td>Table Cell</td>
+        <td class='table-cell--align-right'>564.54</td>
+        <td class='table-cell--shrink'>Table Cell</td>
       </tr>
     </tbody>
   </table>


### PR DESCRIPTION
Adds class names and mixins for styling block lists, and tables. Table cells have self-explanatory modifier classnames `.table-cell--expand`, `.table-cell--shrink` and `.table-cell--align-right`.

See `/styleguide` for examples.

![screen shot 2018-07-17 at 8 46 39 am](https://user-images.githubusercontent.com/40467269/42818187-2b4af604-899e-11e8-8cec-6990f4948453.png)
