### PR TITLE
Redirect CCPO to requests index after login

### DIFF
--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -17,7 +17,7 @@ def root():
 
 @bp.route("/home")
 def home():
-    return render_template("home.html")
+    return redirect(url_for("requests.requests_index"))
 
 
 @bp.route("/styleguide")
@@ -46,7 +46,7 @@ def login_redirect():
     user = auth_context.get_user()
     session["user_id"] = user.id
 
-    return redirect(url_for("requests.requests_index"))
+    return redirect(url_for(".home"))
 
 
 def _is_valid_certificate(request):

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -46,10 +46,7 @@ def login_redirect():
     user = auth_context.get_user()
     session["user_id"] = user.id
 
-    if user.atat_role.name == "ccpo":
-        return redirect(url_for("requests.requests_index"))
-    else:
-        return redirect(url_for("requests.requests_index"))
+    return redirect(url_for("requests.requests_index"))
 
 
 def _is_valid_certificate(request):

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -47,7 +47,7 @@ def login_redirect():
     session["user_id"] = user.id
 
     if user.atat_role.name == "ccpo":
-        return redirect(url_for("atst.home"))
+        return redirect(url_for("requests.requests_index"))
     else:
         return redirect(url_for("requests.requests_index"))
 

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -63,4 +63,4 @@ def login_dev():
     )
     session["user_id"] = user.id
 
-    return redirect(url_for("requests.requests_index"))
+    return redirect(url_for("atst.home"))

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -63,7 +63,4 @@ def login_dev():
     )
     session["user_id"] = user.id
 
-    if user.atat_role.name == "ccpo":
-        return redirect(url_for("requests.requests_index"))
-    else:
-        return redirect(url_for("requests.requests_index"))
+    return redirect(url_for("requests.requests_index"))

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -64,6 +64,6 @@ def login_dev():
     session["user_id"] = user.id
 
     if user.atat_role.name == "ccpo":
-        return redirect(url_for("atst.home"))
+        return redirect(url_for("requests.requests_index"))
     else:
         return redirect(url_for("requests.requests_index"))

--- a/tests/routes/test_home.py
+++ b/tests/routes/test_home.py
@@ -8,12 +8,12 @@ def test_user_with_workspaces_has_workspaces_nav(client, user_session):
     Workspaces._create_workspace_role(user, workspace, "default")
 
     user_session(user)
-    response = client.get("/home")
+    response = client.get("/home", follow_redirects=True)
     assert b'href="/workspaces"' in response.data
 
 
 def test_user_without_workspaces_has_no_workspaces_nav(client, user_session):
     user = UserFactory.create()
     user_session(user)
-    response = client.get("/home")
+    response = client.get("/home", follow_redirects=True)
     assert b'href="/workspaces"' not in response.data

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -57,7 +57,7 @@ def test_successful_login_redirect_ccpo(client, monkeypatch):
     )
 
     assert resp.status_code == 302
-    assert "home" in resp.headers["Location"]
+    assert "requests" in resp.headers["Location"]
     assert session["user_id"]
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -33,7 +33,7 @@ def test_successful_login_redirect_non_ccpo(client, monkeypatch):
     )
 
     assert resp.status_code == 302
-    assert "requests" in resp.headers["Location"]
+    assert "home" in resp.headers["Location"]
     assert session["user_id"]
 
 
@@ -57,7 +57,7 @@ def test_successful_login_redirect_ccpo(client, monkeypatch):
     )
 
     assert resp.status_code == 302
-    assert "requests" in resp.headers["Location"]
+    assert "home" in resp.headers["Location"]
     assert session["user_id"]
 
 
@@ -119,8 +119,6 @@ def test_crl_validation_on_login(client):
             "HTTP_X_SSL_CLIENT_CERT": good_cert,
         },
     )
-    assert resp.status_code == 302
-    assert "requests" in resp.headers["Location"]
     assert session["user_id"]
 
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -5,7 +5,6 @@ import pytest
     "path",
     (
         "/",
-        "/home",
         "/workspaces",
         "/requests",
         "/requests/new/1",


### PR DESCRIPTION
Now a CCPO is redirect to the requests index after logging in. 

I don't think that the /home route is being used anymore. Not sure if we should delete it or not.