### PR TITLE
UI/members add

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -124,7 +124,9 @@ def make_app(config, deps, **kwargs):
         url(r"/workspaces/(\S+)/projects", Workspace, {}, name="workspace_projects"),
         url(r"/workspaces/123456/projects/789/edit", Main, {"page": "project_edit"}, name="project_edit"),
         url(r"/workspaces/123456/members/789/edit", Main, {"page": "member_edit"}, name="member_edit"),
-        url(r"/workspaces/123456/members/new", Main, {"page": "member_new"}, name="member_new"),
+        url(r"/workspaces/123456/members/new/1", Main, {"page": "member_new_account"}, name="member_new_account"),
+        url(r"/workspaces/123456/members/new/2", Main, {"page": "member_new_role"}, name="member_new_role"),
+        url(r"/workspaces/123456/members/new/3", Main, {"page": "member_new_access"}, name="member_new_access"),
     ]
 
     if not ENV == "production":

--- a/atst/app.py
+++ b/atst/app.py
@@ -124,6 +124,7 @@ def make_app(config, deps, **kwargs):
         url(r"/workspaces/(\S+)/projects", Workspace, {}, name="workspace_projects"),
         url(r"/workspaces/123456/projects/789/edit", Main, {"page": "project_edit"}, name="project_edit"),
         url(r"/workspaces/123456/members/789/edit", Main, {"page": "member_edit"}, name="member_edit"),
+        url(r"/workspaces/123456/members/new", Main, {"page": "member_new"}, name="member_new"),
     ]
 
     if not ENV == "production":

--- a/scss/components/_progress_menu.scss
+++ b/scss/components/_progress_menu.scss
@@ -1,5 +1,6 @@
 .progress-menu {
   display: block;
+  margin-top: $gap;
 
   ul {
     list-style: none;

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -57,10 +57,6 @@
     }
   }
 
-  &:hover {
-    background-color: $color-aqua-lightest;
-  }
-
   &--active {
     color: $color-blue;
   }

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -23,7 +23,7 @@
 }
 
 @mixin block-list__description {
-  padding-top: $gap;
+  padding-top: $gap/2;
   font-style: italic;
   line-height: $base-line-height;
 }
@@ -49,12 +49,47 @@
   padding: $gap * 2;
   border-top: 0;
   border-bottom: 1px dashed $color-gray-light;
+  cursor: default;
 
   @at-root li#{&} {
     &:last-child {
       border-bottom-style: solid;
     }
   }
+
+  &:hover {
+    background-color: $color-aqua-lightest;
+  }
+
+  &--active {
+    color: $color-blue;
+  }
+}
+
+@mixin block-list__status {
+  content: "";
+  width: 2rem;
+  height: 2rem;
+  border: 1px solid $color-gray;
+  border-radius: 100%;
+  position: absolute;
+
+  &--active:before {
+    border: 2px solid $color-blue;
+  }
+
+  &--complete:before {
+    content: url('/static/icons/checkmark.svg');
+    background-color: $color-blue;
+    border: 2px solid $color-blue;
+    font-size: $h6-font-size;
+    padding: 1px 2px;
+  }
+
+  &--incomplete:before {
+    border: 2px solid $color-gray-light;
+  }
+
 }
 
 
@@ -88,6 +123,10 @@
 
 .block-list__description {
   @include block-list__description;
+}
+
+.block-list__status {
+ @include block-list__status;
 }
 
 .block-list__item {

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -54,10 +54,6 @@
     &:last-child {
       border-bottom-style: solid;
     }
-
-    &:first-child {
-      border-top: 1px solid $color-black;
-    }
   }
 }
 

--- a/scss/elements/_block_lists.scss
+++ b/scss/elements/_block_lists.scss
@@ -22,6 +22,12 @@
   margin: 0;
 }
 
+@mixin block-list__description {
+  padding-top: $gap;
+  font-style: italic;
+  line-height: $base-line-height;
+}
+
 @mixin block-list__footer {
   @include panel-base;
   @include panel-theme-default;
@@ -47,6 +53,10 @@
   @at-root li#{&} {
     &:last-child {
       border-bottom-style: solid;
+    }
+
+    &:first-child {
+      border-top: 1px solid $color-black;
     }
   }
 }
