### PR TITLE
UI/request approval

### DIFF
--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -72,9 +72,9 @@
 
         <div class="form__sub-fields">
 
-          <h3>Comments to End User</h3>
+          <h3>Comments to Requestor</h3>
 
-          You may leave a comment for the end user explaining what changes are being requested or why further discussion is needed about this request. The user can then re-submit the request with your changes requested or may initiate an offline message (via email) to respond to the CCPO directly. <br> This notes are optional and <b>will be visible to end-users</b>.
+          You may leave a comment for the requestor explaining what changes are being requested or why further discussion is needed about this request. The requestor can then re-submit the request with your changes requested or may initiate an offline message (via email) to respond to the CCPO directly. <br> This notes are optional and <b>will be visible to requestors</b>.
 
           <div class='usa-input'>
             <label for='notes'>Comments <em>(optional)</em></label>
@@ -87,7 +87,7 @@
         <div class="form-row">
           <div class="form-col">
             <h3>Authorizing Officials</h3>
-            <p>This section is not visible to the end user. It will only be visible to CCPO staff.</p>
+            <p>This section is not visible to the requestor. It will only be visible to CCPO staff.</p>
             <p>Provide the name of the key officials for both parties that have authorized this request to move forward.</p>
           </div>
         </div>
@@ -136,13 +136,6 @@
               <input id='ccpo-behalf-fname' type='text' placeholder='Name of approving officer' tabindex='5' />
             </div>
 
-            <div class='usa-input'>
-              <label for='ccpo-behalf-email'>CCPO e-mail</label>
-              <input id='ccpo-behalf-email' type='email' placeholder='i.e. name@mail.mil' tabindex='7' />
-            </div>
-
-
-
           </div>
 
           <div class="form-col">
@@ -151,12 +144,6 @@
               <label for='ccpo-behalf-lname'>Last Name</label>
               <input id='ccpo-behalf-lname' type='text' placeholder='Name of approving officer' tabindex='6' />
             </div>
-
-            <div class='usa-input'>
-              <label for='ccpo-behalf-phone'>CCPO phone number</label>
-              <input id='ccpo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890' tabindex='8' />
-            </div>
-
 
           </div>
         </div>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -94,6 +94,7 @@
         <h4 class="h3">Mission Authorizing Official</h4>
 
         <div class='form-row'>
+
           <div class='form-col'>
 
             <div class='usa-input'>
@@ -101,15 +102,31 @@
               <input id='mo-behalf-fname' type='text' placeholder='First name of mission authorizing official' />
             </div>
 
+          </div>
+
+          <div class='form-col'>
+
             <div class='usa-input'>
               <label for='mo-behalf-lname'>Last Name</label>
               <input id='mo-behalf-lname' type='text' placeholder='Last name of mission authorizing official'/>
             </div>
 
+          </div>
+
+        </div>
+
+        <div class='form-row'>
+
+          <div class='form-col'>
+
             <div class='usa-input'>
               <label for='mo-behalf-email'>Mission Owner e-mail</label>
               <input id='mo-behalf-email' type='email' placeholder='name@mail.mil'/>
             </div>
+
+          </div>
+
+          <div class='form-col'>
 
             <div class='usa-input'>
               <label for='mo-behalf-phone'>Mission Owner phone number</label>
@@ -124,6 +141,7 @@
         <h4 class="h3">CCPO Authorizing Official</h4>
 
         <div class="form-row">
+
           <div class='form-col'>
 
             <div class='usa-input'>
@@ -131,18 +149,26 @@
               <input id='ccpo-behalf-fname' type='text' placeholder='First name of authorizing official' />
             </div>
 
+          </div>
+
+          <div class='form-col'>
+
             <div class='usa-input'>
               <label for='ccpo-behalf-lname'>Last Name</label>
               <input id='ccpo-behalf-lname' type='text' placeholder='Last name of authorizing official' />
             </div>
-          </div>
 
+          </div>
         </div>
 
       </div>
 
+    </div>
 
-    </section>
+  </div>
+
+
+</section>
 
     <section class='action-group'>
       <a href='#' class='usa-button usa-button-big'>Approve Request</a>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -119,12 +119,14 @@
 
           <div class='form-col'>
 
+
             <div class='usa-input'>
               <label for='mo-behalf-email'>Mission Owner e-mail</label>
               <input id='mo-behalf-email' type='email' placeholder='name@mail.mil'/>
             </div>
 
           </div>
