### PR TITLE
Authz permissions

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -26,7 +26,7 @@ def make_app(config, deps, **kwargs):
         url(
             r"/login-redirect",
             LoginRedirect,
-            {"sessions": deps["sessions"], "authnid_client": deps["authnid_client"]},
+            {"sessions": deps["sessions"], "authnid_client": deps["authnid_client"], "authz_client": deps["authz_client"]},
             name="login_redirect",
         ),
         url(r"/home", Main, {"page": "home"}, name="home"),
@@ -88,7 +88,7 @@ def make_app(config, deps, **kwargs):
             url(
                 r"/login-dev",
                 Dev,
-                {"action": "login", "sessions": deps["sessions"]},
+                {"action": "login", "sessions": deps["sessions"], "authz_client": deps["authz_client"]},
                 name="dev-login",
             )
         ]

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -6,16 +6,26 @@ helpers = {"assets": environment}
 
 
 class BaseHandler(tornado.web.RequestHandler):
+
     def get_template_namespace(self):
         ns = super(BaseHandler, self).get_template_namespace()
         helpers["config"] = self.application.config
         ns.update(helpers)
         return ns
 
+    @tornado.gen.coroutine
     def login(self, user):
+        user["atat_permissions"] = yield self._get_user_permissions(user["id"])
         session_id = self.sessions.start_session(user)
         self.set_secure_cookie("atat", session_id)
-        self.redirect("/home")
+        return self.redirect("/home")
+
+    @tornado.gen.coroutine
+    def _get_user_permissions(self, user_id):
+        response = yield self.authz_client.post(
+            "/users", json={"id": user_id, "atat_role": "ccpo"}
+        )
+        return response.json["atat_permissions"]
 
     def get_current_user(self):
         cookie = self.get_secure_cookie("atat")
@@ -24,6 +34,7 @@ class BaseHandler(tornado.web.RequestHandler):
                 session = self.application.sessions.get_session(cookie)
             except SessionNotFoundError:
                 return None
+
         else:
             return None
 

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -16,18 +16,4 @@ class Dev(BaseHandler):
             "first_name": "Test",
             "last_name": "User",
         }
-        user_permissions = yield self.get_or_fetch_user_permissions(user["id"])
-        user["atat_permissions"] = user_permissions
-        self.login(user)
-
-    @tornado.gen.coroutine
-    def get_or_fetch_user_permissions(self, user_id):
-        response = yield self.authz_client.post(
-            "/users", json={"id": user_id, "atat_role": "ccpo"}, raise_error=False
-        )
-        if response.code == 200:
-            return response.json["atat_permissions"]
-        elif response.code == 409:
-            # User already exists
-            response = yield self.authz_client.get("/users/{}".format(user_id))
-            return response.json["atat_permissions"]
+        yield self.login(user)

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -1,15 +1,33 @@
+import tornado.gen
+
 from atst.handler import BaseHandler
 
 
 class Dev(BaseHandler):
-    def initialize(self, action, sessions):
+    def initialize(self, action, sessions, authz_client):
         self.action = action
         self.sessions = sessions
+        self.authz_client = authz_client
 
+    @tornado.gen.coroutine
     def get(self):
         user = {
             "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
             "first_name": "Test",
-            "last_name": "User"
+            "last_name": "User",
         }
+        user_permissions = yield self.get_or_fetch_user_permissions(user["id"])
+        user["atat_permissions"] = user_permissions
         self.login(user)
+
+    @tornado.gen.coroutine
+    def get_or_fetch_user_permissions(self, user_id):
+        response = yield self.authz_client.post(
+            "/users", json={"id": user_id, "atat_role": "ccpo"}, raise_error=False
+        )
+        if response.code == 200:
+            return response.json["atat_permissions"]
+        elif response.code == 409:
+            # User already exists
+            response = yield self.authz_client.get("/users/{}".format(user_id))
+            return response.json["atat_permissions"]