@@ -78,6 +88,10 @@
 
 .block-list__title {
   @include block-list__title;
+}
+
+.block-list__description {
+  @include block-list__description;
 }
 
 .block-list__item {

--- a/scss/elements/_panels.scss
+++ b/scss/elements/_panels.scss
@@ -58,6 +58,10 @@
     h1, h2, h3, h4, h5, h6 {
       margin: 0;
     }
+
+    h1 {
+      font-size: $h2-font-size;
+    }
   }
 }
 

--- a/scss/elements/_typography.scss
+++ b/scss/elements/_typography.scss
@@ -20,6 +20,7 @@ h1, h2, h3, h4, h5, h6 {
 
   + .subtitle * {
     margin-top: 0;
+    color: $color-gray;
   }
 
 }

--- a/templates/member_new.html.to
+++ b/templates/member_new.html.to
@@ -2,7 +2,7 @@
 
 
 {% block template_vars %}
-  {% set roles_workspace = ['Owner','Admin','Developer','Billing Auditor','Security Auditor','CCPO'] %}
+{% set roles_workspace = ['Owner','Admin','Developer','Billing Auditor','Security Auditor','CCPO'] %}
 {% end %}
 
 
@@ -60,12 +60,11 @@
       <h2>Workspace Role</h2>
     </div>
   </div>
-
 </div>
 
 <div class='block-list'>
   <ul>
-  {% for role in roles_workspace %}
+    {% for role in roles_workspace %}
     <li class="block-list__item">
       <div class="block-list__title">{{role}}</div>
       <div class="block-list__description">
@@ -82,6 +81,71 @@
   <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
 </div>
 
+<br>
+
+<div class='panel'>
+  <div class='panel__heading'>
+    <h1>Add new workspace member</h1>
+    <div class='subtitle'>
+      <h2>Project Access</h2>
+    </div>
+  </div>
+</div>
+
+<form class='search-bar'>
+  <div class='usa-input search-input'>
+    <label for='project-search'>Search by project name</label>
+    <input type='search' id='project-search' name='project-search' placeholder="Search by project name"/>
+    <button type="submit">
+      <span class="hide">Search</span>
+    </button>
+  </div>
+</form>
+
+<div class='block-list project-list-item'>
+  <header class='block-list__header'>
+    <h2 class='block-list__title'>{% module Icon('arrow-down') %} Code.mil</h2>
+    <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
+  </header>
+  <ul>
+    <li class='block-list__item project-list-item__environment'>
+      <span class='project-list-item__environment'>
+        Development
+      </span>
+      <div class='project-list-item__environment__actions'>
+        <span class="label">no access </span><a href="#" class="icon-link">set role</a>
+      </div>
+    </li>
+    <li class='block-list__item project-list-item__environment'>
+      <span class='project-list-item__environment'>
+        Sandbox
+      </span>
+      <div class='project-list-item__environment__actions'>
+        <span class="label label--success">Developer</span><a href="#" class="icon-link">set role</a>
+      </div>
+    </li>
+    <li class='block-list__item project-list-item__environment'>
+      <span class='project-list-item__environment'>
+        Production
+      </span>
+      <div class='project-list-item__environment__actions'>
+        <span class="label label--success">Developer</span><a href="#" class="icon-link">set role</a>
+      </div>
+    </li>
+  </ul>
+</div>
+
+<div class='block-list project-list-item'>
+  <header class='block-list__header'>
+    <h2 class='block-list__title'>{% module Icon('arrow-right') %} Digital Dojo</h2>
+    <span class="label">no access</span>
+  </header>
+</div>
+
+<div class='action-group'>
+  <a type='submit' class='usa-button usa-button-primary' value='Save'>Save New Member</a>
+  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
+</div>
 
 {% end %}
 

