### PR TITLE
reports shows real budget information for total spend

### DIFF
--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -154,18 +154,15 @@ CUMULATIVE_BUDGET_BELUGA = {
 
 class Reports:
     @classmethod
-    def workspace_totals(cls, alternate):
-        data = MONTHLY_SPEND_BELUGA if alternate else MONTHLY_SPEND_AARDVARK
-        spent = sum(
-            [
-                spend
-                for project in data.values()
-                for env in project.values()
-                for spend in env.values()
-            ]
-        )
-        budget = 70_000 if alternate else 500_000
-        return {"budget": budget, "spent": spent}
+    def workspace_totals(cls, workspace):
+        if workspace.request and workspace.request.task_order:
+            ws_to = workspace.request.task_order
+            budget = ws_to.budget
+        else:
+            budget = 0
+
+        # spent will be derived from CSP data
+        return {"budget": budget, "spent": 0}
 
     @classmethod
     def monthly_totals(cls, alternate):

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -47,3 +47,19 @@ class TaskOrder(Base):
             for c in self.__table__.columns
             if c.name not in ["id", "attachment_id"]
         }
+
+    @property
+    def budget(self):
+        return sum(
+            filter(
+                None,
+                [
+                    self.clin_0001,
+                    self.clin_0003,
+                    self.clin_1001,
+                    self.clin_1003,
+                    self.clin_2001,
+                    self.clin_2003,
+                ],
+            )
+        )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -109,7 +109,7 @@ def workspace_reports(workspace_id):
     return render_template(
         "workspaces/reports/index.html",
         cumulative_budget=Reports.cumulative_budget(alternate_reports),
-        workspace_totals=Reports.workspace_totals(alternate_reports),
+        workspace_totals=Reports.workspace_totals(workspace),
         monthly_totals=Reports.monthly_totals(alternate_reports),
         current_month=current_month,
         prev_month=prev_month,

--- a/tests/domain/test_reports.py
+++ b/tests/domain/test_reports.py
@@ -1,0 +1,18 @@
+from atst.domain.reports import Reports
+
+from tests.factories import RequestFactory, TaskOrderFactory, WorkspaceFactory
+
+CLIN_NUMS = ["0001", "0003", "1001", "1003", "2001", "2003"]
+
+
+def test_workspace_totals():
+    task_order = TaskOrderFactory.create()
+
+    for num in CLIN_NUMS:
+        setattr(task_order, "clin_{}".format(num), 200)
+
+    request = RequestFactory.create(task_order=task_order)
+    workspace = WorkspaceFactory.create(request=request)
+    report = Reports.workspace_totals(workspace)
+    total = 200 * len(CLIN_NUMS)
+    assert report == {"budget": total, "spent": 0}

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -7,3 +7,15 @@ def test_as_dictionary():
     data = TaskOrderFactory.dictionary()
     real_task_order = TaskOrderFactory.create(**data)
     assert real_task_order.to_dictionary() == data
+
+
+def test_budget():
+    task_order = TaskOrderFactory.create(
+        clin_0001=500,
+        clin_0003=200,
+        clin_1001=None,
+        clin_1003=None,
+        clin_2001=None,
+        clin_2003=None,
+    )
+    assert task_order.budget == 700


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/159974960

We derive the total budget for a workspace/request/task order by summing the CLIN numbers. This is displayed in the "Workspace Total Spend" box on the reports page for the workspace. The "spent" amount is zero for now, because we don't have any CSP data to use.

**note**
Requests that have a task order in EDA (i.e., ones with just the mock task order number) do not get CLIN data populated yet, so the total budget won't be available.