+
 
           <div class='form-col'>
 
@@ -135,13 +137,14 @@
 
           </div>
 
+
+
         </div>
 
 
         <h4 class="h3">CCPO Authorizing Official</h4>
 
         <div class="form-row">
-
           <div class='form-col'>
 
             <div class='usa-input'>
@@ -149,26 +152,18 @@
               <input id='ccpo-behalf-fname' type='text' placeholder='First name of authorizing official' />
             </div>
 
-          </div>
-
-          <div class='form-col'>
-
             <div class='usa-input'>
               <label for='ccpo-behalf-lname'>Last Name</label>
               <input id='ccpo-behalf-lname' type='text' placeholder='Last name of authorizing official' />
             </div>
-
           </div>
+
         </div>
 
       </div>
 
-    </div>
 
-  </div>
-
-
-</section>
+    </section>
 
     <section class='action-group'>
       <a href='#' class='usa-button usa-button-big'>Approve Request</a>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -96,7 +96,7 @@
 
         <div class='form-row'>
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
             <div class='usa-input'>
               <label for='mo-behalf-fname'>First Name</label>
@@ -105,7 +105,7 @@
 
           </div>
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
             <div class='usa-input'>
               <label for='mo-behalf-lname'>Last Name</label>
@@ -118,7 +118,7 @@
 
         <div class='form-row'>
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
 
             <div class='usa-input'>
@@ -129,7 +129,7 @@
           </div>
 
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
             <div class='usa-input'>
               <label for='mo-behalf-phone'>Mission Owner phone number (optional)</label>
@@ -145,7 +145,7 @@
 
         <div class='form-row'>
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-fname'>First Name</label>
@@ -154,7 +154,7 @@
 
           </div>
 
-          <div class='form-col'>
+          <div class='form-col form-col--half'>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-lname'>Last Name</label>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -98,27 +98,22 @@
 
             <div class='usa-input'>
               <label for='mo-behalf-fname'>First Name</label>
-              <input id='mo-behalf-fname' type='text' placeholder='First name of mission authorizing official' tabindex='1' />
+              <input id='mo-behalf-fname' type='text' placeholder='First name of mission authorizing official' />
+            </div>
+
+            <div class='usa-input'>
+              <label for='mo-behalf-lname'>Last Name</label>
+              <input id='mo-behalf-lname' type='text' placeholder='Last name of mission authorizing official'/>
             </div>
 
             <div class='usa-input'>
               <label for='mo-behalf-email'>Mission Owner e-mail</label>
-              <input id='mo-behalf-email' type='email' placeholder='i.e. name@mail.mil' tabindex='3'/>
-            </div>
-
-          </div>
-
-
-          <div class='form-col'>
-
-            <div class='usa-input'>
-              <label for='mo-behalf-lname'>Last Name</label>
-              <input id='mo-behalf-lname' type='text' placeholder='Last name of mission authorizing official' tabindex='2'/>
+              <input id='mo-behalf-email' type='email' placeholder='name@mail.mil'/>
             </div>
 
             <div class='usa-input'>
               <label for='mo-behalf-phone'>Mission Owner phone number</label>
-              <input id='mo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890' tabindex='4'/>
+              <input id='mo-behalf-phone' type='tel' placeholder='(123) 456-7890'/>
             </div>
 
           </div>
@@ -129,23 +124,19 @@
         <h4 class="h3">CCPO Authorizing Official</h4>
 
         <div class="form-row">
-          <div class="form-col">
+          <div class='form-col'>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-fname'>First Name</label>
-              <input id='ccpo-behalf-fname' type='text' placeholder='Name of approving officer' tabindex='5' />
+              <input id='ccpo-behalf-fname' type='text' placeholder='First name of authorizing official' />
             </div>
-
-          </div>
-
-          <div class="form-col">
 
             <div class='usa-input'>
               <label for='ccpo-behalf-lname'>Last Name</label>
-              <input id='ccpo-behalf-lname' type='text' placeholder='Name of approving officer' tabindex='6' />
+              <input id='ccpo-behalf-lname' type='text' placeholder='Last name of authorizing official' />
             </div>
-
           </div>
+
         </div>
 
       </div>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -72,9 +72,9 @@
 
         <div class="form__sub-fields">
 
-          <h3>Comments to Requestor</h3>
+          <h3>Instructions for the Requestor</h3>
 
