### PR TITLE
Query refactors

### DIFF
--- a/atst/domain/common/__init__.py
+++ b/atst/domain/common/__init__.py
@@ -1,0 +1,1 @@
+from .query import Query

--- a/atst/domain/common/query.py
+++ b/atst/domain/common/query.py
@@ -1,0 +1,38 @@
+from sqlalchemy.exc import DataError
+from sqlalchemy.orm.exc import NoResultFound
+
+from atst.domain.exceptions import NotFoundError
+from atst.database import db
+
+
+class Query(object):
+
+    model = None
+
+    @property
+    def resource_name(cls):
+        return cls.model.__class__.lower()
+
+    @classmethod
+    def create(cls, **kwargs):
+        # pylint: disable=E1102
+        return cls.model(**kwargs)
+
+    @classmethod
+    def get(cls, id_):
+        try:
+            resource = db.session.query(cls.model).filter_by(id=id_).one()
+            return resource
+        except (NoResultFound, DataError):
+            raise NotFoundError(cls.resource_name)
+
+    @classmethod
+    def get_all(cls):
+        return db.session.query(cls.model).all()
+
+    @classmethod
+    def add_and_commit(cls, resource):
+        db.session.add(resource)
+        db.session.commit()
+        return resource
+

--- a/atst/domain/common/query.py
+++ b/atst/domain/common/query.py
@@ -35,4 +35,3 @@ class Query(object):
         db.session.add(resource)
         db.session.commit()
         return resource
-

--- a/atst/domain/requests/__init__.py
+++ b/atst/domain/requests/__init__.py
@@ -1,0 +1,1 @@
+from .requests import Requests, create_revision_from_request_body

--- a/atst/domain/requests/query.py
+++ b/atst/domain/requests/query.py
@@ -1,0 +1,71 @@
+from sqlalchemy import exists, and_, exc, text
+
+from atst.database import db
+from atst.domain.common import Query
+from atst.models.request import Request
+
+
+class RequestsQuery(Query):
+    model = Request
+
+    @classmethod
+    def exists(cls, request_id, creator):
+        try:
+            return db.session.query(
+                exists().where(
+                    and_(Request.id == request_id, Request.creator == creator)
+                )
+            ).scalar()
+
+        except exc.DataError:
+            return False
+
+    @classmethod
+    def get_many(cls, creator=None):
+        filters = []
+        if creator:
+            filters.append(Request.creator == creator)
+
+        requests = (
+            db.session.query(Request)
+            .filter(*filters)
+            .order_by(Request.time_created.desc())
+            .all()
+        )
+        return requests
+
+    @classmethod
+    def get_with_lock(cls, request_id):
+        try:
+            # Query for request matching id, acquiring a row-level write lock.
+            # https://www.postgresql.org/docs/10/static/sql-select.html#SQL-FOR-UPDATE-SHARE
+            return (
+                db.session.query(Request)
+                .filter_by(id=request_id)
+                .with_for_update(of=Request)
+                .one()
+            )
+
+        except NoResultFound:
+            raise NotFoundError("requests")
+
+    @classmethod
+    def status_count(cls, status, creator=None):
+        bindings = {"status": status.name}
+        raw = """
+SELECT count(requests_with_status.id)
+FROM (
+    SELECT DISTINCT ON (rse.request_id) r.*, rse.new_status as status
+    FROM request_status_events rse JOIN requests r ON r.id = rse.request_id
+    ORDER BY rse.request_id, rse.sequence DESC
+) as requests_with_status
+WHERE requests_with_status.status = :status
+        """
+
+        if creator:
+            raw += " AND requests_with_status.user_id = :user_id"
+            bindings["user_id"] = creator.id
+
+        results = db.session.execute(text(raw), bindings).fetchone()
+        (count,) = results
+        return count

--- a/atst/domain/requests/requests.py
+++ b/atst/domain/requests/requests.py
@@ -4,7 +4,6 @@ import dateutil
 from atst.domain.authz import Authorization
 from atst.domain.task_orders import TaskOrders
 from atst.domain.workspaces import Workspaces
