### PR TITLE
Only display checkmark if form section is complete

### DIFF
--- a/atst/routes/requests/requests_form.py
+++ b/atst/routes/requests/requests_form.py
@@ -41,6 +41,7 @@ def requests_form_update(screen=1, request_id=None):
         current=screen,
         next_screen=screen + 1,
         request_id=request_id,
+        jedi_request=jedi_flow.request,
         can_submit=jedi_flow.can_submit,
     )
 

--- a/templates/requests/menu.html
+++ b/templates/requests/menu.html
@@ -1,7 +1,7 @@
 <div class="progress-menu progress-menu--four">
   <ul>
     {% for s in screens %}
-      {% if loop.index < current %}
+      {% if jedi_request and s.section in jedi_request.body %}
         {% set step_indicator = 'complete' %}
       {% elif loop.index == current %}
         {% set step_indicator = 'active' %}


### PR DESCRIPTION
Before:
![screen shot 2018-08-10 at 1 20 55 pm](https://user-images.githubusercontent.com/38955572/43971741-42fcb804-9ca0-11e8-8d48-1c1c8e802002.png)

After:
![screen shot 2018-08-10 at 1 20 22 pm](https://user-images.githubusercontent.com/38955572/43971712-2d041646-9ca0-11e8-8cd0-5350cc9708da.png)

Making a pretty stupid check in the template to see if a given request section is complete. After the request schema is solidified in the database we should be able to make a more elegant test.