### PR TITLE
additional logging to CRL checks

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -141,5 +141,5 @@ def make_crl_validator(app):
     crl_locations = []
     for filename in pathlib.Path(app.config["CRL_DIRECTORY"]).glob("*"):
         crl_locations.append(filename.absolute())
-    app.crl_cache = CRLCache(app.config["CA_CHAIN"], crl_locations)
+    app.crl_cache = CRLCache(app.config["CA_CHAIN"], crl_locations, logger=app.logger)
 


### PR DESCRIPTION
This is the debugging branch with additional logging.

Caveat, I can't test the logging locally. There's no easy way to test genuine client auth at the moment against a dev server, and I cannot for the life of me get it to log in the tests anymore. I tried removing the default log config we added in `tests/conftest.py` and adding a new log handler, but no dice. It definitely reaches the logging statement in `CRLCache`, it just doesn't flush the log anywhere I can see. :/  If the rest of the app is logging as normal, it should log in production.