### PR TITLE
Suggest a PE number when PE number is not found

### DIFF
--- a/tests/forms/test_financial.py
+++ b/tests/forms/test_financial.py
@@ -1,0 +1,14 @@
+import pytest
+
+from atst.forms.financial import suggest_pe_id
+
+
+@pytest.mark.parametrize("input,expected", [
+    ('0603502N', None),
+    ('0603502NZ', None),
+    ('603502N', '0603502N'),
+    ('063502N', '0603502N'),
+    ('63502N', '0603502N'),
+])
+def test_suggest_pe_id(input, expected):
+    assert suggest_pe_id(input) == expected


### PR DESCRIPTION
Using the defined format of a PE number (https://www.militaryperiscope.com/terms/t0000241.html), we can suggest a corrected format of the PE number if the user omitted the leading zeros for either the DoD program or category.

Example:

![image](https://user-images.githubusercontent.com/40774582/43144189-83306e58-8f2a-11e8-9638-78c5337d5bfa.png)
