### PR TITLE
Add a member to a workspace

### DIFF
--- a/atst/domain/workspace_users.py
+++ b/atst/domain/workspace_users.py
@@ -33,6 +33,8 @@ class WorkspaceUsers(object):
     @classmethod
     def add(cls, user, workspace_id, role_name):
         role = Roles.get(role_name)
+
+        new_workspace_role = None
         try:
             existing_workspace_role = (
                 db.session.query(WorkspaceRole)
@@ -52,6 +54,8 @@ class WorkspaceUsers(object):
         user.workspace_roles.append(new_workspace_role)
         db.session.add(user)
         db.session.commit()
+
+        return WorkspaceUser(user, new_workspace_role)
 
     @classmethod
     def add_many(cls, workspace_id, workspace_user_dicts):

--- a/atst/domain/workspaces.py
+++ b/atst/domain/workspaces.py
@@ -7,6 +7,8 @@ from atst.domain.exceptions import NotFoundError, UnauthorizedError
 from atst.domain.roles import Roles
 from atst.domain.authz import Authorization
 from atst.models.permissions import Permissions
+from atst.domain.users import Users
+from atst.domain.workspace_users import WorkspaceUsers
 
 
 class Workspaces(object):
@@ -60,6 +62,24 @@ class Workspaces(object):
             .all()
         )
         return workspaces
+
+    @classmethod
+    def create_member(cls, user, workspace, data):
+        if not Authorization.has_workspace_permission(
+            user, workspace, Permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE
+        ):
+            raise UnauthorizedError(user, "create workspace member")
+
+        new_user = Users.get_or_create_by_dod_id(
+            data["dod_id"],
+            first_name=data["first_name"],
+            last_name=data["last_name"],
+            email=data["email"],
+        )
+        workspace_user = WorkspaceUsers.add(
+            new_user, workspace.id, data["workspace_role"]
+        )
+        return workspace_user
 
     @classmethod
     def _create_workspace_role(cls, user, workspace, role_name):

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -106,27 +106,37 @@ COMPLETION_DATE_RANGES = [
 WORKSPACE_ROLES = [
     (
         "owner",
-        "Workspace Owner",
-        "Can add, edit, deactivate access to all projects, environments, and members. Can view budget reports. Can start and edit JEDI Cloud requests.",
+        {
+            "name": "Workspace Owner",
+            "description": "Can add, edit, deactivate access to all projects, environments, and members. Can view budget reports. Can start and edit JEDI Cloud requests.",
+        },
     ),
     (
         "admin",
-        "Administrator",
-        "Can add and edit projects, environments, members, but cannot deactivate. Cannot view budget reports or JEDI Cloud requests.",
+        {
+            "name": "Administrator",
+            "description": "Can add and edit projects, environments, members, but cannot deactivate. Cannot view budget reports or JEDI Cloud requests.",
+        },
     ),
     (
         "developer",
-        "Developer",
-        "Can view only the projects and environments they are granted access to. Can also view members associated with each environment.",
+        {
+            "name": "Developer",
+            "description": "Can view only the projects and environments they are granted access to. Can also view members associated with each environment.",
+        },
     ),
     (
         "billing_auditor",
-        "Billing Auditor",
-        "Can view only the projects and environments they are granted access to. Can also view budgets and reports associated with the workspace.",
+        {
+            "name": "Billing Auditor",
+            "description": "Can view only the projects and environments they are granted access to. Can also view budgets and reports associated with the workspace.",
+        },
     ),
     (
         "security_auditor",
-        "Security Auditor",
-        "Can view only the projects and environments they are granted access to. Can also view activity logs.",
+        {
+            "name": "Security Auditor",
+            "description": "Can view only the projects and environments they are granted access to. Can also view activity logs.",
+        },
     ),
 ]

--- a/atst/models/workspace_user.py
+++ b/atst/models/workspace_user.py
@@ -10,5 +10,9 @@ class WorkspaceUser(object):
         )
         return set(workspace_permissions).union(atat_permissions)
 
+    @property
+    def workspace(self):
+        return self.workspace_role.workspace
+
     def workspace_id(self):
         return self.workspace_role.workspace_id

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -101,3 +101,15 @@ def new_member(workspace_id):
     workspace = Workspaces.get(g.current_user, workspace_id)
     form = NewMemberForm()
     return render_template("member_new.html", workspace=workspace, form=form)
+
+
+@bp.route("/workspaces/<workspace_id>/members/new", methods=["POST"])
+def create_member(workspace_id):
+    workspace = Workspaces.get(g.current_user, workspace_id)
+    form = NewMemberForm(http_request.form)
+
+    if form.validate():
+        Workspaces.create_member(g.current_user, workspace, form.data)
+        return redirect(url_for("workspaces.new_member", memberCreated=True))
+    else:
+        return render_template("member_new.html", workspace=workspace, form=form)

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -110,6 +110,12 @@ def create_member(workspace_id):
 
     if form.validate():
         Workspaces.create_member(g.current_user, workspace, form.data)
