### PR TITLE
implement database sessions for test factories

### DIFF
--- a/tests/domain/test_pe_numbers.py
+++ b/tests/domain/test_pe_numbers.py
@@ -6,20 +6,8 @@ from atst.domain.pe_numbers import PENumbers
 from tests.factories import PENumberFactory
 
 
-@pytest.fixture(scope="function")
-def new_pe_number(session):
-    def make_pe_number(**kwargs):
-        pen = PENumberFactory.create(**kwargs)
-        session.add(pen)
-        session.commit()
-
-        return pen
-
-    return make_pe_number
-
-
-def test_can_get_pe_number(new_pe_number):
-    new_pen = new_pe_number(number="0701367F", description="Combat Support - Offensive")
+def test_can_get_pe_number():
+    new_pen = PENumberFactory.create(number="0701367F", description="Combat Support - Offensive")
     pen = PENumbers.get(new_pen.number)
 
     assert pen.number == new_pen.number

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -9,11 +9,7 @@ from tests.factories import RequestFactory
 
 @pytest.fixture(scope="function")
 def new_request(session):
-    created_request = RequestFactory.create()
-    session.add(created_request)
-    session.commit()
-
-    return created_request
+    return RequestFactory.create()
 
 
 def test_can_get_request(new_request):

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -6,20 +6,8 @@ from atst.domain.task_orders import TaskOrders
 from tests.factories import TaskOrderFactory
 
 
-@pytest.fixture(scope="function")
-def new_task_order(session):
-    def make_task_order(**kwargs):
-        to = TaskOrderFactory.create(**kwargs)
-        session.add(to)
-        session.commit()
-
-        return to
-
-    return make_task_order
-
-
-def test_can_get_task_order(new_task_order):
-    new_to = new_task_order(number="0101969F")
+def test_can_get_task_order():
+    new_to = TaskOrderFactory.create(number="0101969F")
     to = TaskOrders.get(new_to.number)
 
     assert to.id == to.id

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -8,27 +8,36 @@ from atst.models.user import User
 from atst.models.role import Role
 
 
-class RequestFactory(factory.Factory):
+class RequestFactory(factory.alchemy.SQLAlchemyModelFactory):
+
     class Meta:
         model = Request
 
     id = factory.Sequence(lambda x: uuid4())
 
-class PENumberFactory(factory.Factory):
+
+class PENumberFactory(factory.alchemy.SQLAlchemyModelFactory):
+
     class Meta:
         model = PENumber
 
-class TaskOrderFactory(factory.Factory):
+
+class TaskOrderFactory(factory.alchemy.SQLAlchemyModelFactory):
+
     class Meta:
         model = TaskOrder
 
-class RoleFactory(factory.Factory):
+
+class RoleFactory(factory.alchemy.SQLAlchemyModelFactory):
+
     class Meta:
         model = Role
 
     permissions = []
 
-class UserFactory(factory.Factory):
+
+class UserFactory(factory.alchemy.SQLAlchemyModelFactory):
+
     class Meta:
         model = User
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,8 +1,8 @@
 from tests.factories import RequestFactory, UserFactory
 
 
-MOCK_USER = UserFactory.create()
-MOCK_REQUEST = RequestFactory.create(
+MOCK_USER = UserFactory.build()
+MOCK_REQUEST = RequestFactory.build(
     creator=MOCK_USER.id,
     body={
         "financial_verification": {

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -61,11 +61,9 @@ class TestPENumberInForm:
         assert response.status_code == 302
         assert "/requests/financial_verification_submitted" in response.headers.get("Location")
 
-    def test_submit_request_form_with_new_valid_pe_id(self, session, monkeypatch, client):
+    def test_submit_request_form_with_new_valid_pe_id(self, monkeypatch, client):
         self._set_monkeypatches(monkeypatch)
         pe = PENumberFactory.create(number="8675309U", description="sample PE number")
-        session.add(pe)
-        session.commit()
 
         data = dict(self.required_data)
         data['pe_id'] = pe.number


### PR DESCRIPTION
This sets a database session for every test factory so that each factory's `create` method will automatically commit the entry.