### PR TITLE
Final approval #158633809

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -291,6 +291,9 @@ WHERE requests_with_status.status = :status
 
     @classmethod
     def request_changes(cls, user, request, review_data):
-        Requests.set_status(request, RequestStatus.CHANGES_REQUESTED)
+        if request.status == RequestStatus.PENDING_CCPO_ACCEPTANCE:
+            Requests.set_status(request, RequestStatus.CHANGES_REQUESTED)
+        elif request.status == RequestStatus.PENDING_CCPO_APPROVAL:
+            Requests.set_status(request, RequestStatus.CHANGES_REQUESTED_TO_FINVER)
 
         return Requests._add_review(user, request, review_data)

--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -281,8 +281,11 @@ WHERE requests_with_status.status = :status
         return request
 
     @classmethod
-    def accept_for_financial_verification(cls, user, request, review_data):
-        Requests.set_status(request, RequestStatus.PENDING_FINANCIAL_VERIFICATION)
+    def advance(cls, user, request, review_data):
+        if request.status == RequestStatus.PENDING_CCPO_ACCEPTANCE:
+            Requests.set_status(request, RequestStatus.PENDING_FINANCIAL_VERIFICATION)
+        elif request.status == RequestStatus.PENDING_CCPO_APPROVAL:
+            Requests.approve_and_create_workspace(request)
 
         return Requests._add_review(user, request, review_data)
 

--- a/atst/models/request_status_event.py
+++ b/atst/models/request_status_event.py
@@ -16,9 +16,10 @@ class RequestStatus(Enum):
     PENDING_CCPO_ACCEPTANCE = "Pending CCPO Acceptance"
     PENDING_CCPO_APPROVAL = "Pending CCPO Approval"
     CHANGES_REQUESTED = "Changes Requested"
+    CHANGES_REQUESTED_TO_FINVER = "Change Requested to Financial Verification"
     APPROVED = "Approved"
     EXPIRED = "Expired"
-    CANCELED = "Canceled"
+    DELETED = "Deleted"
 
 
 class RequestStatusEvent(Base):

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -60,9 +60,7 @@ def submit_approval(request_id):
     form = CCPOReviewForm(http_request.form)
     if form.validate():
         if http_request.form.get("approved"):
-            Requests.accept_for_financial_verification(
-                g.current_user, request, form.data
-            )
+            Requests.advance(g.current_user, request, form.data)
         else:
             Requests.request_changes(g.current_user, request, form.data)
 

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -181,12 +181,27 @@ def test_set_status_sets_revision():
     assert request.latest_revision == request.status_events[-1].revision
 
 
-def test_accept_for_financial_verification():
+def test_advance_to_financial_verification():
     request = RequestFactory.create()
