### PR TITLE
Show currently active workspace name in label

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -62,11 +62,6 @@ def make_app(config):
 def make_flask_callbacks(app):
     @app.before_request
     def _set_globals():
-        g.navigationContext = (
-            "workspace"
-            if re.match("\/workspaces\/[A-Za-z0-9]*", request.path)
-            else "global"
-        )
         g.dev = os.getenv("FLASK_ENV", "dev") == "dev"
         g.matchesPath = lambda href: re.match("^" + href, request.path)
         g.modal = request.args.get("modal", None)

--- a/atst/domain/workspaces.py
+++ b/atst/domain/workspaces.py
@@ -1,14 +1,33 @@
+class Workspaces(object):
+    MOCK_WORKSPACES = [
+        {
+            "name": "Unclassified IaaS and PaaS for Defense Digital Service (DDS)",
+            "id": "5966187a-eff9-44c3-aa15-4de7a65ac7ff",
+            "task_order": {"number": 123456},
+            "user_count": 23,
+        }
+    ]
+
+    @classmethod
+    def get(cls, workspace_id):
+        return cls.MOCK_WORKSPACES[0]
+
+    @classmethod
+    def get_many(cls):
+        return cls.MOCK_WORKSPACES
+
 class Projects(object):
-    def __init__(self):
+
+    @classmethod
+    def create(cls, creator_id, body):
         pass
 
-    def create(self, creator_id, body):
+    @classmethod
+    def get(cls, project_id):
         pass
 
-    def get(self, project_id):
-        pass
-
-    def get_many(self, workspace_id):
+    @classmethod
+    def get_many(cls, workspace_id):
         return [
             {
                 "id": "187c9bea-9541-45d7-801f-cf8e7a642e93",
@@ -41,21 +60,23 @@ class Projects(object):
             },
         ]
 
-    def update(self, request_id, request_delta):
+    @classmethod
+    def update(cls, request_id, request_delta):
         pass
 
 
 class Members(object):
-    def __init__(self):
+
+    @classmethod
+    def create(cls, creator_id, body):
         pass
 
-    def create(self, creator_id, body):
+    @classmethod
+    def get(cls, request_id):
         pass
 
-    def get(self, request_id):
-        pass
-
-    def get_many(self, workspace_id):
+    @classmethod
+    def get_many(cls, workspace_id):
         return [
             {
                 "first_name": "Danny",
@@ -86,5 +107,6 @@ class Members(object):
             },
         ]
 
-    def update(self, request_id, request_delta):
+    @classmethod
+    def update(cls, request_id, request_delta):
         pass

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -1,29 +1,19 @@
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request as http_request
 
-from atst.domain.workspaces import Projects, Members
+from atst.domain.workspaces import Members, Projects, Workspaces
 
 
 bp = Blueprint("workspaces", __name__)
 
-mock_workspaces = [
-    {
-        "name": "Unclassified IaaS and PaaS for Defense Digital Service (DDS)",
-        "id": "5966187a-eff9-44c3-aa15-4de7a65ac7ff",
-        "task_order": {"number": 123456},
-        "user_count": 23,
-    }
-]
-
 
 @bp.route("/workspaces")
 def workspaces():
-    return render_template("workspaces.html", page=5, workspaces=mock_workspaces)
+    return render_template("workspaces.html", page=5, workspaces=Workspaces.get_many())
 
 
 @bp.route("/workspaces/<workspace_id>/projects")
 def workspace_projects(workspace_id):
-    projects_repo = Projects()
-    projects = projects_repo.get_many(workspace_id)
+    projects = Projects.get_many(workspace_id)
     return render_template(
         "workspace_projects.html", workspace_id=workspace_id, projects=projects
     )
@@ -31,8 +21,7 @@ def workspace_projects(workspace_id):
 
 @bp.route("/workspaces/<workspace_id>/members")
 def workspace_members(workspace_id):
-    members_repo = Members()
-    members = members_repo.get_many(workspace_id)
+    members = Members.get_many(workspace_id)
     return render_template(
         "workspace_members.html", workspace_id=workspace_id, members=members
     )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -5,6 +5,13 @@ from atst.domain.workspaces import Members, Projects, Workspaces
 
 bp = Blueprint("workspaces", __name__)
 
+@bp.context_processor
+def workspace():
+    workspace = None
+    if "workspace_id" in http_request.view_args:
+        workspace = Workspaces.get(http_request.view_args["workspace_id"])
+    return { "workspace": workspace }
+
 
 @bp.route("/workspaces")
 def workspaces():
@@ -14,21 +21,15 @@ def workspaces():
 @bp.route("/workspaces/<workspace_id>/projects")
 def workspace_projects(workspace_id):
     projects = Projects.get_many(workspace_id)
-    return render_template(
-        "workspace_projects.html", workspace_id=workspace_id, projects=projects
-    )
+    return render_template("workspace_projects.html", projects=projects)
 
 
 @bp.route("/workspaces/<workspace_id>/members")
 def workspace_members(workspace_id):
     members = Members.get_many(workspace_id)
