### PR TITLE
Ui/cumulative budget chart

### DIFF
--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -200,5 +200,7 @@ class Reports:
     @classmethod
     def cumulative_budget(cls, alternate):
         return {
-            "months": CUMULATIVE_BUDGET_BELUGA if alternate else CUMULATIVE_BUDGET_AARDVARK
+            "months": CUMULATIVE_BUDGET_BELUGA
+            if alternate
+            else CUMULATIVE_BUDGET_AARDVARK
         }

--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -196,3 +196,9 @@ class Reports:
             "projects": project_totals,
             "workspace": workspace_totals,
         }
+
+    @classmethod
+    def cumulative_budget(cls, alternate):
+        return {
+            "months": CUMULATIVE_BUDGET_BELUGA if alternate else CUMULATIVE_BUDGET_AARDVARK
+        }

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -87,6 +87,7 @@ def workspace_reports(workspace_id):
 
     return render_template(
         "workspaces/reports/index.html",
+        cumulative_budget=Reports.cumulative_budget(alternate_reports),
         workspace_totals=Reports.workspace_totals(alternate_reports),
         monthly_totals=Reports.monthly_totals(alternate_reports),
         current_month=current_month,

--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -1,4 +1,3 @@
-import * as d3 from 'd3'
 import { format } from 'date-fns'
 import { abbreviateDollars, formatDollars } from '../../lib/dollars'
 

--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -130,7 +130,6 @@ export default {
         })
 
       }
-      console.log(monthsRange)
       this.displayedMonths = monthsRange
     }
   }

--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -1,0 +1,65 @@
+import * as d3 from 'd3'
+import { format } from 'date-fns'
+
+export default {
+  name: 'budget-chart',
+  props: {
+    currentMonth: String,
+    months: Object
+  },
+
+  data: function () {
+    return {
+      numMonths: 10,
+      focusedMonthPosition: 4, // 5th spot in zero-based index,
+      height: 300,
+      width: 0,
+      displayedMonths: []
+    }
+  },
+
+  computed: {
+
+  },
+
+  mounted: function () {
+    console.log(this.displayedMonths)
+    this._setDisplayedMonths()
+    this._setMetrics()
+  },
+
+  methods: {
+    _setMetrics: function () {
+      this.width = this.$refs.panel.clientWidth
+      // for (let i = 0; i < this.numMonths; i++) {
+      //   this.displayedMonths[i].metrics.x = (this.width / this.numMonths)
+      // }
+    },
+
+    _setDisplayedMonths: function () {
+      const [month, year] = this.currentMonth.split('/')
+      const monthsRange = []
+      const monthsBack = this.focusedMonthPosition
+      const monthsForward = this.numMonths - this.focusedMonthPosition - 1
+      const start = new Date(year, month - 1 - monthsBack)
+
+      for (let i = 0; i < this.numMonths; i++) {
+        const date = new Date(start.getFullYear(), start.getMonth() + i)
+        const index = format(date, 'MM/YYYY')
+        monthsRange.push({
+          date: {
+            month: format(date, 'MMM'),
+            year: format(date,'YYYY')
+          },
+          budget: this.months[index] || null,
+          isHighlighted: this.currentMonth === index,
+          metrics: {
+            x: 0,
+            width: 0
+          }
+        })
+      }
+      this.displayedMonths = monthsRange
+    }
+  }
+}

--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -1,39 +1,90 @@
 import * as d3 from 'd3'
 import { format } from 'date-fns'
