### PR TITLE
record invalid task order number on the request body

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -244,7 +244,10 @@ WHERE requests_with_status.status = :status
             for (k, v) in financial_data.items()
             if k in TaskOrders.TASK_ORDER_DATA
         }
-        task_order_number = request_data.pop("task_order_number")
+        if task_order_data:
+            task_order_number = request_data.pop("task_order_number")
+        else:
+            task_order_number = request_data.get("task_order_number")
 
         task_order = TaskOrders.get_or_create_task_order(
             task_order_number, task_order_data

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -154,3 +154,8 @@ def test_update_financial_verification_with_invalid_task_order():
     request = RequestFactory.create()
     Requests.update_financial_verification(request.id, request_financial_data)
     assert not request.task_order
+    assert "task_order_number" in request.body.get("financial_verification")
+    assert (
+        request.body["financial_verification"]["task_order_number"]
+        == request_financial_data["task_order_number"]
+    )


### PR DESCRIPTION
This addresses a problem noted [here](https://www.pivotaltracker.com/story/show/158436096/comments/193453188) in PT.

If a user submits an invalid TO number on the basic financial verification form, we don't save it anywhere right now. That means that the field is blank when they move to the extended financial verification form. This PR changes the behavior so that we record the invalid task order number on the request body. That way the field is populated when the user moves to the extended form.

This is probably a temporary fix until we add a real schema for `requests`.