### PR TITLE
Redirect CCPO user to requests page

### DIFF
--- a/atst/models/user.py
+++ b/atst/models/user.py
@@ -27,6 +27,10 @@ class User(Base):
         return self.atat_role.permissions
 
     @property
+    def atat_role_name(self):
+        return self.atat_role.name
+
+    @property
     def full_name(self):
         return "{} {}".format(self.first_name, self.last_name)
 

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -17,12 +17,17 @@ def root():
 
 @bp.route("/home")
 def home():
-    num_workspaces = len(g.current_user.workspace_roles)
+    user = g.current_user
+
+    if user.atat_role_name == "ccpo":
+        return redirect(url_for("requests.requests_index"))
+
+    num_workspaces = len(user.workspace_roles)
 
     if num_workspaces == 0:
         return redirect(url_for("requests.requests_index"))
     elif num_workspaces == 1:
-        workspace_role = g.current_user.workspace_roles[0]
+        workspace_role = user.workspace_roles[0]
         workspace_id = workspace_role.workspace.id
         is_request_owner = workspace_role.role.name == "owner"
 

--- a/tests/routes/test_home.py
+++ b/tests/routes/test_home.py
@@ -84,3 +84,15 @@ def test_non_owner_user_with_mulitple_workspaces_redirected_to_workspaces(
     response = client.get("/home", follow_redirects=False)
 
     assert "/workspaces" in response.location
+
+
+def test_ccpo_user_redirected_to_requests(client, user_session):
+    user = UserFactory.from_atat_role("ccpo")
+    for _ in range(3):
+        workspace = WorkspaceFactory.create()
+        Workspaces._create_workspace_role(user, workspace, "developer")
+
+    user_session(user)
+    response = client.get("/home", follow_redirects=False)
+
+    assert "/requests" in response.location


### PR DESCRIPTION
CCPO users should be redirected to the requests page, regardless of their workspace ownership.