### PR TITLE
Details of use form

### DIFF
--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -1,6 +1,6 @@
 from wtforms.fields.html5 import IntegerField
 from wtforms.fields import RadioField, TextAreaField, SelectField
-from wtforms.validators import Optional
+from wtforms.validators import Optional, Required
 from .fields import DateField
 from .forms import ValidatedForm
 
@@ -19,6 +19,15 @@ class RequestForm(ValidatedForm):
             if self.technical_support_team.data == 'no':
                 self.organization_providing_assistance.validators.append(Optional())
             self.cloud_native.validators.append(Optional())
+
+        try:
+            annual_spend = int(self.estimated_monthly_spend.data or 0) * 12
+        except ValueError:
+            annual_spend = 0
+
+        if annual_spend > 1_000_000:
+            self.number_user_sessions.validators.append(Required())
+            self.average_daily_traffic.validators.append(Required())
 
         return super(RequestForm, self).validate(*args, **kwargs)
 

--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -1,8 +1,10 @@
 from wtforms.fields.html5 import IntegerField
 from wtforms.fields import RadioField, TextAreaField, SelectField
 from wtforms.validators import Optional, Required
+
 from .fields import DateField
 from .forms import ValidatedForm
+from atst.domain.requests import Requests
 
 
 class RequestForm(ValidatedForm):
@@ -25,7 +27,7 @@ class RequestForm(ValidatedForm):
         except ValueError:
             annual_spend = 0
 
-        if annual_spend > 1_000_000:
+        if annual_spend > Requests.AUTO_APPROVE_THRESHOLD:
             self.number_user_sessions.validators.append(Required())
             self.average_daily_traffic.validators.append(Required())
 

--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -1,10 +1,26 @@
 from wtforms.fields.html5 import IntegerField
 from wtforms.fields import RadioField, TextAreaField, SelectField
+from wtforms.validators import Optional
 from .fields import DateField
 from .forms import ValidatedForm
 
 
 class RequestForm(ValidatedForm):
