### PR TITLE
fix bug in request form review step, add more tests

### DIFF
--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -78,7 +78,7 @@ class JEDIRequestFlow(object):
         if self.request:
             if self.form_section == "review_submit":
                 data = self.request.body
-            if self.form_section == "information_about_you":
+            elif self.form_section == "information_about_you":
                 form_data = self.request.body.get(self.form_section, {})
                 data = { **self.map_user_data(self.request.creator), **form_data }
             else:

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -102,3 +102,13 @@ def test_non_creator_info_is_not_autopopulated(monkeypatch, client, user_session
     assert not user.first_name in body
     assert not user.last_name in body
     assert not user.email in body
+
+def test_can_review_data(user_session, client):
+    creator = UserFactory.create()
+    user_session(creator)
+    request = RequestFactory.create(creator=creator)
+    response = client.get("/requests/new/4/{}".format(request.id))
+    body = response.data.decode()
+    # assert a sampling of the request data is on the review page
+    assert request.body["primary_poc"]["fname_poc"] in body
+    assert request.body["information_about_you"]["email_request"] in body

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,5 +1,5 @@
 import pytest
-from tests.mocks import MOCK_USER
+from .factories import UserFactory
 from atst.routes.requests.jedi_request_flow import JEDIRequestFlow
 
 @pytest.fixture
@@ -7,40 +7,43 @@ def screens(app):
     return JEDIRequestFlow(3).screens
 
 
-@pytest.mark.skip()
-def test_stepthrough_request_form(monkeypatch, screens, client):
+def test_stepthrough_request_form(monkeypatch, user_session, screens, client):
+    user = UserFactory.create()
+    user_session(user)
+
     monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.get_current_user", lambda s: MOCK_USER
+        "atst.routes.requests.jedi_request_flow.JEDIRequestFlow.validate", lambda s: True
     )
-    monkeypatch.setattr(
-        "atst.handlers.request_new.RequestNew.check_xsrf_cookie", lambda s: True
-    )
-    monkeypatch.setattr(
-        "atst.handlers.request_new.JEDIRequestFlow.validate", lambda s: True
-    )
+
+    def post_form(url, redirects=False):
+         return client.post(
+            url,
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            data="meaning=42",
+            follow_redirects=redirects
+        )
+
 
     def take_a_step(inc, req=None):
         req_url = "/requests/new/{}".format(inc)
         if req:
             req_url += "/" + req
-        response = client.post(
-            req_url,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data="meaning=42",
-        )
-        return response
+        # we do it twice, with and without redirect, in order to get the
+        # destination url
+        prelim_resp = post_form(req_url)
+        response = post_form(req_url, True)
+        return (prelim_resp.headers.get("Location"), response)
 
     # GET the initial form
-    response = client.get("/requests/new")
+    response = client.get("/requests/new/1")
     assert screens[0]["title"] in response.data.decode()
 
     # POST to each of the form pages up until review and submit
     req_id = None
     for i in range(1, len(screens)):
-        resp = take_a_step(i, req=req_id)
-        __import__('ipdb').set_trace()
-        req_id = resp.effective_url.split("/")[-1]
+        effective_url, resp = take_a_step(i, req=req_id)
+        req_id = effective_url.split("/")[-1]
         screen_title = screens[i]["title"].replace("&", "&amp;")
 
-        assert "/requests/new/{}/{}".format(i + 1, req_id) in resp.effective_url
+        assert "/requests/new/{}/{}".format(i + 1, req_id) in effective_url
         assert screen_title in resp.data.decode()

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,37 +1,38 @@
 import pytest
-from .factories import UserFactory
+from urllib.parse import urlencode
+from .factories import UserFactory, RequestFactory
+
 from atst.routes.requests.jedi_request_flow import JEDIRequestFlow
+from atst.models.request_status_event import RequestStatus
+from atst.domain.requests import Requests
+
 
 @pytest.fixture
 def screens(app):
     return JEDIRequestFlow(3).screens
 
 
-def test_stepthrough_request_form(monkeypatch, user_session, screens, client):
+def test_stepthrough_request_form(user_session, screens, client):
     user = UserFactory.create()
     user_session(user)
+    mock_request = RequestFactory.stub()
 
-    monkeypatch.setattr(
-        "atst.routes.requests.jedi_request_flow.JEDIRequestFlow.validate", lambda s: True
-    )
-
-    def post_form(url, redirects=False):
-         return client.post(
+    def post_form(url, redirects=False, data=""):
+        return client.post(
             url,
             headers={"Content-Type": "application/x-www-form-urlencoded"},
-            data="meaning=42",
-            follow_redirects=redirects
+            data=data,
+            follow_redirects=redirects,
         )
 
-
-    def take_a_step(inc, req=None):
+    def take_a_step(inc, req=None, data=None):
         req_url = "/requests/new/{}".format(inc)
         if req:
             req_url += "/" + req
         # we do it twice, with and without redirect, in order to get the
         # destination url
-        prelim_resp = post_form(req_url)
-        response = post_form(req_url, True)
+        prelim_resp = post_form(req_url, data=data)
+        response = post_form(req_url, True, data=data)
         return (prelim_resp.headers.get("Location"), response)
 
     # GET the initial form
@@ -41,9 +42,26 @@ def test_stepthrough_request_form(monkeypatch, user_session, screens, client):
     # POST to each of the form pages up until review and submit
     req_id = None
     for i in range(1, len(screens)):
-        effective_url, resp = take_a_step(i, req=req_id)
+        # get appropriate form data to POST for this section
+        section = screens[i - 1]["section"]
+        post_data = urlencode(mock_request.body[section])
+
+        effective_url, resp = take_a_step(i, req=req_id, data=post_data)
         req_id = effective_url.split("/")[-1]
         screen_title = screens[i]["title"].replace("&", "&amp;")
 
         assert "/requests/new/{}/{}".format(i + 1, req_id) in effective_url
         assert screen_title in resp.data.decode()
+
+    # at this point, the real request we made and the mock_request bodies
+    # should be equivalent
+    assert Requests.get(req_id).body == mock_request.body
+
+    # finish the review and submit step
+    client.post(
+        "/requests/submit/{}".format(req_id),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+
+    finished_request = Requests.get(req_id)
+    assert finished_request.status == RequestStatus.PENDING_CCPO_APPROVAL


### PR DESCRIPTION
This fixes a bug I introduced in the request form review step: a missing `elif` in the JEDIRequestFlow object meant that the review and submit data was not being populated. This PR fixes that bug and adds a couple tests, including an end-to-end step-through of the request form.