### PR TITLE
dev users

### DIFF
--- a/atst/handler.py
+++ b/atst/handler.py
@@ -24,10 +24,17 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @tornado.gen.coroutine
     def _get_user_permissions(self, user_id):
-        response = yield self.authz_client.post(
-            "/users", json={"id": user_id, "atat_role": "ccpo"}
+        response = yield self.authz_client.get(
+            "/users/{}".format(user_id), raise_error=False
         )
-        return response.json
+        if response.code == 404:
+            response = yield self.authz_client.post(
+                "/users", json={"id": user_id, "atat_role": "developer"}
+            )
+            return response.json
+
+        else:
+            return response.json
 
     def get_current_user(self):
         cookie = self.get_secure_cookie("atat")

--- a/atst/handler.py
+++ b/atst/handler.py
@@ -15,7 +15,9 @@ class BaseHandler(tornado.web.RequestHandler):
 
     @tornado.gen.coroutine
     def login(self, user):
-        user["atat_permissions"] = yield self._get_user_permissions(user["id"])
+        user_permissions = yield self._get_user_permissions(user["id"])
+        user["atat_permissions"] = user_permissions["atat_permissions"]
+        user["atat_role"] = user_permissions["atat_role"]
         session_id = self.sessions.start_session(user)
         self.set_secure_cookie("atat", session_id)
         return self.redirect("/home")
@@ -25,7 +27,7 @@ class BaseHandler(tornado.web.RequestHandler):
         response = yield self.authz_client.post(
             "/users", json={"id": user_id, "atat_role": "ccpo"}
         )
-        return response.json["atat_permissions"]
+        return response.json
 
     def get_current_user(self):
         cookie = self.get_secure_cookie("atat")

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -2,8 +2,22 @@ import tornado.gen
 
 from atst.handler import BaseHandler
 
+_DEV_USERS = {
+    "ccpo": {
+        "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
+        "first_name": "Sam",
+        "last_name": "CCPO",
+    },
+    "owner": {
+        "id": "cce17030-4109-4719-b958-ed109dbb87c8",
+        "first_name": "Olivia",
+        "last_name": "Owner",
+    },
+}
+
 
 class Dev(BaseHandler):
+
     def initialize(self, action, sessions, authz_client):
         self.action = action
         self.sessions = sessions
@@ -11,9 +25,6 @@ class Dev(BaseHandler):
 
     @tornado.gen.coroutine
     def get(self):
-        user = {
-            "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
-            "first_name": "Test",
-            "last_name": "User",
-        }
+        role = self.get_argument("role", "ccpo")
+        user = _DEV_USERS[role]
         yield self.login(user)

--- a/atst/handlers/dev.py
+++ b/atst/handlers/dev.py
@@ -13,8 +13,27 @@ _DEV_USERS = {
         "first_name": "Olivia",
         "last_name": "Owner",
     },
+    "admin": {
+        "id": "66ebf7b8-cbf0-4ed8-a102-5f105330df75",
+        "first_name": "Andreas",
+        "last_name": "Admin",
+    },
+    "developer": {
+        "id": "7707b9f2-5945-49ae-967a-be65baa88baf",
+        "first_name": "Dominick",
+        "last_name": "Developer",
+    },
+    "billing_auditor": {
+        "id": "6978ac0c-442a-46aa-a0c3-ff17b5ec2a8c",
+        "first_name": "Billie",
+        "last_name": "The Billing Auditor",
+    },
+    "security_auditor": {
+        "id": "596fd001-bb1d-4adf-87d8-fa2312e882de",
+        "first_name": "Sawyer",
+        "last_name": "The Security Auditor",
+    },
 }
-
 
 class Dev(BaseHandler):
 
@@ -27,4 +46,12 @@ class Dev(BaseHandler):
     def get(self):
         role = self.get_argument("role", "ccpo")
         user = _DEV_USERS[role]
+        yield self._set_user_permissions(user["id"], role)
         yield self.login(user)
+
+    @tornado.gen.coroutine
+    def _set_user_permissions(self, user_id, role):
+        response = yield self.authz_client.post(
+            "/users", json={"id": user_id, "atat_role": role}
+        )
+        return response.json

--- a/templates/header.html.to
+++ b/templates/header.html.to
@@ -5,7 +5,7 @@
     </a>
 
     <a href="/" class="topbar__link topbar__link--secondary">
