### PR TITLE
Fix PDF uploading

### DIFF
--- a/atst/uploader.py
+++ b/atst/uploader.py
@@ -1,4 +1,6 @@
+from tempfile import NamedTemporaryFile
 from uuid import uuid4
+
 from libcloud.storage.types import Provider
 from libcloud.storage.providers import get_driver
 
@@ -26,13 +28,13 @@ class Uploader:
             )
 
         object_name = uuid4().hex
-        self.container.driver._put_object(
-            stream=iter(fyle.stream),
-            container=self.container,
-            object_name=object_name,
-            verify_hash=False,
-            extra={"acl": "private"},
-        )
+        with NamedTemporaryFile() as tempfile:
+            tempfile.write(fyle.stream.read())
+            self.container.upload_object(
+                file_path=tempfile.name,
+                object_name=object_name,
+                extra={"acl": "private"},
+            )
         return (fyle.filename, object_name)
 
     def download(self, path):

--- a/atst/uploader.py
+++ b/atst/uploader.py
@@ -26,9 +26,11 @@ class Uploader:
             )
 
         object_name = uuid4().hex
-        self.container.upload_object_via_stream(
-            iterator=fyle.stream.__iter__(),
+        self.container.driver._put_object(
+            stream=iter(fyle.stream),
+            container=self.container,
             object_name=object_name,
+            verify_hash=False,
             extra={"acl": "private"},
         )
         return (fyle.filename, object_name)

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:e38bc2f
+          image: registry.atat.codes:443/atst-prod:0696894
           resources:
             requests:
                memory: "2500Mi"
@@ -74,7 +74,7 @@ spec:
           secret:
             secretName: atst-config-ini
             items:
-            - key: atst-overrides.ini
+            - key: override.ini
               path: atst-overrides.ini
               mode: 0644
         - name: nginx-auth-tls

--- a/script/update
+++ b/script/update
@@ -4,6 +4,9 @@
 
 source "$(dirname "${0}")"/../script/include/global_header.inc.sh
 
+# create upload directory for app
+mkdir uploads | true
+
 # Enable DB migration
 MIGRATE_DB="true"
 


### PR DESCRIPTION
Two fixes here:
1. fix a typo in the key name of the secret used to configure the flask app
2. upload the pdf via `libcloud` with a named temporary file instead of streaming. There's [a bug in `libcloud`](https://issues.apache.org/jira/browse/LIBCLOUD-935?focusedCommentId=16152982&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16152982) that prevents us from uploading a stream and verifying that hash of the uploaded file and no clean way to disable hash verification (not sure we would want to, anyway).