### PR TITLE
Pull workspace owner information from Information About You Step

### DIFF
--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -128,11 +128,22 @@ class JEDIRequestFlow(object):
     def map_request_data(self, section, data):
         if section == "primary_poc":
             if data.get("am_poc", False):
+                try:
+                    request_user_info = self.existing_request.body.get("information_about_you", {})
+                except AttributeError:
+                    request_user_info = {}
+
                 data = {
                     **data,
                     "dodid_poc": self.current_user.dod_id,
-                    "fname_poc": self.current_user.first_name,
-                    "lname_poc": self.current_user.last_name,
-                    "email_poc": self.current_user.email,
+                    "fname_poc": request_user_info.get(
+                        "fname_request", self.current_user.first_name
+                    ),
+                    "lname_poc": request_user_info.get(
+                        "lname_request", self.current_user.last_name
+                    ),
+                    "email_poc": request_user_info.get(
+                        "email_request", self.current_user.email
+                    ),
                 }
         return {section: data}

--- a/tests/assert_util.py
+++ b/tests/assert_util.py
@@ -1,0 +1,5 @@
+def dict_contains(superset, subset):
+    """
+    Returns True if dict a is a superset of dict b.
+    """
+    return all(item in superset.items() for item in subset.items())


### PR DESCRIPTION
If the user designates themselves as the workspace owner (on step 3 of the form), and they've entered their personal information on the "Information About You" section, then that information will be used to populate the workspace owner fields.