-      <span>Tech Lead</span>
+      <span>{{ current_user["atat_role"] }}</span>
     </a>
   </nav>
 </header>

--- a/templates/header.html.to
+++ b/templates/header.html.to
@@ -5,7 +5,7 @@
     </a>
 
     <a href="/" class="topbar__link topbar__link--secondary">
-      <span>{{ current_user["atat_role"] }}</span>
+      <span>{{ current_user.get("atat_role") }}</span>
     </a>
   </nav>
 </header>

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -5,6 +5,7 @@ from atst.api_client import ApiClient
 
 
 class MockApiClient(ApiClient):
+
     def __init__(self, service):
         self.service = service
 
@@ -43,6 +44,7 @@ class MockApiClient(ApiClient):
 
 
 class MockRequestsClient(MockApiClient):
+
     @tornado.gen.coroutine
     def get(self, path, **kwargs):
         json = {
@@ -64,44 +66,49 @@ class MockRequestsClient(MockApiClient):
 
 
 class MockAuthzClient(MockApiClient):
+    _json = {
+        "atat_permissions": [
+            "view_original_jedi_request",
+            "review_and_approve_jedi_workspace_request",
+            "modify_atat_role_permissions",
+            "create_csp_role",
+            "delete_csp_role",
+            "deactivate_csp_role",
+            "modify_csp_role_permissions",
+            "view_usage_report",
+            "view_usage_dollars",
+            "add_and_assign_csp_roles",
+            "remove_csp_roles",
+            "request_new_csp_role",
+            "assign_and_unassign_atat_role",
+            "view_assigned_atat_role_configurations",
+            "view_assigned_csp_role_configurations",
+            "deactivate_workspace",
+            "view_atat_permissions",
+            "transfer_ownership_of_workspace",
+            "add_application_in_workspace",
+            "delete_application_in_workspace",
+            "deactivate_application_in_workspace",
+            "view_application_in_workspace",
+            "rename_application_in_workspace",
+            "add_environment_in_application",
+            "delete_environment_in_application",
+            "deactivate_environment_in_application",
+            "view_environment_in_application",
+            "rename_environment_in_application",
+            "add_tag_to_workspace",
+            "remove_tag_from_workspace",
+        ],
+        "atat_role": "ccpo",
+        "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
+        "username": None,
+        "workspace_roles": [],
+    }
+
     @tornado.gen.coroutine
     def post(self, path, **kwargs):
-        json = {
-            "atat_permissions": [
-                "view_original_jedi_request",
-                "review_and_approve_jedi_workspace_request",
-                "modify_atat_role_permissions",
-                "create_csp_role",
-                "delete_csp_role",
-                "deactivate_csp_role",
-                "modify_csp_role_permissions",
-                "view_usage_report",
-                "view_usage_dollars",
-                "add_and_assign_csp_roles",
-                "remove_csp_roles",
-                "request_new_csp_role",
-                "assign_and_unassign_atat_role",
-                "view_assigned_atat_role_configurations",
-                "view_assigned_csp_role_configurations",
-                "deactivate_workspace",
-                "view_atat_permissions",
-                "transfer_ownership_of_workspace",
-                "add_application_in_workspace",
-                "delete_application_in_workspace",
-                "deactivate_application_in_workspace",
-                "view_application_in_workspace",
-                "rename_application_in_workspace",
-                "add_environment_in_application",
-                "delete_environment_in_application",
-                "deactivate_environment_in_application",
-                "view_environment_in_application",
-                "rename_environment_in_application",
-                "add_tag_to_workspace",
-                "remove_tag_from_workspace",
-            ],
-            "atat_role": "ccpo",
-            "id": "164497f6-c1ea-4f42-a5ef-101da278c012",
-            "username": None,
-            "workspace_roles": [],
-        }
-        return self._get_response("POST", path, 200, json=json)
+        return self._get_response("POST", path, 200, json=self._json)
+
+    @tornado.gen.coroutine
+    def get(self, path, **kwargs):
+        return self._get_response("POST", path, 200, json=self._json)


### PR DESCRIPTION
with @richard-dds 

This does two things:
- Adds better permission handling on user login. When a user logs in, ATST will try to fetch their perms from authz. If the user doesn't exist in authz, ATST will add them with a default role of "developer". This is naive handling for now and will probably change later.
- Adds additional dev roles and expands the `/login-dev` endpoint. Now, you can hit that endpoint with a `role` query param containing the name of the role you want to log in as (i.e., `/login-dev?role=owner`).