### PR TITLE
add field to request factory

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -75,6 +75,7 @@ class RequestFactory(factory.alchemy.SQLAlchemyModelFactory):
                 "engineering_assessment": "yes",
                 "technical_support_team": "yes",
                 "estimated_monthly_spend": 100,
+                "average_daily_traffic_gb": 4,
                 "expected_completion_date": "less_than_1_month",
                 "rationalization_software_systems": "yes",
                 "organization_providing_assistance": "in_house_staff"


### PR DESCRIPTION
This fixes the broken test on master.

The integration test is a little brittle and I'm of two minds about it. We have to keep the request factory in-sync with the actual form fields being used in the JSONB column for it to pass. On the one hand, the request form breaks a lot and I think a really specific integration test helps us catch breaking changes and keeps us honest. On the other hand, keeping it up-to-date is a bit of a pain. 🤷‍♂️ 