### PR TITLE
revert Vue to 2.5.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "text-mask-addons": "^3.8.0",
     "uswds": "^1.6.3",
     "v-tooltip": "^2.0.0-rc.33",
-    "vue": "^2.5.17",
+    "vue": "2.5.15",
     "vue-text-mask": "^6.1.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6708,9 +6708,9 @@ vue-text-mask@^6.1.2:
   version "6.1.2"
   resolved "https://registry.yarnpkg.com/vue-text-mask/-/vue-text-mask-6.1.2.tgz#2cc18a1ca04ea66798518a9373929a12256d14b9"
 
-vue@^2.5.17:
-  version "2.5.17"
-  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.17.tgz#0f8789ad718be68ca1872629832ed533589c6ada"
+vue@2.5.15:
+  version "2.5.15"
+  resolved "https://registry.yarnpkg.com/vue/-/vue-2.5.15.tgz#fdb67861dde967cd8d1b53116380f2f269b45202"
 
 wcwidth@^1.0.0, wcwidth@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Fixes a bug in all versions of IE where `v-for` attributes would fail utterly.

See https://www.pivotaltracker.com/story/show/160265154
See https://github.com/vuejs/vue/pull/8048