### PR TITLE
dont destructure props in template

### DIFF
--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -134,16 +134,16 @@
   {% endcall %}
 
   <div is='toggler' default-visible class='block-list project-list-item'>
-    <template slot-scope='{ isVisible, toggle }'>
+    <template slot-scope='props'>
       <header class='block-list__header'>
-      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
           <template v-else>{{ Icon('caret_right') }}</template>
           <h3 class="block-list__title">Code.mil</h3>
         </button>
         <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
       </header>
-      <ul v-show='isVisible'>
+      <ul v-show='props.isVisible'>
         <li class='block-list__item project-list-item__environment'>
           <span class='project-list-item__environment'>
             Development
@@ -173,16 +173,16 @@
   </div>
 
   <div is="toggler" class='block-list project-list-item'>
-    <template slot-scope='{ isVisible, toggle }'>
+    <template slot-scope='props'>
       <header class='block-list__header'>
-      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
           <template v-else>{{ Icon('caret_right') }}</template>
           <h3 class="block-list__title">Digital Dojo</h3>
         </button>
         <span class="label">no access</span>
       </header>
-      <ul v-show='isVisible'>
+      <ul v-show='props.isVisible'>
         <li class='block-list__item project-list-item__environment'>
           <span class='project-list-item__environment'>
             Development


### PR DESCRIPTION
Fix toggler on member-edit screen.

Destructuring props in the template breaks in IE

Fixes https://www.pivotaltracker.com/story/show/160431709