### PR TITLE
display zeroes in the request review template

### DIFF
--- a/templates/requests/_review.html
+++ b/templates/requests/_review.html
@@ -6,8 +6,9 @@
   <div>
     <dt>{{ title | safe }}</dt>
     <dd>
-      {% if data[section] and data[section][item_name] %}
-        {{ data[section][item_name] | findFilter(filter, filter_args) }}
+      {% set value = data.get(section, {}).get(item_name) %}
+      {% if value is not none %}
+        {{ value | findFilter(filter, filter_args) }}
       {% else %}
         {{ RequiredLabel() }}
       {% endif %}


### PR DESCRIPTION
Hardik pointed out that the review page can't display zero for dollar fields: https://www.pivotaltracker.com/story/show/160450606/comments/194225623

This fixes that by checking ensuring that a value is not `None`, instead of just checking if it's falsey.