+
+    def validate(self, *args, **kwargs):
+        if self.jedi_migration.data == 'no':
+            self.rationalization_software_systems.validators.append(Optional())
+            self.technical_support_team.validators.append(Optional())
+            self.organization_providing_assistance.validators.append(Optional())
+            self.engineering_assessment.validators.append(Optional())
+            self.data_transfers.validators.append(Optional())
+            self.expected_completion_date.validators.append(Optional())
+        elif self.jedi_migration.data == 'yes':
+            if self.technical_support_team.data == 'no':
+                self.organization_providing_assistance.validators.append(Optional())
+            self.cloud_native.validators.append(Optional())
+
+        return super(RequestForm, self).validate(*args, **kwargs)
 
     # Details of Use: General
     dod_component = SelectField(

--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -37,16 +37,19 @@ class RequestForm(ValidatedForm):
     jedi_migration = RadioField(
         "Are you using the JEDI Cloud to migrate existing systems?",
         choices=[("yes", "Yes"), ("no", "No")],
+        default="",
     )
 
     rationalization_software_systems = RadioField(
         "Have you completed a “rationalization” of your software systems to move to the cloud?",
         choices=[("yes", "Yes"), ("no", "No"), ("in_progress", "In Progress")],
+        default="",
     )
 
     technical_support_team = RadioField(
         "Are you working with a technical support team experienced in cloud migrations?",
         choices=[("yes", "Yes"), ("no", "No")],
+        default="",
     )
 
     organization_providing_assistance = RadioField(  # this needs to be updated to use checkboxes instead of radio
@@ -56,11 +59,13 @@ class RequestForm(ValidatedForm):
             ("contractor", "Contractor"),
             ("other_dod_organization", "Other DoD organization"),
         ],
+        default="",
     )
 
     engineering_assessment = RadioField(
         "Have you completed an engineering assessment of your software systems for cloud readiness?",
         choices=[("yes", "Yes"), ("no", "No"), ("in_progress", "In Progress")],
+        default="",
     )
 
     data_transfers = SelectField(
@@ -94,6 +99,7 @@ class RequestForm(ValidatedForm):
     cloud_native = RadioField(
         "Are your software systems being developed cloud native?",
         choices=[("yes", "Yes"), ("no", "No")],
+        default="",
     )
 
     # Details of Use: Financial Usage

--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -37,6 +37,9 @@ export default {
       const monthlySpend = this.estimated_monthly_spend || 0
       return monthlySpend * 12
     },
+    jediMigrationOptionSelected: function () {
+      return this.jedi_migration !== ''
+    },
     isJediMigration: function () {
       return this.jedi_migration === 'yes'
     }

--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -17,8 +17,14 @@ export default {
   },
 
   data: function () {
+    const {
+      estimated_monthly_spend = 0,
+      jedi_migration = ''
+    } = this.initialData
+
     return {
-      jedi_migration: this.initialData.jedi_migration
+      estimated_monthly_spend,
+      jedi_migration
     }
   },
 
@@ -27,6 +33,10 @@ export default {
   },
 
   computed: {
+    annualSpend: function () {
+      const monthlySpend = this.estimated_monthly_spend || 0
+      return monthlySpend * 12
+    },
     isJediMigration: function () {
       return this.jedi_migration === 'yes'
     }

--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -1,3 +1,6 @@
+import createNumberMask from 'text-mask-addons/dist/createNumberMask'
+import { conformToMask } from 'vue-text-mask'
+
 import textinput from '../text_input'
 import optionsinput from '../options_input'
 
@@ -39,6 +42,9 @@ export default {
       const monthlySpend = this.estimated_monthly_spend || 0
       return monthlySpend * 12
     },
+    annualSpendStr: function () {
+      return this.formatDollars(this.annualSpend)
+    },
     jediMigrationOptionSelected: function () {
       return this.jedi_migration !== ''
     },
@@ -51,6 +57,10 @@ export default {
   },
 
   methods: {
+    formatDollars: function (intValue) {
+      const mask = createNumberMask({ prefix: '$', allowDecimal: true })
+      return conformToMask(intValue.toString(), mask).conformedValue
+    },
     handleFieldChange: function (event) {
       const { value, name } = event
       if (typeof this[name] !== undefined) {

--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -1,0 +1,43 @@
+import textinput from '../text_input'
+import optionsinput from '../options_input'
+
+export default {
+  name: 'details-of-use',
+
+  components: {
+    textinput,
+    optionsinput,
+  },
+
+  props: {
+    initialData: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+
+  data: function () {
+    return {
+      jedi_migration: this.initialData.jedi_migration
+    }
+  },
+
+  mounted: function () {
+    this.$root.$on('field-change', this.handleFieldChange)
+  },
+
+  computed: {
+    isJediMigration: function () {
+      return this.jedi_migration === 'yes'
+    }
+  },
+
+  methods: {
+    handleFieldChange: function (event) {
+      const { value, name } = event
+      if (typeof this[name] !== undefined) {
+        this[name] = value
+      }
+    },
+  }
+}

--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -19,12 +19,14 @@ export default {
   data: function () {
     const {
       estimated_monthly_spend = 0,
-      jedi_migration = ''
+      jedi_migration = '',
+      technical_support_team = ''
     } = this.initialData
 
     return {
       estimated_monthly_spend,
-      jedi_migration
+      jedi_migration,
+      technical_support_team
     }
   },
 
@@ -42,6 +44,9 @@ export default {
     },
     isJediMigration: function () {
       return this.jedi_migration === 'yes'
+    },
+    hasTechnicalSupportTeam: function () {
+      return this.technical_support_team === 'yes'
     }
   },
 

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -1,0 +1,16 @@
+export default {
+  name: 'optionsinput',
+
+  props: {
+    name: String
+  },
+
+  methods: {
+    onInput: function (e) {
+      this.$root.$emit('field-change', {
+        value: e.target.value,
+        name: this.name
+      })
+    }
+  }
+}

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -89,7 +89,7 @@ export default {
       this.showValid = valid
 
       // Emit a change event
-      this.$emit('fieldChange', {
+      this.$root.$emit('field-change', {
         value,
         valid,
         name: this.name

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -90,7 +90,7 @@ export default {
 
       // Emit a change event
       this.$root.$emit('field-change', {
-        value,
+        value: this._rawValue(value),
         valid,
         name: this.name
       })

--- a/js/index.js
+++ b/js/index.js
@@ -3,12 +3,14 @@ import Vue from 'vue/dist/vue'
 
 import optionsinput from './components/options_input'
 import textinput from './components/text_input'
+import DetailsOfUse from './components/forms/details_of_use'
 
 const app = new Vue({
   el: '#app-root',
   components: {
     optionsinput,
     textinput,
+    DetailsOfUse,
   },
   methods: {
     closeModal: function(name) {

--- a/js/index.js
+++ b/js/index.js
@@ -1,12 +1,14 @@
 import classes from '../styles/atat.scss'
 import Vue from 'vue/dist/vue'
 
+import optionsinput from './components/options_input'
 import textinput from './components/text_input'
 
 const app = new Vue({
   el: '#app-root',
   components: {
-    textinput
+    optionsinput,
+    textinput,
   },
   methods: {
     closeModal: function(name) {

--- a/js/index.js
+++ b/js/index.js
@@ -35,5 +35,6 @@ const app = new Vue({
       const modal = modalOpen.getAttribute("data-modal");
       this.modals[modal] = true;
     }
-  }
+  },
+  delimiters: ['!{', '}']
 })

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -1,32 +1,33 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro OptionsInput(field, inline=False) -%}
-  <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
+  <optionsinput name='{{ field.name }}' inline-template>
+    <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
 
-    <fieldset class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
-      <legend>
-        {{ field.label | striptags}}
+      <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
+        <legend>
+          {{ field.label | striptags}}
 
-        {% if field.description %}
-          <span class='usa-input__help'>{{ field.description | safe }}</span>
-        {% endif %}
+          {% if field.description %}
+            <span class='usa-input__help'>{{ field.description | safe }}</span>
+          {% endif %}
+
+          {% if field.errors %}
+            {{ Icon('alert') }}
+          {% endif %}
+        </legend>
+
+        {{ field() }}
 
         {% if field.errors %}
-          {{ Icon('alert') }}
+          {% for error in field.errors %}
+            <span class='usa-input__message'>{{ error }}</span>
+          {% endfor %}
         {% endif %}
-      </legend>
 
-      {{ field() }}
+      </fieldset>
+    </div>
 
-      {% if field.errors %}
-        {% for error in field.errors %}
-          <span class='usa-input__message'>{{ error }}</span>
-        {% endfor %}
-      {% endif %}
-
-    </fieldset>
-  </div>
-
-
+  </optionsinput>
 
 {%- endmacro %}

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro OptionsInput(field, inline=False) -%}
-  <optionsinput name='{{ field.name }}' inline-template>
+  <optionsinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
     <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
 
       <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -6,6 +6,7 @@
     validation='{{ validation }}'
     {% if field.data %}initial-value='{{ field.data }}'{% endif %}
     {% if field.errors %}v-bind:initial-errors='{{ field.errors }}'{% endif %}
+    key='{{ field.name }}'
     inline-template>
 
     <div

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -17,7 +17,7 @@
   ) }}
 {% endif %}
 
-<details-of-use inline-template v-bind:initial-data='{{ f.data }}'>
+<details-of-use inline-template v-bind:initial-data='{{ f.data|tojson }}'>
   <div>
 
     <p>We’d like to know a little about how you plan to use JEDI Cloud services to process your request. Please answer the following questions to the best of your ability. Note that the CCPO does not directly help with migrating systems to JEDI Cloud. These questions are for learning about your cloud readiness and financial usage of the JEDI Cloud; your estimates will not be used for any department level reporting.</p>
@@ -30,14 +30,18 @@
     <h2>Cloud Readiness</h2>
     {{ TextInput(f.num_software_systems, validation='integer') }}
     {{ OptionsInput(f.jedi_migration) }}
-    <template v-if='isJediMigration' v-cloak>
-      {{ OptionsInput(f.rationalization_software_systems) }}
-      {{ OptionsInput(f.technical_support_team) }}
-      {{ OptionsInput(f.organization_providing_assistance) }}
-      {{ OptionsInput(f.engineering_assessment) }}
-      {{ OptionsInput(f.data_transfers) }}
-      {{ OptionsInput(f.expected_completion_date) }}
-      {{ OptionsInput(f.cloud_native) }}
+    <template v-if="jediMigrationOptionSelected">
+      <template v-if='isJediMigration' v-cloak>
+        {{ OptionsInput(f.rationalization_software_systems) }}
+        {{ OptionsInput(f.technical_support_team) }}
+        {{ OptionsInput(f.organization_providing_assistance) }}
+        {{ OptionsInput(f.engineering_assessment) }}
+        {{ OptionsInput(f.data_transfers) }}
+        {{ OptionsInput(f.expected_completion_date) }}
+      </template>
+      <template v-else-if='!isJediMigration' v-cloak>
+        {{ OptionsInput(f.cloud_native) }}
+      </template>
     </template>
 
     <h2>Financial Usage</h2>

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -42,7 +42,7 @@
 
     <h2>Financial Usage</h2>
     {{ TextInput(f.estimated_monthly_spend, validation='dollars') }}
-    <p>So this means you are spending approximately <b>$X</b> annually</p>
+    <p>So this means you are spending approximately <b>$!{ annualSpend }</b> annually</p>
     {{ TextInput(f.dollar_value, validation='dollars') }}
     {{ TextInput(f.number_user_sessions, validation='integer') }}
     {{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -34,7 +34,9 @@
       <template v-if='isJediMigration' v-cloak>
         {{ OptionsInput(f.rationalization_software_systems) }}
         {{ OptionsInput(f.technical_support_team) }}
-        {{ OptionsInput(f.organization_providing_assistance) }}
+        <template v-if="hasTechnicalSupportTeam">
+          {{ OptionsInput(f.organization_providing_assistance) }}
+        </template>
         {{ OptionsInput(f.engineering_assessment) }}
         {{ OptionsInput(f.data_transfers) }}
         {{ OptionsInput(f.expected_completion_date) }}

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -50,8 +50,10 @@
     {{ TextInput(f.estimated_monthly_spend, validation='dollars') }}
     <p>So this means you are spending approximately <b>!{ annualSpendStr }</b> annually</p>
     {{ TextInput(f.dollar_value, validation='dollars') }}
-    {{ TextInput(f.number_user_sessions, validation='integer') }}
-    {{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}
+    <template v-if="annualSpend > 1000000">
+      {{ TextInput(f.number_user_sessions, validation='integer') }}
+      {{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}
+    </template>
     {{ TextInput(f.start_date, validation='date', placeholder='MM / DD / YYYY') }}
 
   </div>

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -48,7 +48,7 @@
 
     <h2>Financial Usage</h2>
     {{ TextInput(f.estimated_monthly_spend, validation='dollars') }}
-    <p>So this means you are spending approximately <b>$!{ annualSpend }</b> annually</p>
+    <p>So this means you are spending approximately <b>!{ annualSpendStr }</b> annually</p>
     {{ TextInput(f.dollar_value, validation='dollars') }}
     {{ TextInput(f.number_user_sessions, validation='integer') }}
     {{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -17,32 +17,38 @@
   ) }}
 {% endif %}
 
+<details-of-use inline-template v-bind:initial-data='{{ f.data }}'>
+  <div>
 
-<p>We’d like to know a little about how you plan to use JEDI Cloud services to process your request. Please answer the following questions to the best of your ability. Note that the CCPO does not directly help with migrating systems to JEDI Cloud. These questions are for learning about your cloud readiness and financial usage of the JEDI Cloud; your estimates will not be used for any department level reporting.</p>
-<p><em>All fields are required, unless specified optional.</em></p>
+    <p>We’d like to know a little about how you plan to use JEDI Cloud services to process your request. Please answer the following questions to the best of your ability. Note that the CCPO does not directly help with migrating systems to JEDI Cloud. These questions are for learning about your cloud readiness and financial usage of the JEDI Cloud; your estimates will not be used for any department level reporting.</p>
+    <p><em>All fields are required, unless specified optional.</em></p>
 
-<h2>General</h2>
-{{ OptionsInput(f.dod_component) }}
-{{ TextInput(f.jedi_usage, paragraph=True, placeholder="e.g. We are migrating XYZ application to the cloud so that...") }}
+    <h2>General</h2>
+    {{ OptionsInput(f.dod_component) }}
+    {{ TextInput(f.jedi_usage, paragraph=True, placeholder="e.g. We are migrating XYZ application to the cloud so that...") }}
 
-<h2>Cloud Readiness</h2>
-{{ TextInput(f.num_software_systems, validation='integer') }}
-{{ OptionsInput(f.jedi_migration) }}
-{{ OptionsInput(f.rationalization_software_systems) }}
-{{ OptionsInput(f.technical_support_team) }}
-{{ OptionsInput(f.organization_providing_assistance) }}
-{{ OptionsInput(f.engineering_assessment) }}
-{{ OptionsInput(f.data_transfers) }}
-{{ OptionsInput(f.expected_completion_date) }}
-{{ OptionsInput(f.cloud_native) }}
+    <h2>Cloud Readiness</h2>
+    {{ TextInput(f.num_software_systems, validation='integer') }}
+    {{ OptionsInput(f.jedi_migration) }}
+    <template v-if='isJediMigration' v-cloak>
+      {{ OptionsInput(f.rationalization_software_systems) }}
+      {{ OptionsInput(f.technical_support_team) }}
+      {{ OptionsInput(f.organization_providing_assistance) }}
+      {{ OptionsInput(f.engineering_assessment) }}
+      {{ OptionsInput(f.data_transfers) }}
+      {{ OptionsInput(f.expected_completion_date) }}
+      {{ OptionsInput(f.cloud_native) }}
+    </template>
 
-<h2>Financial Usage</h2>
-{{ TextInput(f.estimated_monthly_spend, validation='dollars') }}
-<p>So this means you are spending approximately <b>$X</b> annually</p>
-{{ TextInput(f.dollar_value, validation='dollars') }}
-{{ TextInput(f.number_user_sessions, validation='integer') }}
-{{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}
-{{ TextInput(f.start_date, validation='date', placeholder='MM / DD / YYYY') }}
+    <h2>Financial Usage</h2>
+    {{ TextInput(f.estimated_monthly_spend, validation='dollars') }}
+    <p>So this means you are spending approximately <b>$X</b> annually</p>
+    {{ TextInput(f.dollar_value, validation='dollars') }}
+    {{ TextInput(f.number_user_sessions, validation='integer') }}
+    {{ TextInput(f.average_daily_traffic, placeholder='Gigabytes per day', validation='gigabytes') }}
+    {{ TextInput(f.start_date, validation='date', placeholder='MM / DD / YYYY') }}
 
+  </div>
+</details-of-use>
 
 {% endblock %}

--- a/tests/forms/test_request.py
+++ b/tests/forms/test_request.py
@@ -1,0 +1,63 @@
+import pytest
+
+from atst.forms.request import RequestForm
+
+
+class TestRequestForm:
+
+    form_data = {
+        'dod_component': 'us_air_force',
+        'jedi_usage': 'cloud-ify all the things',
+        'num_software_systems': '12',
+        'estimated_monthly_spend': '34',
+        'dollar_value': '42',
+        'number_user_sessions': '6',
+        'average_daily_traffic': '0',
+        'start_date': '12/12/2012',
+    }
+
+    def test_require_cloud_native_when_not_migrating(self):
+        extra_data = { 'jedi_migration': 'no' }
+        request_form = RequestForm(data={ **self.form_data, **extra_data })
+        assert not request_form.validate()
+        assert request_form.errors == { 'cloud_native': ['Not a valid choice'] }
+
+    def test_require_migration_questions_when_migrating(self):
+        extra_data = { 'jedi_migration': 'yes' }
+        request_form = RequestForm(data={ **self.form_data, **extra_data })
+        assert not request_form.validate()
+        assert request_form.errors == {
+            'rationalization_software_systems': ['Not a valid choice'],
+            'technical_support_team': ['Not a valid choice'],
+            'organization_providing_assistance': ['Not a valid choice'],
+            'engineering_assessment': ['Not a valid choice'],
+            'data_transfers': ['Not a valid choice'],
+            'expected_completion_date': ['Not a valid choice']
+        }
+
+    def test_require_organization_when_technical_support_team(self):
+        extra_data = {
+            'jedi_migration': 'yes',
+            'rationalization_software_systems': 'yes',
+            'technical_support_team': 'yes',
+            'engineering_assessment': 'yes',
+            'data_transfers': 'less_than_100gb',
+            'expected_completion_date': 'less_than_1_month'
+        }
+        request_form = RequestForm(data={ **self.form_data, **extra_data })
+        assert not request_form.validate()
+        assert request_form.errors == {
+            'organization_providing_assistance': ['Not a valid choice'],
+        }
+
+    def test_valid_form_data(self):
+        extra_data = {
+            'jedi_migration': 'yes',
+            'rationalization_software_systems': 'yes',
+            'technical_support_team': 'no',
+            'engineering_assessment': 'yes',
+            'data_transfers': 'less_than_100gb',
+            'expected_completion_date': 'less_than_1_month'
+        }
+        request_form = RequestForm(data={ **self.form_data, **extra_data })
+        assert request_form.validate()

--- a/tests/forms/test_request.py
+++ b/tests/forms/test_request.py
@@ -9,11 +9,20 @@ class TestRequestForm:
         'dod_component': 'us_air_force',
         'jedi_usage': 'cloud-ify all the things',
         'num_software_systems': '12',
-        'estimated_monthly_spend': '34',
+        'estimated_monthly_spend': '1000000',
         'dollar_value': '42',
         'number_user_sessions': '6',
         'average_daily_traffic': '0',
         'start_date': '12/12/2012',
+    }
+    migration_data = {
+        'jedi_migration': 'yes',
+        'rationalization_software_systems': 'yes',
+        'technical_support_team': 'yes',
+        'organization_providing_assistance': 'in_house_staff',
+        'engineering_assessment': 'yes',
+        'data_transfers': 'less_than_100gb',
+        'expected_completion_date': 'less_than_1_month'
     }
 
     def test_require_cloud_native_when_not_migrating(self):
@@ -36,28 +45,41 @@ class TestRequestForm:
         }
 
     def test_require_organization_when_technical_support_team(self):
-        extra_data = {
-            'jedi_migration': 'yes',
-            'rationalization_software_systems': 'yes',
-            'technical_support_team': 'yes',
-            'engineering_assessment': 'yes',
-            'data_transfers': 'less_than_100gb',
-            'expected_completion_date': 'less_than_1_month'
-        }
-        request_form = RequestForm(data={ **self.form_data, **extra_data })
+        data = { **self.form_data, **self.migration_data }
+        del data['organization_providing_assistance']
+
+        request_form = RequestForm(data=data)
         assert not request_form.validate()
         assert request_form.errors == {
             'organization_providing_assistance': ['Not a valid choice'],
         }
 
     def test_valid_form_data(self):
-        extra_data = {
-            'jedi_migration': 'yes',
-            'rationalization_software_systems': 'yes',
-            'technical_support_team': 'no',
-            'engineering_assessment': 'yes',
-            'data_transfers': 'less_than_100gb',
-            'expected_completion_date': 'less_than_1_month'
+        data = { **self.form_data, **self.migration_data }
+        data['technical_support_team'] = 'no'
+        del data['organization_providing_assistance']
+
+        request_form = RequestForm(data=data)
+        assert request_form.validate()
+
+    def test_sessions_required_for_large_projects(self):
+        data = { **self.form_data, **self.migration_data }
+        data['estimated_monthly_spend'] = '9999999'
+        del data['number_user_sessions']
+        del data['average_daily_traffic']
+
+        request_form = RequestForm(data=data)
+        assert not request_form.validate()
+        assert request_form.errors == {
+            'number_user_sessions': ['This field is required.'],
+            'average_daily_traffic': ['This field is required.'],
         }
-        request_form = RequestForm(data={ **self.form_data, **extra_data })
+
+    def test_sessions_not_required_invalid_monthly_spend(self):
+        data = { **self.form_data, **self.migration_data }
+        data['estimated_monthly_spend'] = 'foo'
+        del data['number_user_sessions']
+        del data['average_daily_traffic']
+
+        request_form = RequestForm(data=data)
         assert request_form.validate()


### PR DESCRIPTION
This PR handles toggling some of the JEDI migration-related questions on the Details of Use portion of the request form.

Some general notes:

* I added a new Vue component, `details-of-use`, to encapsulate the logic in the details of use form. If other forms require similar functionality, they can be made into to separate components.

* The entire form data is passed to the Vue form from the Flask form via the `initialData` property:

     <details-of-use inline-template v-bind:initial-data='{{ f.data|tojson }}'>

* The Vue form pulls out the pieces it needs to track in the `data` function -- otherwise, if a property is accessed, Vue complains that it was not defined.

* Text inputs and options inputs (this PR adds an `optioninput` Vue component, similar to the existing `textinput`) will emit _on the root element_ a `field-change` event when their field's value has changed (with the raw value of the field)

* The Vue form registers a handler for the `field-change` event _on the root element_ that updates the field's value on the form.

* The logic for showing/hiding fields is wrapped in a `computed` method on the form to simplify the template.


The functionality included in this pr:

  * if the user does not select an option for the JEDI migration question ("Are you using the JEDI Cloud to migrate existing systems?"), no other questions for the "cloud readiness" section are shown
  * if the user selects "no" to the migration question, they are shown the "cloud native" question.
  * if the user selects "yes" to the migration question, the other questions relating to the migration are shown.
  * if the user selects "yes" to the "are you working with a technical support team", the question regarding the type of support is shown.
  * the annual estimated cost is shown and updated as the user enters the monthly cost.
  * if the annual estimated cost is over one million dollars, the user is required to fill out the traffic/sessions questions.

This PR also updates the server side form to allow the hidden fields to be left blank, rather than requiring input each time.