### PR TITLE
show next-steps modal when request is auto-approved

### DIFF
--- a/atst/handlers/request_submit.py
+++ b/atst/handlers/request_submit.py
@@ -14,4 +14,16 @@ class RequestsSubmit(BaseHandler):
             "/requests/{}/submit".format(request_id),
             allow_nonstandard_methods=True
         )
-        self.redirect("/requests")
+        approved = yield self._check_approved(request_id)
+        if approved:
+            self.redirect("/requests?modal=True")
+        else:
+            self.redirect("/requests")
+
+    @tornado.gen.coroutine
+    def _check_approved(self, request_id):
+        response = yield self.requests_client.get(
+            "/requests/{}".format(request_id)
+        )
+        status = response.json.get("status")
+        return status == "approved"

--- a/templates/requests.html.to
+++ b/templates/requests.html.to
@@ -1,5 +1,34 @@
 {% extends "base.html.to" %}
 
+{% block modal %}
+  {% if modalOpen() %}
+    {% apply modal %}
+      <h1>Your request is now approved!</h1>
+
+      <p>
+        Your next step is to create a <b>Task Order (T.O.)</b> associated with
+        JEDI Cloud. Please consult a <b>Contracting Officer (KO)</b> or
+        <b>Contracting Officer Representative (COR)</b> to help with this step.
+      </p>
+
+      <p>
+        Once the Task Order (T.O.) has been created, we will need the following
+        details to create your account. These details will help keep your cloud
+        usage in sync with your budget.
+      </p>
+
+      {% module Alert("You'll need these details: ",
+        message="<p>Task Order Number</p><p>Contracting Officer: Name, E-mail and Office</p>"
+      ) %}
+
+
+      <div class='action-group'>
+        <a href='/requests' class='action-group__action usa-button'>Close</a>
+      </div>
+    {% end %}
+  {% end %}
+{% end %}
+
 {% block content %}
 
 

--- a/tests/handlers/test_request_submit.py
+++ b/tests/handlers/test_request_submit.py
@@ -1,0 +1,49 @@
+import pytest
+from tests.mocks import MOCK_USER
+
+ERROR_CLASS = "usa-input-error-message"
+APPROVED_MOCK_REQUEST = {
+    "status": "approved"
+}
+
+@pytest.mark.gen_test
+def test_submit_reviewed_request(monkeypatch, http_client, base_url):
+    monkeypatch.setattr(
+        "atst.handlers.request_submit.RequestsSubmit.get_current_user", lambda s: MOCK_USER
+    )
+    monkeypatch.setattr(
+        "atst.handlers.request_submit.RequestsSubmit.check_xsrf_cookie", lambda s: True
+    )
+    # this just needs to send a known invalid form value
+    response = yield http_client.fetch(
+        base_url + "/requests/submit/1",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body="",
+        raise_error=False,
+        follow_redirects=False
+    )
+    assert response.headers["Location"] == "/requests"
+
+
+@pytest.mark.gen_test
+def test_submit_autoapproved_reviewed_request(monkeypatch, http_client, base_url):
+    monkeypatch.setattr(
+        "atst.handlers.request_submit.RequestsSubmit.get_current_user", lambda s: MOCK_USER
+    )
+    monkeypatch.setattr(
+        "atst.handlers.request_submit.RequestsSubmit.check_xsrf_cookie", lambda s: True
+    )
+    monkeypatch.setattr(
+        "tests.mocks.MOCK_REQUEST", APPROVED_MOCK_REQUEST
+    )
+    # this just needs to send a known invalid form value
+    response = yield http_client.fetch(
+        base_url + "/requests/submit/1",
+        method="POST",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        body="",
+        raise_error=False,
+        follow_redirects=False
+    )
+    assert response.headers["Location"] == "/requests?modal=True"


### PR DESCRIPTION
This should complete [this](https://www.pivotaltracker.com/story/show/159014770) PT story.

When a user submits a request with a dollar amount below the auto-approval threshold, they are redirected to the requests screen with a modal explaining next steps. If they submit a request with a dollar amount over the threshold, they don't see the modal.