### PR TITLE
Designate technical poc 159495040

### DIFF
--- a/atst/forms/forms.py
+++ b/atst/forms/forms.py
@@ -6,3 +6,9 @@ class ValidatedForm(FlaskForm):
         """Performs any applicable extra validation. Must
         return True if the form is valid or False otherwise."""
         return True
+
+    @property
+    def data(self):
+        _data = super().data
+        _data.pop("csrf_token", None)
+        return _data

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -1,4 +1,4 @@
-from wtforms.fields import StringField, RadioField
+from wtforms.fields import StringField, BooleanField
 from wtforms.fields.html5 import EmailField
 from wtforms.validators import Required, Email, Length, Optional
 from .forms import ValidatedForm
@@ -19,11 +19,10 @@ class POCForm(ValidatedForm):
         return super().validate(*args, **kwargs)
 
 
-    am_poc = RadioField(
+    am_poc = BooleanField(
         "I am the technical POC.",
-        choices=[("yes", "Yes"), ("no", "No")],
-        default="no",
         validators=[Required()],
+        default=False
     )
 
     fname_poc = StringField("POC First Name", validators=[Required()])

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -9,6 +9,8 @@ class POCForm(ValidatedForm):
 
     def validate(self, *args, **kwargs):
         if self.am_poc.data == "yes":
+            # Prepend Optional validators so that the validation chain
+            # halts if no data exists.
             self.fname_poc.validators.insert(0, Optional())
             self.lname_poc.validators.insert(0, Optional())
             self.email_poc.validators.insert(0, Optional())

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -8,7 +8,7 @@ from .validators import IsNumber
 class POCForm(ValidatedForm):
 
     def validate(self, *args, **kwargs):
-        if self.am_poc.data == "yes":
+        if self.am_poc.data:
             # Prepend Optional validators so that the validation chain
             # halts if no data exists.
             self.fname_poc.validators.insert(0, Optional())

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -21,8 +21,8 @@ class POCForm(ValidatedForm):
 
     am_poc = BooleanField(
         "I am the technical POC.",
-        validators=[Required()],
-        default=False
+        default=False,
+        false_values=(False, "false", "False", "no", "")
     )
 
     fname_poc = StringField("POC First Name", validators=[Required()])

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -1,16 +1,34 @@
-from wtforms.fields import StringField
+from wtforms.fields import StringField, RadioField
 from wtforms.fields.html5 import EmailField
-from wtforms.validators import Required, Email, Length
+from wtforms.validators import Required, Email, Length, Optional
 from .forms import ValidatedForm
 from .validators import IsNumber
 
 
 class POCForm(ValidatedForm):
-    fname_poc = StringField("First Name", validators=[Required()])
 
-    lname_poc = StringField("Last Name", validators=[Required()])
+    def validate(self, *args, **kwargs):
+        if self.am_poc.data == "yes":
+            self.fname_poc.validators.insert(0, Optional())
+            self.lname_poc.validators.insert(0, Optional())
+            self.email_poc.validators.insert(0, Optional())
+            self.dodid_poc.validators.insert(0, Optional())
 
-    email_poc = EmailField("Email Address", validators=[Required(), Email()])
+        return super(POCForm, self).validate(*args, **kwargs)
+
+
+    am_poc = RadioField(
+        "I am the technical POC.",
+        choices=[("yes", "Yes"), ("no", "No")],
+        default="no",
+        validators=[Required()],
+    )
+
+    fname_poc = StringField("POC First Name", validators=[Required()])
+
+    lname_poc = StringField("POC Last Name", validators=[Required()])
+
+    email_poc = EmailField("POC Email Address", validators=[Required(), Email()])
 
     dodid_poc = StringField(
         "DOD ID", validators=[Required(), Length(min=10), IsNumber()]

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -20,16 +20,16 @@ class POCForm(ValidatedForm):
 
 
     am_poc = BooleanField(
-        "I am the technical POC.",
+        "I am the Workspace Owner.",
         default=False,
         false_values=(False, "false", "False", "no", "")
     )
 
-    fname_poc = StringField("POC First Name", validators=[Required()])
+    fname_poc = StringField("First Name", validators=[Required()])
 
-    lname_poc = StringField("POC Last Name", validators=[Required()])
+    lname_poc = StringField("Last Name", validators=[Required()])
 
-    email_poc = EmailField("POC Email Address", validators=[Required(), Email()])
+    email_poc = EmailField("Email Address", validators=[Required(), Email()])
 
     dodid_poc = StringField(
         "DOD ID", validators=[Required(), Length(min=10), IsNumber()]

--- a/atst/forms/poc.py
+++ b/atst/forms/poc.py
@@ -16,7 +16,7 @@ class POCForm(ValidatedForm):
             self.email_poc.validators.insert(0, Optional())
             self.dodid_poc.validators.insert(0, Optional())
 
-        return super(POCForm, self).validate(*args, **kwargs)
+        return super().validate(*args, **kwargs)
 
 
     am_poc = RadioField(

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -122,9 +122,13 @@ class JEDIRequestFlow(object):
         ]
 
     def create_or_update_request(self):
-        request_data = {self.form_section: self.form.data}
         if self.request_id:
-            Requests.update(self.request_id, request_data)
+            self.update_request(self.form_section, self.form.data)
         else:
+            request_data = {self.form_section: self.form.data}
             request = Requests.create(self.current_user, request_data)
             self.request_id = request.id
+
+    def update_request(self, section, data):
+        request_data = {section: data}
+        Requests.update(self.request_id, request_data)

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -126,18 +126,13 @@ class JEDIRequestFlow(object):
             self.request_id = request.id
 
     def map_request_data(self, section, data):
-        user = (
-            self.existing_request.creator
-            if self.existing_request
-            else self.current_user
-        )
         if section == "primary_poc":
-            if data.get("am_poc"):
+            if data.get("am_poc", False):
                 data = {
                     **data,
-                    "dodid_poc": user.dod_id,
-                    "fname_poc": user.first_name,
-                    "lname_poc": user.last_name,
-                    "email_poc": user.email,
+                    "dodid_poc": self.current_user.dod_id,
+                    "fname_poc": self.current_user.first_name,
+                    "lname_poc": self.current_user.last_name,
+                    "email_poc": self.current_user.email,
                 }
         return {section: data}

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -132,7 +132,7 @@ class JEDIRequestFlow(object):
             else self.current_user
         )
         if section == "primary_poc":
-            if data.get("am_poc") == "yes":
+            if data.get("am_poc"):
                 data = {
                     **data,
                     "dodid_poc": user.dod_id,

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -133,6 +133,7 @@ class JEDIRequestFlow(object):
         if section == "primary_poc":
             if data.get("am_poc") == "yes":
                 data = {
+                    **data,
                     "dodid_poc": self.existing_request.creator.dod_id,
                     "fname_poc": self.existing_request.creator.first_name,
                     "lname_poc": self.existing_request.creator.last_name,

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -130,5 +130,14 @@ class JEDIRequestFlow(object):
             self.request_id = request.id
 
     def update_request(self, section, data):
+        if section == "primary_poc":
+            if data.get("am_poc") == "yes":
+                data = {
+                    "dodid_poc": self.existing_request.creator.dod_id,
+                    "fname_poc": self.existing_request.creator.first_name,
+                    "lname_poc": self.existing_request.creator.last_name,
+                    "email_poc": self.existing_request.creator.email
+                }
+
         request_data = {section: data}
         Requests.update(self.request_id, request_data)

--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -103,33 +103,21 @@ class JEDIRequestFlow(object):
                 "title": "Details of Use",
                 "section": "details_of_use",
                 "form": RequestForm,
-                "subitems": [
-                    {
-                        "title": "Overall request details",
-                        "id": "overall-request-details",
-                    },
-                    {"title": "Cloud Resources", "id": "cloud-resources"},
-                    {"title": "Support Staff", "id": "support-staff"},
-                ],
-                "show": True,
             },
             {
                 "title": "Information About You",
                 "section": "information_about_you",
                 "form": OrgForm,
-                "show": True,
             },
             {
                 "title": "Workspace Owner",
                 "section": "primary_poc",
                 "form": POCForm,
-                "show": True,
             },
             {
                 "title": "Review & Submit",
                 "section": "review_submit",
                 "form": ReviewForm,
-                "show": True,
             },
         ]
 

--- a/atst/routes/requests/requests_form.py
+++ b/atst/routes/requests/requests_form.py
@@ -64,35 +64,30 @@ def requests_update(screen=1, request_id=None):
         existing_request=existing_request,
     )
 
-    rerender_args = dict(
-        f=jedi_flow.form,
-        data=post_data,
-        screens=jedi_flow.screens,
-        current=screen,
-        next_screen=jedi_flow.next_screen,
-        request_id=jedi_flow.request_id,
-    )
+    has_next_screen = jedi_flow.next_screen <= len(jedi_flow.screens)
+    valid = jedi_flow.validate() and jedi_flow.validate_warnings()
 
-    if jedi_flow.validate():
+    if valid:
         jedi_flow.create_or_update_request()
-        valid = jedi_flow.validate_warnings()
-        if valid:
-            if jedi_flow.next_screen > len(jedi_flow.screens):
-                where = "/requests"
-            else:
-                where = url_for(
-                    "requests.requests_form_update",
-                    screen=jedi_flow.next_screen,
-                    request_id=jedi_flow.request_id,
-                )
-            return redirect(where)
 
-        else:
-            return render_template(
-                "requests/screen-%d.html" % int(screen), **rerender_args
+        if has_next_screen:
+            where = url_for(
+                "requests.requests_form_update",
+                screen=jedi_flow.next_screen,
+                request_id=jedi_flow.request_id,
             )
-
+        else:
+            where = "/requests"
+        return redirect(where)
     else:
+        rerender_args = dict(
+            f=jedi_flow.form,
+            data=post_data,
+            screens=jedi_flow.screens,
+            current=screen,
+            next_screen=jedi_flow.next_screen,
+            request_id=jedi_flow.request_id,
+        )
         return render_template("requests/screen-%d.html" % int(screen), **rerender_args)
 
 

--- a/js/components/checkbox_input.js
+++ b/js/components/checkbox_input.js
@@ -1,0 +1,17 @@
+export default {
+  name: 'checkboxinput',
+
+  props: {
+    name: String,
+  },
+
+  methods: {
+    onInput: function (e) {
+        console.log(e)
+      this.$root.$emit('field-change', {
+        value: e.target.checked,
+        name: this.name
+      })
+    }
+  }
+}

--- a/js/components/checkbox_input.js
+++ b/js/components/checkbox_input.js
@@ -7,7 +7,6 @@ export default {
 
   methods: {
     onInput: function (e) {
-        console.log(e)
       this.$root.$emit('field-change', {
         value: e.target.checked,
         name: this.name

--- a/js/components/forms/poc.js
+++ b/js/components/forms/poc.js
@@ -1,5 +1,6 @@
 import optionsinput from '../options_input'
 import textinput from '../text_input'
+import checkboxinput from '../checkbox_input'
 
 export default {
   name: 'poc',
@@ -7,6 +8,7 @@ export default {
   components: {
     optionsinput,
     textinput,
+    checkboxinput,
   },
 
   props: {
@@ -18,7 +20,7 @@ export default {
 
   data: function () {
     const {
-      am_poc = 'no'
+      am_poc = false
     } = this.initialData
 
     return {
@@ -28,12 +30,6 @@ export default {
 
   mounted: function () {
     this.$root.$on('field-change', this.handleFieldChange)
-  },
-
-  computed: {
-    amPOC: function () {
-        return this.am_poc === 'yes'
-    },
   },
 
   methods: {

--- a/js/components/forms/poc.js
+++ b/js/components/forms/poc.js
@@ -17,8 +17,12 @@ export default {
   },
 
   data: function () {
+    const {
+      am_poc = 'no'
+    } = this.initialData
+
     return {
-        am_poc: "no"
+        am_poc
     }
   },
 
@@ -35,7 +39,6 @@ export default {
   methods: {
     handleFieldChange: function (event) {
       const { value, name } = event
-      console.log(value, name)
       if (typeof this[name] !== undefined) {
         this[name] = value
       }

--- a/js/components/forms/poc.js
+++ b/js/components/forms/poc.js
@@ -1,0 +1,44 @@
+import optionsinput from '../options_input'
+import textinput from '../text_input'
+
+export default {
+  name: 'poc',
+
+  components: {
+    optionsinput,
+    textinput,
+  },
+
+  props: {
+    initialData: {
+      type: Object,
+      default: () => ({})
+    }
+  },
+
+  data: function () {
+    return {
+        am_poc: "no"
+    }
+  },
+
+  mounted: function () {
+    this.$root.$on('field-change', this.handleFieldChange)
+  },
+
+  computed: {
+    amPOC: function () {
+        return this.am_poc === 'yes'
+    },
+  },
+
+  methods: {
+    handleFieldChange: function (event) {
+      const { value, name } = event
+      console.log(value, name)
+      if (typeof this[name] !== undefined) {
+        this[name] = value
+      }
+    },
+  }
+}

--- a/js/index.js
+++ b/js/index.js
@@ -5,6 +5,7 @@ import VTooltip from 'v-tooltip'
 import optionsinput from './components/options_input'
 import textinput from './components/text_input'
 import DetailsOfUse from './components/forms/details_of_use'
+import poc from './components/forms/poc'
 
 Vue.use(VTooltip)
 
@@ -15,6 +16,7 @@ const app = new Vue({
     optionsinput,
     textinput,
     DetailsOfUse,
+    poc,
   },
   methods: {
     closeModal: function(name) {

--- a/js/index.js
+++ b/js/index.js
@@ -4,6 +4,7 @@ import VTooltip from 'v-tooltip'
 
 import optionsinput from './components/options_input'
 import textinput from './components/text_input'
+import checkboxinput from './components/checkbox_input'
 import DetailsOfUse from './components/forms/details_of_use'
 import poc from './components/forms/poc'
 
@@ -15,6 +16,7 @@ const app = new Vue({
   components: {
     optionsinput,
     textinput,
+    checkboxinput,
     DetailsOfUse,
     poc,
   },

--- a/templates/components/checkbox_input.html
+++ b/templates/components/checkbox_input.html
@@ -1,0 +1,37 @@
+{% from "components/icon.html" import Icon %}
+{% from "components/tooltip.html" import Tooltip %}
+
+{% macro OptionsInput(field, tooltip, inline=False) -%}
+  <optionsinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
+    <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
+
+      <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
+        <legend>
+          <div class="usa-input__title">
+            {{ field.label | striptags}}
+            {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
+          </div>
+
+          {% if field.description %}
+            <span class='usa-input__help'>{{ field.description | safe }}</span>
+          {% endif %}
+
+          {% if field.errors %}
+            {{ Icon('alert',classes="icon-validation") }}
+          {% endif %}
+        </legend>
+
+        {{ field() }}
+
+        {% if field.errors %}
+          {% for error in field.errors %}
+            <span class='usa-input__message'>{{ error }}</span>
+          {% endfor %}
+        {% endif %}
+
+      </fieldset>
+    </div>
+
+  </optionsinput>
+
+{%- endmacro %}

--- a/templates/components/checkbox_input.html
+++ b/templates/components/checkbox_input.html
@@ -1,37 +1,18 @@
-{% from "components/icon.html" import Icon %}
-{% from "components/tooltip.html" import Tooltip %}
 
-{% macro OptionsInput(field, tooltip, inline=False) -%}
-  <optionsinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
+{% macro CheckboxInput(field, inline=False) -%}
+  <checkboxinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
     <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
 
       <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
-          <div class="usa-input__title">
-            {{ field.label | striptags}}
-            {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
-          </div>
+          {{ field() }}
+          {{ field.label }}
 
           {% if field.description %}
             <span class='usa-input__help'>{{ field.description | safe }}</span>
           {% endif %}
-
-          {% if field.errors %}
-            {{ Icon('alert',classes="icon-validation") }}
-          {% endif %}
-        </legend>
-
-        {{ field() }}
-
-        {% if field.errors %}
-          {% for error in field.errors %}
-            <span class='usa-input__message'>{{ error }}</span>
-          {% endfor %}
-        {% endif %}
-
       </fieldset>
     </div>
-
-  </optionsinput>
+  </checkboxinput>
 
 {%- endmacro %}

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -2,7 +2,7 @@
 
 {% from "components/alert.html" import Alert %}
 {% from "components/text_input.html" import TextInput %}
-{% from "components/options_input.html" import OptionsInput %}
+{% from "components/checkbox_input.html" import CheckboxInput %}
 
 {% block subtitle %}
 <h2>Designate a Workspace Owner</h2>
@@ -31,10 +31,9 @@
       <em>This POC may be you.</em>
     </p>
 
-    {{ f.am_poc() }}
-    {{ f.am_poc.label }}
+    {{ CheckboxInput(f.am_poc) }}
 
-    <template v-if="!amPOC" v-cloak>
+    <template v-if="!am_poc" v-cloak>
       {{ TextInput(f.fname_poc,placeholder='First Name') }}
       {{ TextInput(f.lname_poc,placeholder='Last Name') }}
       {{ TextInput(f.email_poc,placeholder='jane@mail.mil', validation='email') }}

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -31,7 +31,8 @@
       <em>This POC may be you.</em>
     </p>
 
-    {{ OptionsInput(f.am_poc) }}
+    {{ f.am_poc() }}
+    {{ f.am_poc.label }}
 
     <template v-if="!amPOC" v-cloak>
       {{ TextInput(f.fname_poc,placeholder='First Name') }}

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -19,17 +19,19 @@
 
 <poc inline-template v-bind:initial-data='{{ f.data|tojson }}'>
   <div>
-    <p>Please designate a Primary Point of Contact that will be responsible for owning the workspace in the JEDI Cloud.</p>
-    <p>The Point of Contact will become the primary owner of the <em>workspace</em> created to use the JEDI Cloud. As a workspace owner, this person will have the ability to:
-      <ul>
-        <li>Create multiple application stacks and environments in the workspace to access the commercial cloud service provider portal</li>
-        <li>Add and manage users in the workspace</li>
-        <li>View the budget and billing history related to this workspace</li>
-        <li>Manage access to the Cloud Service Provider's Console</li>
-        <li>Transfer Workspace ownership to another person</li>
-      </ul>
-      <em>This POC may be you.</em>
+
+    <p>The Workspace Owner is the primary point of contact and technical administrator of the JEDI Workspace and will have the
+      following responsibilities:</p>
+    <ul>
+      <li>Organize your cloud-hosted systems into projects and environments</li>
+      <li>Add users to this workspace and manage members</li>
+      <li>Manage access to the JEDI Cloud service provider’s portal</li>
+    </ul>
     </p>
+
+    <p>This person must be a DoD employee (not a contractor).</p>
+    <p>The Workspace Owner may be you. You will be able to add other administrators later. This person will be invited via email
+      once your request is approved.</p>
 
     {{ CheckboxInput(f.am_poc) }}
 

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -33,7 +33,7 @@
 
     {{ OptionsInput(f.am_poc) }}
 
-    <template v-if="!amPOC">
+    <template v-if="!amPOC" v-cloak>
       {{ TextInput(f.fname_poc,placeholder='First Name') }}
       {{ TextInput(f.lname_poc,placeholder='Last Name') }}
       {{ TextInput(f.email_poc,placeholder='jane@mail.mil', validation='email') }}

--- a/templates/requests/screen-3.html
+++ b/templates/requests/screen-3.html
@@ -2,6 +2,7 @@
 
 {% from "components/alert.html" import Alert %}
 {% from "components/text_input.html" import TextInput %}
+{% from "components/options_input.html" import OptionsInput %}
 
 {% block subtitle %}
 <h2>Designate a Workspace Owner</h2>
@@ -16,20 +17,29 @@
   ) }}
 {% endif %}
 
-<p>The Workspace Owner is the primary point of contact and technical administrator of the JEDI Workspace and will have the following responsibilities:</p>
-  <ul>
-    <li>Organize your cloud-hosted systems into projects and environments</li>
-    <li>Add users to this workspace and manage members</li>
-    <li>Manage access to the JEDI Cloud service provider’s portal</li>
-  </ul>
-</p>
+<poc inline-template v-bind:initial-data='{{ f.data|tojson }}'>
+  <div>
+    <p>Please designate a Primary Point of Contact that will be responsible for owning the workspace in the JEDI Cloud.</p>
+    <p>The Point of Contact will become the primary owner of the <em>workspace</em> created to use the JEDI Cloud. As a workspace owner, this person will have the ability to:
+      <ul>
+        <li>Create multiple application stacks and environments in the workspace to access the commercial cloud service provider portal</li>
+        <li>Add and manage users in the workspace</li>
+        <li>View the budget and billing history related to this workspace</li>
+        <li>Manage access to the Cloud Service Provider's Console</li>
+        <li>Transfer Workspace ownership to another person</li>
+      </ul>
+      <em>This POC may be you.</em>
+    </p>
 
-<p>This person must be a DoD employee (not a contractor).</p>
-<p>The Workspace Owner may be you. You will be able to add other administrators later. This person will be invited via email once your request is approved.</p>
+    {{ OptionsInput(f.am_poc) }}
 
-{{ TextInput(f.fname_poc,placeholder='First Name') }}
-{{ TextInput(f.lname_poc,placeholder='Last Name') }}
-{{ TextInput(f.email_poc,placeholder='jane@mail.mil', validation='email') }}
-{{ TextInput(f.dodid_poc,placeholder='10-digit number on the back of the CAC', validation='dodId') }}
+    <template v-if="!amPOC">
+      {{ TextInput(f.fname_poc,placeholder='First Name') }}
+      {{ TextInput(f.lname_poc,placeholder='Last Name') }}
+      {{ TextInput(f.email_poc,placeholder='jane@mail.mil', validation='email') }}
+      {{ TextInput(f.dodid_poc,placeholder='10-digit number on the back of the CAC', validation='dodId') }}
+    </template>
 
+  </div>
+</poc>
 {% endblock %}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -56,7 +56,7 @@ class RequestFactory(factory.alchemy.SQLAlchemyModelFactory):
     def build_request_body(cls, user, dollar_value=1000000):
         return {
             "primary_poc": {
-                "am_poc": "no",
+                "am_poc": False,
                 "dodid_poc": user.dod_id,
                 "email_poc": user.email,
                 "fname_poc": user.first_name,

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -56,6 +56,7 @@ class RequestFactory(factory.alchemy.SQLAlchemyModelFactory):
     def build_request_body(cls, user, dollar_value=1000000):
         return {
             "primary_poc": {
+                "am_poc": "no",
                 "dodid_poc": user.dod_id,
                 "email_poc": user.email,
                 "fname_poc": user.first_name,

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -1,7 +1,4 @@
 import re
-import pytest
-import urllib
-from tests.mocks import MOCK_USER, MOCK_REQUEST
 from tests.factories import RequestFactory, UserFactory
 from atst.domain.roles import Roles
 from atst.domain.requests import Requests

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -2,6 +2,7 @@ import re
 from tests.factories import RequestFactory, UserFactory
 from atst.domain.roles import Roles
 from atst.domain.requests import Requests
+from urllib.parse import urlencode
 
 
 ERROR_CLASS = "alert--error"
@@ -131,10 +132,17 @@ def test_not_am_poc_allows_user_to_fill_in_poc_info(client, user_session):
     creator = UserFactory.create()
     user_session(creator)
     request = RequestFactory.create(creator=creator, body={})
+    poc_input = {
+        "am_poc": "no",
+        "fname_poc": "test",
+        "lname_poc": "user",
+        "email_poc": "test.user@mail.com",
+        "dodid_poc": "1234567890",
+    }
     response = client.post(
         "/requests/new/3/{}".format(request.id),
         headers={"Content-Type": "application/x-www-form-urlencoded"},
-        data="am_poc=no&fname_poc=test&lname_poc=user&email_poc=test.user@mail.com&dodid_poc=1234567890",
+        data=urlencode(poc_input),
     )
     assert ERROR_CLASS not in response.data.decode()
 

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -125,22 +125,21 @@ def test_not_am_poc_requires_poc_info_to_be_completed(client, user_session):
         "/requests/new/3/{}".format(request.id),
         headers={"Content-Type": "application/x-www-form-urlencoded"},
         data="am_poc=no",
+        follow_redirects=True
     )
     assert ERROR_CLASS in response.data.decode()
 
 
-# def test_not_am_poc_allows_user_to_fill_in_poc_info(client, user_session):
-#     creator = UserFactory.create()
-#     user_session(creator)
-#     request = RequestFactory.create(creator=creator, body={})
-#     client.post(
-#         "/requests/new/3/{}".format(request.id),
-#         headers={"Content-Type": "application/x-www-form-urlencoded"},
-#         data="am_poc=yes",
-#     )
-
-#     assert "Location" not in response.headers
-#     request = Requests.get(request.id)
+def test_not_am_poc_allows_user_to_fill_in_poc_info(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+    request = RequestFactory.create(creator=creator, body={})
+    response = client.post(
+        "/requests/new/3/{}".format(request.id),
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data="am_poc=no&fname_poc=test&lname_poc=user&email_poc=test.user@mail.com&dodid_poc=1234567890",
+    )
+    assert ERROR_CLASS not in response.data.decode()
 
 
 def test_can_review_data(user_session, client):

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -147,7 +147,7 @@ def test_not_am_poc_allows_user_to_fill_in_poc_info(client, user_session):
     assert ERROR_CLASS not in response.data.decode()
 
 
-def test_not_am_poc_allows_user_to_fill_in_poc_info_for_new_request(client, user_session):
+def test_poc_details_can_be_autopopulated_on_new_request(client, user_session):
     creator = UserFactory.create()
     user_session(creator)
     response = client.post(

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -139,6 +139,20 @@ def test_not_am_poc_allows_user_to_fill_in_poc_info(client, user_session):
     assert ERROR_CLASS not in response.data.decode()
 
 
+def test_not_am_poc_allows_user_to_fill_in_poc_info_for_new_request(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+    response = client.post(
+        "/requests/new/3",
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+        data="am_poc=yes",
+    )
+    request_id = response.headers["Location"].split('/')[-1]
+    request = Requests.get(request_id)
+
+    assert request.body["primary_poc"]["dodid_poc"] == creator.dod_id
+
+
 def test_can_review_data(user_session, client):
     creator = UserFactory.create()
     user_session(creator)


### PR DESCRIPTION
Allow a MO to designate themselves as a technical POC. This involves a kind of gross addition to the (already gross) JEDIRequestFlow class that modules the request body data before updating. My opinion is that this is ok for now, but once we finalize the Request body schema we should tackle the big hunk of tech debt known as `atst.routes.requetsts`.

![screen shot 2018-08-14 at 4 32 48 pm](https://user-images.githubusercontent.com/38955572/44116896-c0d2e5c2-9fdf-11e8-8668-45e545f6183d.png)

![screen shot 2018-08-14 at 4 32 55 pm](https://user-images.githubusercontent.com/38955572/44116898-c2e24902-9fdf-11e8-86b3-9a1c95f2cf40.png)
