### PR TITLE
review and submit page bugs (159795524 and 159889979)

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -139,8 +139,6 @@ class Requests(object):
 
     _VALID_SUBMISSION_STATUSES = [
         RequestStatus.STARTED,
-        RequestStatus.PENDING_FINANCIAL_VERIFICATION,
-        RequestStatus.PENDING_CCPO_APPROVAL,
         RequestStatus.CHANGES_REQUESTED,
     ]
 

--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -137,6 +137,13 @@ class Requests(object):
 
         return dollar_value < cls.AUTO_APPROVE_THRESHOLD
 
+    _VALID_SUBMISSION_STATUSES = [
+        RequestStatus.STARTED,
+        RequestStatus.PENDING_FINANCIAL_VERIFICATION,
+        RequestStatus.PENDING_CCPO_APPROVAL,
+        RequestStatus.CHANGES_REQUESTED,
+    ]
+
     @classmethod
     def should_allow_submission(cls, request):
         all_request_sections = [
@@ -145,7 +152,7 @@ class Requests(object):
             "primary_poc",
         ]
         existing_request_sections = request.body.keys()
-        return request.status == RequestStatus.STARTED and all(
+        return request.status in Requests._VALID_SUBMISSION_STATUSES and all(
             section in existing_request_sections for section in all_request_sections
         )
 

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -27,3 +27,8 @@ class Request(Base):
     @property
     def status_displayname(self):
         return self.status_events[-1].displayname
+
+    @property
+    def annual_spend(self):
+        monthly = self.body.get("details_of_use", {}).get("estimated_monthly_spend", 0)
+        return monthly * 12

--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -10,7 +10,7 @@ def map_request(request):
     time_created = pendulum.instance(request.time_created)
     is_new = time_created.add(days=1) > pendulum.now()
     app_count = request.body.get("details_of_use", {}).get("num_software_systems", 0)
-    annual_usage = request.body.get("details_of_use", {}).get("dollar_value", 0)
+    annual_usage = request.annual_spend
     update_url = url_for(
         "requests.requests_form_update", screen=1, request_id=request.id
     )

--- a/templates/requests/screen-4.html
+++ b/templates/requests/screen-4.html
@@ -21,7 +21,7 @@
 
   <p>Before you can submit your request, please take a moment to review the information entered in the form. You may make changes by clicking the edit link on each section. When all information looks right, go ahead and submit.</p>
 
-  {% if f.errors or not can_submit%}
+  {% if f.errors or not can_submit %}
     {{ Alert('Please complete all sections',
       message="<p>In order to submit your JEDI Cloud request, you'll need to complete all required sections of this form without error. Missing or invalid fields are noted below.</p>",
       level='error'
@@ -114,20 +114,23 @@
       <dd>{{ data['details_of_use']['dollar_value'] or RequiredLabel() }}</dd>
     </div>
 
-    <div>
-      <dt>Number of User Sessions</dt>
-      <dd>{{ data['details_of_use']['number_user_sessions'] or RequiredLabel() }}</dd>
-    </div>
+    {% set dollar_value = data['details_of_use']['dollar_value'] | int %}
+    {% if dollar_value > 1000000 %}
+      <div>
+        <dt>Number of User Sessions</dt>
+        <dd>{{ data['details_of_use']['number_user_sessions'] or RequiredLabel() }}</dd>
+      </div>
 
-    <div>
-      <dt>Average Daily Traffic (Number of Requests)</dt>
-      <dd>{{ data['details_of_use']['average_daily_traffic'] or RequiredLabel() }}</dd>
-    </div>
+      <div>
+        <dt>Average Daily Traffic (Number of Requests)</dt>
+        <dd>{{ data['details_of_use']['average_daily_traffic'] or RequiredLabel() }}</dd>
+      </div>
 
-    <div>
-      <dt>Average Daily Traffic (GB)</dt>
-      <dd>{{ data['details_of_use']['average_daily_traffic_gb'] or RequiredLabel() }}</dd>
-    </div>
+      <div>
+        <dt>Average Daily Traffic (GB)</dt>
+        <dd>{{ data['details_of_use']['average_daily_traffic_gb'] or RequiredLabel() }}</dd>
+      </div>
+    {% endif %}
 
     <div>
       <dt>Start Date</dt>

--- a/templates/requests/screen-4.html
+++ b/templates/requests/screen-4.html
@@ -114,8 +114,7 @@
       <dd>{{ data['details_of_use']['dollar_value'] or RequiredLabel() }}</dd>
     </div>
 
-    {% set dollar_value = data['details_of_use']['dollar_value'] | int %}
-    {% if dollar_value > 1000000 %}
+    {% if jedi_request and jedi_request.annual_spend > 1000000 %}
       <div>
         <dt>Number of User Sessions</dt>
         <dd>{{ data['details_of_use']['number_user_sessions'] or RequiredLabel() }}</dd>

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -54,7 +54,7 @@ def test_dont_auto_approve_if_no_dollar_value_specified(new_request):
 def test_should_allow_submission(new_request):
     assert Requests.should_allow_submission(new_request)
 
-    RequestStatusEventFactory.create(request=new_request, new_status=RequestStatus.PENDING_FINANCIAL_VERIFICATION)
+    RequestStatusEventFactory.create(request=new_request, new_status=RequestStatus.CHANGES_REQUESTED)
     assert Requests.should_allow_submission(new_request)
 
     del new_request.body['details_of_use']

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -54,6 +54,9 @@ def test_dont_auto_approve_if_no_dollar_value_specified(new_request):
 def test_should_allow_submission(new_request):
     assert Requests.should_allow_submission(new_request)
 
+    RequestStatusEventFactory.create(request=new_request, new_status=RequestStatus.PENDING_FINANCIAL_VERIFICATION)
+    assert Requests.should_allow_submission(new_request)
+
     del new_request.body['details_of_use']
     assert not Requests.should_allow_submission(new_request)
 

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -68,3 +68,8 @@ def test_request_status_pending_deleted_displayname():
     request = Requests.set_status(request, RequestStatus.CANCELED)
 
     assert request.status_displayname == "Canceled"
+
+def test_annual_spend():
+    request = RequestFactory.create()
+    monthly = request.body.get("details_of_use").get("estimated_monthly_spend")
+    assert request.annual_spend == monthly * 12


### PR DESCRIPTION
This fixes two bugs on the review and submit page.

1. https://www.pivotaltracker.com/story/show/159795524

We should only show the data usage fields on the "review and submit" form if they're necessary for the request (i.e., it's total value is greater than one million).

2. https://www.pivotaltracker.com/story/show/159889979

The alert telling you that you have errors or missing data on the "review and submit" is displayed if you successfully submit a request and then come back to that page. If a user submits a valid request and then comes back to that form page (changes requested, bored, etc.), they shouldn't see that alert. 

It's displaying in those circumstances because `Requests.should_allow_submission` has `STARTED` as the only acceptable status value. I've updated it to accept a range of statuses.