### PR TITLE
Add missing required validators

### DIFF
--- a/atst/forms/request.py
+++ b/atst/forms/request.py
@@ -106,6 +106,7 @@ class RequestForm(ValidatedForm):
             ("5PB-10PB", "5PB-10PB"),
             ("Above 10PB", "Above 10PB"),
         ],
+        validators=[Required()],
     )
 
     expected_completion_date = SelectField(
@@ -117,6 +118,7 @@ class RequestForm(ValidatedForm):
             ("3-6 months", "3-6 months"),
             ("Above 12 months", "Above 12 months"),
         ],
+        validators=[Required()],
     )
 
     cloud_native = RadioField(

--- a/tests/forms/test_request.py
+++ b/tests/forms/test_request.py
@@ -32,7 +32,11 @@ class TestRequestForm:
         assert request_form.errors == {"cloud_native": ["Not a valid choice"]}
 
     def test_require_migration_questions_when_migrating(self):
-        extra_data = {"jedi_migration": "yes"}
+        extra_data = {
+            "jedi_migration": "yes",
+            "data_transfers": "",
+            "expected_completion_date": "",
+        }
         request_form = RequestForm(data={**self.form_data, **extra_data})
         assert not request_form.validate()
         assert request_form.errors == {
@@ -40,8 +44,8 @@ class TestRequestForm:
             "technical_support_team": ["Not a valid choice"],
             "organization_providing_assistance": ["Not a valid choice"],
             "engineering_assessment": ["Not a valid choice"],
-            "data_transfers": ["Not a valid choice"],
-            "expected_completion_date": ["Not a valid choice"],
+            "data_transfers": ["This field is required."],
+            "expected_completion_date": ["This field is required."],
         }
 
     def test_require_organization_when_technical_support_team(self):


### PR DESCRIPTION
When the request is a migration, we need to require answers for data transfer and expected completion date:

![image](https://user-images.githubusercontent.com/40774582/44350802-3bb6e580-a46e-11e8-96df-72d5940e5ae6.png)
