### PR TITLE
Small request form fixes

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -146,3 +146,7 @@ class Requests(object):
         return request.status == "incomplete" and all(
             section in existing_request_sections for section in all_request_sections
         )
+
+    @classmethod
+    def is_pending_financial_verification(cls, request):
+        return request.status == RequestStatus.PENDING_FINANCIAL_VERIFICATION

--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -143,7 +143,7 @@ class Requests(object):
             "primary_poc",
         ]
         existing_request_sections = request.body.keys()
-        return request.status == "incomplete" and all(
+        return request.status == RequestStatus.STARTED and all(
             section in existing_request_sections for section in all_request_sections
         )
 

--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -1,5 +1,5 @@
 import pendulum
-from flask import render_template, g
+from flask import render_template, g, url_for
 
 from . import requests_bp
 from atst.domain.requests import Requests
@@ -9,6 +9,8 @@ def map_request(request):
     time_created = pendulum.instance(request.time_created)
     is_new = time_created.add(days=1) > pendulum.now()
     app_count = request.body.get("details_of_use", {}).get("num_software_systems", 0)
+    update_url = url_for('requests.requests_form_update', screen=1, request_id=request.id)
+    verify_url = url_for('requests.financial_verification', request_id=request.id)
 
     return {
         "order_id": request.id,
@@ -17,6 +19,7 @@ def map_request(request):
         "app_count": app_count,
         "date": time_created.format("M/DD/YYYY"),
         "full_name": request.creator.full_name,
+        "edit_link": verify_url if Requests.is_pending_financial_verification(request) else update_url
     }
 
 

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -76,7 +76,7 @@ class JEDIRequestFlow(object):
 
     @property
     def can_submit(self):
-        return self.request and self.request.status != "incomplete"
+        return self.request and Requests.should_allow_submission(self.request)
 
     @property
     def next_screen(self):

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -88,7 +88,7 @@
           {% for r in requests %}
           <tr>
             <th scope="row">
-              <a class='icon-link icon-link--large' href="{{ url_for('requests.requests_form_update', screen=1, request_id=r['order_id']) if r["status"] != "approved" else url_for('requests.financial_verification', request_id=r['order_id']) }}">{{ r['order_id'] }}</a>
+              <a class='icon-link icon-link--large' href="{{ r['edit_link'] }}">{{ r['order_id'] }}</a>
               {% if r['is_new'] %}<span class="usa-label">New</span>
             </th>
             {% endif %}

--- a/templates/requests/menu.html
+++ b/templates/requests/menu.html
@@ -1,13 +1,21 @@
 <div class="progress-menu progress-menu--four">
   <ul>
     {% for s in screens %}
-    <li class="progress-menu__item">
-      <a href="{{ url_for('requests.requests_form_update', screen=loop.index, request_id=request_id) if request_id else url_for('requests.requests_form_new', screen=loop.index) }}"
-        {% if g.matchesPath('/requests/new/{{ loop.index + 1 }}') %}class="active"{% endif %}
-      >
-        {{ s['title'] }}
-      </a>
-    </li>
+      {% if loop.index < current %}
+        {% set step_indicator = 'complete' %}
+      {% elif loop.index == current %}
+        {% set step_indicator = 'active' %}
+      {% else %}
+        {% set step_indicator = 'incomplete' %}
+      {% endif %}
+
+      <li class="progress-menu__item progress-menu__item--{{ step_indicator }}">
+        <a href="{{ url_for('requests.requests_form_update', screen=loop.index, request_id=request_id) if request_id else url_for('requests.requests_form_new', screen=loop.index) }}"
+          {% if g.matchesPath('/requests/new/{{ loop.index + 1 }}') %}class="active"{% endif %}
+        >
+          {{ s['title'] }}
+        </a>
+      </li>
     {% endfor %}
   </ul>
 </div>

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -50,6 +50,13 @@ def test_dont_auto_approve_if_no_dollar_value_specified(new_request):
     assert request.status == RequestStatus.PENDING_CCPO_APPROVAL
 
 
+def test_should_allow_submission(new_request):
+    assert Requests.should_allow_submission(new_request)
+
+    del new_request.body['details_of_use']
+    assert not Requests.should_allow_submission(new_request)
+
+
 def test_exists(session):
     user_allowed = UserFactory.create()
     user_denied = UserFactory.create()


### PR DESCRIPTION
This PR fixes three things with the request form:

* link to the financial verification page from the requests index when the request is pending financial verification
* fix form submission from the review & submit page to disallow submission when fields were skipped
* hook up progress indicator styles to the form header:
![image](https://user-images.githubusercontent.com/40774582/43870218-7130b87c-9b44-11e8-8065-74b2f2fc1ff7.png)
