### PR TITLE
Ui/meter fix

### DIFF
--- a/styles/elements/_graphs.scss
+++ b/styles/elements/_graphs.scss
@@ -1,6 +1,5 @@
 meter {
   -moz-appearance: none;
-  appearance: none;
   display: block;
   background: $color-gray-lightest;
 

--- a/styles/sections/_reports.scss
+++ b/styles/sections/_reports.scss
@@ -222,6 +222,8 @@
 
       &.meter-cell {
         padding-left: 0;
+        position: relative;
+        min-width: 4rem;
 
         @include media($medium-screen) {
           min-width: 12rem;
@@ -231,7 +233,6 @@
           width: 100%;
           height: 3rem;
           background: $color-white;
-          position: relative;
           display: none;
 
           @include media($medium-screen) {
@@ -241,14 +242,17 @@
           &::-webkit-meter-bar {
             background: $color-white;
           }
+        }
 
-          &::before {
-            content: attr(title);
-            position: absolute;
-            top: .5rem;
-            left: $gap;
-            @include h5;
+        .spend-table__meter-value {
+          @include h5;
+
+          @include media($medium-screen) {
+            display: block;
             color: $color-white;
+            position: absolute;
+            top: 2.3rem;
+            left: $gap;
           }
         }
       }

--- a/templates/workspace_reports.html
+++ b/templates/workspace_reports.html
@@ -130,7 +130,8 @@
             <td class='table-cell--align-right previous-month'>$30,000</td>
             <td class='table-cell--align-right current-month'>$31,000</td>
             <td class='table-cell--expand current-month meter-cell'>
-              <meter value='31000' min='0' max='62000' title='50%'></meter>
+              <span class='spend-table__meter-value'>50%</span>
+              <meter value='31000' min='0' max='62000'></meter>
             </td>
           </tr>
 
@@ -166,7 +167,8 @@
             <td class='table-cell--align-right previous-month'>$30,000</td>
             <td class='table-cell--align-right current-month'>$31,000</td>
             <td class='table-cell--expand current-month meter-cell'>
-              <meter value='31000' min='0' max='62000' title='50%'></meter>
+              <span class='spend-table__meter-value'>50%</span>
+              <meter value='31000' min='0' max='62000'></meter>
             </td>
           </tr>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2353,10 +2353,6 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-flexibility@1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/flexibility/-/flexibility-1.0.6.tgz#faa5caf65708c91317508a491d194f434f2eba74"
-
 flush-write-stream@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.0.3.tgz#c5d586ef38af6097650b49bc41b55fabb19f35bd"
@@ -4815,12 +4811,6 @@ postcss-filter-plugins@^2.0.0:
   resolved "https://registry.yarnpkg.com/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz#82245fdf82337041645e477114d8e593aa18b8ec"
   dependencies:
     postcss "^5.0.4"
-
-postcss-flexibility@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/postcss-flexibility/-/postcss-flexibility-2.0.0.tgz#5612c1b85d6595ed480966839928a41617a6a768"
-  dependencies:
-    postcss "^6.0.1"
 
 postcss-merge-idents@^2.1.5:
   version "2.1.7"


### PR DESCRIPTION
Some minor fixes to the meter element.

- Remove `appearance: none`, this is now auto-prefixed and inadvertently hides the bar in Chrome.
- Don't use `content: attr(title)` on the meter element. Meter pseudo elements are only supported in Chrome. Its replaced with an actual element, which is more accessible anyway.