### PR TITLE
Update copy on Technical Point of Contact form

### DIFF
--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -6,11 +6,11 @@ from .validators import IsNumber
 
 
 class POCForm(ValidatedForm):
-    fname_poc = StringField("POC First Name", validators=[Required()])
+    fname_poc = StringField("First Name", validators=[Required()])
 
-    lname_poc = StringField("POC Last Name", validators=[Required()])
+    lname_poc = StringField("Last Name", validators=[Required()])
 
-    email_poc = EmailField("POC Email Address", validators=[Required(), Email()])
+    email_poc = EmailField("Email Address", validators=[Required(), Email()])
 
     dodid_poc = StringField(
         "DOD ID", validators=[Required(), Length(min=10), IsNumber()]

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -120,7 +120,7 @@ class JEDIRequestFlow(object):
                 "show": True,
             },
             {
-                "title": "Primary Point of Contact",
+                "title": "Workspace Owner",
                 "section": "primary_poc",
                 "form": POCForm,
                 "show": True,

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -4,7 +4,7 @@
 {% from "components/text_input.html" import TextInput %}
 
 {% block subtitle %}
-<h2>Primary Government/Military <br> Point of Contact (POC)</h2>
+<h2>Designate a Workspace Owner</h2>
 {% endblock %}
 
 {% block form %}
@@ -16,17 +16,16 @@
   ) }}
 {% endif %}
 
-<p>Please designate a Primary Point of Contact that will be responsible for owning the workspace in the JEDI Cloud.</p>
-<p>The Point of Contact will become the primary owner of the <em>workspace</em> created to use the JEDI Cloud. As a workspace owner, this person will have the ability to:
+<p>The Workspace Owner is the primary point of contact and technical administrator of the JEDI Workspace and will have the following responsibilities:</p>
   <ul>
-    <li>Create multiple application stacks and environments in the workspace to access the commercial cloud service provider portal</li>
-    <li>Add and manage users in the workspace</li>
-    <li>View the budget and billing history related to this workspace</li>
-    <li>Manage access to the Cloud Service Provider's Console</li>
-    <li>Transfer Workspace ownership to another person</li>
+    <li>Organize your cloud-hosted systems into projects and environments</li>
+    <li>Add users to this workspace and manage members</li>
+    <li>Manage access to the JEDI Cloud service provider’s portal</li>
   </ul>
-  <em>This POC may be you.</em>
 </p>
+
+<p>This person must be a DoD employee (not a contractor).</p>
+<p>The Workspace Owner may be you. You will be able to add other administrators later. This person will be invited via email once your request is approved.</p>
 
 {{ TextInput(f.fname_poc,placeholder='First Name') }}
 {{ TextInput(f.lname_poc,placeholder='Last Name') }}


### PR DESCRIPTION
Updates the copy on the "Technical Point of Contact" form, henceforth known as the "Workspace Owner":

![image](https://user-images.githubusercontent.com/40774582/44054078-99ffaabe-9f0f-11e8-8ed4-2165b8eaa304.png)

I've left the section of the stored form unchanged for backwards compatibility, so it'll still be `primary_poc` in the form data.