--- a/templates/member_new.html.to
+++ b/templates/member_new.html.to
@@ -1,0 +1,31 @@
+{% extends "base_workspace.html.to" %}
+
+{% block workspace_content %}
+
+
+{% include 'members_menu.html.to' %}
+
+<div class='panel'>
+  <div class='panel__heading'>
+    <h1>Add New Member</h1>
+    <div class='subtitle'>
+      <h2>Account Details</h2>
+    </div>
+  </div>
+
+  <div class='panel__content'>
+    <form action=''>
+
+
+    </form>
+  </div>
+</div>
+
+<div class='action-group'>
+  <a type='submit' class='usa-button usa-button-primary' value='Set Workspace Role'>Next: Set Workspace Role</a>
+  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
+</div>
+
+
+{% end %}
+

--- a/templates/member_new.html.to
+++ b/templates/member_new.html.to
@@ -15,7 +15,25 @@
 
   <div class='panel__content'>
     <form action=''>
+      <div class="usa-input">
+        <label for="">First Name</label>
+        <input id="" name="" value="">
+      </div>
 
+      <div class="usa-input">
+        <label for="">Last Name</label>
+        <input id="" name="" value="">
+      </div>
+
+      <div class="usa-input">
+        <label for="">DOD ID</label>
+        <input id="" name="" value="" placeholder="10-digit number on the back of the CAC">
+      </div>
+
+      <div class="usa-input">
+        <label for="">E-mail Address</label>
+        <input id="" name="" value="" placeholder="jane@mail.mil">
+      </div>
 
     </form>
   </div>

--- a/templates/member_new.html.to
+++ b/templates/member_new.html.to
@@ -1,5 +1,11 @@
 {% extends "base_workspace.html.to" %}
 
+
+{% block template_vars %}
+  {% set roles_workspace = ['Owner','Admin','Developer','Billing Auditor','Security Auditor','CCPO'] %}
+{% end %}
+
+
 {% block workspace_content %}
 
 
@@ -7,7 +13,7 @@
 
 <div class='panel'>
   <div class='panel__heading'>
-    <h1>Add New Member</h1>
+    <h1>Add new workspace member</h1>
     <div class='subtitle'>
       <h2>Account Details</h2>
     </div>
@@ -37,6 +43,38 @@
 
     </form>
   </div>
+</div>
+
+<div class='action-group'>
+  <a type='submit' class='usa-button usa-button-primary' value='Set Project Access'>Next: Set Project Access</a>
+  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
+</div>
+
+
+<br>
+
+<div class='panel'>
+  <div class='panel__heading'>
+    <h1>Add new workspace member</h1>
+    <div class='subtitle'>
+      <h2>Workspace Role</h2>
+    </div>
+  </div>
+
+</div>
+
+<div class='block-list'>
+  <ul>
+  {% for role in roles_workspace %}
+    <li class="block-list__item">
+      <div class="block-list__title">{{role}}</div>
+      <div class="block-list__description">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur asperiores ad quos porro, nobis quod repellat omnis sunt id error, sed, odit minima nisi fuga expedita nam sapiente ipsa facere.
+      </div>
+    </li>
+    {% end %}
+  </ul>
+
 </div>
 
 <div class='action-group'>

--- a/templates/member_new_access.html.to
+++ b/templates/member_new_access.html.to
@@ -1,87 +1,10 @@
 {% extends "base_workspace.html.to" %}
 
 
-{% block template_vars %}
-{% set roles_workspace = ['Owner','Admin','Developer','Billing Auditor','Security Auditor','CCPO'] %}
-{% end %}
-
-
 {% block workspace_content %}
 
 
 {% include 'members_menu.html.to' %}
