### PR TITLE
make annual spending threshold available to request templates

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -31,6 +31,7 @@ def deep_merge(source, destination: dict):
 
 class Requests(object):
     AUTO_APPROVE_THRESHOLD = 1000000
+    ANNUAL_SPEND_THRESHOLD = 1000000
 
     @classmethod
     def create(cls, creator, body):

--- a/atst/routes/requests/__init__.py
+++ b/atst/routes/requests/__init__.py
@@ -1,7 +1,13 @@
 from flask import Blueprint
 
+from atst.domain.requests import Requests
+
 requests_bp = Blueprint("requests", __name__)
 
 from . import index
 from . import requests_form
 from . import financial_verification
+
+@requests_bp.context_processor
+def annual_spend_threshold():
+    return { "annual_spend_threshold": Requests.ANNUAL_SPEND_THRESHOLD }

--- a/templates/requests/screen-1.html
+++ b/templates/requests/screen-1.html
@@ -65,7 +65,7 @@
     </div>
 
     <transition name='slide'>
-      <template v-if="annualSpend > 1000000">
+      <template v-if="annualSpend > {{ annual_spend_threshold }}">
         <fieldset class='form__sub-fields'>
           <h3>Because the approximate annual spend is over $1,000,000, please answer a few additional questions.</h3>
           {{ TextInput(f.number_user_sessions, validation='integer', placeholder="0") }}

--- a/templates/requests/screen-4.html
+++ b/templates/requests/screen-4.html
@@ -143,7 +143,7 @@
       </dd>
     </div>
 
-    {% if jedi_request and jedi_request.annual_spend > 1000000 %}
+    {% if jedi_request and jedi_request.annual_spend > annual_spend_threshold %}
 
       <div>
         <dt>Number of User Sessions</dt>


### PR DESCRIPTION
This makes the annual spend threshold available to the request templates so that we don't hard-code it there.