-          You may leave a comment for the requestor explaining what changes are being requested or why further discussion is needed about this request. The requestor can then re-submit the request with your changes requested or may initiate an offline message (via email) to respond to the CCPO directly. <br> This notes are optional and <b>will be visible to requestors</b>.
+          Provide instructions or notes for additional information that is necessary to approve the request here. The requestor may then re-submit the updated request or initiate contact outside of AT-AT if further discussion is required. <b>These notes will be visible to the person making the JEDI request</b>.
 
           <div class='usa-input'>
             <label for='notes'>Comments <em>(optional)</em></label>
@@ -87,8 +87,9 @@
         <div class="form-row">
           <div class="form-col">
             <h3>Authorizing Officials</h3>
-            <p>This section is not visible to the requestor. It will only be visible to CCPO staff.</p>
+            <p>This section is not visible to the person making the request. It is only viewable by CCPO staff.</p>
             <p>Provide the name of the key officials for both parties that have authorized this request to move forward.</p>
+
           </div>
         </div>
         <h4 class="h3">Mission Authorizing Official</h4>
@@ -121,7 +122,7 @@
 
 
             <div class='usa-input'>
-              <label for='mo-behalf-email'>Mission Owner e-mail</label>
+              <label for='mo-behalf-email'>Mission Owner e-mail (optional)</label>
               <input id='mo-behalf-email' type='email' placeholder='name@mail.mil'/>
             </div>
 
@@ -131,20 +132,16 @@
           <div class='form-col'>
 
             <div class='usa-input'>
-              <label for='mo-behalf-phone'>Mission Owner phone number</label>
+              <label for='mo-behalf-phone'>Mission Owner phone number (optional)</label>
               <input id='mo-behalf-phone' type='tel' placeholder='(123) 456-7890'/>
             </div>
 
           </div>
 
-
-
         </div>
 
 
         <h4 class="h3">CCPO Authorizing Official</h4>
-
-
 
         <div class='form-row'>
 
@@ -168,8 +165,26 @@
 
         </div>
 
-      </div>
 
+
+        <h4 class="h3">CCPO Internal Notes</h4>
+
+        <p>You may add additional comments and notes for internal CCPO reference and follow-up here.</p>
+
+        <div class='form-row'>
+
+          <div class='form-col'>
+
+            <div class='usa-input'>
+              <label for='notes'>Internal Comments <em>(optional)</em></label>
+              <textarea id='notes' placeholder='Add notes or comments for internal CCPO reference.'/></textarea>
+            </div>
+
+          </div>
+
+        </div>
+
+      </div>
 
     </section>
 

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -144,18 +144,26 @@
 
         <h4 class="h3">CCPO Authorizing Official</h4>
 
-        <div class="form-row">
+
+
+        <div class='form-row'>
+
           <div class='form-col'>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-fname'>First Name</label>
-              <input id='ccpo-behalf-fname' type='text' placeholder='First name of authorizing official' />
+              <input id='ccpo-behalf-fname' type='text' placeholder='First name of CCPO authorizing official' />
             </div>
+
+          </div>
+
+          <div class='form-col'>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-lname'>Last Name</label>
-              <input id='ccpo-behalf-lname' type='text' placeholder='Last name of authorizing official' />
+              <input id='ccpo-behalf-lname' type='text' placeholder='Last name of CCPO authorizing official'/>
             </div>
+
           </div>
 
         </div>

--- a/templates/request_approval.html
+++ b/templates/request_approval.html
@@ -1,6 +1,7 @@
 {% extends "base.html" %}
 
 {% from "components/icon.html" import Icon %}
+{% from "components/alert.html" import Alert %}
 
 {% block content %}
 
@@ -68,56 +69,107 @@
       </header>
 
       <div class='panel__content'>
-        <p>Here is some good text explaining what the CCPO needs to do in order to approve the request. This text should also explain why we are asking for multiple people's names and the risk of boiling the ocean.</p>
+
+        <div class="form__sub-fields">
+
+          <h3>Comments to End User</h3>
+
+          You may leave a comment for the end user explaining what changes are being requested or why further discussion is needed about this request. The user can then re-submit the request with your changes requested or may initiate an offline message (via email) to respond to the CCPO directly. <br> This notes are optional and <b>will be visible to end-users</b>.
+
+          <div class='usa-input'>
+            <label for='notes'>Comments <em>(optional)</em></label>
+            <textarea id='notes' placeholder='Add notes or comments explaining what changes are being requested or why further discussion is needed about this request.'/></textarea>
+          </div>
 
 
-        <div class='usa-input'>
-          <label for='notes'>Notes</label>
-          <textarea id='notes' placeholder='Add notes or comments related to the approval or disapproval of this request.'/></textarea>
         </div>
