### PR TITLE
Add migrate db before server startup

### DIFF
--- a/script/uwsgi_server
+++ b/script/uwsgi_server
@@ -4,5 +4,8 @@
 
 source "$(dirname "${0}")"/../script/include/global_header.inc.sh
 
+# Before starting the server, apply any pending migrations to the DB
+migrate_db
+
 # Launch UWSGI
 run_command "uwsgi --ini ${UWSGI_CONFIG_FULLPATH}"


### PR DESCRIPTION
This PR adds a migrate step before launching the UWSGI server.
This ensures a fresh deploy properly updates the DB before starting the
server and accepting traffic