### PR TITLE
Remove SASS gem install (now using parcel)

### DIFF
--- a/script/setup
+++ b/script/setup
@@ -5,9 +5,6 @@
 
 source "$(dirname "${0}")"/../script/include/global_header.inc.sh
 
-# Turn on sass compiler installation
-INSTALL_SASS="true"
-
 # Enable database resetting
 RESET_DB="true"
 
@@ -17,4 +14,5 @@ source ./script/include/run_setup
 # Fetch and import the PE numbers
 run_command "python script/ingest_pe_numbers.py"
 
+# Compile assets and generate hash-named static files
 yarn build


### PR DESCRIPTION
This PR turns off the INSTALL_SASS option, so we do not bother installing the sass gem (we now use node-sass via parcel)