### PR TITLE
Redirect to projects/new after FV-related request approval

### DIFF
--- a/atst/forms/new_project.py
+++ b/atst/forms/new_project.py
@@ -1,7 +1,7 @@
 from flask_wtf import Form
 from wtforms.fields import StringField, TextAreaField, FieldList
 from wtforms.validators import Required
-from atst.forms.validators import ListItemRequired
+from atst.forms.validators import ListItemRequired, ListItemsUnique
 
 
 class NewProjectForm(Form):
@@ -12,7 +12,10 @@ class NewProjectForm(Form):
     description = TextAreaField(label="Description", validators=[Required()])
     environment_names = FieldList(
         StringField(label="Environment Name"),
-        validators=[ListItemRequired(message="Provide at least one environment name.")],
+        validators=[
+            ListItemRequired(message="Provide at least one environment name."),
+            ListItemsUnique(message="Environment names must be unique."),
+        ],
     )
 
     @property

--- a/atst/forms/validators.py
+++ b/atst/forms/validators.py
@@ -64,8 +64,7 @@ def ListItemRequired(message="Please provide at least one.", empty_values=("", N
 
 def ListItemsUnique(message="Items must be unique"):
     def _list_items_unique(form, field):
-        sorted_values = sorted(v for v in field.data)
-        if sorted_values != sorted(set(sorted_values)):
+        if len(field.data) > len(set(field.data)):
             raise ValidationError(message)
 
     return _list_items_unique

--- a/atst/forms/validators.py
+++ b/atst/forms/validators.py
@@ -60,3 +60,12 @@ def ListItemRequired(message="Please provide at least one.", empty_values=("", N
             raise ValidationError(message)
 
     return _list_item_required
+
+
+def ListItemsUnique(message="Items must be unique"):
+    def _list_items_unique(form, field):
+        sorted_values = sorted(v for v in field.data)
+        if sorted_values != sorted(set(sorted_values)):
+            raise ValidationError(message)
+
+    return _list_items_unique

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -45,7 +45,7 @@ def update_financial_verification(request_id):
             new_workspace = Requests.approve_and_create_workspace(updated_request)
             return redirect(
                 url_for(
-                    "workspaces.workspace_projects",
+                    "workspaces.new_project",
                     workspace_id=new_workspace.id,
                     newWorkspace=True,
                 )

--- a/styles/elements/_block_lists.scss
+++ b/styles/elements/_block_lists.scss
@@ -18,7 +18,14 @@
 
   .icon-tooltip {
     margin: -$gap;
+  }
 
+  &--grow {
+    display: inline-block;
+    width: 100%;
+    p {
+      margin-bottom: 0;
+    }
   }
 }
 

--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -31,6 +31,10 @@
         <div class='alert__message'>{{ message | safe }}</div>
       {% endif %}
 
+      {% if caller %}
+        <div class='alert__message'>{{ caller() }}</div>
+      {% endif %}
+
       {% if fragment %}
         <div class='alert__message'>
           {% include fragment %}

--- a/templates/workspace_project_new.html
+++ b/templates/workspace_project_new.html
@@ -9,6 +9,14 @@
 {% block workspace_content %}
 
 {% set modalName = "newProjectConfirmation" %}
+{% if request.args.get("newWorkspace") %}
+  {{ Alert('Workspace created!',
+    message="\
+      <p>You are now ready to create projects and environments within the JEDI Cloud.</p>
+    ",
+    level='success'
+  ) }}
+{% endif %}
 
 <new-project inline-template v-bind:initial-data='{{ form.data|tojson }}'>
   <form method="POST" action="{{ url_for('workspaces.update_project', workspace_id=workspace.id) }}" >

--- a/templates/workspace_project_new.html
+++ b/templates/workspace_project_new.html
@@ -40,14 +40,12 @@
     <div class="panel">
       <div class="panel__heading panel__heading--grow">
         <h1>Add a new project</h1>
-        {{ Tooltip(
-          "AT-AT allows you to organize your workspace into multiple projects, each of which may have environments.",
-          title="learn more"
-        )}}
       </div>
 
-
       <div class="panel__content">
+        <p>
+          AT-AT allows you to organize your workspace into multiple projects, each of which may have environments.
+        </p>
         {{ TextInput(form.name) }}
         {{ TextInput(form.description, paragraph=True) }}
       </div>
@@ -62,12 +60,11 @@
     {% endif %}
 
       <div class="block-list project-list-item">
-        <header class="block-list__header">
+        <header class="block-list__header block-list__header--grow">
           <h2 class="block-list__title">Project Environments</h2>
-          {{ Tooltip(
-            "Each environment created within a project is an enclave of cloud resources that is logically separated from each other for increased security.",
-            title="learn more"
-          )}}
+          <p>
+            Each environment created within a project is an enclave of cloud resources that is logically separated from each other for increased security.
+          </p>
         </header>
 
         <ul>

--- a/templates/workspace_project_new.html
+++ b/templates/workspace_project_new.html
@@ -52,11 +52,9 @@
     </div>
 
     {% if form.environment_names.errors %}
-      {% call Alert("Missing Environments", level="error") %}
-        {% for error in form.environment_names.errors %}
-          <p>{{ error }}</p>
-        {% endfor %}
-      {% endcall %}
+      {% for error in form.environment_names.errors %}
+        {{ Alert(error, level="error") }}
+      {% endfor %}
     {% endif %}
 
       <div class="block-list project-list-item">

--- a/templates/workspace_project_new.html
+++ b/templates/workspace_project_new.html
@@ -54,7 +54,11 @@
     </div>
 
     {% if form.environment_names.errors %}
-      {{ Alert("Missing Environments", message="Provide at least one environment name.", level="error") }}
+      {% call Alert("Missing Environments", level="error") %}
+        {% for error in form.environment_names.errors %}
+          <p>{{ error }}</p>
+        {% endfor %}
+      {% endcall %}
     {% endif %}
 
       <div class="block-list project-list-item">

--- a/templates/workspace_projects.html
+++ b/templates/workspace_projects.html
@@ -5,15 +5,6 @@
 
 {% block workspace_content %}
 
-{% if request.args.get("newWorkspace") %}
-  {{ Alert('Workspace created!',
-    message="\
-      <p>You are now ready to create projects and environments within the JEDI Cloud.</p>
-    ",
-    level='success'
-  ) }}
-{% endif %}
-
 {% for project in workspace.projects %}
   <div class='block-list project-list-item'>
     <header class='block-list__header'>

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -63,7 +63,7 @@ class TestListItemsUnique:
     @pytest.mark.parametrize(
         "invalid", [["a", "a", "a"], ["one", "two", "two", "three"]]
     )
-    def test_ListItemsUnique_rejects_non_letters(
+    def test_ListItemsUnique_rejects_duplicate_names(
         self, invalid, dummy_form, dummy_field
     ):
         validator = ListItemsUnique()

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -1,7 +1,7 @@
 from wtforms.validators import ValidationError
 import pytest
 
-from atst.forms.validators import Alphabet, IsNumber, PhoneNumber
+from atst.forms.validators import Alphabet, IsNumber, PhoneNumber, ListItemsUnique
 
 
 class TestIsNumber:
@@ -48,6 +48,21 @@ class TestAlphabet:
     @pytest.mark.parametrize("invalid", ["", "hi mark", "cloud9"])
     def test_Alphabet_rejects_non_letters(self, invalid, dummy_form, dummy_field):
         validator = Alphabet()
+        dummy_field.data = invalid
+        with pytest.raises(ValidationError):
+            validator(dummy_form, dummy_field)
+
+
+class TestListItemsUnique:
+    @pytest.mark.parametrize("valid", [["a", "aa", "aaa"], ["one", "two", "three"]])
+    def test_ListItemsUnique_allows_unique_items(self, valid, dummy_form, dummy_field):
+        validator = ListItemsUnique()
+        dummy_field.data = valid
+        validator(dummy_form, dummy_field)
+
+    @pytest.mark.parametrize("invalid", [["a", "a", "a"], ["one", "two", "two", "three"]])
+    def test_ListItemsUnique_rejects_non_letters(self, invalid, dummy_form, dummy_field):
+        validator = ListItemsUnique()
         dummy_field.data = invalid
         with pytest.raises(ValidationError):
             validator(dummy_form, dummy_field)

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -60,8 +60,12 @@ class TestListItemsUnique:
         dummy_field.data = valid
         validator(dummy_form, dummy_field)
 
-    @pytest.mark.parametrize("invalid", [["a", "a", "a"], ["one", "two", "two", "three"]])
-    def test_ListItemsUnique_rejects_non_letters(self, invalid, dummy_form, dummy_field):
+    @pytest.mark.parametrize(
+        "invalid", [["a", "a", "a"], ["one", "two", "two", "three"]]
+    )
+    def test_ListItemsUnique_rejects_non_letters(
+        self, invalid, dummy_form, dummy_field
+    ):
         validator = ListItemsUnique()
         dummy_field.data = invalid
         with pytest.raises(ValidationError):

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -137,4 +137,4 @@ class TestPENumberInForm:
         response = self.submit_data(client, data, extended=True)
 
         assert response.status_code == 302
-        assert "/workspaces" in response.headers.get("Location")
+        assert "/projects/new" in response.headers.get("Location")


### PR DESCRIPTION
After a user updates their financial verification information and the request is approved, they are now redirected right to the new project form, rather than the project listing page. The form also now shows the "workspace created!" modal.

The copy that was hidden in the tooltips is now inline.

I also added a bonus validation which ensures that environment names are unique. Includes a small tweak to `components/alert` to allow us to pass blocks rather than just a message string.

![screen shot 2018-08-24 at 2 27 36 pm](https://user-images.githubusercontent.com/38955572/44601251-ddf60680-a7a9-11e8-8d15-23dd3f875686.png)

