### PR TITLE
Review history #159038479

### DIFF
--- a/atst/filters.py
+++ b/atst/filters.py
@@ -65,9 +65,9 @@ def renderList(value):
     return app.jinja_env.filters["safe"]("<br>".join(value))
 
 
-def formattedDate(value):
+def formattedDate(value, formatter="%m/%d/%Y"):
     if value:
-        return value.strftime("%m/%d/%Y")
+        return value.strftime(formatter)
     else:
         return "-"
 

--- a/atst/models/request_review.py
+++ b/atst/models/request_review.py
@@ -20,3 +20,11 @@ class RequestReview(Base):
     phone_mao = Column(String)
     fname_ccpo = Column(String)
     lname_ccpo = Column(String)
+
+    @property
+    def full_name_mao(self):
+        return "{} {}".format(self.fname_mao, self.lname_mao)
+
+    @property
+    def full_name_ccpo(self):
+        return "{} {}".format(self.fname_ccpo, self.lname_ccpo)

--- a/atst/models/request_review.py
+++ b/atst/models/request_review.py
@@ -22,6 +22,10 @@ class RequestReview(Base):
     lname_ccpo = Column(String)
 
     @property
+    def full_name_reviewer(self):
+        return self.reviewer.full_name
+
+    @property
     def full_name_mao(self):
         return "{} {}".format(self.fname_mao, self.lname_mao)
 

--- a/atst/models/request_status_event.py
+++ b/atst/models/request_status_event.py
@@ -42,3 +42,12 @@ class RequestStatusEvent(Base):
     @property
     def displayname(self):
         return self.new_status.value