-from atst.models.request import Request
 from atst.models.request_revision import RequestRevision
 from atst.models.request_status_event import RequestStatusEvent, RequestStatus
 from atst.models.request_review import RequestReview
@@ -103,7 +102,7 @@ class Requests(object):
         return workspace
 
     @classmethod
-    def set_status(cls, request: Request, status: RequestStatus):
+    def set_status(cls, request, status: RequestStatus):
         status_event = RequestStatusEvent(
             new_status=status, revision=request.latest_revision
         )

--- a/atst/domain/workspaces/query.py
+++ b/atst/domain/workspaces/query.py
@@ -1,41 +1,10 @@
 from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
+from atst.domain.common import Query
 from atst.domain.exceptions import NotFoundError
 from atst.models.workspace import Workspace
 from atst.models.workspace_role import WorkspaceRole
-
-
-class Query(object):
-
-    model = None
-
-    @property
-    def resource_name(cls):
-        return cls.model.__class__.lower()
-
-    @classmethod
-    def create(cls, **kwargs):
-        # pylint: disable=E1102
-        return cls.model(**kwargs)
-
-    @classmethod
-    def get(cls, id_):
-        try:
-            resource = db.session.query(cls.model).filter_by(id=id_).one()
-            return resource
-        except NoResultFound:
-            raise NotFoundError(cls.resource_name)
-
-    @classmethod
-    def get_all(cls):
-        return db.session.query(cls.model).all()
-
-    @classmethod
-    def add_and_commit(cls, resource):
-        db.session.add(resource)
-        db.session.commit()
-        return resource
 
 
 class WorkspaceQuery(Query):

--- a/atst/domain/workspaces/query.py
+++ b/atst/domain/workspaces/query.py
@@ -7,7 +7,7 @@ from atst.models.workspace import Workspace
 from atst.models.workspace_role import WorkspaceRole
 
 
-class WorkspaceQuery(Query):
+class WorkspacesQuery(Query):
     model = Workspace
 
     @classmethod

--- a/atst/domain/workspaces/query.py
+++ b/atst/domain/workspaces/query.py
@@ -1,0 +1,64 @@
+from sqlalchemy.orm.exc import NoResultFound
+
+from atst.database import db
+from atst.domain.exceptions import NotFoundError
+from atst.models.workspace import Workspace
+from atst.models.workspace_role import WorkspaceRole
+
+
+class Query(object):
+
+    model = None
+
+    @property
+    def resource_name(cls):
+        return cls.model.__class__.lower()
+
+    @classmethod
+    def create(cls, **kwargs):
+        # pylint: disable=E1102
+        return cls.model(**kwargs)
+
+    @classmethod
+    def get(cls, id_):
+        try:
+            resource = db.session.query(cls.model).filter_by(id=id_).one()
+            return resource
+        except NoResultFound:
+            raise NotFoundError(cls.resource_name)
+
+    @classmethod
+    def get_all(cls):
+        return db.session.query(cls.model).all()
+
+    @classmethod
+    def add_and_commit(cls, resource):
+        db.session.add(resource)
+        db.session.commit()
+        return resource
+
+
+class WorkspaceQuery(Query):
+    model = Workspace
+
+    @classmethod
+    def get_by_request(cls, request):
+        try:
+            workspace = db.session.query(Workspace).filter_by(request=request).one()
+        except NoResultFound:
+            raise NotFoundError("workspace")
+
+        return workspace
+
+    @classmethod
+    def get_for_user(cls, user):
+        return (
+            db.session.query(Workspace)
+            .join(WorkspaceRole)
+            .filter(WorkspaceRole.user == user)
+            .all()
+        )
+
+    @classmethod
+    def create_workspace_role(cls, user, role, workspace):
+        return WorkspaceRole(user=user, role=role, workspace=workspace)

