### PR TITLE
Accessibility fixes for tooltip

### DIFF
--- a/templates/components/tooltip.html
+++ b/templates/components/tooltip.html
@@ -2,8 +2,8 @@
 
 {% macro Tooltip(message,title='Help') -%}
 
-  <span class="icon-tooltip" v-tooltip.top="{content: '{{message}}'}">
+  <button type="button" tabindex="0" class="icon-tooltip" v-tooltip.top="{content: '{{message}}', container: false}">
     {{ Icon('help') }}<span>{{ title }}</span>
-  </span>
+  </button>
 
 {%- endmacro %}


### PR DESCRIPTION
Use a button element.
Add tabindex to allow tabbing to trigger popover.
Set container to false, which renders the content as a sibling of the button, making it discoverable to screen-readers.