### PR TITLE
Run tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,11 @@ before_script:
 script:
   - docker run -d --entrypoint='/bin/sh' -t --name current-atst-tester "${TESTER_IMAGE1_NAME}"
   - docker container exec -t current-atst-tester script/sync-crls
-  - docker commit current-atst-tester "${TESTER_IMAGE2_NAME}"
+  - docker commit
+    --change='ENTRYPOINT ["/usr/bin/dumb-init", "--"]'
+    --change='CMD ["bash", "-c", "${APP_DIR}/script/cibuild"]'
+    current-atst-tester
+    "${TESTER_IMAGE2_NAME}"
   - docker cp current-atst-tester:/opt/atat/atst/crl/. ./crl/
   - docker container stop current-atst-tester
   - docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,3 @@
-def test_the_tester():
-    assert False
-
 def test_hello_world(client):
     response = client.get("/")
     assert response.status_code == 200

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,3 +1,6 @@
+def test_the_tester():
+    assert False
+
 def test_hello_world(client):
     response = client.get("/")
     assert response.status_code == 200


### PR DESCRIPTION
This PR resurrects the previous `script` command to run the tests on the docker tester image and moves the other commands to `after_success` so they are only run if the tests pass.

It _appears_ that the last step of `after_success` (`- docker run --add-host "postgreshost:${postgres_ip}" --add-host "redishost:${redis_ip}" "${TESTER_IMAGE2_NAME}"`) should run the tests, but that is not the case -- I added a test that always fails and [the travis build](https://travis-ci.org/dod-ccpo/atst/builds/416324949?utm_source=github_status&utm_medium=notification) succeeded without error. Updating the script step correctly makes the [build fail](https://travis-ci.org/dod-ccpo/atst/builds/416329881?utm_source=github_status&utm_medium=notification).

It seems the `TESTER_IMAGE2_NAME` image is not actually used elsewhere, so I'm not sure if the `after_success` block can be removed entirely.