### PR TITLE
Resubmit financial verification #159047362

### DIFF
--- a/atst/domain/requests.py
+++ b/atst/domain/requests.py
@@ -191,6 +191,10 @@ class Requests(object):
         return request.status == RequestStatus.PENDING_FINANCIAL_VERIFICATION
 
     @classmethod
+    def is_pending_financial_verification_changes(cls, request):
+        return request.status == RequestStatus.CHANGES_REQUESTED_TO_FINVER
+
+    @classmethod
     def is_pending_ccpo_acceptance(cls, request):
         return request.status == RequestStatus.PENDING_CCPO_ACCEPTANCE
 

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -39,3 +39,10 @@ class TaskOrder(Base):
     @property
     def verified(self):
         return self.source == Source.EDA
+
+    def to_dictionary(self):
+        return {
+            c.name: getattr(self, c.name)
+            for c in self.__table__.columns
+            if c.name not in ["id", "attachment_id"]
+        }

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -14,14 +14,6 @@ from atst.domain.exceptions import NotFoundError
 from atst.forms.ccpo_review import CCPOReviewForm
 
 
-def task_order_dictionary(task_order):
-    return {
-        c.name: getattr(task_order, c.name)
-        for c in task_order.__table__.columns
-        if c.name not in ["id", "attachment_id"]
-    }
-
-
 def render_approval(request, form=None):
     data = request.body
     pending_final_approval = Requests.is_pending_ccpo_approval(request)
@@ -29,7 +21,7 @@ def render_approval(request, form=None):
         Requests.is_pending_ccpo_acceptance(request) or pending_final_approval
     )
     if pending_final_approval and request.task_order:
-        data["task_order"] = task_order_dictionary(request.task_order)
+        data["task_order"] = request.task_order.to_dictionary()
 
     return render_template(
         "requests/approval.html",

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -6,6 +6,13 @@ from atst.domain.requests import Requests
 from atst.forms.financial import FinancialForm, ExtendedFinancialForm
 
 
+def task_order_data(task_order):
+    data = task_order.to_dictionary()
+    data["task_order_number"] = task_order.number
+    data["funding_type"] = task_order.funding_type.value
+    return data
+
+
 def financial_form(data):
     if http_request.args.get("extended"):
         return ExtendedFinancialForm(data=data)
@@ -16,7 +23,11 @@ def financial_form(data):
 @requests_bp.route("/requests/verify/<string:request_id>", methods=["GET"])
 def financial_verification(request_id=None):
     request = Requests.get(g.current_user, request_id)
-    form = financial_form(request.body.get("financial_verification"))
+    form_data = request.body.get("financial_verification")
+    if request.task_order:
+        form_data.update(task_order_data(request.task_order))
+
+    form = financial_form(form_data)
     return render_template(
         "requests/financial_verification.html",
         f=form,

--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -57,6 +57,26 @@ class RequestsIndex(object):
             "extended_view": False,
         }
 
+    def _edit_link_for_request(self, viewing_role, request):
+        if viewing_role == "ccpo":
+            return url_for("requests.approval", request_id=request.id)
+        elif Requests.is_pending_financial_verification(request):
+            return url_for(
+                "requests.financial_verification", request_id=request.id
+            )
+        elif Requests.is_pending_financial_verification_changes(request):
+            return url_for(
+                "requests.financial_verification", request_id=request.id, extended=True
+            )
+        elif Requests.is_pending_ccpo_acceptance(
+            request
+        ) or Requests.is_pending_ccpo_approval(request):
+            return url_for("requests.view_pending_request", request_id=request.id)
+        else:
+            return url_for(
+                "requests.requests_form_update", screen=1, request_id=request.id
+            )
+
     def _map_request(self, request, viewing_role):
         time_created = pendulum.instance(request.time_created)
         is_new = time_created.add(days=1) > pendulum.now()
@@ -64,21 +84,6 @@ class RequestsIndex(object):
             "num_software_systems", 0
         )
         annual_usage = request.annual_spend
-
-        if viewing_role == "ccpo":
-            edit_link = url_for("requests.approval", request_id=request.id)
-        elif Requests.is_pending_financial_verification(request):
-            edit_link = url_for(
-                "requests.financial_verification", request_id=request.id
-            )
-        elif Requests.is_pending_ccpo_acceptance(
-            request
-        ) or Requests.is_pending_ccpo_approval(request):
-            edit_link = url_for("requests.view_pending_request", request_id=request.id)
-        else:
-            edit_link = url_for(
-                "requests.requests_form_update", screen=1, request_id=request.id
-            )
 
         return {
             "workspace_id": request.workspace.id if request.workspace else None,
@@ -90,7 +95,7 @@ class RequestsIndex(object):
             "last_edited_timestamp": request.latest_revision.time_updated,
             "full_name": request.creator.full_name,
             "annual_usage": annual_usage,
-            "edit_link": edit_link,
+            "edit_link": self._edit_link_for_request(viewing_role, request),
             "action_required": request.action_required_by == viewing_role,
             "dod_component": request.latest_revision.dod_component,
         }

--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -61,9 +61,7 @@ class RequestsIndex(object):
         if viewing_role == "ccpo":
             return url_for("requests.approval", request_id=request.id)
         elif Requests.is_pending_financial_verification(request):
-            return url_for(
-                "requests.financial_verification", request_id=request.id
-            )
+            return url_for("requests.financial_verification", request_id=request.id)
         elif Requests.is_pending_financial_verification_changes(request):
             return url_for(
                 "requests.financial_verification", request_id=request.id, extended=True

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -10,7 +10,7 @@ from atst.models.request_revision import RequestRevision
 from atst.models.request_review import RequestReview
 from atst.models.request_status_event import RequestStatusEvent, RequestStatus
 from atst.models.pe_number import PENumber
-from atst.models.task_order import TaskOrder
+from atst.models.task_order import TaskOrder, Source, FundingType
 from atst.models.user import User
 from atst.models.role import Role
 from atst.models.workspace import Workspace
@@ -165,6 +165,17 @@ class PENumberFactory(Base):
 class TaskOrderFactory(Base):
     class Meta:
         model = TaskOrder
+
+    source = Source.MANUAL
+    funding_type = FundingType.PROC
+    funding_type_other = None
+    number = "toABC123"
+    clin_0001 = random.randrange(100, 100000)
+    clin_0003 = random.randrange(100, 100000)
+    clin_1001 = random.randrange(100, 100000)
+    clin_1003 = random.randrange(100, 100000)
+    clin_2001 = random.randrange(100, 100000)
+    clin_2003 = random.randrange(100, 100000)
 
 
 class WorkspaceFactory(Base):

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -1,0 +1,9 @@
+from atst.models.task_order import TaskOrder
+
+from tests.factories import TaskOrderFactory
+
+
+def test_as_dictionary():
+    data = TaskOrderFactory.dictionary()
+    real_task_order = TaskOrderFactory.create(**data)
+    assert real_task_order.to_dictionary() == data


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/n/projects/2160940/stories/159047362

When a CCPO has asked for changes to a request with task order information, a mission owner clicks  the request ID on their requests index page and is taken back to the financial verification form. The original data is there and they can update and resubmit it.

Note that we don't display CCPO comments about rejections/changes yet; those are in the next sprint.