### PR TITLE
fix border and text color in hover/focused

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -79,7 +79,7 @@
       margin-left: $gap;
     }
   }
-  
+
   .usa-input__title {
     display: flex;
     align-items: center;
@@ -90,7 +90,7 @@
       margin-left: $gap/2;
     }
   }
-  
+
   .usa-input__help {
     @include h4;
     font-weight: normal;
@@ -111,8 +111,8 @@
 
     &:hover,
     &:focus {
-      border-color: $color-blue;
-      color: $color-blue;
+      border-color: $color-blue !important;
+      color: $color-blue-darker;
       box-shadow: inset 0 0 0 1px $color-blue;
       &::placeholder {
         color: $color-blue;


### PR DESCRIPTION
When a field is focused or hovered, the active blue color will override success or error states, preventing a weird combination of borders.

![screen shot 2018-08-14 at 11 43 26 am](https://user-images.githubusercontent.com/40467269/44102283-534df744-9fb7-11e8-99b2-954f7736bbe1.png)
![screen shot 2018-08-14 at 11 43 43 am](https://user-images.githubusercontent.com/40467269/44102285-54588d16-9fb7-11e8-8c21-4b025b30cf1a.png)
