### PR TITLE
Add counts for KPI (159705475)

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -158,7 +158,7 @@ class Requests(object):
         return request.status == RequestStatus.PENDING_CCPO_APPROVAL
 
     @classmethod
-    def count_status(self, status):
+    def status_count(cls, status):
         raw = text("""
 SELECT count(requests_with_status.id)
 FROM (
@@ -173,4 +173,20 @@ WHERE requests_with_status.status = :status;
         results = db.session.execute(raw, {"status": status}).fetchone()
         (count,) = results
         return count
+
+    @classmethod
+    def in_progress_count(cls):
+        return sum([
+            Requests.status_count(RequestStatus.STARTED),
+            Requests.status_count(RequestStatus.PENDING_FINANCIAL_VERIFICATION),
+            Requests.status_count(RequestStatus.CHANGES_REQUESTED),
+        ])
+
+    @classmethod
+    def pending_ccpo_count(cls):
+        return Requests.status_count(RequestStatus.PENDING_CCPO_APPROVAL)
+
+    @classmethod
+    def completed_count(cls):
+        return Requests.status_count(RequestStatus.APPROVED)
 

--- a/atst/models/request_status_event.py
+++ b/atst/models/request_status_event.py
@@ -15,7 +15,7 @@ class RequestStatus(Enum):
     CHANGES_REQUESTED = "Changes Requested"
     APPROVED = "Approved"
     EXPIRED = "Expired"
-    DELETED = "Deleted"
+    CANCELED = "Canceled"
 
 
 class RequestStatusEvent(Base):

--- a/atst/models/request_status_event.py
+++ b/atst/models/request_status_event.py
@@ -12,6 +12,7 @@ class RequestStatus(Enum):
     STARTED = "Started"
     PENDING_FINANCIAL_VERIFICATION = "Pending Financial Verification"
     PENDING_CCPO_APPROVAL = "Pending CCPO Approval"
+    CHANGES_REQUESTED = "Changes Requested"
     APPROVED = "Approved"
     EXPIRED = "Expired"
     DELETED = "Deleted"

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -51,16 +51,16 @@
   {% if extended_view %}
     <div class="row kpi">
       <div class="kpi__item col col--grow">
-        <div class="kpi__item__value">3</div>
-        <div class="kpi__item__description">Pending Requests</div>
+        <div class="kpi__item__value">{{ kpi_inprogress }}</div>
+        <div class="kpi__item__description">In Progress</div>
       </div>
       <div class="kpi__item col col--grow">
-        <div class="kpi__item__value">2,456</div>
-        <div class="kpi__item__description">Completed Requests This Year</div>
+        <div class="kpi__item__value">{{ kpi_pending }}</div>
+        <div class="kpi__item__description">Pending CCPO Action</div>
       </div>
       <div class="kpi__item col col--grow">
-        <div class="kpi__item__value">234</div>
-        <div class="kpi__item__description">Denied Requests</div>
+        <div class="kpi__item__value">{{ kpi_completed }}</div>
+        <div class="kpi__item__description">Completed (Overall)</div>
       </div>
     </div>
   {% endif %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -69,6 +69,7 @@ def session(db, request):
     ]
     for factory in factory_list:
         factory._meta.sqlalchemy_session = session
+        factory._meta.sqlalchemy_session_persistence = "commit"
 
     yield session
 

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -77,3 +77,14 @@ def test_status_count(session):
     assert Requests.status_count(RequestStatus.PENDING_FINANCIAL_VERIFICATION) == 1
     assert Requests.status_count(RequestStatus.STARTED) == 1
     assert Requests.in_progress_count() == 2
+
+def test_status_count_scoped_to_creator(session):
+    # make sure table is empty
+    session.query(Request).delete()
+
+    user = UserFactory.create()
+    request1 = RequestFactory.create()
+    request2 = RequestFactory.create(creator=user)
+
+    assert Requests.status_count(RequestStatus.STARTED) == 2
+    assert Requests.status_count(RequestStatus.STARTED, creator=user) == 1

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -3,9 +3,10 @@ from uuid import uuid4
 
 from atst.domain.exceptions import NotFoundError
 from atst.domain.requests import Requests
+from atst.models.request import Request
 from atst.models.request_status_event import RequestStatus
 
-from tests.factories import RequestFactory, UserFactory
+from tests.factories import RequestFactory, UserFactory, RequestStatusEventFactory
 
 
 @pytest.fixture(scope="function")
@@ -63,3 +64,15 @@ def test_exists(session):
     request = RequestFactory.create(creator=user_allowed)
     assert Requests.exists(request.id, user_allowed)
     assert not Requests.exists(request.id, user_denied)
+
+
+def test_count_status(session):
+    # make sure table is empty
+    session.query(Request).delete()
+
+    request1 = RequestFactory.create()
+    request2 = RequestFactory.create()
+    RequestStatusEventFactory.create(sequence=2, request_id=request2.id, new_status=RequestStatus.PENDING_FINANCIAL_VERIFICATION)
+
+    assert Requests.count_status(RequestStatus.PENDING_FINANCIAL_VERIFICATION) == 1
+    assert Requests.count_status(RequestStatus.STARTED) == 1

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -66,7 +66,7 @@ def test_exists(session):
     assert not Requests.exists(request.id, user_denied)
 
 
-def test_count_status(session):
+def test_status_count(session):
     # make sure table is empty
     session.query(Request).delete()
 
@@ -74,5 +74,6 @@ def test_count_status(session):
     request2 = RequestFactory.create()
     RequestStatusEventFactory.create(sequence=2, request_id=request2.id, new_status=RequestStatus.PENDING_FINANCIAL_VERIFICATION)
 
-    assert Requests.count_status(RequestStatus.PENDING_FINANCIAL_VERIFICATION) == 1
-    assert Requests.count_status(RequestStatus.STARTED) == 1
+    assert Requests.status_count(RequestStatus.PENDING_FINANCIAL_VERIFICATION) == 1
+    assert Requests.status_count(RequestStatus.STARTED) == 1
+    assert Requests.in_progress_count() == 2

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -39,6 +39,7 @@ class RequestStatusEventFactory(factory.alchemy.SQLAlchemyModelFactory):
         model = RequestStatusEvent
 
     id = factory.Sequence(lambda x: uuid4())
+    sequence = 1
 
 
 class RequestFactory(factory.alchemy.SQLAlchemyModelFactory):

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -65,6 +65,6 @@ def test_request_status_pending_expired_displayname():
 
 def test_request_status_pending_deleted_displayname():
     request = RequestFactory.create()
-    request = Requests.set_status(request, RequestStatus.DELETED)
+    request = Requests.set_status(request, RequestStatus.CANCELED)
 
-    assert request.status_displayname == "Deleted"
+    assert request.status_displayname == "Canceled"


### PR DESCRIPTION
Relates to [this](https://www.pivotaltracker.com/story/show/159705475) PT story.

This wires up the KPI that @luisgov designed on a previous PR and changes the category names per discussion with DDS. Thanks to @richard-dds for helping me figure out the gnarly SQL. (If either you or @patricksmithdds want to take a crack at using the ORM, be my guest.)

**notes**

- I've separated rendering the CCPO and non-CCPO requests index view into separate functions.
- I updated one of the RequestStatus names, per @luisgov on the PT story.

<img width="1385" alt="screen shot 2018-08-14 at 4 56 25 pm" src="https://user-images.githubusercontent.com/38955503/44118500-5c5f198a-9fe4-11e8-8ae2-4d914eed23d9.png">
