### PR TITLE
Ie/fix layout

### DIFF
--- a/styles/components/_global_layout.scss
+++ b/styles/components/_global_layout.scss
@@ -29,8 +29,24 @@
     overflow-x: hidden;
     flex-grow: 1;
 
+    @include ie-only {
+      max-width: 85%;
+    }
+
     @include media($medium-screen) {
       margin: $gap * 2;
+    }
+
+    @include media($large-screen) {
+      @include ie-only {
+        max-width: 80%;
+      }
+    }
+
+    @include media($xlarge-screen) {
+      @include ie-only {
+        max-width: $site-max-width;
+      }
     }
   }
 }

--- a/styles/components/_topbar.scss
+++ b/styles/components/_topbar.scss
@@ -50,6 +50,7 @@
       flex-direction: row;
       align-items: stretch;
       justify-content: flex-end;
+      -ms-flex-pack: start;
 
       .topbar__link {
         &:first-child {

--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -35,3 +35,10 @@
 [v-cloak] {
   display: none
 }
+
+@mixin ie-only {
+  // Applies to IE 10+
+  @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+    @content;
+  }
+}


### PR DESCRIPTION
Fixes some issues with the layout in IE 10 and 11.

- Topbar links were not aligned properly, and flowing off the screen
- Main layout was also flowing off the screen

This adds an IE-specific flex style to the header, to get it to layout properly.
Also adds a general purpose mixin `@inclue ie-only { ... }` which applies to IE 10 and 11. This is used on the main layout to manually set some max widths at various screen sizes.

Fixes https://www.pivotaltracker.com/story/show/160430777

![screen shot 2018-09-12 at 9 45 18 am](https://user-images.githubusercontent.com/40467269/45429229-e3d85c80-b670-11e8-912e-ae6dc5356d74.png)