--- a/atst/domain/workspaces/workspaces.py
+++ b/atst/domain/workspaces/workspaces.py
@@ -4,7 +4,7 @@ from atst.models.permissions import Permissions
 from atst.domain.users import Users
 from atst.domain.workspace_users import WorkspaceUsers
 
-from .query import WorkspaceQuery
+from .query import WorkspacesQuery
 from .scopes import ScopedWorkspace
 
 
@@ -12,14 +12,14 @@ class Workspaces(object):
     @classmethod
     def create(cls, request, name=None):
         name = name or request.id
-        workspace = WorkspaceQuery.create(request=request, name=name)
+        workspace = WorkspacesQuery.create(request=request, name=name)
         Workspaces._create_workspace_role(request.creator, workspace, "owner")
-        WorkspaceQuery.add_and_commit(workspace)
+        WorkspacesQuery.add_and_commit(workspace)
         return workspace
 
     @classmethod
     def get(cls, user, workspace_id):
-        workspace = WorkspaceQuery.get(workspace_id)
+        workspace = WorkspacesQuery.get(workspace_id)
         Authorization.check_workspace_permission(
             user, workspace, Permissions.VIEW_WORKSPACE, "get workspace"
         )
@@ -28,7 +28,7 @@ class Workspaces(object):
 
     @classmethod
     def get_for_update(cls, user, workspace_id):
-        workspace = WorkspaceQuery.get(workspace_id)
+        workspace = WorkspacesQuery.get(workspace_id)
         Authorization.check_workspace_permission(
             user, workspace, Permissions.ADD_APPLICATION_IN_WORKSPACE, "add project"
         )
@@ -37,11 +37,11 @@ class Workspaces(object):
 
     @classmethod
     def get_by_request(cls, request):
-        return WorkspaceQuery.get_by_request(request)
+        return WorkspacesQuery.get_by_request(request)
 
     @classmethod
     def get_with_members(cls, user, workspace_id):
