### PR TITLE
Add back missing import in new project template

### DIFF
--- a/templates/workspaces/projects/new.html
+++ b/templates/workspaces/projects/new.html
@@ -1,5 +1,7 @@
 {% extends "workspaces/base.html" %}
 
+{% from "components/alert.html" import Alert %}
+
 {% block workspace_content %}
 
 {% set modalName = "newProjectConfirmation" %}


### PR DESCRIPTION
I somehow lost this import when rebasing my template changes. This fixes the error when a workspace is approved.