### PR TITLE
Allow for multiple date formats

### DIFF
--- a/atst/forms/fields.py
+++ b/atst/forms/fields.py
@@ -7,7 +7,17 @@ import pendulum
 class DateField(DateField):
     def _value(self):
         if self.data:
-            return pendulum.parse(self.data).date()
+            date_formats = [
+                "YYYY-MM-DD",
+                "MM/DD/YYYY"
+            ]
+            for _format in date_formats:
+                try:
+                    return pendulum.from_format(self.data, _format).date()
+                except (ValueError, pendulum.parsing.exceptions.ParserError):
+                    pass
+
+            raise ValueError("Unable to parse string {}".format(self.data))
         else:
             return None
 

--- a/tests/forms/test_fields.py
+++ b/tests/forms/test_fields.py
@@ -1,0 +1,25 @@
+import pytest
+from wtforms import Form
+import pendulum
+
+from atst.forms.fields import DateField
+
+
+class MyForm(Form):
+    date = DateField()
+
+
+def test_date_ie_format():
+    form = MyForm(data={"date": "12/24/2018"})
+    assert form.date._value() == pendulum.date(2018, 12, 24)
+
+
+def test_date_sane_format():
+    form = MyForm(data={"date": "2018-12-24"})
+    assert form.date._value() == pendulum.date(2018, 12, 24)
+
+
+def test_date_insane_format():
+    form = MyForm(data={"date": "hello"})
+    with pytest.raises(ValueError):
+        form.date._value()


### PR DESCRIPTION
It seems like IE provides a different date format than Chrome or Firefox. This PR changes the DateField field type to allow for multiple formats.