### PR TITLE
Add cac certs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ script:
   - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE1_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
   - docker commit current-atst-tester "${TESTER_IMAGE2_NAME}"
-  - docker cp current-atst-tester:/opt/atat/atst/crl ./crl
+  - docker cp current-atst-tester:/opt/atat/atst/crl/* ./crl/
   - docker container stop current-atst-tester
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 sudo: required
-language: python
-python: "3.6"
+language: minimal
 services:
   - docker
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,9 @@ git:
     submodules: false
 env:
   global:
-    - TESTER_IMAGE_NAME=atst-tester
     - PROD_IMAGE_NAME=atst-prod
+    - TESTER_IMAGE1_NAME=atst-tester-nocrls
+    - TESTER_IMAGE2_NAME=atst-tester
 cache:
   directories:
     - crl
@@ -25,14 +26,15 @@ before_script:
   - export postgres_ip="$(docker inspect -f "{{ .NetworkSettings.IPAddress }}" postgres96)"
   - export redis_ip="$(docker inspect -f "{{ .NetworkSettings.IPAddress }}" redis)"
   - docker login -u $ATAT_DOCKER_REGISTRY_USERNAME -p $ATAT_DOCKER_REGISTRY_PASSWORD $ATAT_DOCKER_REGISTRY_URL
-  - docker build --tag "${TESTER_IMAGE_NAME}" --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" . -f deploy/docker/tester/Dockerfile
+  - docker build --tag "${TESTER_IMAGE1_NAME}" --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" . -f deploy/docker/tester/Dockerfile
 
 script:
-  - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
-  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE1_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
+  - docker commit current-atst-tester "${TESTER_IMAGE2_NAME}"
   - docker cp current-atst-tester:/opt/atat/atst/crl ./crl
   - docker container stop current-atst-tester
+  - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"
 
 before_deploy:
   - docker build --tag "${PROD_IMAGE_NAME}" . -f deploy/docker/prod/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE1_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
   - docker commit current-atst-tester "${TESTER_IMAGE2_NAME}"
-  - docker cp current-atst-tester:/opt/atat/atst/crl/* ./crl/
+  - docker cp current-atst-tester:/opt/atat/atst/crl/. ./crl/
   - docker container stop current-atst-tester
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,10 @@ before_script:
 
 script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker container exec -t current-atst-tester script/sync-crls
+  - docker cp current-atst-tester:crl ./crl
+  - docker container stop current-atst-tester
 
 before_deploy:
   - docker build --tag "${PROD_IMAGE_NAME}" . -f deploy/docker/prod/Dockerfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_install:
   - git submodule update --init --recursive
 
 before_script:
+  - rm -rf ./crl/*
   - docker run -d --name postgres96 postgres:9.6-alpine
   - docker run -d --name redis redis:4.0.10-alpine
   - docker run --link postgres96:postgres96 --link redis:redis waisbrot/wait

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
   - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
-  - docker cp current-atst-tester:crl ./crl
+  - docker cp current-atst-tester:/opt/atat/atst/crl ./crl
   - docker container stop current-atst-tester
 
 before_deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,4 +49,4 @@ deploy:
   provider: script
   script: echo "** Image push only for now... stay tuned! **"
   on:
-    all_branches: true
+    branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
 
 script:
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE_NAME}"
-  - docker run -d --entrypoint='/bin/sh' --name current-atst-tester "${TESTER_IMAGE_NAME}"
+  - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
   - docker cp current-atst-tester:crl ./crl
   - docker container stop current-atst-tester

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ env:
   global:
     - TESTER_IMAGE_NAME=atst-tester
     - PROD_IMAGE_NAME=atst-prod
+cache:
+  directories:
+    - crl
 
 before_install:
   # Use sed to replace the SSH URL with the public URL

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,4 +48,4 @@ deploy:
   provider: script
   script: echo "** Image push only for now... stay tuned! **"
   on:
-    branch: master
+    all_branches: true

--- a/deploy/kubernetes/atst-debugger.yml
+++ b/deploy/kubernetes/atst-debugger.yml
@@ -1,0 +1,43 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: atst-debugger
+  namespace: atat
+spec:
+  securityContext:
+    fsGroup: 101
+  containers:
+    - name: atst-debugger
+      image: registry.atat.codes:443/atst-prod:a1916b1
+      args: ["/bin/bash", "-c", "while true; do date; sleep 45; done"]
+      envFrom:
+      - configMapRef:
+          name: atst-envvars
+      volumeMounts:
+        - name: atst-config
+          mountPath: "/opt/atat/atst/atst-overrides.ini"
+          subPath: atst-overrides.ini
+        - name: uwsgi-config
+          mountPath: "/opt/atat/atst/uwsgi-config.ini"
+          subPath: uwsgi-config.ini
+        - name: uwsgi-socket-dir
+          mountPath: "/var/run/uwsgi"
+  volumes:
+    - name: atst-config
+      secret:
+        secretName: atst-config-ini
+        items:
+        - key: atst-overrides.ini
+          path: atst-overrides.ini
+          mode: 0644
+    - name: uwsgi-config
+      configMap:
+        name: atst-config
+        items:
+        - key: uwsgi-config
+          path: uwsgi-config.ini
+          mode: 0644
+    - name: uwsgi-socket-dir
+      emptyDir:
+        medium: Memory
+  restartPolicy: Never

--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -55,9 +55,9 @@ data:
         ssl_stapling_verify on;
         resolver 8.8.8.8 8.8.4.4;
         # Request and validate client certificate
-        #ssl_verify_client on;
-        #ssl_verify_depth 10;
-        #ssl_client_certificate /etc/nginx/ssl/ca/client-ca.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 10;
+        ssl_client_certificate /etc/nginx/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {

--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -57,7 +57,7 @@ data:
         # Request and validate client certificate
         ssl_verify_client on;
         ssl_verify_depth 10;
-        ssl_client_certificate /etc/nginx/ssl/client-ca-bundle.pem;
+        ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:e9b6f76
+          image: registry.atat.codes:443/atst-prod:2030b4d
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -47,6 +47,9 @@ spec:
           volumeMounts:
             - name: nginx-auth-tls
               mountPath: "/etc/ssl/private"
+            - name: nginx-client-ca-bundle
+              mountPath: "/etc/ssl/client-ca-bundle.pem"
+              subPath: client-ca-bundle.pem
             - name: nginx-config
               mountPath: "/etc/nginx/conf.d/atst.conf"
               subPath: atst.conf
@@ -78,6 +81,13 @@ spec:
             - key: tls.key
               path: auth.atat.key
               mode: 0640
+        - name: nginx-ca-bundle
+          secret:
+            secretName: nginx-client-ca-bundle
+            items:
+            - key: client-ca-bundle.pem
+              path: client-ca-bundle.pem
+              mode: 0666
         - name: nginx-config
           configMap:
             name: atst-nginx

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:2030b4d
+          image: registry.atat.codes:443/atst-prod:93b9317
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:93b9317
+          image: registry.atat.codes:443/atst-prod:5ac3343
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -32,6 +32,9 @@ spec:
             - name: atst-config
               mountPath: "/opt/atat/atst/atst-overrides.ini"
               subPath: atst-overrides.ini
+            - name: nginx-client-ca-bundle
+              mountPath: "/opt/atat/atst/ssl/server-certs/ca-chain.pem"
+              subPath: client-ca-bundle.pem
             - name: uwsgi-config
               mountPath: "/opt/atat/atst/uwsgi-config.ini"
               subPath: uwsgi-config.ini

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -81,7 +81,7 @@ spec:
             - key: tls.key
               path: auth.atat.key
               mode: 0640
-        - name: nginx-ca-bundle
+        - name: nginx-client-ca-bundle
           secret:
             secretName: nginx-client-ca-bundle
             items:

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,10 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:5ac3343
+          image: registry.atat.codes:443/atst-prod:a1916b1
+          resources:
+            requests:
+               memory: "2500Mi"
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/set_clientca_secret.sh
+++ b/deploy/kubernetes/set_clientca_secret.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl -n atat delete secret atst-config-ini
+kubectl -n atat create secret generic nginx-client-ca-bundle --from-file="${1}"

--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -10,7 +10,7 @@ APP_USER="atst"
 APP_UID="8010"
 
 # Add additional packages required by app dependencies
-ADDITIONAL_PACKAGES="postgresql-libs python3 uwsgi uwsgi-python3"
+ADDITIONAL_PACKAGES="postgresql-libs python3 rsync uwsgi uwsgi-python3"
 
 # Run the shared alpine setup script
 source ./script/include/run_alpine_setup


### PR DESCRIPTION
This PR makes CAC auth work again!
Both containers get the CA bundle from an independently managed Kubernetes secret, and the ATST Travis build now includes updating the CRL files.

CRL next steps:
I would like to see if the CRL source supports If-Modified-Since, and update the sync script so that it will not rsync files smaller than 450 bytes. That way we should only be downloading updated CRL files, and we'll never overwrite an existing file with an empty one.