### PR TITLE
WIP: Curl httpclient

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ Unipath = "==1.1"
 wtforms-tornado = "*"
 pendulum = "*"
 redis = "*"
-pycurl = "*"
+pycurl = {version = "*", sys_platform = "!= 'darwin'"}
 
 [dev-packages]
 bandit = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ Unipath = "==1.1"
 wtforms-tornado = "*"
 pendulum = "*"
 redis = "*"
+pycurl = "*"
 
 [dev-packages]
 bandit = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "25c2d44de8e03dd749009fb7c96f7564740981e73238776eecc152865bf62b44"
+            "sha256": "ebca0cecf63f9f11f6677ddf3ee15a41860710315fb629c2d966b17eab9417ae"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -49,6 +49,7 @@
                 "sha256:fe12f59e7bc6c217f12c6726c2617238fd4c0d53b28db956de592252da4e5bb0"
             ],
             "index": "pypi",
+            "markers": "sys_platform != 'darwin'",
             "version": "==7.43.0.2"
         },
         "python-dateutil": {
@@ -146,10 +147,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:8704779744963d56a2625ec2949eb150bd499fc099510161ddbb2b64e2d98138",
-                "sha256:add3fd690e7c1fe92436d17be461feeaa173e6f33e0789734310334da0f30027"
+                "sha256:0a0c484279a5f08c9bcedd6fa9b42e378866a7dcc695206b92d59dc9f2d9760d",
+                "sha256:218e36cf8d98a42f16214e8670819ce307fa707d1dcf7f9af84c7aede1febc7f"
             ],