-
-<div class='panel'>
-  <div class='panel__heading'>
-    <h1>Add new workspace member</h1>
-    <div class='subtitle'>
-      <h2>Account Details</h2>
-    </div>
-  </div>
-
-  <div class='panel__content'>
-    <form action=''>
-      <div class="usa-input">
-        <label for="">First Name</label>
-        <input id="" name="" value="">
-      </div>
-
-      <div class="usa-input">
-        <label for="">Last Name</label>
-        <input id="" name="" value="">
-      </div>
-
-      <div class="usa-input">
-        <label for="">DOD ID</label>
-        <input id="" name="" value="" placeholder="10-digit number on the back of the CAC">
-      </div>
-
-      <div class="usa-input">
-        <label for="">E-mail Address</label>
-        <input id="" name="" value="" placeholder="jane@mail.mil">
-      </div>
-
-    </form>
-  </div>
-</div>
-
-<div class='action-group'>
-  <a type='submit' class='usa-button usa-button-primary' value='Set Project Access'>Next: Set Project Access</a>
-  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
-</div>
-
-
-<br>
-
-<div class='panel'>
-  <div class='panel__heading'>
-    <h1>Add new workspace member</h1>
-    <div class='subtitle'>
-      <h2>Workspace Role</h2>
-    </div>
-  </div>
-</div>
-
-<div class='block-list'>
-  <ul>
-    {% for role in roles_workspace %}
-    <li class="block-list__item">
-      <div class="block-list__title">{{role}}</div>
-      <div class="block-list__description">
-        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur asperiores ad quos porro, nobis quod repellat omnis sunt id error, sed, odit minima nisi fuga expedita nam sapiente ipsa facere.
-      </div>
-    </li>
-    {% end %}
-  </ul>
-
-</div>
-
-<div class='action-group'>
-  <a type='submit' class='usa-button usa-button-primary' value='Set Workspace Role'>Next: Set Workspace Role</a>
-  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
-</div>
-
-<br>
 
 <div class='panel'>
   <div class='panel__heading'>
@@ -144,7 +67,7 @@
 
 <div class='action-group'>
   <a type='submit' class='usa-button usa-button-primary' value='Save'>Save New Member</a>
-  <a type='submit' class='icon-link' value='Cancel'>Cancel</a>
+  <a class='icon-link' value='Cancel'>Cancel</a>
 </div>
 
 {% end %}

--- a/templates/member_new_account.html.to
+++ b/templates/member_new_account.html.to
@@ -1,0 +1,48 @@
+{% extends "base_workspace.html.to" %}
+
+{% block workspace_content %}
+
+
+{% include 'members_menu.html.to' %}
+
+<div class='panel'>
+  <div class='panel__heading'>
+    <h1>Add new workspace member</h1>
+    <div class='subtitle'>
+      <h2>Account Details</h2>
+    </div>
+  </div>
+
+  <div class='panel__content'>
+    <form action=''>
+      <div class="usa-input">
+        <label for="">First Name</label>
+        <input id="" name="" value="">
+      </div>
+
+      <div class="usa-input">
+        <label for="">Last Name</label>
+        <input id="" name="" value="">
+      </div>
+
+      <div class="usa-input">
+        <label for="">DOD ID</label>
+        <input id="" name="" value="" placeholder="10-digit number on the back of the CAC">
+      </div>
+
+      <div class="usa-input">
+        <label for="">E-mail Address</label>
+        <input id="" name="" value="" placeholder="jane@mail.mil">
+      </div>
+
+    </form>
+  </div>
+</div>
+
+<div class='action-group'>
+  <a href="{{ reverse_url('member_new_role') }}" type='submit' class='usa-button usa-button-primary' value='Set Project Access'>Next: Set Project Access</a>
+  <a class='icon-link' value='Cancel'>Cancel</a>
+</div>
+
+{% end %}
+

--- a/templates/member_new_role.html.to
+++ b/templates/member_new_role.html.to
@@ -1,0 +1,43 @@
+{% extends "base_workspace.html.to" %}
+
+
+{% block template_vars %}
+{% set roles_workspace = ['Owner','Admin','Developer','Billing Auditor','Security Auditor','CCPO'] %}
+{% end %}
+
+
+{% block workspace_content %}
+
+
+{% include 'members_menu.html.to' %}
+
+<div class='panel'>
+  <div class='panel__heading'>
+    <h1>Add new workspace member</h1>
+    <div class='subtitle'>
+      <h2>Workspace Role</h2>
+    </div>
+  </div>
+</div>
+
+<div class='block-list'>
+  <ul>
+    {% for role in roles_workspace %}
+    <li class="block-list__item">
+      <div class="block-list__title">{{role}}</div>
+      <div class="block-list__description">
+        Lorem ipsum dolor sit amet, consectetur adipisicing elit. Pariatur asperiores ad quos porro, nobis quod repellat omnis sunt id error, sed, odit minima nisi fuga expedita nam sapiente ipsa facere.
+      </div>
+    </li>
+    {% end %}
+  </ul>
+
+</div>
+
+<div class='action-group'>
+  <a href="{{ reverse_url('member_new_access') }}" type='submit' class='usa-button usa-button-primary' value='Set Workspace Role'>Next: Set Workspace Role</a>
+  <a class='icon-link' value='Cancel'>Cancel</a>
+</div>
+
+{% end %}
+

