### PR TITLE
Confirm project creation 

### DIFF
--- a/js/components/forms/details_of_use.js
+++ b/js/components/forms/details_of_use.js
@@ -1,11 +1,14 @@
 import createNumberMask from 'text-mask-addons/dist/createNumberMask'
 import { conformToMask } from 'vue-text-mask'
 
+import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
 import optionsinput from '../options_input'
 
 export default {
   name: 'details-of-use',
+
+  mixins: [FormMixin],
 
   components: {
     textinput,
@@ -33,10 +36,6 @@ export default {
     }
   },
 
-  mounted: function () {
-    this.$root.$on('field-change', this.handleFieldChange)
-  },
-
   computed: {
     annualSpend: function () {
       const monthlySpend = this.estimated_monthly_spend || 0
@@ -60,12 +59,6 @@ export default {
     formatDollars: function (intValue) {
       const mask = createNumberMask({ prefix: '$', allowDecimal: true })
       return conformToMask(intValue.toString(), mask).conformedValue
-    },
-    handleFieldChange: function (event) {
-      const { value, name } = event
-      if (typeof this[name] !== undefined) {
-        this[name] = value
-      }
-    },
+    }
   }
 }

--- a/js/components/forms/financial.js
+++ b/js/components/forms/financial.js
@@ -1,8 +1,11 @@
+import FormMixin from '../../mixins/form'
 import optionsinput from '../options_input'
 import textinput from '../text_input'
 
 export default {
   name: 'financial',
+
+  mixins: [FormMixin],
 
   components: {
     optionsinput,
@@ -24,18 +27,5 @@ export default {
     return {
       funding_type
     }
-  },
-
-  mounted: function () {
-    this.$root.$on('field-change', this.handleFieldChange)
-  },
-
-  methods: {
-    handleFieldChange: function (event) {
-      const { value, name } = event
-      if (typeof this[name] !== undefined) {
-        this[name] = value
-      }
-    },
   }
 }

--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -1,9 +1,12 @@
+import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
 
 const createEnvironment = (name) => ({ name })
 
 export default {
   name: 'new-project',
+
+  mixins: [FormMixin],
 
   components: {
     textinput
@@ -19,6 +22,7 @@ export default {
   data: function () {
     const {
       environment_names,
+      name,
     } = this.initialData
 
     const environments = (
@@ -29,6 +33,7 @@ export default {
 
     return {
       environments,
+      name,
     }
   },
 

--- a/js/components/forms/poc.js
+++ b/js/components/forms/poc.js
@@ -1,9 +1,12 @@
+import FormMixin from '../../mixins/form'
 import optionsinput from '../options_input'
 import textinput from '../text_input'
 import checkboxinput from '../checkbox_input'
 
 export default {
   name: 'poc',
+
+  mixins: [FormMixin],
 
   components: {
     optionsinput,
@@ -26,18 +29,5 @@ export default {
     return {
         am_poc
     }
-  },
-
-  mounted: function () {
-    this.$root.$on('field-change', this.handleFieldChange)
-  },
-
-  methods: {
-    handleFieldChange: function (event) {
-      const { value, name } = event
-      if (typeof this[name] !== undefined) {
-        this[name] = value
-      }
-    },
   }
 }

--- a/js/index.js
+++ b/js/index.js
@@ -10,8 +10,11 @@ import poc from './components/forms/poc'
 import financial from './components/forms/financial'
 import toggler from './components/toggler'
 import NewProject from './components/forms/new_project'
+import Modal from './mixins/modal'
 
 Vue.use(VTooltip)
+
+Vue.mixin(Modal)
 
 const app = new Vue({
   el: '#app-root',
@@ -25,28 +28,11 @@ const app = new Vue({
     financial,
     NewProject
   },
-  methods: {
-    closeModal: function(name) {
-      this.modals[name] = false
-    },
-    openModal: function (name) {
-      this.modals[name] = true
-    }
-  },
-  data: function() {
-    return {
-      modals: {
-        styleguideModal: false,
-        pendingFinancialVerification: false,
-        pendingCCPOApproval: false,
-      }
-    }
-  },
   mounted: function() {
-    const modalOpen = document.querySelector("#modalOpen");
+    const modalOpen = document.querySelector("#modalOpen")
     if (modalOpen) {
-      const modal = modalOpen.getAttribute("data-modal");
-      this.modals[modal] = true;
+      const modal = modalOpen.getAttribute("data-modal")
+      this.openModal(modal)
     }
   },
   delimiters: ['!{', '}']

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -1,0 +1,14 @@
+export default {
+  mounted: function () {
+    this.$root.$on('field-change', this.handleFieldChange)
+  },
+
+  methods: {
+    handleFieldChange: function (event) {
+      const { value, name } = event
+      if (typeof this[name] !== undefined) {
+        this[name] = value
+      }
+    },
+  }
+}

--- a/js/mixins/modal.js
+++ b/js/mixins/modal.js
@@ -1,0 +1,20 @@
+export default {
+  methods: {
+    closeModal: function(name) {
+      this.modals[name] = false
+    },
+    openModal: function (name) {
+      this.modals[name] = true
+    }
+  },
+  data: function() {
+    return {
+      modals: {
+        styleguideModal: false,
+        newProjectConfirmation: false,
+        pendingFinancialVerification: false,
+        pendingCCPOApproval: false,
+      }
+    }
+  }
+}

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -8,7 +8,7 @@
             {{ caller() }}
 
             {% if dismissable %}
-              <button class='icon-link modal__dismiss' v-on:click='closeModal("{{name}}")'>
+              <button type='button' class='icon-link modal__dismiss' v-on:click='closeModal("{{name}}")'>
                 {{ Icon('x') }}
                 <span>Close</span>
               </button>

--- a/templates/workspace_project_new.html
+++ b/templates/workspace_project_new.html
@@ -1,4 +1,5 @@
 {% from "components/icon.html" import Icon %}
+{% from "components/modal.html" import Modal %}
 {% from "components/text_input.html" import TextInput %}
 {% from "components/tooltip.html" import Tooltip %}
 {% from "components/alert.html" import Alert %}
@@ -6,8 +7,27 @@
 {% extends "base_workspace.html" %}
 
 {% block workspace_content %}
+
+{% set modalName = "newProjectConfirmation" %}
+
 <new-project inline-template v-bind:initial-data='{{ form.data|tojson }}'>
   <form method="POST" action="{{ url_for('workspaces.update_project', workspace_id=workspace.id) }}" >
+    {% call Modal(name=modalName, dismissable=False) %}
+      <h1>Are you sure you want to create <strong>!{ name }</strong> project?</h1>
+
+      <p>
+      When you click "Create Project" the following environments will be created as individual cloud resource groups under <strong>!{ name }</strong> project:
+      <span v-for="(environment, index) in environments">
+        <strong>!{environment.name}</strong><template v-if="index < (environments.length - 1)">, </template>
+      </span>
+      </p>
+
+      <div class='action-group'>
+        <button type='submit' class='action-group__action usa-button'>Create Project</button>
+        <a v-on:click="closeModal('{{ modalName }}')" class='action-group__action'>Cancel</a>
+      </div>
+    {% endcall %}
+
     {{ form.csrf_token }}
     <div class="panel">
       <div class="panel__heading panel__heading--grow">
@@ -58,8 +78,7 @@
 
 
       <div class="action-group">
-        <input type="submit" value="Create Project" class="usa-button usa-button-primary">
-        <a href="{{ url_for('workspaces.workspace_projects', workspace_id=workspace.id) }}" class="action-group__action">Cancel</a>
+        <div v-on:click="openModal('{{ modalName }}')" class="usa-button usa-button-primary">Create Project</div>
       </div>
 
     </div>


### PR DESCRIPTION
On the "new project" page, show a modal to the user to confirm that they want to create cloud resources:

![image](https://user-images.githubusercontent.com/40774582/44551421-1f78aa00-a6f5-11e8-9ad1-602fdf0e0147.png)

This PR includes a bit of refactoring of the Vue code to use mixins, for two particular cases:

1. the modals on the root app were not available in sub-components and so could not be used from the form. A global mixin makes the modals available everywhere
2. each form was implementing the same "handle field change" method, so we can put that in a mixin and inherit it wherever its necessary