### PR TITLE
fix hide/unhide mixins

### DIFF
--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -5,6 +5,7 @@
 @mixin hide {
   border: 0;
   clip: rect(0 0 0 0);
+  clip-path: inset(100%);
   height: 1px;
   margin: -1px;
   overflow: hidden;
@@ -18,14 +19,13 @@
 }
 
 @mixin unhide {
-  border: unset;
-  clip: unset;
-  height: unset;
-  margin: unset;
-  overflow: unset;
-  padding: unset;
-  position: unset;
-  width: unset;
+  clip: auto;
+  clip-path: none;
+  height: auto;
+  overflow: visible;
+  position: static;
+  white-space: inherit;
+  width: auto;
 }
 
 @mixin line-max {


### PR DESCRIPTION
Fixes the hide/unhide sass mixins, which were failing in IE and forcing the navigation to always be collapsed.

See bug https://www.pivotaltracker.com/story/show/160146411