### PR TITLE
grey/italic input placeholder

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -112,6 +112,11 @@
     max-width: 32em;
     resize: none;
 
+    &::placeholder {
+      color: $color-gray;
+      font-style: italic;
+    }
+
     &:hover,
     &:focus {
       border-color: $color-blue !important;


### PR DESCRIPTION
This explicitly makes input placeholders gray and italicized. IE's default placeholder looks like normal input.

![screen shot 2018-08-31 at 10 01 53 am](https://user-images.githubusercontent.com/40467269/44916952-f499e180-ad04-11e8-8648-45d0bda4feec.png)

See bug https://www.pivotaltracker.com/story/show/160146701