### PR TITLE
Lint entire `atst` module

### DIFF
--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -1,7 +1,6 @@
 import re
 from wtforms.fields.html5 import EmailField
 from wtforms.fields import StringField, SelectField
-from wtforms.form import Form
 from wtforms.validators import Required, Email
 
 from atst.domain.exceptions import NotFoundError
@@ -41,7 +40,7 @@ def suggest_pe_id(pe_id):
 
 def validate_pe_id(field, existing_request):
     try:
-        pe_number = PENumbers.get(field.data)
+        PENumbers.get(field.data)
     except NotFoundError:
         suggestion = suggest_pe_id(field.data)
         error_str = (

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -2,7 +2,7 @@ from wtforms.fields import StringField
 from wtforms.fields.html5 import EmailField
 from wtforms.validators import Required, Email, Length
 from .forms import ValidatedForm
-from .validators import IsNumber, Alphabet
+from .validators import IsNumber
 
 
 class POCForm(ValidatedForm):

--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -1,10 +1,7 @@
 from wtforms.fields.html5 import IntegerField
-from wtforms.fields import RadioField, StringField, TextAreaField, SelectField
-from wtforms.validators import NumberRange, InputRequired
+from wtforms.fields import RadioField, TextAreaField, SelectField
 from .fields import DateField
 from .forms import ValidatedForm
-from .validators import DateRange
-import pendulum
 
 
 class RequestForm(ValidatedForm):

--- a/script/test
+++ b/script/test
@@ -10,7 +10,7 @@ export FLASK_ENV=test
 RESET_DB="true"
 
 # Define all relevant python files and directories for this app
-PYTHON_FILES="./app.py ./atst ./config"
+PYTHON_FILES="./app.py ./atst/** ./config"
 
 # Enable Python testing
 RUN_PYTHON_TESTS="true"


### PR DESCRIPTION
I realized that some linting errors weren't being picked up in `script/test`. Looks like pylint doesn't recurse by default, so I made a small change to `script/test`.

Also fixed the linting errors.