### PR TITLE
Only show Workspaces in the side nav if the current user is in at least one workspace

### DIFF
--- a/templates/navigation/global_navigation.html
+++ b/templates/navigation/global_navigation.html
@@ -21,6 +21,9 @@
         {"label":"New Request", "href":url_for("requests.requests_form_new", screen=1), "icon": "plus", "active": g.matchesPath('/requests/new')},
       ]
       ) }}
-    {{ SidenavItem("Workspaces", href="/workspaces", icon="cloud", active=g.matchesPath('/workspaces')) }}
+
+    {% if g.current_user.workspace_roles %}
+      {{ SidenavItem("Workspaces", href="/workspaces", icon="cloud", active=g.matchesPath('/workspaces')) }}
+    {% endif %}
   </ul>
 </div>

--- a/tests/routes/test_home.py
+++ b/tests/routes/test_home.py
@@ -1,0 +1,19 @@
+from tests.factories import UserFactory, WorkspaceFactory
+from atst.domain.workspaces import Workspaces
+
+
+def test_user_with_workspaces_has_workspaces_nav(client, user_session):
+    user = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(user, workspace, "default")
+
+    user_session(user)
+    response = client.get("/home")
+    assert b'href="/workspaces"' in response.data
+
+
+def test_user_without_workspaces_has_no_workspaces_nav(client, user_session):
+    user = UserFactory.create()
+    user_session(user)
+    response = client.get("/home")
+    assert b'href="/workspaces"' not in response.data


### PR DESCRIPTION
## Description
If a user is not in any workspaces, the Workspaces tab on the side nav bar will not appear.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/159967260

## Screenshots
![screen shot 2018-08-24 at 10 41 17 am](https://user-images.githubusercontent.com/42577527/44590932-49c87700-a78a-11e8-9535-2b13f6981fee.png)
