### PR TITLE
Require PE ID in financial verification form

### DIFF
--- a/atst/forms/fields.py
+++ b/atst/forms/fields.py
@@ -29,8 +29,10 @@ class NewlineListField(Field):
     widget = TextArea()
 
     def _value(self):
-        if self.data:
-            return "\n".join(self.data)
+        if isinstance(self.data, list):
+            return '\n'.join(self.data)
+        elif self.data:
+            return self.data
         else:
             return ""
 

--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -70,7 +70,7 @@ class FinancialForm(ValidatedForm):
         "Unique Item Identifier (UII)s related to your application(s) if you already have them."
     )
 
-    pe_id = StringField("Program Element (PE) Number related to your request")
+    pe_id = StringField("Program Element (PE) Number related to your request", validators=[Required()])
 
     treasury_code = StringField("Program Treasury Code")
 

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -25,10 +25,10 @@ def update_financial_verification(request_id):
 
     if form.validate():
         request_data = {"financial_verification": post_data}
-        Requests.update(request_id, request_data)
         valid = form.perform_extra_validation(
             existing_request.body.get("financial_verification")
         )
+        Requests.update(request_id, request_data)
         if valid:
             return redirect(url_for("requests.financial_verification_submitted"))
         else:

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -41,4 +41,4 @@ def update_financial_verification(request_id):
 
 @requests_bp.route("/requests/financial_verification_submitted")
 def financial_verification_submitted():
-    pass
+    return render_template("requests/financial_verification_submitted.html")

--- a/templates/requests/financial_verification_submitted.html
+++ b/templates/requests/financial_verification_submitted.html
@@ -1,4 +1,4 @@
-{% extends "../base.html.to" %}
+{% extends "base.html" %}
 
 {% block content %}
 
@@ -15,4 +15,4 @@
   </div>
 </div>
 
-{% end %}
+{% endblock %}

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -72,3 +72,14 @@ class TestPENumberInForm:
 
         assert response.status_code == 302
         assert "/requests/financial_verification_submitted" in response.headers.get("Location")
+
+    def test_submit_request_form_with_missing_pe_id(self, monkeypatch, client):
+        self._set_monkeypatches(monkeypatch)
+
+        data = dict(self.required_data)
+        data['pe_id'] = ''
+
+        response = self.submit_data(client, data)
+
+        assert "There were some errors, see below" in response.data.decode()
+        assert response.status_code == 200


### PR DESCRIPTION
Don't allow the user to submit the financial verification form without a PE id. This PR also fixes a route that wasn't migrated over during the monolith work properly.