-    return render_template(
-        "workspace_members.html", workspace_id=workspace_id, members=members
-    )
+    return render_template("workspace_members.html", members=members)
 
 
 @bp.route("/workspaces/<workspace_id>/reports")
 def workspace_reports(workspace_id):
-    return render_template(
-        "workspace_reports.html", workspace_id=workspace_id
-    )
+    return render_template("workspace_reports.html")

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,7 +1,3 @@
-{# TODO: set this context elsewhere #}
-{# set context='workspace' #}
-{% set context=g.navigationContext %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/templates/error_base.html
+++ b/templates/error_base.html
@@ -1,7 +1,3 @@
-{# TODO: set this context elsewhere #}
-{# set context='workspace' #}
-{% set context=g.navigationContext %}
-
 <!DOCTYPE html>
 <html>
 <head>

--- a/templates/navigation/global_navigation.html
+++ b/templates/navigation/global_navigation.html
@@ -1,6 +1,6 @@
 {% from "components/sidenav_item.html" import SidenavItem %}
 
-<div class="global-navigation sidenav global-navigation__context--{{context}}">
+<div class="global-navigation sidenav">
   <ul>
     {% if g.dev %}
       {{ SidenavItem("Styleguide",

--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -6,9 +6,9 @@
       {{ Icon('shield', classes='topbar__link-icon') }}
     </a>
 
-    <div class="topbar__context topbar__context--{{context}}">
+    <div class="topbar__context {% if workspace %}topbar__context--workspace{% endif %}">
       <a href="/" class="topbar__link">
-        <span class="topbar__link-label">{{ "Workspace 123456" if context == 'workspace' else "JEDI" }}</span>
+        <span class="topbar__link-label">{{ ("Workspace " + workspace.name) if workspace else "JEDI" }}</span>
         {{ Icon('caret_down', classes='topbar__link-icon icon--tiny') }}
       </a>
 

--- a/templates/navigation/workspace_navigation.html
+++ b/templates/navigation/workspace_navigation.html
@@ -4,8 +4,8 @@
   <ul>
     {{ SidenavItem(
       "Projects",
-      href=url_for("workspaces.workspace_projects", workspace_id=123456),
-      active=g.matchesPath('\/workspaces\/[A-Za-z0-9]*\/projects'),
+      href=url_for("workspaces.workspace_projects", workspace_id=workspace.id),
+      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/projects'),
       subnav=[
         {
           "label": "Add New Project",
@@ -18,8 +18,8 @@
 
     {{ SidenavItem(
       "Members",
-      href=url_for("workspaces.workspace_members", workspace_id=123456),
-      active=g.matchesPath('\/workspaces\/[A-Za-z0-9]*\/members'),
+      href=url_for("workspaces.workspace_members", workspace_id=workspace.id),
+      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/members'),
       subnav=[
         {
           "label": "Add New Member",
@@ -32,8 +32,8 @@
 
     {{ SidenavItem(
       "Funding & Reports",
-      href='/workspaces/123456/reports',
-      active=g.matchesPath('\/workspaces\/[A-Za-z0-9]*\/reports')
+      href=url_for("workspaces.workspace_reports", workspace_id=workspace.id),
+      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/reports')
     ) }}
   </ul>
 </nav>

--- a/templates/workspace_projects.html
+++ b/templates/workspace_projects.html
@@ -8,7 +8,7 @@
   <div class='block-list project-list-item'>
     <header class='block-list__header'>
       <h2 class='block-list__title'>{{ project['name'] }} ({{ project['environments']|length }} environments)</h2>
-      <a class='icon-link' href='/workspaces/123456/projects/789/edit'>
+      <a class='icon-link' href=''>
         {{ Icon('edit') }}
         <span>edit</span>
       </a>

--- a/templates/workspace_reports.html
+++ b/templates/workspace_reports.html
@@ -4,7 +4,7 @@
 
 {% block workspace_content %}
 
-  {{ Alert("Funding Information & Reports for Workspace " + workspace_id,
+  {{ Alert("Funding Information & Reports for Workspace " + workspace.name,
     message="<p>On this screen you'll find detailed reporting information on this workspace. This message needs to be written better and be dismissable.</p>",
     actions=[
       {"label": "Learn More", "href": "/", "icon": "info"},


### PR DESCRIPTION
This branch updates the nav header to include the name of the workspace, if one is currently active:

![image](https://user-images.githubusercontent.com/40774582/44422927-9c1f5300-a552-11e8-927b-9476d4137e83.png)

This PR accomplishes this by adding a `context_processor` to the workspaces blueprint that checks for a `workspace_id` in the URL and uses that to look up the workspace. 

If there is no current workspace, then `workspace` will be undefined in the template. We can use this knowledge instead of manually defining a `navigationContext`, so I removed that variable.

Since we're no longer hard-coding `123456`, some of the regex's setting the active flag on links was no longer valid. Instead of a regex, I use something like `request.url_rule.rule.startswith('/workspaces/<workspace_id>/projects')`