### PR TITLE
move pe number ingestion for setup into a migration

### DIFF
--- a/alembic/versions/2c2a2af465d3_add_pe_numbers.py
+++ b/alembic/versions/2c2a2af465d3_add_pe_numbers.py
@@ -1,7 +1,7 @@
 """add PE numbers
 
 Revision ID: 2c2a2af465d3
-Revises: 0845b2f0f401
+Revises: 14cd800904bc
 Create Date: 2018-08-27 16:26:51.707146
 
 """
@@ -17,7 +17,7 @@ from atst.models.pe_number import PENumber
 
 # revision identifiers, used by Alembic.
 revision = '2c2a2af465d3'
-down_revision = '0845b2f0f401'
+down_revision = '14cd800904bc'
 branch_labels = None
 depends_on = None
 

--- a/alembic/versions/2c2a2af465d3_add_pe_numbers.py
+++ b/alembic/versions/2c2a2af465d3_add_pe_numbers.py
@@ -1,0 +1,44 @@
+"""add PE numbers
+
+Revision ID: 2c2a2af465d3
+Revises: 0845b2f0f401
+Create Date: 2018-08-27 16:26:51.707146
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import insert
+from urllib.request import urlopen
+import csv
+
+from atst.app import make_config
+from atst.models.pe_number import PENumber
+
+
+# revision identifiers, used by Alembic.
+revision = '2c2a2af465d3'
+down_revision = '0845b2f0f401'
+branch_labels = None
+depends_on = None
+
+
+def get_pe_numbers(url):
+    response = urlopen(url)
+    t = response.read().decode("utf-8")
+    return list(csv.reader(t.split("\r\n")))
+
+
+def upgrade():
+    config = make_config()
+    pe_numbers = get_pe_numbers(config["PE_NUMBER_CSV_URL"])
+    db = op.get_bind()
+    stmt = insert(PENumber).values(pe_numbers)
+    do_update = stmt.on_conflict_do_update(
+        index_elements=["number"], set_=dict(description=stmt.excluded.description)
+    )
+    db.execute(do_update)
+
+
+def downgrade():
+    db = op.get_bind()
+    db.execute("TRUNCATE TABLE pe_number")

--- a/script/setup
+++ b/script/setup
@@ -14,8 +14,5 @@ RESET_DB="true"
 # Run the shared setup script
 source ./script/include/run_setup
 
-# Fetch and import the PE numbers
-run_command "python script/ingest_pe_numbers.py"
-
 # Compile assets and generate hash-named static files
 yarn build

--- a/script/update
+++ b/script/update
@@ -9,6 +9,3 @@ MIGRATE_DB="true"
 
 # Run the shared update script
 source ./script/include/run_update
-
-# Fetch and import/update the PE numbers
-run_command "python script/ingest_pe_numbers.py"


### PR DESCRIPTION
This should take care of [this](https://www.pivotaltracker.com/story/show/160063695) bug. It moves PE number ingestion into a migration so that it will get run during our CD. I think both schema and state are fair game for migrations, and having the list of PE numbers is required initial state for the app. I got rid of related code in `PENumbers` that's not used anywhere else.