-        return redirect(url_for("workspaces.new_member", memberCreated=True))
+        return redirect(
+            url_for(
+                "workspaces.workspace_members",
+                workspace_id=workspace.id,
+                memberCreated=True,
+            )
+        )
     else:
         return render_template("member_new.html", workspace=workspace, form=form)

--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -40,7 +40,6 @@ export default {
   methods: {
     change: function (e) {
       this.value = e.target.value
-      console.log(this.value)
       this.showError = false
       setTimeout(() => this.$refs.popover.hide(), 300)
     }

--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -26,17 +26,21 @@ export default {
 
   computed: {
     label: function () {
-      return this.value
-        ? this.choices.find((choice) => {
+      if (this.value) {
+        const selectedChoice = this.choices.find((choice) => {
           return this.value === choice[0]
         })[1]
-        : this.defaultLabel
+        return selectedChoice.name
+      } else {
+        return this.defaultLabel
+      }
     }
   },
 
   methods: {
     change: function (e) {
       this.value = e.target.value
+      console.log(this.value)
       this.showError = false
       setTimeout(() => this.$refs.popover.hide(), 300)
     }

--- a/templates/components/selector.html
+++ b/templates/components/selector.html
@@ -44,13 +44,13 @@
                   v-bind:checked='value === choice[0]'
                   v-on:change='change'/>
                 <label v-bind:for="'{{ field.name }}_' + choice[0]">
-                  <template v-if='choices[2]'>
+                  <template v-if='choice[1].description'>
                     <dl>
-                      <dt v-html='choice[1]'></dt>
-                      <dd v-html='choice[2]'></dd>
+                      <dt v-html='choice[1].name'></dt>
+                      <dd v-html='choice[1].description'></dd>
                     </dl>
                   </template>
-                  <span v-else v-html='choice[1]'>
+                  <span v-else v-html='choice[1].name'>
                 </label>
               </template>
             </li>

--- a/templates/member_new.html
+++ b/templates/member_new.html
@@ -7,7 +7,8 @@
 
 {% block content %}
 
-<form method="POST" action="" autocomplete="false">
+<form method="POST" action="{{ url_for('workspaces.create_member', workspace_id=workspace.id) }}" autocomplete="false">
+  {{ form.csrf_token }}
 
   <div class="panel">
 
@@ -27,9 +28,7 @@
 
 
   <div class='action-group'>
-    <a href='#' class='action-group__action usa-button usa-button-big'>
-      Add User
-    </a>
+    <button class="usa-button usa-button-big usa-button-primary" tabindex="0">Add User</button>
     <a href='#' class='action-group__action icon-link'>
       {{ Icon('x') }}
       <span>Cancel</span>

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -98,7 +98,7 @@ def test_can_create_workspace_user():
         "last_name": "User",
         "email": "new.user@mail.com",
         "workspace_role": "developer",
-        "dod_id": "1234567890"
+        "dod_id": "1234567890",
     }
 
     new_member = Workspaces.create_member(owner, workspace, user_data)
@@ -114,7 +114,7 @@ def test_need_permission_to_create_workspace_user():
         "last_name": "User",
         "email": "new.user@mail.com",
         "workspace_role": "developer",
-        "dod_id": "1234567890"
+        "dod_id": "1234567890",
     }
 
     with pytest.raises(UnauthorizedError):

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -87,3 +87,35 @@ def test_get_for_update_blocks_developer():
 
     with pytest.raises(UnauthorizedError):
         Workspaces.get_for_update(developer, workspace.id)
+
+
+def test_can_create_workspace_user():
+    owner = UserFactory.create()
+    workspace = Workspaces.create(RequestFactory.create(creator=owner))
+
+    user_data = {
+        "first_name": "New",
+        "last_name": "User",
+        "email": "new.user@mail.com",
+        "workspace_role": "developer",
+        "dod_id": "1234567890"
+    }
+
+    new_member = Workspaces.create_member(owner, workspace, user_data)
+    assert new_member.workspace == workspace
+
+
+def test_need_permission_to_create_workspace_user():
+    workspace = Workspaces.create(request=RequestFactory.create())
+    random_user = UserFactory.create()
+
+    user_data = {
+        "first_name": "New",
+        "last_name": "User",
+        "email": "new.user@mail.com",
+        "workspace_role": "developer",
+        "dod_id": "1234567890"
+    }
+
+    with pytest.raises(UnauthorizedError):
+        Workspaces.create_member(random_user, workspace, user_data)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/158072111

With @montana-mil.

Hooks up the new member form to a new route that creates the member in the workspace.

Includes a change to the Selector component to make it play nicely with WTForms. Since the WTForms SelectField always expects a tuple with a 2-arity, I collapsed the second and third elements into an object with keys `name` and `description`.