### PR TITLE
IE workspace Role selector formatting

### DIFF
--- a/styles/elements/_block_lists.scss
+++ b/styles/elements/_block_lists.scss
@@ -120,6 +120,15 @@
         color: $color-primary;
       }
     }
+
+    @include ie-only {
+
+      dl {
+        width: 100%;
+        padding-left: $gap*4;
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
This PR fixes an IE bug where the workspace role selector formatting looked messed up.

story: https://www.pivotaltracker.com/n/projects/2160940/stories/160430470

---

![screen shot 2018-09-12 at 12 04 56](https://user-images.githubusercontent.com/38014252/45438191-83ebb100-b684-11e8-91c8-ee93fe23465b.png)