-    review_data = RequestReviewFactory.dictionary()
-    Requests.accept_for_financial_verification(
-        UserFactory.create(), request, review_data
+    RequestStatusEventFactory.create(
+        request=request,
+        revision=request.latest_revision,
+        new_status=RequestStatus.PENDING_CCPO_ACCEPTANCE,
     )
+    review_data = RequestReviewFactory.dictionary()
+    Requests.advance(UserFactory.create(), request, review_data)
     assert request.status == RequestStatus.PENDING_FINANCIAL_VERIFICATION
     current_review = request.latest_status.review
     assert current_review.fname_mao == review_data["fname_mao"]
+
+
+def test_advance_to_approval():
+    request = RequestFactory.create()
+    RequestStatusEventFactory.create(
+        request=request,
+        revision=request.latest_revision,
+        new_status=RequestStatus.PENDING_CCPO_APPROVAL,
+    )
+    review_data = RequestReviewFactory.dictionary()
+    Requests.advance(UserFactory.create(), request, review_data)
+    assert request.status == RequestStatus.APPROVED

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -182,11 +182,8 @@ def test_set_status_sets_revision():
 
 
 def test_advance_to_financial_verification():
-    request = RequestFactory.create()
-    RequestStatusEventFactory.create(
-        request=request,
-        revision=request.latest_revision,
-        new_status=RequestStatus.PENDING_CCPO_ACCEPTANCE,
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
     )
     review_data = RequestReviewFactory.dictionary()
     Requests.advance(UserFactory.create(), request, review_data)
@@ -196,12 +193,31 @@ def test_advance_to_financial_verification():
 
 
 def test_advance_to_approval():
-    request = RequestFactory.create()
-    RequestStatusEventFactory.create(
-        request=request,
-        revision=request.latest_revision,
-        new_status=RequestStatus.PENDING_CCPO_APPROVAL,
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_APPROVAL
     )
     review_data = RequestReviewFactory.dictionary()
     Requests.advance(UserFactory.create(), request, review_data)
     assert request.status == RequestStatus.APPROVED
+
+
+def test_request_changes_to_request_application():
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
+    )
+    review_data = RequestReviewFactory.dictionary()
+    Requests.request_changes(UserFactory.create(), request, review_data)
+    assert request.status == RequestStatus.CHANGES_REQUESTED
+    current_review = request.latest_status.review
+    assert current_review.fname_mao == review_data["fname_mao"]
+
+
+def test_request_changes_to_financial_verification_info():
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_APPROVAL
+    )
+    review_data = RequestReviewFactory.dictionary()
+    Requests.request_changes(UserFactory.create(), request, review_data)
+    assert request.status == RequestStatus.CHANGES_REQUESTED_TO_FINVER
+    current_review = request.latest_status.review
+    assert current_review.fname_mao == review_data["fname_mao"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -148,6 +148,14 @@ class RequestFactory(Base):
 
         return RequestRevisionFactory.build(**data)
 
+    @classmethod
+    def create_with_status(cls, status=RequestStatus.STARTED, **kwargs):
+        request = RequestFactory(**kwargs)
+        RequestStatusEventFactory.create(
+            request=request, revision=request.latest_revision, new_status=status
+        )
+        return request
+
 
 class PENumberFactory(Base):
     class Meta:

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -65,9 +65,9 @@ def test_request_status_pending_expired_displayname():
 
 def test_request_status_pending_deleted_displayname():
     request = RequestFactory.create()
-    request = Requests.set_status(request, RequestStatus.CANCELED)
+    request = Requests.set_status(request, RequestStatus.DELETED)
 
-    assert request.status_displayname == "Canceled"
+    assert request.status_displayname == "Deleted"
 
 
 def test_annual_spend():

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -10,6 +10,7 @@ from tests.factories import (
     TaskOrderFactory,
     UserFactory,
     RequestReviewFactory,
+    RequestStatusEventFactory,
 )
 
 
@@ -71,6 +72,11 @@ def test_can_submit_request_approval(client, user_session):
     user = UserFactory.from_atat_role("ccpo")
     user_session(user)
     request = RequestFactory.create()
+    RequestStatusEventFactory.create(
+        request=request,
+        revision=request.latest_revision,
+        new_status=RequestStatus.PENDING_CCPO_ACCEPTANCE,
+    )
     review_data = RequestReviewFactory.dictionary()
     review_data["approved"] = True
     response = client.post(

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -71,11 +71,8 @@ def test_task_order_download_does_not_exist(client, user_session):
 def test_can_submit_request_approval(client, user_session):
     user = UserFactory.from_atat_role("ccpo")
     user_session(user)
-    request = RequestFactory.create()
-    RequestStatusEventFactory.create(
-        request=request,
-        revision=request.latest_revision,
-        new_status=RequestStatus.PENDING_CCPO_ACCEPTANCE,
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
     )
     review_data = RequestReviewFactory.dictionary()
     review_data["approved"] = True
@@ -89,7 +86,9 @@ def test_can_submit_request_approval(client, user_session):
 def test_can_submit_request_denial(client, user_session):
     user = UserFactory.from_atat_role("ccpo")
     user_session(user)
-    request = RequestFactory.create()
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
+    )
     review_data = RequestReviewFactory.dictionary()
     review_data["denied"] = True
     response = client.post(


### PR DESCRIPTION
This adds some final behavior so that this PT story works: https://www.pivotaltracker.com/story/show/159047028

If a CCPO reviews a request that is "Pending CCPO Approval" (i.e., has manually entered task order info), the requests status is updated appropriately. A denial results in "Changes Request to FInancial Verification" and an approval results in an "Approved" request with a corresponding workspace.

notes:
- This does not add any notifications for the mission owner; those are on separate stories.
- This also updates the request statuses per the [google doc](https://docs.google.com/document/d/12VDyiP_-YNmnbOZoQ6O015wvOt3HiY4pARHNCcKdmWc/edit)