-            "version": "==2.0"
+            "version": "==2.0.1"
         },
         "atomicwrites": {
             "hashes": [

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3bea02ccdb0e3877f2595d7fb405408114ec8947e0484d5b4aaf14a4c8ff78b2"
+            "sha256": "25c2d44de8e03dd749009fb7c96f7564740981e73238776eecc152865bf62b44"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -32,6 +32,25 @@
             "index": "pypi",
             "version": "==2.0.2"
         },
+        "pycurl": {
+            "hashes": [
+                "sha256:0f0cdfc7a92d4f2a5c44226162434e34f7d6967d3af416a6f1448649c09a25a4",
+                "sha256:10510a0016c862af467c6e069e051409f15f5831552bed03f5104b395a5d7dd1",
+                "sha256:14e407e00a3881bd6778107945e37b52491a7f1906be8e34af52e55b4776230d",
+                "sha256:208dd2c89e80d32a69397ba8a5cdb3bc0dc60f961a4f2a9662e5e1624dc799d1",
+                "sha256:283b6fbfbee4c1b5f5cb8c375f4d078295e8781d471f0d990f5f751339799db8",
+                "sha256:4109cdfbae56423a315e1191c05d5b5ade1f6068cc7d502ec62fb6466ea73ef0",
+                "sha256:6dc6ee5e7628400083471cba8044010860fe8b22e4dee05e42150a68047d7d9d",
+                "sha256:794bda39ea6fe434b6e1f58ab3bea9f0e6123fb43702fecd760eed6f1547b20a",
+                "sha256:d7480a0b6eda713e11d8fa9a39efafec7c5f2339ba6d9911920fc1e2630c8b24",
+                "sha256:dae7277e7c06da00947f3cd32c095b1e65eae09f07478ada4ea9dfa57020b646",
+                "sha256:df6f42787c39304522a00ecaa0a7fac5daffd0aa89044c68fc9fd5d683dd2ed5",
+                "sha256:eccea049aef47decc380746b3ff242d95636d578c907d0eab3b00918292d6c48",
+                "sha256:fe12f59e7bc6c217f12c6726c2617238fd4c0d53b28db956de592252da4e5bb0"
+            ],
+            "index": "pypi",
+            "version": "==7.43.0.2"
+        },
         "python-dateutil": {
             "hashes": [
                 "sha256:1adb80e7a782c12e52ef9a8182bebeb73f1d7e24e374397af06fb4956c8dc5c0",
@@ -44,7 +63,6 @@
                 "sha256:1d936da41ee06216d89fdc7ead1ee9a5da2811a8787515a976b646e110c3f622",
                 "sha256:e4ef42e82b0b493c5849eed98b5ab49d6767caf982127e9a33167f1153b36cc5"
             ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==2018.5"
         },
         "redis": {
@@ -128,10 +146,10 @@
         },
         "astroid": {
             "hashes": [
-                "sha256:a8d8c7fe34e34e868426b9bafce852c355a3951eef60bc831b2ed541558f8d37",
-                "sha256:e722228b5259ce8c7cbf75f3b0ee8b483cfbd4df01167474a84087d1aeade22c"
+                "sha256:8704779744963d56a2625ec2949eb150bd499fc099510161ddbb2b64e2d98138",
+                "sha256:add3fd690e7c1fe92436d17be461feeaa173e6f33e0789734310334da0f30027"
             ],
-            "version": "==2.0.0.dev4"
+            "version": "==2.0"
         },
         "atomicwrites": {
             "hashes": [
@@ -199,17 +217,17 @@
         },
         "gitdb2": {
             "hashes": [
-                "sha256:b60e29d4533e5e25bb50b7678bbc187c8f6bcff1344b4f293b2ba55c85795f09",
-                "sha256:cf9a4b68e8c4da8d42e48728c944ff7af2d8c9db303ac1ab32eac37aa4194b0e"
+                "sha256:87783b7f4a8f6b71c7fe81d32179b3c8781c1a7d6fa0c69bff2f315b00aff4f8",
+                "sha256:bb4c85b8a58531c51373c89f92163b92f30f81369605a67cd52d1fc21246c044"
             ],
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "gitpython": {
             "hashes": [
-                "sha256:1ec4c44846cf76a1e55769560673a97731849c9d05401e035e607495f10db959",
-                "sha256:b60b045cf64a321e5b620debb49890099fa6c7be6dfb7fb249027e5d34227301"
+                "sha256:563221e5a44369c6b79172f455584c9ebbb122a13368cc82cb4b5addff788f82",
+                "sha256:8237dc5bfd6f1366abeee5624111b9d6879393d84745a507de0fda86043b65a8"
             ],
-            "version": "==2.1.10"
+            "version": "==2.1.11"
         },
         "ipdb": {
             "hashes": [
@@ -239,7 +257,6 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==4.3.4"
         },
         "jedi": {
@@ -339,7 +356,6 @@
                 "sha256:d345c8fe681115900d6da8d048ba67c25df42973bda370783cd58826442dcd7c",
                 "sha256:e160a7fcf25762bb60efc7e171d4497ff1d8d2d75a3d0df7a21b76821ecbf5c5"
             ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==0.6.0"
         },
         "prompt-toolkit": {
@@ -362,7 +378,6 @@
                 "sha256:3fd59af7435864e1a243790d322d763925431213b6b8529c6ca71081ace3bbf7",
                 "sha256:e31fb2767eb657cbde86c454f02e99cb846d3cd9d61b318525140214fdc0e98e"
             ],
-            "markers": "python_version != '3.3.*' and python_version >= '2.7' and python_version != '3.2.*' and python_version != '3.1.*' and python_version != '3.0.*'",
             "version": "==1.5.4"
         },
         "pygments": {
@@ -374,11 +389,11 @@
         },
         "pylint": {
             "hashes": [
-                "sha256:285c9ae7255acb584057fe31051a37498985e632b99fc0ec93b7eb38a1b137f9",
-                "sha256:dd5c0fc4e6a4cb9483a4367699099a7dfc8a13de9ecac4cb16855ffac68d49de"
+                "sha256:248a7b19138b22e6390cba71adc0cb03ac6dd75a25d3544f03ea1728fa20e8f4",
+                "sha256:9cd70527ef3b099543eeabeb5c80ff325d86b477aa2b3d49e264e12d12153bc8"
             ],
             "index": "pypi",
-            "version": "==2.0.0.dev2"
+            "version": "==2.0.0"
         },
         "pytest": {
             "hashes": [
@@ -405,11 +420,15 @@
         },
         "pyyaml": {
             "hashes": [
+                "sha256:1cbc199009e78f92d9edf554be4fe40fb7b0bef71ba688602a00e97a51909110",
                 "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
                 "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
                 "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
+                "sha256:6f89b5c95e93945b597776163403d47af72d243f366bf4622ff08bdfd1c950b7",
                 "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
-                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
+                "sha256:be622cc81696e24d0836ba71f6272a2b5767669b0d79fdcf0295d51ac2e156c8",
+                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b",
+                "sha256:f39411e380e2182ad33be039e8ee5770a5d9efe01a2bfb7ae58d9ba31c4a2a9d"
             ],
             "version": "==4.2b4"
         },
@@ -428,10 +447,10 @@
         },
         "smmap2": {
             "hashes": [
-                "sha256:b78ee0f1f5772d69ff50b1cbdb01b8c6647a8354f02f23b488cf4b2cfc923956",
-                "sha256:c7530db63f15f09f8251094b22091298e82bf6c699a6b8344aaaef3f2e1276c3"
+                "sha256:0dd53d991af487f9b22774fa89451358da3607c02b9b886a54736c6a313ece0b",
+                "sha256:dc216005e529d57007ace27048eb336dcecb7fc413cfb3b2f402bb25972b69c6"
             ],
-            "version": "==2.0.3"
+            "version": "==2.0.4"
         },
         "stevedore": {
             "hashes": [

--- a/atst/api_client.py
+++ b/atst/api_client.py
@@ -1,5 +1,5 @@
 import tornado.gen
-from tornado.httpclient import AsyncHTTPClient
+from tornado.curl_httpclient import CurlAsyncHTTPClient
 from json import dumps, loads, decoder
 
 
@@ -8,7 +8,7 @@ class ApiClient(object):
         self.base_url = base_url
         if api_version:
             self.base_url = f"{base_url}/api/{api_version}"
-        self.client = AsyncHTTPClient()
+        self.client = CurlAsyncHTTPClient()
         self.validate_cert = validate_cert
 
     @tornado.gen.coroutine

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -15,6 +15,10 @@ INSTALL_NODE_PACKAGES="true"
 # Run the shared bootstrap script
 source ./script/include/run_bootstrap
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pipenv run pip install --no-cache-dir pycurl
+fi
+
 # Link USWDS fonts into the /static directory
 rm -f ./static/fonts
 ln -s ../node_modules/uswds/src/fonts ./static/fonts


### PR DESCRIPTION
I'm putting this up mostly so the attempt is documented. Pycurl and pipenv don't play nice together. This adds pycurl to the `Pipfile` but excludes it on macos installations (nice feature, thanks pipenv). `script/bootstrap` tries a more specific macos install using pip directly in the pipenv shell. I think something like this worked for @ddsdevon , but my tests still don't pass even after I blow away my virtualenv and rebuild it. I'm open to suggestions if anyone has further ideas.