### PR TITLE
CCPO should not see request status alerts

### DIFF
--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -39,8 +39,8 @@ def requests_index():
 
     mapped_requests = [map_request(r) for r in requests]
 
-    pending_fv = any(Requests.is_pending_financial_verification(r) for r in requests) and not is_ccpo
-    pending_ccpo = any(Requests.is_pending_ccpo_approval(r) for r in requests) and not is_ccpo
+    pending_fv = not is_ccpo and any(Requests.is_pending_financial_verification(r) for r in requests)
+    pending_ccpo = not is_ccpo and any(Requests.is_pending_ccpo_approval(r) for r in requests)
 
     return render_template(
         "requests.html",


### PR DESCRIPTION
Very small PR related to these two PT stories:

- https://www.pivotaltracker.com/story/show/159014770
- https://www.pivotaltracker.com/story/show/159007546

I realized that the CCPO should not see the status alerts on the requests index page. Those are for the PSO/MO who created the request.

CCPO view:

<img width="1385" alt="screen shot 2018-08-14 at 10 33 48 am" src="https://user-images.githubusercontent.com/38955503/44098227-9b79e6e0-9fad-11e8-89be-9eede1468968.png">

Other view:

<img width="1387" alt="screen shot 2018-08-14 at 10 33 27 am" src="https://user-images.githubusercontent.com/38955503/44098230-9cc9cbdc-9fad-11e8-974d-d01f1a2b7ce9.png">
