### PR TITLE
Add cac certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-language: python
-python: "3.6"
+language: minimal
 services:
   - docker
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ git:
     submodules: false
 env:
   global:
-    - TESTER_IMAGE_NAME=atst-tester
     - PROD_IMAGE_NAME=atst-prod
+    - TESTER_IMAGE1_NAME=atst-tester-nocrls
+    - TESTER_IMAGE2_NAME=atst-tester
 cache:
   directories:
     - crl
@@ -25,14 +26,15 @@ before_script:
   - export postgres_ip="$(docker inspect -f "{{ .NetworkSettings.IPAddress }}" postgres96)"
   - export redis_ip="$(docker inspect -f "{{ .NetworkSettings.IPAddress }}" redis)"
   - docker login -u $ATAT_DOCKER_REGISTRY_USERNAME -p $ATAT_DOCKER_REGISTRY_PASSWORD $ATAT_DOCKER_REGISTRY_URL
-  - docker build --tag "${TESTER_IMAGE_NAME}" --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" . -f deploy/docker/tester/Dockerfile
+  - docker build --tag "${TESTER_IMAGE1_NAME}" --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" . -f deploy/docker/tester/Dockerfile
 
 script:
-  - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
-  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE1_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
+  - docker commit current-atst-tester "${TESTER_IMAGE2_NAME}"
   - docker cp current-atst-tester:/opt/atat/atst/crl ./crl
   - docker container stop current-atst-tester
+  - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"
 
 before_deploy:
   - docker build --tag "${PROD_IMAGE_NAME}" . -f deploy/docker/prod/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ before_script:
 
 script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker container exec -t current-atst-tester script/sync-crls
+  - docker cp current-atst-tester:crl ./crl
+  - docker container stop current-atst-tester
 
 before_deploy:
   - docker build --tag "${PROD_IMAGE_NAME}" . -f deploy/docker/prod/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
   - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
-  - docker cp current-atst-tester:crl ./crl
+  - docker cp current-atst-tester:/opt/atat/atst/crl ./crl
   - docker container stop current-atst-tester
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
-  - docker run -d --entrypoint='/bin/sh' --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
   - docker cp current-atst-tester:crl ./crl
   - docker container stop current-atst-tester

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   global:
     - TESTER_IMAGE_NAME=atst-tester
     - PROD_IMAGE_NAME=atst-prod
+cache:
+  directories:
+    - crl
 
 before_install:
   # Use sed to replace the SSH URL with the public URL

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2b149e0d8c23814a2c701b53f5c75b36714a2ccd4e2a2769924ef6e2a3f09e97"
+            "sha256": "5fc8273838354406366b401529a6f512a73ac6a8ecea6699afa4ab7b4996bf13"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -316,7 +316,6 @@
                 "sha256:a68ac5e15e76e7e5dd2b8f94007233e01effe3e50e8daddf69acfd81cb686baf",
                 "sha256:b5725a0bd4ba422ab0e66e89e030c806576753ea3ee08554382c14e685d117b5"
             ],
-            "markers": "python_version >= '2.6' and python_version != '3.1.*' and python_version != '3.0.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version < '4'",
             "version": "==1.23"
         },
         "webassets": {
@@ -448,7 +447,6 @@
                 "sha256:0e9a1227a3a0f3297a485715e72ee6eb77081b17b629367042b586e38c03c867",
                 "sha256:b4840807a94a3bad0217d6ed3f9b65a1cc6e1db1c99e1184673056ae2c0a4c4d"
             ],
-            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version >= '2.7' and python_version != '3.0.*'",
             "version": "==0.8.17"
         },
         "flask": {
@@ -501,6 +499,7 @@
                 "sha256:b9c40e9750f3d77e6e4d441d8b0266cf555e7cdabdcff33c4fd06366ca761ef8",
                 "sha256:ec9ef8f4a9bc6f71eec99e1806bfa2de401650d996c59330782b89a5555c1497"
             ],
