### PR TITLE
prepopulate current user as ccpo authorizing official on a request re…

### DIFF
--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -15,6 +15,10 @@ from atst.forms.ccpo_review import CCPOReviewForm
 from atst.forms.internal_comment import InternalCommentForm
 
 
+def map_ccpo_authorizing(user):
+    return {"fname_ccpo": user.first_name, "lname_ccpo": user.last_name}
+
+
 def render_approval(request, form=None):
     data = request.body
     pending_final_approval = Requests.is_pending_ccpo_approval(request)
@@ -26,6 +30,10 @@ def render_approval(request, form=None):
 
     internal_comment_form = InternalCommentForm(text=request.internal_comments_text)
 
+    if not form:
+        mo_data = map_ccpo_authorizing(g.current_user)
+        form = CCPOReviewForm(data=mo_data)
+
     return render_template(
         "requests/approval.html",
         data=data,
@@ -35,7 +43,7 @@ def render_approval(request, form=None):
         pending_review=pending_review,
         financial_review=pending_final_approval,
         pdf_available=request.task_order and request.task_order.pdf,
-        f=form or CCPOReviewForm(),
+        f=form,
         internal_comment_form=internal_comment_form,
     )
 

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -24,6 +24,18 @@ def test_ccpo_can_view_approval(user_session, client):
     assert response.status_code == 200
 
 
+def test_ccpo_prepopulated_as_mission_owner(user_session, client):
+    user = UserFactory.from_atat_role("ccpo")
+    user_session(user)
+
+    request = RequestFactory.create_with_status(RequestStatus.PENDING_CCPO_ACCEPTANCE)
+    response = client.get(url_for("requests.approval", request_id=request.id))
+
+    body = response.data.decode()
+    assert user.first_name in body
+    assert user.last_name in body
+
+
 def test_non_ccpo_cannot_view_approval(user_session, client):
     user = UserFactory.create()
     user_session(user)


### PR DESCRIPTION
…view

For this PT story: https://www.pivotaltracker.com/story/show/160298590

This just adds default data for the CCPO fields when a CCPO user first loads the request review page.