### PR TITLE
use InputRequired validation for clin fields

### DIFF
--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -1,7 +1,7 @@
 import re
 from wtforms.fields.html5 import EmailField
 from wtforms.fields import StringField, FileField
-from wtforms.validators import Required, Email, Regexp
+from wtforms.validators import InputRequired, Required, Email, Regexp
 from flask_wtf.file import FileAllowed
 
 from atst.domain.exceptions import NotFoundError
@@ -168,42 +168,42 @@ class ExtendedFinancialForm(BaseFinancialForm):
 
     clin_0001 = StringField(
         "<dl><dt>CLIN 0001</dt> - <dd>Unclassified IaaS and PaaS Amount</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )
 
     clin_0003 = StringField(
         "<dl><dt>CLIN 0003</dt> - <dd>Unclassified Cloud Support Package</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )
 
     clin_1001 = StringField(
         "<dl><dt>CLIN 1001</dt> - <dd>Unclassified IaaS and PaaS Amount <br> OPTION PERIOD 1</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )
 
     clin_1003 = StringField(
         "<dl><dt>CLIN 1003</dt> - <dd>Unclassified Cloud Support Package <br> OPTION PERIOD 1</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )
 
     clin_2001 = StringField(
         "<dl><dt>CLIN 2001</dt> - <dd>Unclassified IaaS and PaaS Amount <br> OPTION PERIOD 2</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )
 
     clin_2003 = StringField(
         "<dl><dt>CLIN 2003</dt> - <dd>Unclassified Cloud Support Package <br> OPTION PERIOD 2</dd></dl>",
-        validators=[Required()],
+        validators=[InputRequired()],
         description="Review your task order document, the amounts for each CLIN must match exactly here",
         filters=[number_to_int],
     )

--- a/tests/forms/test_financial.py
+++ b/tests/forms/test_financial.py
@@ -1,4 +1,5 @@
 import pytest
+from werkzeug.datastructures import ImmutableMultiDict
 
 from atst.forms.financial import suggest_pe_id, FinancialForm, ExtendedFinancialForm
 from atst.eda_client import MockEDAClient
@@ -98,3 +99,13 @@ def test_task_order_number_validation(monkeypatch):
     form_valid.perform_extra_validation({})
 
     assert "task_order_number" not in form_valid.errors
+
+
+def test_can_submit_zero_for_clin():
+    form_first = ExtendedFinancialForm()
+    form_first.validate()
+    assert "clin_0001" in form_first.errors
+    form_data = ImmutableMultiDict([("clin_0001", "0")])
+    form_second = ExtendedFinancialForm(form_data)
+    form_second.validate()
+    assert "clin_0001" not in form_second.errors


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/160450606

This is an important WTForms distinction I didn't know about: if a user can enter a value that is falsey in Python (like zero) into a required field, we should be using the WTForms `InputRequired` validator, not plain `Required`. Plain `Required` will fail falsey values.