### PR TITLE
Update kubernetes deployment to have 2 replicas

### DIFF
--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -12,7 +12,7 @@ metadata:
   name: atst
   namespace: atat
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     type: RollingUpdate
   template:

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,10 +24,10 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:23e5c04
+          image: registry.atat.codes:443/atst-prod:e38bc2f
           resources:
             requests:
-               memory: "6000Mi"
+               memory: "2500Mi"
           envFrom:
           - configMapRef:
               name: atst-envvars


### PR DESCRIPTION
Now that #181 and #188 are merged, the app no longer needs an exorbitant amount of memory to run. Therefore, we can lower the requested memory amount and scale up the number of replicas allowing zero-downtime deploys with a rolling update. 

The changes here reflect running the following commands on the cluster:

```
$ kubectl -n atat set resources deployment.apps/atst -c atst --requests=memory=2500Mi
$ kubectl -n atat scale deployment.apps/atst --replicas=2
```

These commands have already been run, so the cluster is currently running in this configuration.