+            "markers": "python_version != '3.1.*' and python_version != '3.2.*' and python_version != '3.3.*' and python_version != '3.0.*' and python_version >= '2.7'",
             "version": "==4.3.4"
         },
         "itsdangerous": {
@@ -689,15 +688,11 @@
         },
         "pyyaml": {
             "hashes": [
-                "sha256:1cbc199009e78f92d9edf554be4fe40fb7b0bef71ba688602a00e97a51909110",
                 "sha256:254bf6fda2b7c651837acb2c718e213df29d531eebf00edb54743d10bcb694eb",
                 "sha256:3108529b78577327d15eec243f0ff348a0640b0c3478d67ad7f5648f93bac3e2",
                 "sha256:3c17fb92c8ba2f525e4b5f7941d850e7a48c3a59b32d331e2502a3cdc6648e76",
-                "sha256:6f89b5c95e93945b597776163403d47af72d243f366bf4622ff08bdfd1c950b7",
                 "sha256:8d6d96001aa7f0a6a4a95e8143225b5d06e41b1131044913fecb8f85a125714b",
-                "sha256:be622cc81696e24d0836ba71f6272a2b5767669b0d79fdcf0295d51ac2e156c8",
-                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b",
-                "sha256:f39411e380e2182ad33be039e8ee5770a5d9efe01a2bfb7ae58d9ba31c4a2a9d"
+                "sha256:c8a88edd93ee29ede719080b2be6cb2333dfee1dccba213b422a9c8e97f2967b"
             ],
             "version": "==4.2b4"
         },

--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -55,9 +55,9 @@ data:
         ssl_stapling_verify on;
         resolver 8.8.8.8 8.8.4.4;
         # Request and validate client certificate
-        #ssl_verify_client on;
-        #ssl_verify_depth 10;
-        #ssl_client_certificate /etc/nginx/ssl/ca/client-ca.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 10;
+        ssl_client_certificate /etc/nginx/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {

--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -57,7 +57,7 @@ data:
         # Request and validate client certificate
         ssl_verify_client on;
         ssl_verify_depth 10;
-        ssl_client_certificate /etc/nginx/ssl/client-ca-bundle.pem;
+        ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:e9b6f76
+          image: registry.atat.codes:443/atst-prod:2030b4d
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -47,6 +47,9 @@ spec:
           volumeMounts:
             - name: nginx-auth-tls
               mountPath: "/etc/ssl/private"
+            - name: nginx-client-ca-bundle
+              mountPath: "/etc/ssl/client-ca-bundle.pem"
+              subPath: client-ca-bundle.pem
             - name: nginx-config
               mountPath: "/etc/nginx/conf.d/atst.conf"
               subPath: atst.conf
@@ -78,6 +81,13 @@ spec:
             - key: tls.key
               path: auth.atat.key
               mode: 0640
+        - name: nginx-ca-bundle
+          secret:
+            secretName: nginx-client-ca-bundle
+            items:
+            - key: client-ca-bundle.pem
+              path: client-ca-bundle.pem
+              mode: 0666
         - name: nginx-config
           configMap:
             name: atst-nginx

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:2030b4d
+          image: registry.atat.codes:443/atst-prod:93b9317
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -32,6 +32,9 @@ spec:
             - name: atst-config
               mountPath: "/opt/atat/atst/atst-overrides.ini"
               subPath: atst-overrides.ini
+            - name: nginx-client-ca-bundle
+              mountPath: "/opt/atat/atst/ssl/server-certs/ca-chain.pem"
+              subPath: client-ca-bundle.pem
             - name: uwsgi-config
               mountPath: "/opt/atat/atst/uwsgi-config.ini"
               subPath: uwsgi-config.ini

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -81,7 +81,7 @@ spec:
             - key: tls.key
               path: auth.atat.key
               mode: 0640
-        - name: nginx-ca-bundle
+        - name: nginx-client-ca-bundle
           secret:
             secretName: nginx-client-ca-bundle
             items:

--- a/deploy/kubernetes/set_clientca_secret.sh
+++ b/deploy/kubernetes/set_clientca_secret.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n atat delete secret atst-config-ini
+kubectl -n atat create secret generic nginx-client-ca-bundle --from-file="${1}"

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -10,7 +10,7 @@ APP_USER="atst"
 APP_UID="8010"
 
 # Add additional packages required by app dependencies
-ADDITIONAL_PACKAGES="postgresql-libs python3 uwsgi uwsgi-python3"
+ADDITIONAL_PACKAGES="postgresql-libs python3 rsync uwsgi uwsgi-python3"
 
 # Run the shared alpine setup script
 source ./script/include/run_alpine_setup


### PR DESCRIPTION
This PR adds the files and configuration necessary for CAC auth.

- Switch to minimal Travis image since we do all Python things inside containers
- Fetched CRL files inside a running container, which is them saved to a new image
- Copuy CRL files to the Travis filesystem so the directory can be cached and reused
- Update nginx configuration to enable SSL client cert validation