--- a/templates/members_menu.html.to
+++ b/templates/members_menu.html.to
@@ -1,13 +1,13 @@
 <div class="progress-menu progress-menu--three">
   <ul>
     <li class="progress-menu__item">
-      <a href="#">Account Details</a>
+      <a href="{{ reverse_url('member_new_account') }}">Account Details</a>
     </li>
     <li class="progress-menu__item">
-      <a href="#">Workspace Role</a>
+      <a href="{{ reverse_url('member_new_role') }}">Workspace Role</a>
     </li>
     <li class="progress-menu__item">
-      <a href="#">Project Access</a>
+      <a href="{{ reverse_url('member_new_access') }}">Project Access</a>
     </li>
   </ul>
 </div>

--- a/templates/members_menu.html.to
+++ b/templates/members_menu.html.to
@@ -1,0 +1,13 @@
+<div class="progress-menu progress-menu--three">
+  <ul>
+    <li class="progress-menu__item">
+      <a href="#">Account Details</a>
+    </li>
+    <li class="progress-menu__item">
+      <a href="#">Workspace Role</a>
+    </li>
+    <li class="progress-menu__item">
+      <a href="#">Project Access</a>
+    </li>
+  </ul>
+</div>

--- a/templates/navigation/workspace_navigation.html.to
+++ b/templates/navigation/workspace_navigation.html.to
@@ -21,7 +21,7 @@
       subnav=[
         {
           "label": "Add New Member",
-          "href": "/workspaces/123456/members/new",
+          "href": "/workspaces/123456/members/new/1",
           "active": matchesPath('/workspaces/123456/members/new'),
           "icon": "plus"
         },

--- a/templates/navigation/workspace_navigation.html.to
+++ b/templates/navigation/workspace_navigation.html.to
@@ -7,7 +7,7 @@
       subnav=[
         {
           "label": "Add New Project",
-          "href":"/",
+          "href":"#",
           "active": matchesPath('workspaces/projects/new'),
           "icon": "plus"
         }
@@ -21,13 +21,13 @@
       subnav=[
         {
           "label": "Add New Member",
-          "href": "",
-          "active": matchesPath('/workspaces/members/new'),
+          "href": "/workspaces/123456/members/new",
+          "active": matchesPath('/workspaces/123456/members/new'),
           "icon": "plus"
         },
         {
           "label": "Editing Member",
-          "href": "",
+          "href": "/workspaces/123456/members/789/edit",
           "active": matchesPath('/workspaces/123456/members/789/edit')
         }
       ]


### PR DESCRIPTION
This PR adds the UI for the three step process for adding a user to a workspace:
* `member_new_account`
* `member_new_role`
* `member_new_access`

This is NOT functional yet, and it is only the static interface.

**Account Details**
![screen shot 2018-08-06 at 14 16 36](https://user-images.githubusercontent.com/38014252/43733707-89a1b7fc-9983-11e8-89a1-d393e68b3e7b.png)

**Workspace Role**
![screen shot 2018-08-06 at 14 17 30](https://user-images.githubusercontent.com/38014252/43733716-925a147a-9983-11e8-9c85-2727397c185b.png)

**Project Access**
![screen shot 2018-08-06 at 14 17 09](https://user-images.githubusercontent.com/38014252/43733727-9a45a8f2-9983-11e8-920f-94af95456dd8.png)
