### PR TITLE
Add jinja filter to format dollars

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -10,7 +10,7 @@ from flask_wtf.csrf import CSRFProtect
 
 from atst.database import db
 from atst.assets import environment as assets_environment
-
+from atst.filters import register_filters
 from atst.routes import bp
 from atst.routes.workspaces import bp as workspace_routes
 from atst.routes.requests import requests_bp
@@ -40,6 +40,7 @@ def make_app(config):
 
     make_flask_callbacks(app)
     make_crl_validator(app)
+    register_filters(app)
 
     db.init_app(app)
     csrf.init_app(app)
@@ -76,11 +77,6 @@ def make_flask_callbacks(app):
             "atat_role": "default",
             "atat_permissions": [],
         }
-
-    @app.template_filter('iconSvg')
-    def _iconSvg(name):
-        with open('static/icons/'+name+'.svg') as contents:
-            return contents.read()
 
 
 def map_config(config):

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -3,5 +3,14 @@ def iconSvg(name):
         return contents.read()
 
 
+def dollars(value):
+    try:
+        numberValue = float(value)
+    except ValueError:
+        numberValue = 0
+    return "${:,.0f}".format(numberValue)
+
+
 def register_filters(app):
     app.jinja_env.filters['iconSvg'] = iconSvg
+    app.jinja_env.filters['dollars'] = dollars

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -1,0 +1,7 @@
+def iconSvg(name):
+    with open('static/icons/'+name+'.svg') as contents:
+        return contents.read()
+
+
+def register_filters(app):
+    app.jinja_env.filters['iconSvg'] = iconSvg

--- a/templates/requests.html
+++ b/templates/requests.html
@@ -116,7 +116,7 @@
               <td>{{ r['full_name'] }}</td>
               <td></td>
             {% endif %}
-            <td>${{ r['annual_usage'] }}</td>
+            <td>{{ r['annual_usage'] | dollars }}</td>
             <td>{{ r['status'] }}</td>
           </tr>
           {% endfor %}

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,0 +1,15 @@
+import pytest
+
+from atst.filters import dollars
+
+
+@pytest.mark.parametrize("input,expected", [
+    ('0', '$0'),
+    ('123.00', '$123'),
+    ('1234567', '$1,234,567'),
+    ('-1234', '$-1,234'),
+    ('one', '$0'),
+])
+def test_dollar_fomatter(input, expected):
+    assert dollars(input) == expected
+


### PR DESCRIPTION
On the requests table, the dollar formatting was missing. Now, we'll add the commas in the appropriate spots:

![image](https://user-images.githubusercontent.com/40774582/44348447-73bb2a00-a468-11e8-815f-cbfb3976752e.png)

The filter will currently not show any decimals.