--- a/atst/handlers/login_redirect.py
+++ b/atst/handlers/login_redirect.py
@@ -14,9 +14,7 @@ class LoginRedirect(BaseHandler):
         if token:
             user = yield self._fetch_user_info(token)
             if user:
-                authz_user = yield self.create_authz_user(user["id"])
-                user["atat_permissions"] = authz_user["atat_permissions"]
-                self.login(user)
+                yield self.login(user)
             else:
                 self.write_error(401)
 
@@ -38,10 +36,3 @@ class LoginRedirect(BaseHandler):
 
             else:
                 raise error
-
-    @tornado.gen.coroutine
-    def create_authz_user(self, user_id):
-        response = yield self.authz_client.post(
-            "/users", json={"id": user_id, "atat_role": "ccpo"}
-        )
-        return response.json

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -27,15 +27,17 @@ class Request(BaseHandler):
     @tornado.gen.coroutine
     def get(self):
         user = self.get_current_user()
+        requests = yield self.fetch_requests(user)
+        mapped_requests = [map_request(user, request) for request in requests]
+        self.render("requests.html.to", page=self.page, requests=mapped_requests)
 
+    @tornado.gen.coroutine
+    def fetch_requests(self, user):
         if "review_and_approve_jedi_workspace_request" in user["atat_permissions"]:
             response = yield self.requests_client.get("/requests")
-            requests = response.json
         else:
             response = yield self.requests_client.get(
                 "/requests?creator_id={}".format(user["id"])
             )
-            requests = response.json["requests"]
 
-        mapped_requests = [map_request(user, request) for request in requests]
-        self.render("requests.html.to", page=self.page, requests=mapped_requests)
+        return response.json["requests"]

--- a/atst/handlers/request.py
+++ b/atst/handlers/request.py
@@ -27,9 +27,15 @@ class Request(BaseHandler):
     @tornado.gen.coroutine
     def get(self):
         user = self.get_current_user()
-        response = yield self.requests_client.get(
-            "/users/{}/requests".format(user["id"])
-        )
-        requests = response.json["requests"]
+
+        if "review_and_approve_jedi_workspace_request" in user["atat_permissions"]:
+            response = yield self.requests_client.get("/requests")
+            requests = response.json
+        else:
+            response = yield self.requests_client.get(
+                "/requests?creator_id={}".format(user["id"])
+            )
+            requests = response.json["requests"]
+
         mapped_requests = [map_request(user, request) for request in requests]
         self.render("requests.html.to", page=self.page, requests=mapped_requests)

--- a/atst/handlers/request_new.py
+++ b/atst/handlers/request_new.py
@@ -52,9 +52,7 @@ class RequestNew(BaseHandler):
 
         if request_id:
             response = yield self.requests_client.get(
-                "/users/{}/requests/{}".format(
-                    self.get_current_user()["id"], request_id
-                ),
+                "/requests/{}".format(request_id),
                 raise_error=False,
             )
             if response.ok:
@@ -75,14 +73,6 @@ class RequestNew(BaseHandler):
             request_id=request_id,
             can_submit=jedi_flow.can_submit
         )
-
-    @tornado.gen.coroutine
-    def get_request(self, request_id):
-        request = yield self.requests_client.get(
-            "/users/{}/requests/{}".format(self.get_current_user()["id"], request_id),
-            raise_error=False,
-        )
-        return request
 
 
 class JEDIRequestFlow(object):

--- a/config/base.ini
+++ b/config/base.ini
@@ -2,7 +2,7 @@
 PORT=8000
 ENVIRONMENT = dev
 DEBUG = true
-AUTHZ_BASE_URL = http://localhost
+AUTHZ_BASE_URL = http://localhost:8002
 AUTHNID_BASE_URL= https://localhost:8001
 COOKIE_SECRET = some-secret-please-replace
 SECRET = change_me_into_something_secret

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,14 +1,14 @@
 import pytest
 
 from atst.app import make_app, make_deps, make_config