+
+    @property
+    def log_name(self):
+        if self.new_status == RequestStatus.CHANGES_REQUESTED:
+            return "Denied"
+        elif self.new_status == RequestStatus.PENDING_FINANCIAL_VERIFICATION:
+            return "Accepted"
+        else:
+            return self.displayname

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -35,7 +35,7 @@ def render_approval(request, form=None):
     return render_template(
         "requests/approval.html",
         data=data,
-        statuses=request.status_events,
+        statuses=reversed(request.status_events),
         request_id=request.id,
         status=request.status.value,
         pending_review=pending_review,

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -35,6 +35,7 @@ def render_approval(request, form=None):
     return render_template(
         "requests/approval.html",
         data=data,
+        statuses=request.status_events,
         request_id=request.id,
         status=request.status.value,
         pending_review=pending_review,

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -35,9 +35,9 @@ def render_approval(request, form=None):
     return render_template(
         "requests/approval.html",
         data=data,
-        statuses=reversed(request.status_events),
+        status_events=reversed(request.status_events),
         request_id=request.id,
-        status=request.status.value,
+        current_status=request.status.value,
         pending_review=pending_review,
         financial_review=pending_final_approval,
         pdf_available=request.task_order and request.task_order.pdf,

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -142,60 +142,42 @@
       <div>
         <div class='approval-log'>
           <ol>
-            <li>
-              <article class='approval-log__log-item'>
-                <div>
-                  <h3 class='approval-log__log-item__header'>Denied by Darth Vader</h3>
-                  <p>"You have failed me for the last time, Admiral. Captain Piett. Yes, my lord. Make ready to land out troops beyond the energy shield and deploy the fleet so that nothing gets off that system."</p>
 
-                  <div class='approval-log__behalfs'>
-                    <div class='approval-log__behalf'>
-                      <h3 class='approval-log__log-item__header'>Mission Owner approval on behalf of:</h3>
-                      <span>Grand Moff Tarkin</span>
-                      <span>tarkin@empire.mil</span>
-                      <span>(234) 567-8901</span>
+            {% for status in statuses %}
+              {% if status.review %}
+                <li>
+                  <article class='approval-log__log-item'>
+                    <div>
+                      <h3 class='approval-log__log-item__header'>Denied by Darth Vader</h3>
+                      {% if status.review.comment %}
+                        <p>{{ status.review.comment }}</p>
+                      {% endif %}
+
+                      <div class='approval-log__behalfs'>
+                        {% if status.review.lname_mao %}
+                          <div class='approval-log__behalf'>
+                            <h3 class='approval-log__log-item__header'>Mission Owner approval on behalf of:</h3>
+                            <span>{{ status.review.full_name_mao }}</span>
+                            <span>{{ status.review.email_mao }}</span>
+                            <span>{{ status.review.phone_mao }}</span>
+                          </div>
+                        {% endif %}
+
+                        {% if status.review.lname_ccpo %}
+                          <div class='approval-log__behalf'>
+                            <h3 class='approval-log__log-item__header'>CCPO approval on behalf of:</h3>
+                            <span>{{ status.review.full_name_ccpo }}</span>
+                          </div>
+                        {% endif %}
+                      </div>
                     </div>
-
-                    <div class='approval-log__behalf'>
-                      <h3 class='approval-log__log-item__header'>CCPO approval on behalf of:</h3>
-                      <span>Emperor Palpatine</span>
-                      <span>palpatine@empire.mil</span>
-                      <span>(345) 678-9012</span>
-                    </div>
-                  </div>
-                </div>
-
-                <footer class='approval-log__log-item__timestamp'><time datetime='2018-07-02 04:23:02 EST'>2018-07-02 04:23:02 EST</time></footer>
-              </article>
-            </li>
+                    <footer class='approval-log__log-item__timestamp'><time datetime='2018-07-02 04:23:02 EST'>{{ status.time_created.strftime("%Y-%m-%d %H:%M:%S %Z") }}</time></footer>
+                  </article>
+                </li>
+              {% endif %}
+            {% endfor %}
 
 
-            <li>
-              <article class='approval-log__log-item'>
-                <div>
-                  <h3 class='approval-log__log-item__header'>Denied by Darth Vader</h3>
-                  <p>"You have failed me for the last time, Admiral. Captain Piett. Yes, my lord. Make ready to land out troops beyond the energy shield and deploy the fleet so that nothing gets off that system."</p>
-
-                  <div class='approval-log__behalfs'>
-                    <div class='approval-log__behalf'>
-                      <h3 class='approval-log__log-item__header'>Mission Owner approval on behalf of:</h3>
-                      <span>Grand Moff Tarkin</span>
-                      <span>tarkin@empire.mil</span>
-                      <span>(234) 567-8901</span>
-                    </div>
-
-                    <div class='approval-log__behalf'>
-                      <h3 class='approval-log__log-item__header'>CCPO approval on behalf of:</h3>
-                      <span>Emperor Palpatine</span>
-                      <span>palpatine@empire.mil</span>
-                      <span>(345) 678-9012</span>
-                    </div>
-                  </div>
-                </div>
-
-                <footer class='approval-log__log-item__timestamp'><time datetime='2018-07-02 04:23:02 EST'>2018-07-02 04:23:02 EST</time></footer>
-              </article>
-            </li>
           </ol>
         </div>
       </div>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -20,7 +20,7 @@
     <section class='panel'>
       <header class='panel__heading request-approval__heading'>
         <h1 class='h2'>Request #{{ request_id }}</h1>
-        <span class='label label--info'>{{ status }}</span>
+        <span class='label label--info'>{{ current_status }}</span>
       </header>
 
       <div class='panel__content'>
@@ -143,35 +143,35 @@
         <div class='approval-log'>
           <ol>
 
-            {% for status in statuses %}
-              {% if status.review %}
+            {% for status_event in status_events %}
+              {% if status_event.review %}
                 <li>
                   <article class='approval-log__log-item'>
                     <div>
-                      <h3 class='approval-log__log-item__header'>{{ status.log_name }} by {{ status.review.full_name_reviewer }}</h3>
-                      {% if status.review.comment %}
-                        <p>{{ status.review.comment }}</p>
+                      <h3 class='approval-log__log-item__header'>{{ status_event.log_name }} by {{ status_event.review.full_name_reviewer }}</h3>
+                      {% if status_event.review.comment %}
+                        <p>{{ status_event.review.comment }}</p>
                       {% endif %}
 
                       <div class='approval-log__behalfs'>
-                        {% if status.review.lname_mao %}
+                        {% if status_event.review.lname_mao %}
                           <div class='approval-log__behalf'>
                             <h3 class='approval-log__log-item__header'>Mission Owner approval on behalf of:</h3>
-                            <span>{{ status.review.full_name_mao }}</span>
-                            <span>{{ status.review.email_mao }}</span>
-                            <span>{{ status.review.phone_mao }}</span>
+                            <span>{{ status_event.review.full_name_mao }}</span>
+                            <span>{{ status_event.review.email_mao }}</span>
+                            <span>{{ status_event.review.phone_mao }}</span>
                           </div>
                         {% endif %}
 
-                        {% if status.review.lname_ccpo %}
+                        {% if status_event.review.lname_ccpo %}
                           <div class='approval-log__behalf'>
                             <h3 class='approval-log__log-item__header'>CCPO approval on behalf of:</h3>
-                            <span>{{ status.review.full_name_ccpo }}</span>
+                            <span>{{ status_event.review.full_name_ccpo }}</span>
                           </div>
                         {% endif %}
                       </div>
                     </div>
-                    {% set timestamp=status.time_created | formattedDate("%Y-%m-%d %H:%M:%S %Z") %}
+                    {% set timestamp=status_event.time_created | formattedDate("%Y-%m-%d %H:%M:%S %Z") %}
                     <footer class='approval-log__log-item__timestamp'><time datetime='{{ timestamp }}'>{{ timestamp }}</time></footer>
                   </article>
                 </li>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -171,7 +171,7 @@
                         {% endif %}
                       </div>
                     </div>
-                    {% set timestamp=status.time_created.strftime("%Y-%m-%d %H:%M:%S %Z") %}
+                    {% set timestamp=status.time_created | formattedDate("%Y-%m-%d %H:%M:%S %Z") %}
                     <footer class='approval-log__log-item__timestamp'><time datetime='{{ timestamp }}'>{{ timestamp }}</time></footer>
                   </article>
                 </li>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -148,7 +148,7 @@
                 <li>
                   <article class='approval-log__log-item'>
                     <div>
-                      <h3 class='approval-log__log-item__header'>Denied by Darth Vader</h3>
+                      <h3 class='approval-log__log-item__header'>{{ status.log_name }} by {{ status.review.full_name_reviewer }}</h3>
                       {% if status.review.comment %}
                         <p>{{ status.review.comment }}</p>
                       {% endif %}
@@ -171,12 +171,12 @@
                         {% endif %}
                       </div>
                     </div>
-                    <footer class='approval-log__log-item__timestamp'><time datetime='2018-07-02 04:23:02 EST'>{{ status.time_created.strftime("%Y-%m-%d %H:%M:%S %Z") }}</time></footer>
+                    {% set timestamp=status.time_created.strftime("%Y-%m-%d %H:%M:%S %Z") %}
+                    <footer class='approval-log__log-item__timestamp'><time datetime='{{ timestamp }}'>{{ timestamp }}</time></footer>
                   </article>
                 </li>
               {% endif %}
             {% endfor %}
-
 
           </ol>
         </div>


### PR DESCRIPTION
Here's the PT story: https://www.pivotaltracker.com/n/projects/2160940/stories/159038479

This wires up the CCPO approval log.

Few notes:
- I implemented this so that the actions are "approve", "accept", or "deny" because of the new request status.
- The timezone in the timestamp is expressed as a UTC offset for right now; that's what we get at the moment without importing more Python dependencies. It won't stay like this. I added a new story, #160419017, to address how we want to format timestamps. I think we should make a deliberate decision about how we want to display timestamps to end-users here.
- The story doesn't specify it, but I have the logs displayed in reverse order so that the most recent action is first.