+
+        <div class="form-row">
+          <div class="form-col">
+            <h3>Authorizing Officials</h3>
+            <p>This section is not visible to the end user. It will only be visible to CCPO staff.</p>
+            <p>Provide the name of the key officials for both parties that have authorized this request to move forward.</p>
+          </div>
+        </div>
+        <h4 class="h3">Mission Authorizing Official</h4>
 
         <div class='form-row'>
           <div class='form-col'>
+
             <div class='usa-input'>
-              <label for='mo-behalf-name'>Mission Owner approval on behalf of</label>
-              <input id='mo-behalf-name' type='text' placeholder='Name of approving officer'/>
+              <label for='mo-behalf-fname'>First Name</label>
+              <input id='mo-behalf-fname' type='text' placeholder='First name of mission authorizing official' tabindex='1' />
             </div>
 
             <div class='usa-input'>
               <label for='mo-behalf-email'>Mission Owner e-mail</label>
-              <input id='mo-behalf-email' type='email' placeholder='i.e. name@mail.mil'/>
+              <input id='mo-behalf-email' type='email' placeholder='i.e. name@mail.mil' tabindex='3'/>
+            </div>
+
+          </div>
+
+
+          <div class='form-col'>
+
+            <div class='usa-input'>
+              <label for='mo-behalf-lname'>Last Name</label>
+              <input id='mo-behalf-lname' type='text' placeholder='Last name of mission authorizing official' tabindex='2'/>
             </div>
 
             <div class='usa-input'>
               <label for='mo-behalf-phone'>Mission Owner phone number</label>
-              <input id='mo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890'/>
+              <input id='mo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890' tabindex='4'/>
             </div>
+
           </div>
 
-          <div class='form-col'>
+        </div>
+
+
+        <h4 class="h3">CCPO Authorizing Official</h4>
+
+        <div class="form-row">
+          <div class="form-col">
+
             <div class='usa-input'>
-              <label for='ccpo-behalf-name'>CCPO approval on behalf of</label>
-              <input id='ccpo-behalf-name' type='text' placeholder='Name of approving officer'/>
+              <label for='ccpo-behalf-fname'>First Name</label>
+              <input id='ccpo-behalf-fname' type='text' placeholder='Name of approving officer' tabindex='5' />
             </div>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-email'>CCPO e-mail</label>
-              <input id='ccpo-behalf-email' type='email' placeholder='i.e. name@mail.mil'/>
+              <input id='ccpo-behalf-email' type='email' placeholder='i.e. name@mail.mil' tabindex='7' />
+            </div>
+
+
+
+          </div>
+
+          <div class="form-col">
+
+            <div class='usa-input'>
+              <label for='ccpo-behalf-lname'>Last Name</label>
+              <input id='ccpo-behalf-lname' type='text' placeholder='Name of approving officer' tabindex='6' />
             </div>
 
             <div class='usa-input'>
               <label for='ccpo-behalf-phone'>CCPO phone number</label>
-              <input id='ccpo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890'/>
+              <input id='ccpo-behalf-phone' type='tel' placeholder='i.e. (123) 456-7890' tabindex='8' />
             </div>
+
+
           </div>
         </div>
+
       </div>
+
+
     </section>
 
     <section class='action-group'>
-      <a href='/' class='usa-button usa-button-big'>Approve Request</a>
-      <a href='/' class='usa-button usa-button-big usa-button-secondary'>Deny Request</a>
-      <a href='/' class='icon-link'>
+      <a href='#' class='usa-button usa-button-big'>Approve Request</a>
+      <a href='#' class='usa-button usa-button-big usa-button-secondary'>Mark as Changes Requested</a>
+      <a href='#' class='icon-link'>
         {{ Icon('x') }}
         <span>Cancel</span>
       </a>


### PR DESCRIPTION
This PR adds the static UI for the CCPO approval step.
`http://localhost:8000/request_approval`

Next steps will be to abstract the fields and leverage the TextInput module and make the form submit.

![screencapture-localhost-8000-request_approval-2018-09-05-13_37_47](https://user-images.githubusercontent.com/38014252/45113787-e8e95900-b110-11e8-985e-8acad8767940.png)