-from tests.mocks import MockApiClient, MockRequestsClient
+from tests.mocks import MockApiClient, MockRequestsClient, MockAuthzClient
 from atst.sessions import DictSessions
 
 
 @pytest.fixture
 def app():
     TEST_DEPS = {
-        "authz_client": MockApiClient("authz"),
+        "authz_client": MockAuthzClient("authz"),
         "requests_client": MockRequestsClient("requests"),
         "authnid_client": MockApiClient("authnid"),
         "sessions": DictSessions(),

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -49,7 +49,7 @@ class MockRequestsClient(MockApiClient):
             "id": "66b8ef71-86d3-48ef-abc2-51bfa1732b6b",
             "creator": "49903ae7-da4a-49bf-a6dc-9dff5d004238",
             "body": {},
-            "status": "incomplete"
+            "status": "incomplete",
         }
         return self._get_response("GET", path, 200, json=json)
 
@@ -61,3 +61,47 @@ class MockRequestsClient(MockApiClient):
             "body": {},
         }
         return self._get_response("POST", path, 202, json=json)
+
+
+class MockAuthzClient(MockApiClient):
+    @tornado.gen.coroutine
+    def post(self, path, **kwargs):
+        json = {
+            "atat_permissions": [
+                "view_original_jedi_request",
+                "review_and_approve_jedi_workspace_request",
+                "modify_atat_role_permissions",
+                "create_csp_role",
+                "delete_csp_role",
+                "deactivate_csp_role",
+                "modify_csp_role_permissions",
+                "view_usage_report",
+                "view_usage_dollars",
+                "add_and_assign_csp_roles",
+                "remove_csp_roles",
+                "request_new_csp_role",
+                "assign_and_unassign_atat_role",
+                "view_assigned_atat_role_configurations",
+                "view_assigned_csp_role_configurations",
+                "deactivate_workspace",
+                "view_atat_permissions",
+                "transfer_ownership_of_workspace",
+                "add_application_in_workspace",
+                "delete_application_in_workspace",
+                "deactivate_application_in_workspace",
+                "view_application_in_workspace",
+                "rename_application_in_workspace",
+                "add_environment_in_application",
+                "delete_environment_in_application",
+                "deactivate_environment_in_application",
+                "view_environment_in_application",
+                "rename_environment_in_application",
+                "add_tag_to_workspace",
+                "remove_tag_from_workspace",
+            ],
+            "atat_role": "ccpo",
+            "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
+            "username": None,
+            "workspace_roles": [],
+        }
+        return self._get_response("POST", path, 200, json=json)

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -3,7 +3,7 @@ import pytest
 import tornado.web
 import tornado.gen
 
-MOCK_USER = {"user": {"id": "438567dd-25fa-4d83-a8cc-8aa8366cb24a"}}
+MOCK_USER = {"id": "438567dd-25fa-4d83-a8cc-8aa8366cb24a"}
 @tornado.gen.coroutine
 def _fetch_user_info(c, t):
     return MOCK_USER

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -73,3 +73,6 @@ def test_valid_login_creates_session(app, monkeypatch, http_client, base_url):
         raise_error=False,
     )
     assert len(app.sessions.sessions) == 1
+    session = list(app.sessions.sessions.values())[0]
+    assert "atat_permissions" in session["user"]
+    assert isinstance(session["user"]["atat_permissions"], list)


### PR DESCRIPTION
with @richard-dds 

This is related to [this](https://www.pivotaltracker.com/n/projects/2160940/stories/158074173) PT story. It does two things:

- When a user logs in, they are added to the authz database. (For now, they are a CCPO by default.)
- We now check that the "review_and_approve_jedi_workspace_request" permission exists for the current user when listing requests on `/requests`. If it is, we list all requests. If not, we scope the requests to the current user.