-        workspace = WorkspaceQuery.get(workspace_id)
+        workspace = WorkspacesQuery.get(workspace_id)
         Authorization.check_workspace_permission(
             user,
             workspace,
@@ -54,9 +54,9 @@ class Workspaces(object):
     @classmethod
     def for_user(cls, user):
         if Authorization.has_atat_permission(user, Permissions.VIEW_WORKSPACE):
-            workspaces = WorkspaceQuery.get_all()
+            workspaces = WorkspacesQuery.get_all()
         else:
-            workspaces = WorkspaceQuery.get_for_user(user)
+            workspaces = WorkspacesQuery.get_for_user(user)
         return workspaces
 
     @classmethod
@@ -95,6 +95,6 @@ class Workspaces(object):
     @classmethod
     def _create_workspace_role(cls, user, workspace, role_name):
         role = Roles.get(role_name)
-        workspace_role = WorkspaceQuery.create_workspace_role(user, role, workspace)
-        WorkspaceQuery.add_and_commit(workspace_role)
+        workspace_role = WorkspacesQuery.create_workspace_role(user, role, workspace)
+        WorkspacesQuery.add_and_commit(workspace_role)
         return workspace_role

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -63,18 +63,6 @@ def test_workspaces_get_ensures_user_is_in_workspace(workspace, workspace_owner)
         Workspaces.get(outside_user, workspace.id)
 
 
-def test_workspaces_get_many_with_no_workspaces():
-    workspaces = Workspaces.get_many(UserFactory.build())
-    assert workspaces == []
-
-
-def test_workspaces_get_many_returns_a_users_workspaces(workspace, workspace_owner):
-    # random workspace
-    Workspaces.create(RequestFactory.create())
-
-    assert Workspaces.get_many(workspace_owner) == [workspace]
-
-
 def test_get_for_update_allows_owner(workspace, workspace_owner):
     Workspaces.get_for_update(workspace_owner, workspace.id)
 

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -7,20 +7,36 @@ from atst.domain.workspace_users import WorkspaceUsers
 from atst.domain.projects import Projects
 from atst.domain.environments import Environments
 
-from tests.factories import WorkspaceFactory, RequestFactory, UserFactory
+from tests.factories import RequestFactory, UserFactory
 
 
-def test_can_create_workspace():
-    request = RequestFactory.create()
-    workspace = Workspaces.create(request, name="frugal-whale")
+@pytest.fixture(scope="function")
+def workspace_owner():
+    return UserFactory.create()
+
+
+@pytest.fixture(scope="function")
+def request_(workspace_owner):
+    return RequestFactory.create(creator=workspace_owner)
+
+
+@pytest.fixture(scope="function")
+def workspace(request_):
+    workspace = Workspaces.create(request_)
+    return workspace
+
+
+def test_can_create_workspace(request_):
+    workspace = Workspaces.create(request_, name="frugal-whale")
     assert workspace.name == "frugal-whale"
-    assert workspace.request == request
 
 
-def test_default_workspace_name_is_request_id():
-    request = RequestFactory.create()
-    workspace = Workspaces.create(request)
-    assert workspace.name == str(request.id)
+def test_request_is_associated_with_workspace(workspace, request_):
+    assert workspace.request == request_
+
+
+def test_default_workspace_name_is_request_id(workspace, request_):
+    assert workspace.name == str(request_.id)
 
 
 def test_get_nonexistent_workspace_raises():
@@ -28,33 +44,21 @@ def test_get_nonexistent_workspace_raises():
         Workspaces.get(UserFactory.build(), uuid4())
 
 
-def test_can_get_workspace_by_request():
-    workspace = WorkspaceFactory.create()
+def test_can_get_workspace_by_request(workspace):
     found = Workspaces.get_by_request(workspace.request)
     assert workspace == found
 
 
-def test_creating_workspace_adds_owner():
-    user = UserFactory.create()
-    request = RequestFactory.create(creator=user)
-    workspace = Workspaces.create(request)
-    assert workspace.roles[0].user == user
+def test_creating_workspace_adds_owner(workspace, workspace_owner):
+    assert workspace.roles[0].user == workspace_owner
 
 
-def test_workspace_has_timestamps():
-    request = RequestFactory.create()
-    workspace = Workspaces.create(request)
+def test_workspace_has_timestamps(workspace):
     assert workspace.time_created == workspace.time_updated
 
 
-def test_workspaces_get_ensures_user_is_in_workspace():
-    owner = UserFactory.create()
+def test_workspaces_get_ensures_user_is_in_workspace(workspace, workspace_owner):
     outside_user = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
-
-    workspace_ = Workspaces.get(owner, workspace.id)
-    assert workspace_ == workspace
-
     with pytest.raises(UnauthorizedError):
         Workspaces.get(outside_user, workspace.id)
 
@@ -64,37 +68,26 @@ def test_workspaces_get_many_with_no_workspaces():
     assert workspaces == []
 
 
-def test_workspaces_get_many_returns_a_users_workspaces():
-    user = UserFactory.create()
-    users_workspace = Workspaces.create(RequestFactory.create(creator=user))
-
+def test_workspaces_get_many_returns_a_users_workspaces(workspace, workspace_owner):
     # random workspace
     Workspaces.create(RequestFactory.create())
 
-    assert Workspaces.get_many(user) == [users_workspace]
+    assert Workspaces.get_many(workspace_owner) == [workspace]
 
 
-def test_get_for_update_allows_owner():
-    owner = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
-    Workspaces.get_for_update(owner, workspace.id)
+def test_get_for_update_allows_owner(workspace, workspace_owner):
+    Workspaces.get_for_update(workspace_owner, workspace.id)
 
 
-def test_get_for_update_blocks_developer():
-    owner = UserFactory.create()
+def test_get_for_update_blocks_developer(workspace):
     developer = UserFactory.create()
-
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
     WorkspaceUsers.add(developer, workspace.id, "developer")
 
     with pytest.raises(UnauthorizedError):
         Workspaces.get_for_update(developer, workspace.id)
 
 
-def test_can_create_workspace_user():
-    owner = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
-
+def test_can_create_workspace_user(workspace, workspace_owner):
     user_data = {
         "first_name": "New",
         "last_name": "User",
@@ -103,12 +96,11 @@ def test_can_create_workspace_user():
         "dod_id": "1234567890",
     }
 
-    new_member = Workspaces.create_member(owner, workspace, user_data)
+    new_member = Workspaces.create_member(workspace_owner, workspace, user_data)
     assert new_member.workspace == workspace
 
 
-def test_need_permission_to_create_workspace_user():
-    workspace = Workspaces.create(request=RequestFactory.create())
+def test_need_permission_to_create_workspace_user(workspace, workspace_owner):
     random_user = UserFactory.create()
 
     user_data = {
@@ -123,9 +115,7 @@ def test_need_permission_to_create_workspace_user():
         Workspaces.create_member(random_user, workspace, user_data)
 
 
-def test_update_workspace_user_role():
-    owner = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
+def test_update_workspace_user_role(workspace, workspace_owner):
     user_data = {
         "first_name": "New",
         "last_name": "User",
@@ -133,17 +123,17 @@ def test_update_workspace_user_role():
         "workspace_role": "developer",
         "dod_id": "1234567890",
     }
-    member = Workspaces.create_member(owner, workspace, user_data)
+    member = Workspaces.create_member(workspace_owner, workspace, user_data)
     role_name = "admin"
 
-    updated_member = Workspaces.update_member(owner, workspace, member, role_name)
+    updated_member = Workspaces.update_member(
+        workspace_owner, workspace, member, role_name
+    )
     assert updated_member.workspace == workspace
     assert updated_member.role == role_name
 
 
-def test_need_permission_to_update_workspace_user_role():
-    owner = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
+def test_need_permission_to_update_workspace_user_role(workspace, workspace_owner):
     random_user = UserFactory.create()
     user_data = {
         "first_name": "New",
@@ -152,41 +142,38 @@ def test_need_permission_to_update_workspace_user_role():
         "workspace_role": "developer",
         "dod_id": "1234567890",
     }
-    member = Workspaces.create_member(owner, workspace, user_data)
+    member = Workspaces.create_member(workspace_owner, workspace, user_data)
     role_name = "developer"
 
     with pytest.raises(UnauthorizedError):
         Workspaces.update_member(random_user, workspace, member, role_name)
 
 
-def test_owner_can_view_workspace_members():
-    owner = UserFactory.create()
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
-    workspace = Workspaces.get_with_members(owner, workspace.id)
+def test_owner_can_view_workspace_members(workspace, workspace_owner):
+    workspace_owner = UserFactory.create()
+    workspace = Workspaces.create(RequestFactory.create(creator=workspace_owner))
+    workspace = Workspaces.get_with_members(workspace_owner, workspace.id)
 
     assert workspace
 
 
-def test_ccpo_can_view_workspace_members():
-    workspace = Workspaces.create(RequestFactory.create(creator=UserFactory.create()))
+def test_ccpo_can_view_workspace_members(workspace, workspace_owner):
     ccpo = UserFactory.from_atat_role("ccpo")
-    workspace = Workspaces.get_with_members(ccpo, workspace.id)
-
-    assert workspace
+    assert Workspaces.get_with_members(ccpo, workspace.id)
 
 
-def test_random_user_cannot_view_workspace_members():
-    workspace = Workspaces.create(RequestFactory.create(creator=UserFactory.create()))
+def test_random_user_cannot_view_workspace_members(workspace):
     developer = UserFactory.from_atat_role("developer")
 
     with pytest.raises(UnauthorizedError):
         workspace = Workspaces.get_with_members(developer, workspace.id)
 
 
-def test_scoped_workspace_only_returns_a_users_projects_and_environments():
-    workspace = WorkspaceFactory.create()
+def test_scoped_workspace_only_returns_a_users_projects_and_environments(
+    workspace, workspace_owner
+):
     new_project = Projects.create(
-        workspace.owner,
+        workspace_owner,
         workspace,
         "My Project",
         "My project",
@@ -194,7 +181,7 @@ def test_scoped_workspace_only_returns_a_users_projects_and_environments():
     )
     developer = UserFactory.from_atat_role("developer")
     dev_environment = Environments.add_member(
-        workspace.owner, new_project.environments[0], developer
+        workspace_owner, new_project.environments[0], developer
     )
 
     scoped_workspace = Workspaces.get(developer, workspace.id)
@@ -205,11 +192,12 @@ def test_scoped_workspace_only_returns_a_users_projects_and_environments():
     assert scoped_workspace.projects[0].environments == [dev_environment]
 
 
-def test_scoped_workspace_returns_all_projects_for_workspace_admin():
-    workspace = Workspaces.create(RequestFactory.create())
+def test_scoped_workspace_returns_all_projects_for_workspace_admin(
+    workspace, workspace_owner
+):
     for _ in range(5):
         Projects.create(
-            workspace.owner,
+            workspace_owner,
             workspace,
             "My Project",
             "My project",
@@ -225,34 +213,35 @@ def test_scoped_workspace_returns_all_projects_for_workspace_admin():
     assert len(scoped_workspace.projects[0].environments) == 3
 
 
-def test_scoped_workspace_returns_all_projects_for_workspace_owner():
-    workspace = Workspaces.create(RequestFactory.create())
-    owner = workspace.owner
+def test_scoped_workspace_returns_all_projects_for_workspace_owner(
+    workspace, workspace_owner
+):
     for _ in range(5):
         Projects.create(
-            owner, workspace, "My Project", "My project", ["dev", "staging", "prod"]
+            workspace_owner,
+            workspace,
+            "My Project",
+            "My project",
+            ["dev", "staging", "prod"],
         )
 
-    scoped_workspace = Workspaces.get(owner, workspace.id)
+    scoped_workspace = Workspaces.get(workspace_owner, workspace.id)
 
     assert len(scoped_workspace.projects) == 5
     assert len(scoped_workspace.projects[0].environments) == 3
 
 
-def test_for_user_workspace_member():
+def test_for_user_returns_assigned_workspaces_for_user(workspace, workspace_owner):
     bob = UserFactory.from_atat_role("default")
-    workspace = Workspaces.create(RequestFactory.create())
     Workspaces.add_member(workspace, bob, "developer")
-
     Workspaces.create(RequestFactory.create())
-
     bobs_workspaces = Workspaces.for_user(bob)
+
     assert len(bobs_workspaces) == 1
 
 
-def test_for_user_ccpo():
+def test_for_user_returns_all_workspaces_for_ccpo(workspace, workspace_owner):
     sam = UserFactory.from_atat_role("ccpo")
-    workspace = Workspaces.create(RequestFactory.create())
     Workspaces.create(RequestFactory.create())
 
     sams_workspaces = Workspaces.for_user(sam)

--- a/tests/models/test_requests.py
+++ b/tests/models/test_requests.py
@@ -4,7 +4,8 @@ from tests.factories import (
     RequestStatusEventFactory,
     RequestReviewFactory,
 )
-from atst.domain.requests import Requests, RequestStatus
+from atst.domain.requests import Requests
+from atst.models.request_status_event import RequestStatus
 
 
 def test_pending_financial_requires_mo_action():


### PR DESCRIPTION
I thought it might be nice to start moving some of the query logic out of the domain classes. I created two new classes, RequestsQuery and WorkspacesQuery, to house sql-alchemy specific code. I also created a base Query class with a basic CRUD implementation.

I also threw in a refactor to the workspaces domain tests, since we have so many of them and they were getting out of hand.

Let me know if you like the pattern. If not, we can just keep the test cleanup.