### PR TITLE
Requests index view 159274521

### DIFF
--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -10,6 +10,7 @@ def map_request(request):
     time_created = pendulum.instance(request.time_created)
     is_new = time_created.add(days=1) > pendulum.now()
     app_count = request.body.get("details_of_use", {}).get("num_software_systems", 0)
+    annual_usage = request.body.get("details_of_use", {}).get("dollar_value", 0)
     update_url = url_for(
         "requests.requests_form_update", screen=1, request_id=request.id
     )
@@ -22,6 +23,7 @@ def map_request(request):
         "app_count": app_count,
         "date": time_created.format("M/DD/YYYY"),
         "full_name": request.creator.full_name,
+        "annual_usage": annual_usage,
         "edit_link": verify_url if Requests.is_pending_financial_verification(
             request
         ) else update_url,
@@ -47,4 +49,5 @@ def requests_index():
         requests=mapped_requests,
         pending_financial_verification=pending_fv,
         pending_ccpo_approval=pending_ccpo,
+        extended_view=is_ccpo
     )

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -101,7 +101,6 @@
             {% endif %}
             <th scope="col">Projected Annual Usage ($)</th>
             <th scope="col">Request Status</th>
-            <th scope="col" class="table-cell--shrink">Actions</th>
           </tr>
         </thead>
         <tbody>
@@ -119,9 +118,6 @@
             {% endif %}
             <td>${{ r['annual_usage'] }}</td>
             <td>{{ r['status'] }}</td>
-            <td class="table-cell--shrink">
-              <a href="/request/approval" class='icon-link'>Approval</a>
-            </td>
           </tr>
           {% endfor %}
         </tbody>

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -65,25 +65,27 @@
 
   <div class="col col--grow">
 
-    <form class='search-bar'>
-      <div class='usa-input search-input'>
-        <label for='requests-search'>Search requests by Order ID</label>
-        <input type='search' id='requests-search' name='requests-search' placeholder="Search by Order ID"/>
-        <button type="submit">
-          <span class="hide">Search</span>
-        </button>
-      </div>
+    {% if extended_view %}
+      <form class='search-bar'>
+        <div class='usa-input search-input'>
+          <label for='requests-search'>Search requests by Order ID</label>
+          <input type='search' id='requests-search' name='requests-search' placeholder="Search by Order ID"/>
+          <button type="submit">
+            <span class="hide">Search</span>
+          </button>
+        </div>
 
-      <div class='usa-input'>
-        <label for='filter-status'>Filter requests by status</label>
-        <select id="filter-status" name="filter-status">
-          <option value="" selected disabled>Filter by status</option>
-          <option value="">Active</option>
-          <option value="">Pending</option>
-          <option value="">Denied</option>
-        </select>
-      </div>
-    </form>
+        <div class='usa-input'>
+          <label for='filter-status'>Filter requests by status</label>
+          <select id="filter-status" name="filter-status">
+            <option value="" selected disabled>Filter by status</option>
+            <option value="">Active</option>
+            <option value="">Pending</option>
+            <option value="">Denied</option>
+          </select>
+        </div>
+      </form>
+    {% endif %}
 
     <div class='responsive-table-wrapper'>
       <table>
@@ -91,8 +93,12 @@
           <tr>
             <th scope="col">Order ID</th>
             <th scope="col">Request Date</th>
-            <th scope="col">Requester</th>
-            <th scope="col">Total Apps</th>
+            {% if extended_view %}
+              <th scope="col">Requester</th>
+              <th scope="col">Total Apps</th>
+            {% else %}
+              <th scope="col">Annual Usage</th>
+            {% endif %}
             <th scope="col">Status</th>
             <th scope="col" class="table-cell--shrink">Actions</th>
           </tr>
@@ -106,8 +112,12 @@
             </th>
             {% endif %}
             <td>{{ r['date'] }}</td>
-            <td>{{ r['full_name'] }}</td>
-            <td>{{ r['app_count'] }}</td>
+            {% if extended_view %}
+              <td>{{ r['full_name'] }}</td>
+              <td>{{ r['app_count'] }}</td>
+            {% else %}
+              <td>{{ r['annual_usage'] }}</td>
+            {% endif %}
             <td>{{ r['status'] }}</td>
             <td class="table-cell--shrink">
               <a href="" class='icon-link'>Download</a>

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -48,20 +48,22 @@
 
   {% endif %}
 
-  <div class="row kpi">
-    <div class="kpi__item col col--grow">
-      <div class="kpi__item__value">3</div>
-      <div class="kpi__item__description">Pending Requests</div>
+  {% if extended_view %}
+    <div class="row kpi">
+      <div class="kpi__item col col--grow">
+        <div class="kpi__item__value">3</div>
+        <div class="kpi__item__description">Pending Requests</div>
+      </div>
+      <div class="kpi__item col col--grow">
+        <div class="kpi__item__value">2,456</div>
+        <div class="kpi__item__description">Completed Requests This Year</div>
+      </div>
+      <div class="kpi__item col col--grow">
+        <div class="kpi__item__value">234</div>
+        <div class="kpi__item__description">Denied Requests</div>
+      </div>
     </div>
-    <div class="kpi__item col col--grow">
-      <div class="kpi__item__value">2,456</div>
-      <div class="kpi__item__description">Completed Requests This Year</div>
-    </div>
-    <div class="kpi__item col col--grow">
-      <div class="kpi__item__value">234</div>
-      <div class="kpi__item__description">Denied Requests</div>
-    </div>
-  </div>
+  {% endif %}
 
   <div class="col col--grow">
 
@@ -91,15 +93,14 @@
       <table>
         <thead>
           <tr>
-            <th scope="col">Order ID</th>
-            <th scope="col">Request Date</th>
+            <th scope="col">JEDI Cloud Request ID</th>
+            <th scope="col">Date Request Initiated / Created</th>
             {% if extended_view %}
               <th scope="col">Requester</th>
-              <th scope="col">Total Apps</th>
-            {% else %}
-              <th scope="col">Annual Usage</th>
+              <th scope="col">Reason Flagged</th>
             {% endif %}
-            <th scope="col">Status</th>
+            <th scope="col">Projected Annual Usage ($)</th>
+            <th scope="col">Request Status</th>
             <th scope="col" class="table-cell--shrink">Actions</th>
           </tr>
         </thead>
@@ -114,13 +115,11 @@
             <td>{{ r['date'] }}</td>
             {% if extended_view %}
               <td>{{ r['full_name'] }}</td>
-              <td>{{ r['app_count'] }}</td>
-            {% else %}
-              <td>{{ r['annual_usage'] }}</td>
+              <td></td>
             {% endif %}
+            <td>${{ r['annual_usage'] }}</td>
             <td>{{ r['status'] }}</td>
             <td class="table-cell--shrink">
-              <a href="" class='icon-link'>Download</a>
               <a href="/request/approval" class='icon-link'>Approval</a>
             </td>
           </tr>


### PR DESCRIPTION
Relates to [this](https://www.pivotaltracker.com/story/show/159274521) PT story. 

This adjusts the requests index view depending on whether the user is a CCPO or PSO/MO. (Screenshots [here](https://www.pivotaltracker.com/story/show/159274521/comments/193023582)).

A PSO/MO should see the following columns:

- JEDI Cloud Request ID
- Date request initiated / created
- Projected Annual Usage ($) 
- Request Status
- Actions

A CCPO should see:

- the KPI counts
- the search and filter bars
- additional "requester" and "reason flagged" request columns (the latter will be iterated on and implemented later, per https://www.pivotaltracker.com/story/show/159274521/comments/193021706)
