### PR TITLE
Test cleanup

### DIFF
--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,2 +1,3 @@
 [default]
 PGHOST = postgreshost
+PGDATABASE = atat_test

--- a/script/test
+++ b/script/test
@@ -6,6 +6,12 @@ source "$(dirname "${0}")"/../script/include/global_header.inc.sh
 
 export FLASK_ENV=test
 
+# Set database name
+DATABASE_NAME="atat_test"
+
+# Enable database resetting
+RESET_DB="true"
+
 # Define all relevant python files and directories for this app
 PYTHON_FILES="./app.py ./atst ./config"
 


### PR DESCRIPTION
This updates the commit our scriptz submodule points to so that we can configure script/test to reset the test database. It also updates CI config to use the test DB, since that's the one the tests expect.