### PR TITLE
Redirect non-ccpo users to requests page after CAC or dev login

### DIFF
--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -46,7 +46,10 @@ def login_redirect():
     user = auth_context.get_user()
     session["user_id"] = user.id
 
-    return redirect(url_for("atst.home"))
+    if user.atat_role.name == "ccpo":
+        return redirect(url_for("atst.home"))
+    else:
+        return redirect(url_for("requests.requests_index"))
 
 
 def _is_valid_certificate(request):

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -61,4 +61,8 @@ def login_dev():
         email=user_data["email"]
     )
     session["user_id"] = user.id
-    return redirect(url_for("atst.home"))
+
+    if user.atat_role.name == "ccpo":
+        return redirect(url_for("atst.home"))
+    else:
+        return redirect(url_for("requests.requests_index"))


### PR DESCRIPTION
## Description
After logging in, all users were being redirected to the home page. It's more likely that non-ccpo users (PSO and MO mainly) will be going directly to the requests page when they log in. This PR changes non-ccpo users' redirect so that it automatically goes to requests instead of home.

This should work after CAC login, but I was only able to verify that it works for dev log ins. 

## PivotalTracker
https://www.pivotaltracker.com/story/show/159109928