+import { abbreviateDollars, formatDollars } from '../../lib/dollars'
+
+const TOP_OFFSET = 20
+const BOTTOM_OFFSET = 60
+const CHART_HEIGHT = 360
 
 export default {
   name: 'budget-chart',
   props: {
     currentMonth: String,
-    months: Object
+    months: Object,
+    budget: String
   },
 
   data: function () {
+    const heightScale = this.budget / (CHART_HEIGHT - TOP_OFFSET - BOTTOM_OFFSET)
     return {
       numMonths: 10,
-      focusedMonthPosition: 4, // 5th spot in zero-based index,
-      height: 300,
+      focusedMonthPosition: 4,
+      height: CHART_HEIGHT,
+      heightScale,
+      budgetHeight: CHART_HEIGHT - BOTTOM_OFFSET - (this.budget / heightScale),
+      baseHeight: CHART_HEIGHT - BOTTOM_OFFSET,
       width: 0,
-      displayedMonths: []
+      displayedMonths: [],
+      spendPath: '',
+      projectedPath: '',
+      displayBudget: formatDollars(parseFloat(this.budget))
     }
   },
 
-  computed: {
-
-  },
-
   mounted: function () {
-    console.log(this.displayedMonths)
     this._setDisplayedMonths()
     this._setMetrics()
+    addEventListener('resize', this._setMetrics)
   },
 
   methods: {
     _setMetrics: function () {
       this.width = this.$refs.panel.clientWidth
-      // for (let i = 0; i < this.numMonths; i++) {
-      //   this.displayedMonths[i].metrics.x = (this.width / this.numMonths)
-      // }
+      this.spendPath = ''
+      this.projectedPath = ''
+
+      let lastSpend = 0
+      let lastSpendPoint = ''
+
+      for (let i = 0; i < this.numMonths; i++) {
+        const { metrics, budget } = this.displayedMonths[i]
+        const blockWidth = (this.width / this.numMonths)
+        const blockX = blockWidth * i
+        const spend = budget
+          ? budget.spend || lastSpend
+          : 0
+        const cumulative = budget
+          ? budget.cumulative || budget.projected
+          : 0
+        const barHeight = spend / this.heightScale
+        lastSpend = spend
+        const cumulativeY = this.height - (cumulative / this.heightScale) - BOTTOM_OFFSET
+        const cumulativeX = blockX + blockWidth/2
+        const cumulativePoint = `${cumulativeX} ${cumulativeY}`
+
+        this.displayedMonths[i].metrics = Object.assign(metrics, {
+          blockWidth,
+          blockX,
+          barHeight,
+          barWidth: 30,
+          barX: blockX + (blockWidth/2 - 15),
+          barY: this.height - barHeight - BOTTOM_OFFSET,
+          cumulativeR: 2.5,
+          cumulativeY,
+          cumulativeX
+        })
+
+        if (budget && budget.spend) {
+          this.spendPath += this.spendPath === '' ? 'M' : ' L'
+          this.spendPath += cumulativePoint
+          lastSpendPoint = cumulativePoint
+        }
+
+        if (budget && budget.projected) {
+          this.projectedPath += this.projectedPath === '' ? `M${lastSpendPoint} L` : ' L'
+          this.projectedPath += cumulativePoint
+        }
+      }
     },
 
     _setDisplayedMonths: function () {
@@ -43,22 +94,43 @@ export default {
       const monthsForward = this.numMonths - this.focusedMonthPosition - 1
       const start = new Date(year, month - 1 - monthsBack)
 
+      let previousAmount = 0
+
       for (let i = 0; i < this.numMonths; i++) {
         const date = new Date(start.getFullYear(), start.getMonth() + i)
         const index = format(date, 'MM/YYYY')
+        const budget = this.months[index] || null
+        const spendAmount = budget ? budget.spend || previousAmount : 0
+        const cumulativeAmount = budget ? budget.cumulative || budget.projected : 0
+        previousAmount = spendAmount
+
         monthsRange.push({
+          budget,
+          spendAmount: formatDollars(spendAmount),
+          abbreviatedSpend: abbreviateDollars(spendAmount),
+          cumulativeAmount: formatDollars(cumulativeAmount),
+          abbreviatedCumulative: abbreviateDollars(cumulativeAmount),
           date: {
+            monthIndex: format(date, 'M'),
             month: format(date, 'MMM'),
             year: format(date,'YYYY')
           },
-          budget: this.months[index] || null,
           isHighlighted: this.currentMonth === index,
           metrics: {
-            x: 0,
-            width: 0
+            blockWidth: 0,
+            blockX: 0,
+            barHeight: 0,
+            barWidth: 0,
+            barX: 0,
+            barY: 0,
+            cumulativeY: 0,
+            cumulativeX: 0,
+            cumulativeR: 0
           }
         })
+
       }
+      console.log(monthsRange)
       this.displayedMonths = monthsRange
     }
   }

--- a/js/index.js
+++ b/js/index.js
@@ -1,3 +1,4 @@
+import 'svg-innerhtml'
 import 'babel-polyfill'
 
 import classes from '../styles/atat.scss'

--- a/js/index.js
+++ b/js/index.js
@@ -14,6 +14,7 @@ import toggler from './components/toggler'
 import NewProject from './components/forms/new_project'
 import Modal from './mixins/modal'
 import selector from './components/selector'
+import BudgetChart from './components/charts/budget_chart'
 
 Vue.use(VTooltip)
 
@@ -30,7 +31,8 @@ const app = new Vue({
     poc,
     financial,
     NewProject,
-    selector
+    selector,
+    BudgetChart
   },
   mounted: function() {
     const modalOpen = document.querySelector("#modalOpen")

--- a/js/lib/dollars.js
+++ b/js/lib/dollars.js
@@ -1,0 +1,12 @@
+export const formatDollars = value => `$${value.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}`
+
+export const abbreviateDollars = (value, decimals = 1) => {
+  if (value === null) { return null } // terminate early
+  if (value === 0) { return '0' } // terminate early
+  var b = (value).toPrecision(2).split("e"), // get power
+      k = b.length === 1 ? 0 : Math.floor(Math.min(b[1].slice(1), 14) / 3), // floor at decimals, ceiling at trillions
+      c = k < 1 ? value.toFixed(0 + decimals) : (value / Math.pow(10, k * 3) ).toFixed(decimals), // divide by power
+      d = c < 0 ? c : Math.abs(c), // enforce -0 is 0
+      e = d + ['', 'k', 'M', 'B', 'T'][k]; // append power
+  return e;
+}

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "autoprefixer": "^9.1.3",
     "babel-polyfill": "^6.26.0",
+    "d3": "^5.7.0",
+    "date-fns": "^1.29.0",
     "npm": "^6.0.1",
     "parcel": "^1.9.7",
     "text-mask-addons": "^3.8.0",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "date-fns": "^1.29.0",
     "npm": "^6.0.1",
     "parcel": "^1.9.7",
+    "svg-innerhtml": "^1.1.0",
     "text-mask-addons": "^3.8.0",
     "uswds": "^1.6.3",
     "v-tooltip": "^2.0.0-rc.33",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "autoprefixer": "^9.1.3",
     "babel-polyfill": "^6.26.0",
-    "d3": "^5.7.0",
     "date-fns": "^1.29.0",
     "npm": "^6.0.1",
     "parcel": "^1.9.7",

--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -34,7 +34,7 @@
 @import 'components/search_bar';
 @import 'components/forms';
 @import 'components/selector';
-
+@import 'components/budget_chart';
 
 @import 'sections/login';
 @import 'sections/request_approval';

--- a/styles/components/_budget_chart.scss
+++ b/styles/components/_budget_chart.scss
@@ -1,0 +1,80 @@
+.budget-chart {
+  .budget-chart__header {
+    border-bottom: 1px solid $color-gray-light;
+  }
+
+  .budget-chart__block {
+    fill: $color-white;
+    cursor: pointer;
+
+    &--highlighted {
+      fill: $color-aqua-lightest;
+    }
+
+    &:hover {
+      fill: $color-aqua-lightest;
+    }
+  }
+
+  svg {
+    display: block;
+
+    a {
+      text-decoration: none;
+      &:focus {
+        outline: none;
+        stroke: $color-gray-light;
+        stroke-dasharray: 2px;
+      }
+    }
+  }
+
+  .budget-chart__bar {
+    fill: $color-blue;
+
+    &--projected {
+      fill: transparent;
+      stroke-width: 2px;
+      stroke: $color-blue;
+      stroke-dasharray: 2px;
+    }
+  }
+
+  .budget-chart__cumulative__dot {
+    fill: $color-gold;
+  }
+
+  .budget-chart__projected-path {
+    stroke-width: 1px;
+    stroke: $color-gold;
+    stroke-dasharray: 2px;
+    fill: none;
+  }
+
+  .budget-chart__spend-path {
+    stroke-width: 1px;
+    stroke: $color-gold;
+    fill: none;
+  }
+
+  .budget-chart__budget-line {
+    stroke-width: 2px;
+    stroke: $color-gray-light;
+    stroke-dasharray: 2px;
+  }
+
+  .budget-chart__label {
+    @include h6;
+    font-weight: bold;
+    text-transform: none;
+    fill: $color-gray;
+
+    &--strong {
+      fill: $color-black;
+    }
+  }
+
+  .budget-chart__budget-text {
+
+  }
+}

--- a/styles/components/_budget_chart.scss
+++ b/styles/components/_budget_chart.scss
@@ -1,6 +1,62 @@
 .budget-chart {
   .budget-chart__header {
     border-bottom: 1px solid $color-gray-light;
+
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+
+    .budget-chart__legend {
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+      align-items: center;
+
+      dl {
+        margin: 0 0 0 ($gap * 2);
+
+        > div {
+          margin: 0;
+          display: flex;
+          flex-direction: row-reverse;
+          align-items: center;
+
+          dt {
+            @include small-label;
+          }
+
+          .budget-chart__legend__dot {
+            width: $gap;
+            height: $gap;
+            border-radius: $gap / 2;
+            margin: 0 $gap;
+
+            &.accumulated {
+              background-color: $color-gold;
+            }
+            &.monthly {
+              background-color: $color-blue;
+            }
+          }
+
+          .budget-chart__legend__line {
+            height: 2px;
+            width: $gap * 3;
+            border-top-width: 2px;
+            border-top-style: dashed;
+            margin: $gap;
+
+            &.spend {
+              border-color: $color-blue;
+            }
+            &.accumulated {
+              border-color: $color-gold;
+            }
+          }
+        }
+      }
+    }
   }
 
   .budget-chart__block {
@@ -36,7 +92,7 @@
       fill: transparent;
       stroke-width: 2px;
       stroke: $color-blue;
-      stroke-dasharray: 2px;
+      stroke-dasharray: 4px;
     }
   }
 
@@ -47,7 +103,7 @@
   .budget-chart__projected-path {
     stroke-width: 1px;
     stroke: $color-gold;
-    stroke-dasharray: 2px;
+    stroke-dasharray: 4px;
     fill: none;
   }
 
@@ -60,21 +116,15 @@
   .budget-chart__budget-line {
     stroke-width: 2px;
     stroke: $color-gray-light;
-    stroke-dasharray: 2px;
+    stroke-dasharray: 4px;
   }
 
   .budget-chart__label {
-    @include h6;
-    font-weight: bold;
-    text-transform: none;
+    @include small-label;
     fill: $color-gray;
 
     &--strong {
       fill: $color-black;
     }
-  }
-
-  .budget-chart__budget-text {
-
   }
 }

--- a/styles/core/_grid.scss
+++ b/styles/core/_grid.scss
@@ -42,5 +42,6 @@
   &.col--grow {
     flex: 1;
     flex-grow: 1;
+    overflow: auto
   }
 }

--- a/styles/elements/_panels.scss
+++ b/styles/elements/_panels.scss
@@ -62,13 +62,13 @@
   }
 
   .panel__heading {
-    margin: $gap * 2;
+    padding: $gap * 2;
     @include media($medium-screen) {
-      margin: $gap * 4;
+      padding: $gap * 4;
     }
 
     &--tight {
-      margin: $gap*2;
+      padding: $gap*2;
     }
 
     h1, h2, h3, h4, h5, h6 {

--- a/styles/elements/_typography.scss
+++ b/styles/elements/_typography.scss
@@ -68,3 +68,9 @@ dl {
     margin-bottom: $gap * 2;
   }
 }
+
+@mixin small-label {
+  font-size: $h6-font-size;
+  font-weight: $font-bold;
+  color: $color-black;
+}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -134,16 +134,16 @@
   {% endcall %}
 
   <div is='toggler' default-visible class='block-list project-list-item'>
-    <template slot-scope='{ isVisible, toggle }'>
+    <template slot-scope='props'>
       <header class='block-list__header'>
-      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
           <template v-else>{{ Icon('caret_right') }}</template>
           <h3 class="block-list__title">Code.mil</h3>
         </button>
         <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
       </header>
-      <ul v-show='isVisible'>
+      <ul v-show='props.isVisible'>
         <li class='block-list__item project-list-item__environment'>
           <span class='project-list-item__environment'>
             Development
@@ -173,16 +173,16 @@
   </div>
 
   <div is="toggler" class='block-list project-list-item'>
-    <template slot-scope='{ isVisible, toggle }'>
+    <template slot-scope='props'>
       <header class='block-list__header'>
-      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
           <template v-else>{{ Icon('caret_right') }}</template>
           <h3 class="block-list__title">Digital Dojo</h3>
         </button>
         <span class="label">no access</span>
       </header>
-      <ul v-show='isVisible'>
+      <ul v-show='props.isVisible'>
         <li class='block-list__item project-list-item__environment'>
           <span class='project-list-item__environment'>
             Development

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -149,7 +149,7 @@
               v-bind:class='{ "budget-chart__block--highlighted": month.isHighlighted }'
               v-bind:width='month.metrics.blockWidth'
               v-bind:x='month.metrics.blockX'
-              v-bind:height='height'/>
+              v-bind:height='height'></rect>
 
             {# budget bar #}
             <rect
@@ -159,8 +159,7 @@
               v-bind:width='month.metrics.barWidth'
               v-bind:height='month.metrics.barHeight'
               v-bind:x='month.metrics.barX'
-              v-bind:y='month.metrics.barY'>
-            </rect>
+              v-bind:y='month.metrics.barY'></rect>
 
             {# cumulative dot #}
             <circle
@@ -168,7 +167,7 @@
               class='budget-chart__cumulative__dot'
               v-bind:r='month.metrics.cumulativeR'
               v-bind:cx='month.metrics.cumulativeX'
-              v-bind:cy='month.metrics.cumulativeY'/>
+              v-bind:cy='month.metrics.cumulativeY'></circle>
 
             {# abbreviated cumulative label #}
             <text
@@ -177,7 +176,7 @@
               v-bind:y='month.metrics.cumulativeY - 10'
               text-anchor='middle'
               class='budget-chart__label'
-              v-html='month.abbreviatedCumulative'/>
+              v-html='month.abbreviatedCumulative'></text>
 
             {# abbreviated spend label #}
             <text
@@ -185,7 +184,7 @@
               v-bind:y='baseHeight + 20'
               text-anchor='middle'
               class='budget-chart__label'
-              v-html='"+" + month.abbreviatedSpend'/>
+              v-html='"+" + month.abbreviatedSpend'></text>
 
             {# month label #}
             <text
@@ -193,13 +192,13 @@
               v-bind:y='baseHeight + 40'
               text-anchor='middle'
               class='budget-chart__label budget-chart__label--strong'
-              v-html='month.date.month'/>
+              v-html='month.date.month'></text>
           </g>
         </a>
 
         {# spend/projected budget path lines #}
-        <path class='budget-chart__projected-path' v-bind:d='projectedPath'/>
-        <path class='budget-chart__spend-path' v-bind:d='spendPath'/>
+        <path class='budget-chart__projected-path' v-bind:d='projectedPath'></path>
+        <path class='budget-chart__spend-path' v-bind:d='spendPath'></path>
 
         {# max budget line #}
         <line
@@ -207,7 +206,7 @@
           x1='0'
           v-bind:x2='width'
           v-bind:y1='budgetHeight'
-          v-bind:y2='budgetHeight'/>
+          v-bind:y2='budgetHeight'></line>
 
         <text
           x='20'
@@ -217,7 +216,7 @@
           x='20'
           v-bind:y='budgetHeight + 40'
           class='budget-chart__label'
-          v-html='displayBudget'/>
+          v-html='displayBudget'></text>
       </svg>
     </div>
   </budget-chart>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -94,6 +94,19 @@
   {% set prev_month_index = prev_month.strftime('%m/%Y') %}
   {% set two_months_ago_index = two_months_ago.strftime('%m/%Y') %}
 
+  <budget-chart current-month='{{ current_month_index }}' v-bind:months='{{ cumulative_budget.months | tojson }}' inline-template>
+    <div class='budget-chart panel' ref='panel'>
+      <header class='panel__heading panel__heading--tight'>
+        <h2 class='h3'>Cumulative Budget</h2>
+      </header>
+      <svg v-bind:height="height" v-bind:width="width">
+        <g v-for='month in displayedMonths'>
+          <rect v-if='month.budget' width='20' height='100' v-bind:x='month.metrics.x' />
+        </g>
+      </svg>
+    </div>
+  </budget-chart>
+
   <div class='spend-table responsive-table-wrapper'>
     <div class='spend-table__header'>
       <h2 class='spend-table__title'>Total spend per month</h2>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -99,7 +99,31 @@
     <div class='budget-chart panel' ref='panel'>
       <header class='budget-chart__header panel__heading panel__heading--tight'>
         <h2 class='h3'>Cumulative Budget</h2>
+
+        <div class='budget-chart__legend'>
+          <dl class='budget-chart__legend__spend'>
+            <div>
+              <dt>Monthly Spend</dt>
+              <dd class='budget-chart__legend__dot monthly'><span class='usa-sr-only'>Monthly spend visual key</span></dd>
+            </div>
+
+            <div>
+              <dt>Accumulated Spend</dt>
+              <dd class='budget-chart__legend__dot accumulated'><span class='usa-sr-only'>Accumulated spend visual key</span></dd>
+            </div>
+          </dl>
+          <dl class='budget-chart__legend__projected'>
+            <div>
+              <dt>Projected</dt>
+              <dd>
+                <div class='budget-chart__legend__line spend'><span class='usa-sr-only'>Projected monthly spend visual key</span></div>
+                <div class='budget-chart__legend__line accumulated'><span class='usa-sr-only'>Projected accumulated spend visual key</span></div>
+              </dd>
+            </div>
+          </dl>
+        </div>
       </header>
+
       <svg v-bind:height='height' v-bind:width='width'>
         <g v-for='month in displayedMonths' >
           {# make this clickable to focus on that month #}

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -93,16 +93,107 @@
   {% set current_month_index = current_month.strftime('%m/%Y') %}
   {% set prev_month_index = prev_month.strftime('%m/%Y') %}
   {% set two_months_ago_index = two_months_ago.strftime('%m/%Y') %}
+  {% set reports_url = url_for("workspaces.workspace_reports", workspace_id=workspace.id) %}
 
-  <budget-chart current-month='{{ current_month_index }}' v-bind:months='{{ cumulative_budget.months | tojson }}' inline-template>
+  <budget-chart budget={{ budget }} current-month='{{ current_month_index }}' v-bind:months='{{ cumulative_budget.months | tojson }}' inline-template>
     <div class='budget-chart panel' ref='panel'>
-      <header class='panel__heading panel__heading--tight'>
+      <header class='budget-chart__header panel__heading panel__heading--tight'>
         <h2 class='h3'>Cumulative Budget</h2>
       </header>
-      <svg v-bind:height="height" v-bind:width="width">
-        <g v-for='month in displayedMonths'>
-          <rect v-if='month.budget' width='20' height='100' v-bind:x='month.metrics.x' />
-        </g>
+      <svg v-bind:height='height' v-bind:width='width'>
+        <g v-for='month in displayedMonths' >
+          {# make this clickable to focus on that month #}
+          <a v-bind:href='"{{ reports_url }}?month=" + month.date.monthIndex + "&year=" + month.date.year'>
+            <title>
+              <span v-html='month.date.month + " " + month.date.year'></span>&nbsp;|&nbsp;<!--
+              --><template v-if='month.budget'><!--
+                --><template v-if='month.budget.spend'>Spend:</template><!--
+                --><template v-if='month.budget.projected'>Projected Spend:</template><!--
+                --><span v-html='month.spendAmount'></span><!--
+                -->&nbsp;|&nbsp;<!--
+                --><template v-if='month.budget.cumulative'>Total:</template><!--
+                --><template v-if='month.budget.projected'>Projected Total:</template><!--
+                --><span v-html='month.cumulativeAmount'></span><!--
+              --></template><!--
+
+              --><template v-else>No spend for this month</template>
+            </title>
+
+            {# container block #}
+            <rect
+              class='budget-chart__block'
+              v-bind:class='{ "budget-chart__block--highlighted": month.isHighlighted }'
+              v-bind:width='month.metrics.blockWidth'
+              v-bind:x='month.metrics.blockX'
+              v-bind:height='height'/>
+
+            {# budget bar #}
+            <rect
+              v-if='month.budget'
+              class='budget-chart__bar'
+              v-bind:class='{ "budget-chart__bar--projected": month.budget.projected }'
+              v-bind:width='month.metrics.barWidth'
+              v-bind:height='month.metrics.barHeight'
+              v-bind:x='month.metrics.barX'
+              v-bind:y='month.metrics.barY'>
+            </rect>
+
+            {# cumulative dot #}
+            <circle
+              v-if='month.budget'
+              class='budget-chart__cumulative__dot'
+              v-bind:r='month.metrics.cumulativeR'
+              v-bind:cx='month.metrics.cumulativeX'
+              v-bind:cy='month.metrics.cumulativeY'/>
+
+            {# abbreviated cumulative label #}
+            <text
+              v-if='month.budget'
+              v-bind:x='month.metrics.cumulativeX'
+              v-bind:y='month.metrics.cumulativeY - 10'
+              text-anchor='middle'
+              class='budget-chart__label'
+              v-html='month.abbreviatedCumulative'/>
+
+            {# abbreviated spend label #}
+            <text
+              v-bind:x='month.metrics.cumulativeX'
+              v-bind:y='baseHeight + 20'
+              text-anchor='middle'
+              class='budget-chart__label'
+              v-html='"+" + month.abbreviatedSpend'/>
+
+            {# month label #}
+            <text
+              v-bind:x='month.metrics.cumulativeX'
+              v-bind:y='baseHeight + 40'
+              text-anchor='middle'
+              class='budget-chart__label budget-chart__label--strong'
+              v-html='month.date.month'/>
+          </g>
+        </a>
+
+        {# spend/projected budget path lines #}
+        <path class='budget-chart__projected-path' v-bind:d='projectedPath'/>
+        <path class='budget-chart__spend-path' v-bind:d='spendPath'/>
+
+        {# max budget line #}
+        <line
+          class='budget-chart__budget-line'
+          x1='0'
+          v-bind:x2='width'
+          v-bind:y1='budgetHeight'
+          v-bind:y2='budgetHeight'/>
+
+        <text
+          x='20'
+          v-bind:y='budgetHeight + 20'
+          class='budget-chart__label'>Total Budget</text>
+        <text
+          x='20'
+          v-bind:y='budgetHeight + 40'
+          class='budget-chart__label'
+          v-html='displayBudget'/>
       </svg>
     </div>
   </budget-chart>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -253,11 +253,11 @@
 
       {% for project_name, project_totals in monthly_totals['projects'].items() %}
         <tbody is='toggler' class='spend-table__project'>
-          <template slot-scope='{ isVisible, toggle }'>
+          <template slot-scope='props'>
             <tr>
               <th scope='rowgroup'>
-                <button v-on:click='toggle' class='icon-link icon-link--large spend-table__project__toggler'>
-                  <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+                <button v-on:click='props.toggle' class='icon-link icon-link--large spend-table__project__toggler'>
+                  <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
                   <template v-else>{{ Icon('caret_right') }}</template>
                   {{ project_name }}
                 </button>
@@ -272,7 +272,7 @@
             </tr>
 
             {% for env_name, env_totals in monthly_totals['environments'][project_name].items() %}
-              <tr v-show='isVisible'>
+              <tr v-show='props.isVisible'>
                 <th scope='rowgroup'><a href='#' class='icon-link spend-table__project__env'>{{ Icon('link') }} {{ env_name }}</a></th>
                 <td class='table-cell--align-right previous-month'>{{ env_totals.get(two_months_ago_index, 0) | dollars }}</td>
                 <td class='table-cell--align-right previous-month'>{{ env_totals.get(prev_month_index, 0) | dollars }}</td>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,10 +1444,6 @@ command-exists@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.7.tgz#16828f0c3ff2b0c58805861ef211b64fc15692a8"
 
-commander@2:
-  version "2.17.1"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
-
 commander@^2.11.0, commander@^2.9.0, commander@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
@@ -1808,222 +1804,6 @@ currently-unhandled@^0.4.1:
 cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
-
-d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
-  version "1.2.4"
-  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
-
-d3-axis@1:
-  version "1.0.12"
-  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
-
-d3-brush@1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.6.tgz#33691f2032d9db6c5d8cb684ff255a9883629e21"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
-d3-chord@1:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
-  dependencies:
-    d3-array "1"
-    d3-path "1"
-
-d3-collection@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
-
-d3-color@1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
-
-d3-contour@1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
-  dependencies:
-    d3-array "^1.1.1"
-
-d3-dispatch@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.5.tgz#e25c10a186517cd6c82dd19ea018f07e01e39015"
-
-d3-drag@1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.3.tgz#46e206ad863ec465d88c588098a1df444cd33c64"
-  dependencies:
-    d3-dispatch "1"
-    d3-selection "1"
-
-d3-dsv@1:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.10.tgz#4371c489a2a654a297aca16fcaf605a6f31a6f51"
-  dependencies:
-    commander "2"
-    iconv-lite "0.4"
-    rw "1"
-
-d3-ease@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.5.tgz#8ce59276d81241b1b72042d6af2d40e76d936ffb"
-
-d3-fetch@1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.1.2.tgz#957c8fbc6d4480599ba191b1b2518bf86b3e1be2"
-  dependencies:
-    d3-dsv "1"
-
-d3-force@1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.1.2.tgz#16664d0ac71d8727ef5effe0b374feac8050d6cd"
-  dependencies:
-    d3-collection "1"
-    d3-dispatch "1"
-    d3-quadtree "1"
-    d3-timer "1"
-
-d3-format@1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.2.tgz#6a96b5e31bcb98122a30863f7d92365c00603562"
-
-d3-geo@1:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.11.1.tgz#3f35e582c0d29296618b02a8ade0fdffb2c0e63c"
-  dependencies:
-    d3-array "1"
-
-d3-hierarchy@1:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#7a6317bd3ed24e324641b6f1e76e978836b008cc"
-
-d3-interpolate@1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
-  dependencies:
-    d3-color "1"
-
-d3-path@1:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
-
-d3-polygon@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.5.tgz#9a645a0a64ff6cbf9efda96ee0b4a6909184c363"
-
-d3-quadtree@1:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.5.tgz#305394840b01f51a341a0da5008585e837fe7e9b"
-
-d3-random@1:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
-
-d3-scale-chromatic@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz#dad4366f0edcb288f490128979c3c793583ed3c0"
-  dependencies:
-    d3-color "1"
-    d3-interpolate "1"
-
-d3-scale@2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.2.tgz#4e932b7b60182aee9073ede8764c98423e5f9a94"
-  dependencies:
-    d3-array "^1.2.0"
-    d3-collection "1"
-    d3-format "1"
-    d3-interpolate "1"
-    d3-time "1"
-    d3-time-format "2"
-
-d3-selection@1, d3-selection@^1.1.0:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.2.tgz#6e70a9df60801c8af28ac24d10072d82cbfdf652"
-
-d3-shape@1:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.2.tgz#f9dba3777a5825f9a8ce8bc928da08c17679e9a7"
-  dependencies:
-    d3-path "1"
-
-d3-time-format@2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.3.tgz#ae06f8e0126a9d60d6364eac5b1533ae1bac826b"
-  dependencies:
-    d3-time "1"
-
-d3-time@1:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.10.tgz#8259dd71288d72eeacfd8de281c4bf5c7393053c"
-
-d3-timer@1:
-  version "1.0.9"
-  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.9.tgz#f7bb8c0d597d792ff7131e1c24a36dd471a471ba"
-
-d3-transition@1:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.3.tgz#3a435b05ce9cef9524fe0d38121cfb6905331ca6"
-  dependencies:
-    d3-color "1"
-    d3-dispatch "1"
-    d3-ease "1"
-    d3-interpolate "1"
-    d3-selection "^1.1.0"
-    d3-timer "1"
-
-d3-voronoi@1:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
-
-d3-zoom@1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.3.tgz#f444effdc9055c38077c4299b4df999eb1d47ccb"
-  dependencies:
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-interpolate "1"
-    d3-selection "1"
-    d3-transition "1"
-
-d3@^5.7.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/d3/-/d3-5.7.0.tgz#f189d338bdde62acf02f308918e0ec34dd7568f9"
-  dependencies:
-    d3-array "1"
-    d3-axis "1"
-    d3-brush "1"
-    d3-chord "1"
-    d3-collection "1"
-    d3-color "1"
-    d3-contour "1"
-    d3-dispatch "1"
-    d3-drag "1"
-    d3-dsv "1"
-    d3-ease "1"
-    d3-fetch "1"
-    d3-force "1"
-    d3-format "1"
-    d3-geo "1"
-    d3-hierarchy "1"
-    d3-interpolate "1"
-    d3-path "1"
-    d3-polygon "1"
-    d3-quadtree "1"
-    d3-random "1"
-    d3-scale "2"
-    d3-scale-chromatic "1"
-    d3-selection "1"
-    d3-shape "1"
-    d3-time "1"
-    d3-time-format "2"
-    d3-timer "1"
-    d3-transition "1"
-    d3-voronoi "1"
-    d3-zoom "1"
 
 dashdash@^1.12.0:
   version "1.14.1"
@@ -3029,12 +2809,6 @@ humanize-ms@^1.2.1:
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
   dependencies:
     ms "^2.0.0"
-
-iconv-lite@0.4:
-  version "0.4.24"
-  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
-  dependencies:
-    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
@@ -5922,10 +5696,6 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
-
-rw@1:
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1444,6 +1444,10 @@ command-exists@^1.2.6:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/command-exists/-/command-exists-1.2.7.tgz#16828f0c3ff2b0c58805861ef211b64fc15692a8"
 
+commander@2:
+  version "2.17.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.17.1.tgz#bd77ab7de6de94205ceacc72f1716d29f20a77bf"
+
 commander@^2.11.0, commander@^2.9.0, commander@~2.16.0:
   version "2.16.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.16.0.tgz#f16390593996ceb4f3eeb020b31d78528f7f8a50"
@@ -1805,11 +1809,231 @@ cyclist@~0.2.2:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/cyclist/-/cyclist-0.2.2.tgz#1b33792e11e914a2fd6d6ed6447464444e5fa640"
 
+d3-array@1, d3-array@^1.1.1, d3-array@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/d3-array/-/d3-array-1.2.4.tgz#635ce4d5eea759f6f605863dbcfc30edc737f71f"
+
+d3-axis@1:
+  version "1.0.12"
+  resolved "https://registry.yarnpkg.com/d3-axis/-/d3-axis-1.0.12.tgz#cdf20ba210cfbb43795af33756886fb3638daac9"
+
+d3-brush@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-brush/-/d3-brush-1.0.6.tgz#33691f2032d9db6c5d8cb684ff255a9883629e21"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3-chord@1:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/d3-chord/-/d3-chord-1.0.6.tgz#309157e3f2db2c752f0280fedd35f2067ccbb15f"
+  dependencies:
+    d3-array "1"
+    d3-path "1"
+
+d3-collection@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
+
+d3-color@1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.2.3.tgz#6c67bb2af6df3cc8d79efcc4d3a3e83e28c8048f"
+
+d3-contour@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-contour/-/d3-contour-1.3.2.tgz#652aacd500d2264cb3423cee10db69f6f59bead3"
+  dependencies:
+    d3-array "^1.1.1"
+
+d3-dispatch@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-dispatch/-/d3-dispatch-1.0.5.tgz#e25c10a186517cd6c82dd19ea018f07e01e39015"
+
+d3-drag@1:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/d3-drag/-/d3-drag-1.2.3.tgz#46e206ad863ec465d88c588098a1df444cd33c64"
+  dependencies:
+    d3-dispatch "1"
+    d3-selection "1"
+
+d3-dsv@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-dsv/-/d3-dsv-1.0.10.tgz#4371c489a2a654a297aca16fcaf605a6f31a6f51"
+  dependencies:
+    commander "2"
+    iconv-lite "0.4"
+    rw "1"
+
+d3-ease@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-ease/-/d3-ease-1.0.5.tgz#8ce59276d81241b1b72042d6af2d40e76d936ffb"
+
+d3-fetch@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-fetch/-/d3-fetch-1.1.2.tgz#957c8fbc6d4480599ba191b1b2518bf86b3e1be2"
+  dependencies:
+    d3-dsv "1"
+
+d3-force@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-force/-/d3-force-1.1.2.tgz#16664d0ac71d8727ef5effe0b374feac8050d6cd"
+  dependencies:
+    d3-collection "1"
+    d3-dispatch "1"
+    d3-quadtree "1"
+    d3-timer "1"
+
+d3-format@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-format/-/d3-format-1.3.2.tgz#6a96b5e31bcb98122a30863f7d92365c00603562"
+
+d3-geo@1:
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/d3-geo/-/d3-geo-1.11.1.tgz#3f35e582c0d29296618b02a8ade0fdffb2c0e63c"
+  dependencies:
+    d3-array "1"
+
+d3-hierarchy@1:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/d3-hierarchy/-/d3-hierarchy-1.1.8.tgz#7a6317bd3ed24e324641b6f1e76e978836b008cc"
+
+d3-interpolate@1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-interpolate/-/d3-interpolate-1.3.2.tgz#417d3ebdeb4bc4efcc8fd4361c55e4040211fd68"
+  dependencies:
+    d3-color "1"
+
+d3-path@1:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/d3-path/-/d3-path-1.0.7.tgz#8de7cd693a75ac0b5480d3abaccd94793e58aae8"
+
+d3-polygon@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-polygon/-/d3-polygon-1.0.5.tgz#9a645a0a64ff6cbf9efda96ee0b4a6909184c363"
+
+d3-quadtree@1:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/d3-quadtree/-/d3-quadtree-1.0.5.tgz#305394840b01f51a341a0da5008585e837fe7e9b"
+
+d3-random@1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/d3-random/-/d3-random-1.1.2.tgz#2833be7c124360bf9e2d3fd4f33847cfe6cab291"
+
+d3-scale-chromatic@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/d3-scale-chromatic/-/d3-scale-chromatic-1.3.3.tgz#dad4366f0edcb288f490128979c3c793583ed3c0"
+  dependencies:
+    d3-color "1"
+    d3-interpolate "1"
+
+d3-scale@2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/d3-scale/-/d3-scale-2.1.2.tgz#4e932b7b60182aee9073ede8764c98423e5f9a94"
+  dependencies:
+    d3-array "^1.2.0"
+    d3-collection "1"
+    d3-format "1"
+    d3-interpolate "1"
+    d3-time "1"
+    d3-time-format "2"
+
+d3-selection@1, d3-selection@^1.1.0:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/d3-selection/-/d3-selection-1.3.2.tgz#6e70a9df60801c8af28ac24d10072d82cbfdf652"
+
+d3-shape@1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/d3-shape/-/d3-shape-1.2.2.tgz#f9dba3777a5825f9a8ce8bc928da08c17679e9a7"
+  dependencies:
+    d3-path "1"
+
+d3-time-format@2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/d3-time-format/-/d3-time-format-2.1.3.tgz#ae06f8e0126a9d60d6364eac5b1533ae1bac826b"
+  dependencies:
+    d3-time "1"
+
+d3-time@1:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/d3-time/-/d3-time-1.0.10.tgz#8259dd71288d72eeacfd8de281c4bf5c7393053c"
+
+d3-timer@1:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/d3-timer/-/d3-timer-1.0.9.tgz#f7bb8c0d597d792ff7131e1c24a36dd471a471ba"
+
+d3-transition@1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/d3-transition/-/d3-transition-1.1.3.tgz#3a435b05ce9cef9524fe0d38121cfb6905331ca6"
+  dependencies:
+    d3-color "1"
+    d3-dispatch "1"
+    d3-ease "1"
+    d3-interpolate "1"
+    d3-selection "^1.1.0"
+    d3-timer "1"
+
+d3-voronoi@1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/d3-voronoi/-/d3-voronoi-1.1.4.tgz#dd3c78d7653d2bb359284ae478645d95944c8297"
+
+d3-zoom@1:
+  version "1.7.3"
+  resolved "https://registry.yarnpkg.com/d3-zoom/-/d3-zoom-1.7.3.tgz#f444effdc9055c38077c4299b4df999eb1d47ccb"
+  dependencies:
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-interpolate "1"
+    d3-selection "1"
+    d3-transition "1"
+
+d3@^5.7.0:
+  version "5.7.0"
+  resolved "https://registry.yarnpkg.com/d3/-/d3-5.7.0.tgz#f189d338bdde62acf02f308918e0ec34dd7568f9"
+  dependencies:
+    d3-array "1"
+    d3-axis "1"
+    d3-brush "1"
+    d3-chord "1"
+    d3-collection "1"
+    d3-color "1"
+    d3-contour "1"
+    d3-dispatch "1"
+    d3-drag "1"
+    d3-dsv "1"
+    d3-ease "1"
+    d3-fetch "1"
+    d3-force "1"
+    d3-format "1"
+    d3-geo "1"
+    d3-hierarchy "1"
+    d3-interpolate "1"
+    d3-path "1"
+    d3-polygon "1"
+    d3-quadtree "1"
+    d3-random "1"
+    d3-scale "2"
+    d3-scale-chromatic "1"
+    d3-selection "1"
+    d3-shape "1"
+    d3-time "1"
+    d3-time-format "2"
+    d3-timer "1"
+    d3-transition "1"
+    d3-voronoi "1"
+    d3-zoom "1"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
   dependencies:
     assert-plus "^1.0.0"
+
+date-fns@^1.29.0:
+  version "1.29.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
 
 date-now@^0.1.4:
   version "0.1.4"
@@ -2805,6 +3029,12 @@ humanize-ms@^1.2.1:
   resolved "https://registry.yarnpkg.com/humanize-ms/-/humanize-ms-1.2.1.tgz#c46e3159a293f6b896da29316d8b6fe8bb79bbed"
   dependencies:
     ms "^2.0.0"
+
+iconv-lite@0.4:
+  version "0.4.24"
+  resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
+  dependencies:
+    safer-buffer ">= 2.1.2 < 3"
 
 iconv-lite@^0.4.4, iconv-lite@~0.4.13:
   version "0.4.23"
@@ -5692,6 +5922,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rw@1:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/rw/-/rw-1.3.3.tgz#3f862dfa91ab766b14885ef4d01124bfda074fb4"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6505,6 +6505,10 @@ supports-color@^5.3.0, supports-color@^5.4.0:
   dependencies:
     has-flag "^3.0.0"
 
+svg-innerhtml@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/svg-innerhtml/-/svg-innerhtml-1.1.0.tgz#5e5d1efbc32596479e73a1e8e221d1222678b678"
+
 svgo@^0.7.0:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/svgo/-/svgo-0.7.2.tgz#9f5772413952135c6fefbf40afe6a4faa88b4bb5"


### PR DESCRIPTION
This adds an SVG budget chart to the reports screen.

Fixture data for a number of months is supplied to the template through the route. Presumably little will need to change when "real" data is supplied.

Notably missing is the end-of-TO projection for how the current and cumulative spend will fall relative to the total budget. I.e. will it be under/over budget.

Also missing are future projections of monthly spend. Currently, the projected monthly spends are duplicates of the most recent actual monthly spend.

We can prioritize if and how we want to stub these out in a later PR, if needed.

![screen shot 2018-09-11 at 9 57 33 am](https://user-images.githubusercontent.com/40467269/45369597-491a4800-b5b4-11e8-8e55-ee1b973d5831.png)
 
Note: An IE/Javascript bug (not related to this work) will prevent this screen from being visible. Bug is tracked here: https://www.pivotaltracker.com/story/show/160417558