### PR TITLE
create requests for existing users

### DIFF
--- a/script/seed.py
+++ b/script/seed.py
@@ -21,11 +21,15 @@ def seed_db():
     for dev_user in DEV_USERS.values():
         try:
             user = Users.create(**dev_user)
-            users.append(user)
         except AlreadyExistsError:
-            pass
+            user = Users.get_by_dod_id(dev_user["dod_id"])
+
+        users.append(user)
 
     for user in users:
+        if Requests.get_many(creator=user):
+            continue
+
         requests = []
         for dollar_value in [1, 200, 3000, 40000, 500000, 1000000]:
             request = RequestFactory.build(creator=user)


### PR DESCRIPTION
The seed script will only create requests for users who didn't already exist. I run into a problem a lot where I rebuild my database, start the app, and then try to check something without running the seed script. When that happens, Amanda never gets any requests, and I have to clear the database again to rerun the seed script. I think it's more convenient if the script checks to see if a user has any existing requests, and if not, adds the default ones (plus workspace, etc.). 