### PR TITLE
Assign and Update Environment Roles for Workspace Users

### DIFF
--- a/atst/domain/environment_roles.py
+++ b/atst/domain/environment_roles.py
@@ -1,0 +1,16 @@
+from atst.models.environment_role import EnvironmentRole
+from atst.database import db
+
+
+class EnvironmentRoles(object):
+    @classmethod
+    def get(cls, user_id, environment_id):
+        existing_env_role = (
+            db.session.query(EnvironmentRole)
+            .filter(
+                EnvironmentRole.user_id == user_id,
+                EnvironmentRole.environment_id == environment_id,
+            )
+            .one_or_none()
+        )
+        return existing_env_role

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -27,7 +27,7 @@ class Environments(object):
         db.session.commit()
 
     @classmethod
-    def add_member(cls, user, environment, member, role=None):
+    def add_member(cls, environment, member, role):
         environment_user = EnvironmentRole(
             user=member, environment=environment, role=role
         )

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
 from atst.models.environment import Environment
-from atst.models.environment_role import EnvironmentRole, CSPRole
+from atst.models.environment_role import EnvironmentRole
 from atst.models.project import Project
 from atst.models.permissions import Permissions
 from atst.domain.authz import Authorization
@@ -27,9 +27,9 @@ class Environments(object):
         db.session.commit()
 
     @classmethod
-    def add_member(cls, user, environment, member, role=CSPRole.NONSENSE_ROLE):
+    def add_member(cls, user, environment, member, role=None):
         environment_user = EnvironmentRole(
-            user=member, environment=environment, role=role.value
+            user=member, environment=environment, role=role
         )
         db.session.add(environment_user)
         db.session.commit()
@@ -57,9 +57,9 @@ class Environments(object):
         return env
 
     @classmethod
-    def update_environment_role(cls, ids_and_roles, workspace_user):
+    def update_environment_role(cls, user, ids_and_roles, workspace_user):
         Authorization.check_workspace_permission(
-            workspace_user.user,
+            user,
             workspace_user.workspace,
             Permissions.ADD_AND_ASSIGN_CSP_ROLES,
             "assign environment roles",

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -54,13 +54,13 @@ class Environments(object):
         return env
 
     @classmethod
-    def update_environment_role(cls, environment_data, workspace_user):
+    def update_environment_role(cls, ids_and_roles, workspace_user):
         # TODO need to check permissions?
-        for i in range(len(environment_data)):
-            new_role = environment_data[i]["role"]
-            environment = Environments.get(environment_data[i]["id"])
+        for i in range(len(ids_and_roles)):
+            new_role = ids_and_roles[i]["role"]
+            environment = Environments.get(ids_and_roles[i]["id"])
             env_role = EnvironmentRole.get(
-                workspace_user.user_id, environment_data[i]["id"]
+                workspace_user.user_id, ids_and_roles[i]["id"]
             )
             if env_role:
                 env_role.role = new_role

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -4,7 +4,6 @@ from atst.database import db
 from atst.models.environment import Environment
 from atst.models.environment_role import EnvironmentRole, CSPRole
 from atst.models.project import Project
-from atst.domain.users import Users
 
 from .exceptions import NotFoundError
 
@@ -59,13 +58,13 @@ class Environments(object):
         new_role = environment_data["user_role_name"]
         environment = Environments.get(cls=cls, environment_id=environment_data["id"])
         if workspace_user.has_environment_roles:
-            env_role = EnvironmentRole.get(workspace_user.user_id, environment.id)
+            env_role = EnvironmentRole.get(
+                workspace_user.user_id, environment_data["id"]
+            )
             env_role.role = new_role
         else:
             env_role = EnvironmentRole(
-                user=workspace_user.user,
-                environment=environment,
-                role=new_role
+                user=workspace_user.user, environment=environment, role=new_role
             )
         db.session.add(env_role)
         db.session.commit()

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -6,6 +6,7 @@ from atst.models.environment_role import EnvironmentRole, CSPRole
 from atst.models.project import Project
 from atst.models.permissions import Permissions
 from atst.domain.authz import Authorization
+from atst.domain.environment_roles import EnvironmentRoles
 
 from .exceptions import NotFoundError
 
@@ -67,7 +68,7 @@ class Environments(object):
         for id_and_role in ids_and_roles:
             new_role = id_and_role["role"]
             environment = Environments.get(id_and_role["id"])
-            env_role = EnvironmentRole.get(workspace_user.user_id, id_and_role["id"])
+            env_role = EnvironmentRoles.get(workspace_user.user_id, id_and_role["id"])
             if env_role:
                 env_role.role = new_role
             else:

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -44,6 +44,7 @@ class Environments(object):
             .all()
         )
 
+    @classmethod
     def get(cls, environment_id):
         try:
             env = db.session.query(Environment).filter_by(id=environment_id).one()
@@ -56,11 +57,9 @@ class Environments(object):
     def update_environment_role(cls, environment_data, workspace_user):
         # TODO need to check permissions?
         new_role = environment_data["user_role_name"]
-        environment = Environments.get(cls=cls, environment_id=environment_data["id"])
-        if workspace_user.has_environment_roles:
-            env_role = EnvironmentRole.get(
-                workspace_user.user_id, environment_data["id"]
-            )
+        environment = Environments.get(environment_data["id"])
+        env_role = EnvironmentRole.get(member.user_id, environment_data["id"])
+        if env_role:
             env_role.role = new_role
         else:
             env_role = EnvironmentRole(

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -58,8 +58,8 @@ class Environments(object):
     @classmethod
     def update_environment_role(cls, ids_and_roles, workspace_user):
         Authorization.check_workspace_permission(
-            user,
-            workspace,
+            workspace_user.user,
+            workspace_user.workspace,
             Permissions.ADD_AND_ASSIGN_CSP_ROLES,
             "assign environment roles",
         )

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -27,9 +27,9 @@ class Environments(object):
         db.session.commit()
 
     @classmethod
-    def add_member(cls, environment, member, role):
+    def add_member(cls, environment, user, role):
         environment_user = EnvironmentRole(
-            user=member, environment=environment, role=role
+            user=user, environment=environment, role=role
         )
         db.session.add(environment_user)
         db.session.commit()

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -1,7 +1,12 @@
+from sqlalchemy.orm.exc import NoResultFound
+
 from atst.database import db
 from atst.models.environment import Environment
 from atst.models.environment_role import EnvironmentRole, CSPRole
 from atst.models.project import Project
+from atst.domain.users import Users
+
+from .exceptions import NotFoundError
 
 
 class Environments(object):
@@ -39,3 +44,28 @@ class Environments(object):
             .filter(Project.id == Environment.project_id)
             .all()
         )
+
+    def get(cls, environment_id):
+        try:
+            env = db.session.query(Environment).filter_by(id=environment_id).one()
+        except NoResultFound:
+            raise NotFoundError("environment")
+
+        return env
+
+    @classmethod
+    def update_environment_role(cls, environment_data, workspace_user):
+        # TODO need to check permissions?
+        new_role = environment_data["user_role_name"]
+        environment = Environments.get(cls=cls, environment_id=environment_data["id"])
+        if workspace_user.has_environment_roles:
+            env_role = EnvironmentRole.get(workspace_user.user_id, environment.id)
+            env_role.role = new_role
+        else:
+            env_role = EnvironmentRole(
+                user=workspace_user.user,
+                environment=environment,
+                role=new_role
+            )
+        db.session.add(env_role)
+        db.session.commit()

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -56,14 +56,17 @@ class Environments(object):
     @classmethod
     def update_environment_role(cls, environment_data, workspace_user):
         # TODO need to check permissions?
-        new_role = environment_data["user_role_name"]
-        environment = Environments.get(environment_data["id"])
-        env_role = EnvironmentRole.get(member.user_id, environment_data["id"])
-        if env_role:
-            env_role.role = new_role
-        else:
-            env_role = EnvironmentRole(
-                user=workspace_user.user, environment=environment, role=new_role
+        for i in range(len(environment_data)):
+            new_role = environment_data[i]["role"]
+            environment = Environments.get(environment_data[i]["id"])
+            env_role = EnvironmentRole.get(
+                workspace_user.user_id, environment_data[i]["id"]
             )
-        db.session.add(env_role)
-        db.session.commit()
+            if env_role:
+                env_role.role = new_role
+            else:
+                env_role = EnvironmentRole(
+                    user=workspace_user.user, environment=environment, role=new_role
+                )
+            db.session.add(env_role)
+            db.session.commit()

--- a/atst/domain/projects.py
+++ b/atst/domain/projects.py
@@ -14,9 +14,6 @@ class Projects(object):
         project = Project(workspace=workspace, name=name, description=description)
         Environments.create_many(project, environment_names)
 
-        for environment in project.environments:
-            Environments.add_member(user, environment, user)
-
         db.session.add(project)
         db.session.commit()
 

--- a/atst/domain/projects.py
+++ b/atst/domain/projects.py
@@ -51,9 +51,9 @@ class Projects(object):
         )
 
     @classmethod
-    def get_all(cls, workspace_user, workspace):
+    def get_all(cls, user, workspace_user, workspace):
         Authorization.check_workspace_permission(
-            workspace_user.user,
+            user,
             workspace,
             Permissions.VIEW_APPLICATION_IN_WORKSPACE,
             "view project in workspace",

--- a/atst/domain/projects.py
+++ b/atst/domain/projects.py
@@ -49,3 +49,21 @@ class Projects(object):
             .filter(EnvironmentRole.user_id == user.id)
             .all()
         )
+
+    @classmethod
+    def get_all(cls, workspace_user, workspace):
+        Authorization.check_workspace_permission(
+            workspace_user.user,
+            workspace,
+            Permissions.VIEW_APPLICATION_IN_WORKSPACE,
+            "view project in workspace",
+        )
+
+        try:
+            projects = (
+                db.session.query(Project).filter_by(workspace_id=workspace.id).all()
+            )
+        except NoResultFound:
+            raise NotFoundError("projects")
+
+        return projects

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -186,45 +186,6 @@ ENVIRONMENT_ROLES = [
     ),
 ]
 
-ENVIRONMENT_ROLES = [
-    ("no_access", {"name": "no access", "description": "No environment access."}),
-    (
-        "database_admin",
-        {
-            "name": "Database Administrator",
-            "description": "Configures cloud-based database services.",
-        },
-    ),
-    (
-        "devops",
-        {
-            "name": "DevOps",
-            "description": "Provisions, deprovisions, and deploys cloud-based IaaS and PaaS computing, networking, and storage services, including pre-configured machine images.",
-        },
-    ),
-    (
-        "billing_admin",
-        {
-            "name": "Billing Administrator",
-            "description": "Views cloud resource usage, budget reports, and invoices; Tracks budgets, including spend reports, cost planning and projections, and sets limits based on cloud service usage.",
-        },
-    ),
-    (
-        "security_admin",
-        {
-            "name": "Security Administrator",
-            "description": "Accesses information security and control tools of cloud resources which include viewing cloud resource usage logging, user roles and permissioning history.",
-        },
-    ),
-    (
-        "financial_auditor",
-        {
-            "name": "Financial Auditor",
-            "description": "Views cloud resource usage and budget reports.",
-        },
-    ),
-]
-
 FUNDING_TYPES = [
     ("", "- Select -"),
     ("RDTE", "Research, Development, Testing & Evaluation (RDT&E)"),

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -187,7 +187,13 @@ ENVIRONMENT_ROLES = [
 ]
 
 ENVIRONMENT_ROLES = [
-    (None, {"name": "No access", "description": "No environment access."}),
+    (
+        "no_access",
+        {
+            "name": "no access",
+            "description": "No environment access."
+        }
+    ),
     (
         "database_admin",
         {

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -187,13 +187,7 @@ ENVIRONMENT_ROLES = [
 ]
 
 ENVIRONMENT_ROLES = [
-    (
-        "no_access",
-        {
-            "name": "no access",
-            "description": "No environment access."
-        }
-    ),
+    ("no_access", {"name": "no access", "description": "No environment access."}),
     (
         "database_admin",
         {

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -187,17 +187,18 @@ ENVIRONMENT_ROLES = [
 ]
 
 ENVIRONMENT_ROLES = [
+    (None, {"name": "No access", "description": "No environment access."}),
     (
-        "developer",
+        "meow",
         {
-            "name": "Developer",
+            "name": "Meow",
             "description": "Configures cloud-based IaaS and PaaS computing, networking, and storage services.",
         },
     ),
     (
-        "owner",
+        "woof",
         {
-            "name": "Workspace Owner",
+            "name": "Woof",
             "description": "Can add, edit, deactivate access to all projects, environments, and members. Can view budget reports. Can start and edit JEDI Cloud requests.",
         },
     ),

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -189,17 +189,38 @@ ENVIRONMENT_ROLES = [
 ENVIRONMENT_ROLES = [
     (None, {"name": "No access", "description": "No environment access."}),
     (
-        "meow",
+        "database_admin",
         {
-            "name": "Meow",
-            "description": "Configures cloud-based IaaS and PaaS computing, networking, and storage services.",
+            "name": "Database Administrator",
+            "description": "Configures cloud-based database services.",
         },
     ),
     (
-        "woof",
+        "devops",
         {
-            "name": "Woof",
-            "description": "Can add, edit, deactivate access to all projects, environments, and members. Can view budget reports. Can start and edit JEDI Cloud requests.",
+            "name": "DevOps",
+            "description": "Provisions, deprovisions, and deploys cloud-based IaaS and PaaS computing, networking, and storage services, including pre-configured machine images.",
+        },
+    ),
+    (
+        "billing_admin",
+        {
+            "name": "Billing Administrator",
+            "description": "Views cloud resource usage, budget reports, and invoices; Tracks budgets, including spend reports, cost planning and projections, and sets limits based on cloud service usage.",
+        },
+    ),
+    (
+        "security_admin",
+        {
+            "name": "Security Administrator",
+            "description": "Accesses information security and control tools of cloud resources which include viewing cloud resource usage logging, user roles and permissioning history.",
+        },
+    ),
+    (
+        "financial_auditor",
+        {
+            "name": "Financial Auditor",
+            "description": "Views cloud resource usage and budget reports.",
         },
     ),
 ]

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -186,6 +186,23 @@ ENVIRONMENT_ROLES = [
     ),
 ]
 
+ENVIRONMENT_ROLES = [
+    (
+        "developer",
+        {
+            "name": "Developer",
+            "description": "Configures cloud-based IaaS and PaaS computing, networking, and storage services.",
+        },
+    ),
+    (
+        "owner",
+        {
+            "name": "Workspace Owner",
+            "description": "Can add, edit, deactivate access to all projects, environments, and members. Can view budget reports. Can start and edit JEDI Cloud requests.",
+        },
+    ),
+]
+
 FUNDING_TYPES = [
     ("", "- Select -"),
     ("RDTE", "Research, Development, Testing & Evaluation (RDT&E)"),

--- a/atst/forms/edit_member.py
+++ b/atst/forms/edit_member.py
@@ -3,11 +3,15 @@ from wtforms.validators import Optional
 
 from atst.forms.fields import SelectField
 
-from .data import WORKSPACE_ROLES
+from .data import WORKSPACE_ROLES, ENVIRONMENT_ROLES
 
 
 class EditMemberForm(Form):
 
     workspace_role = SelectField(
         "Workspace Role", choices=WORKSPACE_ROLES, validators=[Optional()]
+    )
+
+    environment_role = SelectField(
+        "Environment Role", choices=ENVIRONMENT_ROLES, validators=[Optional()]
     )

--- a/atst/forms/edit_member.py
+++ b/atst/forms/edit_member.py
@@ -1,4 +1,4 @@
-from flask_wtf import Form
+from flask_wtf import FlaskForm
 from wtforms.validators import Optional
 
 from atst.forms.fields import SelectField
@@ -6,7 +6,7 @@ from atst.forms.fields import SelectField
 from .data import WORKSPACE_ROLES, ENVIRONMENT_ROLES
 
 
-class EditMemberForm(Form):
+class EditMemberForm(FlaskForm):
 
     workspace_role = SelectField(
         "Workspace Role", choices=WORKSPACE_ROLES, validators=[Optional()]

--- a/atst/forms/edit_member.py
+++ b/atst/forms/edit_member.py
@@ -1,17 +1,15 @@
 from flask_wtf import FlaskForm
-from wtforms.validators import Optional, Required
+from wtforms.validators import Required
 
 from atst.forms.fields import SelectField
 
-from .data import WORKSPACE_ROLES, ENVIRONMENT_ROLES
+from .data import WORKSPACE_ROLES
 
 
 class EditMemberForm(FlaskForm):
+    # This form also accepts a field for each environment in each project
+    #  that the user is a member of
 
     workspace_role = SelectField(
         "Workspace Role", choices=WORKSPACE_ROLES, validators=[Required()]
-    )
-
-    environment_role = SelectField(
-        "Environment Role", choices=ENVIRONMENT_ROLES, validators=[Optional()]
     )

--- a/atst/forms/edit_member.py
+++ b/atst/forms/edit_member.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms.validators import Optional
+from wtforms.validators import Optional, Required
 
 from atst.forms.fields import SelectField
 
@@ -9,7 +9,7 @@ from .data import WORKSPACE_ROLES, ENVIRONMENT_ROLES
 class EditMemberForm(FlaskForm):
 
     workspace_role = SelectField(
-        "Workspace Role", choices=WORKSPACE_ROLES, validators=[Optional()]
+        "Workspace Role", choices=WORKSPACE_ROLES, validators=[Required()]
     )
 
     environment_role = SelectField(

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -26,18 +26,6 @@ class EnvironmentRole(Base, mixins.TimestampsMixin):
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     user = relationship("User", backref="environment_roles")
 
-    @classmethod
-    def get(cls, user_id, environment_id):
-        existing_env_role = (
-            db.session.query(EnvironmentRole)
-            .filter(
-                EnvironmentRole.user_id == user_id,
-                EnvironmentRole.environment_id == environment_id,
-            )
-            .one_or_none()
-        )
-        return existing_env_role
-
 
 Index(
     "environments_role_user_environment",

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -4,6 +4,8 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from atst.models import Base, types, mixins
+from atst.database import db
+from .types import Id
 
 
 class CSPRole(Enum):
@@ -23,6 +25,18 @@ class EnvironmentRole(Base, mixins.TimestampsMixin):
 
     user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     user = relationship("User", backref="environment_roles")
+
+    @classmethod
+    def get(cls, user_id, environment_id):
+        existing_env_role = (
+            db.session.query(EnvironmentRole)
+            .filter(
+                EnvironmentRole.user_id == user_id,
+                EnvironmentRole.environment_id == environment_id,
+            )
+            .one_or_none()
+        )
+        return existing_env_role
 
 
 Index(

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -4,8 +4,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 
 from atst.models import Base, types, mixins
-from atst.database import db
-from .types import Id
 
 
 class CSPRole(Enum):

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -7,7 +7,7 @@ from atst.models import Base, types, mixins
 
 
 class CSPRole(Enum):
-    NONSENSE_ROLE = "nonesense_role"
+    NONSENSE_ROLE = "nonsense_role"
 
 
 class EnvironmentRole(Base, mixins.TimestampsMixin):

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -14,6 +14,7 @@ from atst.domain.projects import Projects
 from atst.domain.reports import Reports
 from atst.domain.workspaces import Workspaces
 from atst.domain.workspace_users import WorkspaceUsers
+from atst.domain.environments import Environments
 from atst.forms.new_project import NewProjectForm
 from atst.forms.new_member import NewMemberForm
 from atst.forms.edit_member import EditMemberForm

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -15,6 +15,7 @@ from atst.domain.reports import Reports
 from atst.domain.workspaces import Workspaces
 from atst.domain.workspace_users import WorkspaceUsers
 from atst.domain.environments import Environments
+from atst.models.environment_role import EnvironmentRole
 from atst.forms.new_project import NewProjectForm
 from atst.forms.new_member import NewMemberForm
 from atst.forms.edit_member import EditMemberForm
@@ -222,6 +223,7 @@ def view_member(workspace_id, member_id):
         member=member,
         projects=projects,
         form=form,
+        EnvironmentRole=EnvironmentRole,
     )
 
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -241,6 +241,8 @@ def update_member(workspace_id, member_id):
                 g.current_user, workspace, member, form.data["workspace_role"]
             )
             new_role_name = member.role_displayname
+        if form.data["environment_role"]:
+            print (form.data)
 
         return redirect(
             url_for(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -1,3 +1,4 @@
+import re, ast
 from datetime import date, timedelta
 
 from flask import (
@@ -239,6 +240,13 @@ def update_member(workspace_id, member_id):
         "edit this workspace user",
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
+
+    environment_data = []
+    form_dict = http_request.form.to_dict()
+    for entry in form_dict:
+        if re.match("env_", entry):
+            environment_data.append(ast.literal_eval(form_dict[entry]))
+
     form = EditMemberForm(http_request.form)
 
     if form.validate():
@@ -248,14 +256,8 @@ def update_member(workspace_id, member_id):
                 g.current_user, workspace, member, form.data["workspace_role"]
             )
             new_role_name = member.role_displayname
-        if form.data["environment_role"]:
-            new_env_role = form.data["environment_role"]
-            environment_data = {
-                "id": "9432c6a5-2f9d-4c9c-b553-4c175852fb65",
-                "name": "this environment",
-                "user_role_name": new_env_role,
-            }
-            Environments.update_environment_role(environment_data, member)
+
+        Environments.update_environment_role(environment_data, member)
 
         return redirect(
             url_for(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -214,9 +214,14 @@ def view_member(workspace_id, member_id):
         "edit this workspace user",
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
+    projects = Projects.get_all(member, workspace)
     form = EditMemberForm(workspace_role=member.role, environment_role="")
     return render_template(
-        "workspaces/members/edit.html", form=form, workspace=workspace, member=member
+        "workspaces/members/edit.html",
+        workspace=workspace,
+        member=member,
+        projects=projects,
+        form=form,
     )
 
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -1,4 +1,4 @@
-import re, ast
+import re
 from datetime import date, timedelta
 
 from flask import (
@@ -241,11 +241,13 @@ def update_member(workspace_id, member_id):
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
 
-    environment_data = []
+    ids_and_roles = []
     form_dict = http_request.form.to_dict()
     for entry in form_dict:
         if re.match("env_", entry):
-            environment_data.append(ast.literal_eval(form_dict[entry]))
+            env_id = entry[4:]
+            env_role = form_dict[entry]
+            ids_and_roles.append({"id": env_id, "role": env_role})
 
     form = EditMemberForm(http_request.form)
 
@@ -257,7 +259,7 @@ def update_member(workspace_id, member_id):
             )
             new_role_name = member.role_displayname
 
-        Environments.update_environment_role(environment_data, member)
+        Environments.update_environment_role(ids_and_roles, member)
 
         return redirect(
             url_for(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -242,7 +242,13 @@ def update_member(workspace_id, member_id):
             )
             new_role_name = member.role_displayname
         if form.data["environment_role"]:
-            print (form.data)
+            new_env_role = form.data["environment_role"]
+            environment_data = {
+                "id": "9432c6a5-2f9d-4c9c-b553-4c175852fb65",
+                "name": "this environment",
+                "user_role_name": new_env_role,
+            }
+            Environments.update_environment_role(environment_data, member)
 
         return redirect(
             url_for(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -214,7 +214,7 @@ def view_member(workspace_id, member_id):
         "edit this workspace user",
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
-    form = EditMemberForm(workspace_role=member.role)
+    form = EditMemberForm(workspace_role=member.role, environment_role="")
     return render_template(
         "workspaces/members/edit.html", form=form, workspace=workspace, member=member
     )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -16,7 +16,7 @@ from atst.domain.reports import Reports
 from atst.domain.workspaces import Workspaces
 from atst.domain.workspace_users import WorkspaceUsers
 from atst.domain.environments import Environments
-from atst.models.environment_role import EnvironmentRole
+from atst.domain.environment_roles import EnvironmentRoles
 from atst.forms.new_project import NewProjectForm
 from atst.forms.new_member import NewMemberForm
 from atst.forms.edit_member import EditMemberForm
@@ -224,7 +224,7 @@ def view_member(workspace_id, member_id):
         member=member,
         projects=projects,
         form=form,
-        EnvironmentRole=EnvironmentRole,
+        EnvironmentRoles=EnvironmentRoles,
     )
 
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -216,7 +216,7 @@ def view_member(workspace_id, member_id):
         "edit this workspace user",
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
-    projects = Projects.get_all(member, workspace)
+    projects = Projects.get_all(g.current_user, member, workspace)
     form = EditMemberForm(workspace_role=member.role, environment_role="")
     return render_template(
         "workspaces/members/edit.html",
@@ -259,7 +259,7 @@ def update_member(workspace_id, member_id):
             )
             new_role_name = member.role_displayname
 
-        Environments.update_environment_role(ids_and_roles, member)
+        Environments.update_environment_role(g.current_user, ids_and_roles, member)
 
         return redirect(
             url_for(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -218,7 +218,7 @@ def view_member(workspace_id, member_id):
     )
     member = WorkspaceUsers.get(workspace_id, member_id)
     projects = Projects.get_all(g.current_user, member, workspace)
-    form = EditMemberForm(workspace_role=member.role, environment_role="")
+    form = EditMemberForm(workspace_role=member.role)
     return render_template(
         "workspaces/members/edit.html",
         workspace=workspace,

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -21,6 +21,7 @@ from atst.forms.new_project import NewProjectForm
 from atst.forms.new_member import NewMemberForm
 from atst.forms.edit_member import EditMemberForm
 from atst.forms.workspace import WorkspaceForm
+from atst.forms.data import ENVIRONMENT_ROLES
 from atst.domain.authz import Authorization
 from atst.models.permissions import Permissions
 
@@ -224,6 +225,7 @@ def view_member(workspace_id, member_id):
         member=member,
         projects=projects,
         form=form,
+        choices=ENVIRONMENT_ROLES,
         EnvironmentRoles=EnvironmentRoles,
     )
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -249,7 +249,8 @@ def update_member(workspace_id, member_id):
         if re.match("env_", entry):
             env_id = entry[4:]
             env_role = form_dict[entry]
-            ids_and_roles.append({"id": env_id, "role": env_role})
+            if env_role:
+                ids_and_roles.append({"id": env_id, "role": env_role})
 
     form = EditMemberForm(http_request.form)
 

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -23,29 +23,30 @@ export default {
 
   data: function () {
     return {
-      value: this.initialData,
+      new_role: this.initialData,
     }
   },
 
   methods: {
     change: function (e) {
-      this.value = e.target.value
+      e.preventDefault()
+      this.new_role = e.target.value
     },
     cancel: function (current_role, selected_role) {
       if (current_role != selected_role) {
-        this.value = current_role
+        this.new_role = current_role
       }
-    }
+    },
   },
 
   computed: {
     displayName: function () {
       for (var arr in this.choices) {
-        if (this.choices[arr][0] == this.value) {
+        if (this.choices[arr][0] == this.new_role) {
           return this.choices[arr][1].name
         }
       }
-      return this.value ? this.value : "no access"
+      return this.new_role ? this.new_role : "no access"
     },
     label_class: function () {
       return this.displayName === "no access" ?

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -18,12 +18,13 @@ export default {
 
   props: {
     choices: Array,
-    initialData: String
-
+    initialData: String,
   },
 
   data: function () {
-    return { value: this.initialData }
+    return {
+      value: this.initialData,
+    }
   },
 
   methods: {
@@ -33,9 +34,10 @@ export default {
     readableName: function (role) {
       return role.replace(/[_]/g, " ")
     },
+    cancel: function (current_role, selected_role) {
+      if (current_role != selected_role) {
+        this.value = current_role
+      }
+    }
   },
-
-  mounted: function () {
-    console.log(this.initialData, this.choices)
-  }
 }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -18,7 +18,8 @@ export default {
 
   props: {
     choices: Array,
-    initialData: Object
+    initialData: String
+
   },
 
   data: function () {
@@ -28,6 +29,11 @@ export default {
   methods: {
     change: function (e) {
       this.value = e.target.value
-    }
+    },
+    // method to map ugly name to human readable name here
+  },
+
+  mounted: function () {
+    console.log(this.initialData, this.choices)
   }
 }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -18,7 +18,7 @@ export default {
 
   props: {
     choices: Array,
-    initialData: String
+    initialData: Object
   },
 
   data: function () {

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -45,10 +45,10 @@ export default {
           return this.choices[arr][1].name
         }
       }
-      return this.value
+      return this.value ? this.value : "no access"
     },
     label_class: function () {
-      return this.value === "no_access" ?
+      return this.displayName === "no access" ?
         "label" : "label label--success"
     }
   }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -1,0 +1,40 @@
+import FormMixin from '../../mixins/form'
+import textinput from '../text_input'
+import Selector from '../selector'
+import Modal from '../../mixins/modal'
+import toggler from '../toggler'
+
+export default {
+  name: 'edit-workspace-member',
+
+  mixins: [FormMixin, Modal],
+
+  components: {
+    toggler,
+    Modal,
+    Selector,
+    textinput
+  },
+
+  props: {
+    choices: Array,
+    initialData: String
+  },
+
+  data: function () {
+    return { value: this.initialData }
+  },
+
+  methods: {
+    change: function (e) {
+      this.value = e.target.value
+    },
+    readableName: function (role) {
+      return role.replace(/[_]/g, " ")
+    },
+  },
+
+  mounted: function () {
+    console.log(this.initialData, this.choices)
+  }
+}

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -28,13 +28,6 @@ export default {
   methods: {
     change: function (e) {
       this.value = e.target.value
-    },
-    readableName: function (role) {
-      return role.replace(/[_]/g, " ")
-    },
-  },
-
-  mounted: function () {
-    console.log(this.initialData, this.choices)
+    }
   }
 }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -24,6 +24,7 @@ export default {
   data: function () {
     return {
       value: this.initialData,
+      label_class: this.initialData,
     }
   },
 
@@ -31,7 +32,10 @@ export default {
     change: function (e) {
       this.value = e.target.value
     },
-    readableName: function (role) {
+    displayName: function (role) {
+      this.label_class = role === "no_access" ?
+        "label" : "label label--success"
+
       return role.replace(/[_]/g, " ")
     },
     cancel: function (current_role, selected_role) {

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -32,10 +32,8 @@ export default {
       e.preventDefault()
       this.new_role = e.target.value
     },
-    cancel: function (current_role, selected_role) {
-      if (current_role != selected_role) {
-        this.new_role = current_role
-      }
+    cancel: function () {
+      this.new_role = this.initialData
     },
   },
 
@@ -51,6 +49,6 @@ export default {
     label_class: function () {
       return this.displayName === "no access" ?
         "label" : "label label--success"
-    }
+    },
   }
 }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -24,7 +24,6 @@ export default {
   data: function () {
     return {
       value: this.initialData,
-      label_class: this.initialData,
     }
   },
 
@@ -32,16 +31,25 @@ export default {
     change: function (e) {
       this.value = e.target.value
     },
-    displayName: function (role) {
-      this.label_class = role === "no_access" ?
-        "label" : "label label--success"
-
-      return role.replace(/[_]/g, " ")
-    },
     cancel: function (current_role, selected_role) {
       if (current_role != selected_role) {
         this.value = current_role
       }
     }
   },
+
+  computed: {
+    displayName: function () {
+      for (var arr in this.choices) {
+        if (this.choices[arr][0] == this.value) {
+          return this.choices[arr][1].name
+        }
+      }
+      return this.value
+    },
+    label_class: function () {
+      return this.value === "no_access" ?
+        "label" : "label label--success"
+    }
+  }
 }

--- a/js/components/forms/edit_workspace_member.js
+++ b/js/components/forms/edit_workspace_member.js
@@ -30,7 +30,9 @@ export default {
     change: function (e) {
       this.value = e.target.value
     },
-    // method to map ugly name to human readable name here
+    readableName: function (role) {
+      return role.replace(/[_]/g, " ")
+    },
   },
 
   mounted: function () {

--- a/js/index.js
+++ b/js/index.js
@@ -13,6 +13,7 @@ import poc from './components/forms/poc'
 import financial from './components/forms/financial'
 import toggler from './components/toggler'
 import NewProject from './components/forms/new_project'
+import EditWorkspaceMember from './components/forms/edit_workspace_member'
 import Modal from './mixins/modal'
 import selector from './components/selector'
 import BudgetChart from './components/charts/budget_chart'
@@ -39,7 +40,8 @@ const app = new Vue({
     BudgetChart,
     SpendTable,
     CcpoApproval,
-    LocalDatetime
+    LocalDatetime,
+    EditWorkspaceMember,
   },
 
   mounted: function() {

--- a/js/mixins/modal.js
+++ b/js/mixins/modal.js
@@ -11,12 +11,6 @@ export default {
   },
   data: function() {
     return {
-      modals: {
-        styleguidemodal: false,
-        newprojectconfirmation: false,
-        pendingfinancialverification: false,
-        pendingccpoapproval: false,
-      },
       activeModal: null,
     }
   }

--- a/js/mixins/modal.js
+++ b/js/mixins/modal.js
@@ -1,23 +1,23 @@
 export default {
   methods: {
     closeModal: function(name) {
-      this.modals[name] = false
+      this.activeModal = null
       this.$emit('modalOpen', false)
     },
     openModal: function (name) {
-      this.modals[name] = true
+      this.activeModal = name
       this.$emit('modalOpen', true)
     }
   },
   data: function() {
     return {
       modals: {
-        styleguideModal: false,
-        rolesModal: false,
-        newProjectConfirmation: false,
-        pendingFinancialVerification: false,
-        pendingCCPOApproval: false,
-      }
+        styleguidemodal: false,
+        newprojectconfirmation: false,
+        pendingfinancialverification: false,
+        pendingccpoapproval: false,
+      },
+      activeModal: null,
     }
   }
 }

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -27,7 +27,7 @@ WORKSPACE_USERS = [
         "first_name": "Mario",
         "last_name": "Hudson",
         "email": "hudson@mil.gov",
-        "workspace_role": "ccpo",
+        "workspace_role": "billing_auditor",
         "dod_id": "0000000002",
     },
     {

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro Modal(name, dismissable=False) -%}
-  <template v-if='modals.{{name}} === true' v-cloak>
+  <div v-show='modals.{{name}} === true' v-cloak>
     <div class='modal {% if dismissable %}modal--dismissable{% endif%}'>
       <div class='modal__container'>
         <div class='modal__dialog' role='dialog' aria-modal='true'>
@@ -18,5 +18,5 @@
         </div>
       </div>
     </div>
-  </template>
+  </div>
 {%- endmacro %}

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro Modal(name, dismissable=False) -%}
-  <div v-if="activeModal === '{{name}}'" v-cloak>
+  <div v-show="activeModal === '{{name}}'" v-cloak>
     <div class='modal {% if dismissable %}modal--dismissable{% endif%}'>
       <div class='modal__container'>
         <div class='modal__dialog' role='dialog' aria-modal='true'>

--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro Modal(name, dismissable=False) -%}
-  <div v-show='modals.{{name}} === true' v-cloak>
+  <div v-if="activeModal === '{{name}}'" v-cloak>
     <div class='modal {% if dismissable %}modal--dismissable{% endif%}'>
       <div class='modal__container'>
         <div class='modal__dialog' role='dialog' aria-modal='true'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -74,8 +74,6 @@
             </span>
 
             <div class='project-list-item__environment__actions'>
-              <div>{{ form.data["environment_role"] }}</div>
-
               <span v-bind:class="label_class" v-html:on=displayName></span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
               {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -67,7 +67,7 @@
           {% set role = EnvironmentRoles.get(member.user_id, env.id).role %}
 
         <li class='block-list__item'>
-          <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>
+          <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ choices | tojson }}'>
           <div class='project-list-item__environment'>
             <span class='project-list-item__environment__link'>
               {{ env.name }}
@@ -81,7 +81,7 @@
               {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
                   <div class='block-list'>
                     <ul>
-                      {% for choice in form.environment_role.choices %}
+                      {% for choice in choices %}
                       <li class='block-list__item block-list__item--selectable'>
 
                         {% if choice[0] != ""  %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -52,16 +52,16 @@
 
   {% for project in projects %}
   <div is='toggler' default-visible class='block-list project-list-item'>
-    <template slot-scope='{ isVisible, toggle }'>
+    <template slot-scope='props'>
       <header class='block-list__header'>
-      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+      <button v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
           <template v-else>{{ Icon('caret_right') }}</template>
           <h3 class="block-list__title">{{ project.name }}</h3>
         </button>
         <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
       </header>
-      <ul v-show='isVisible'>
+      <ul v-show='props.isVisible'>
         {% for env in project.environments %}
 
           {% set role = EnvironmentRoles.get(member.user_id, env.id).role %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -7,137 +7,143 @@
 
 {% block content %}
 
-<edit-workspace-member inline-template v-bind:initial-data='{{ form.data|tojson }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>
-  <form method="POST" action="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=member.user_id) }}" autocomplete="false">
-    {{ form.csrf_token }}
+<form method="POST" action="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=member.user_id) }}" autocomplete="false">
+  {{ form.csrf_token }}
 
-    <div class='panel member-card'>
-      <div class='member-card__header'>
-        <h1 class='member-card__heading'>{{ member.user.full_name }}</h1>
+  <div class='panel member-card'>
+    <div class='member-card__header'>
+      <h1 class='member-card__heading'>{{ member.user.full_name }}</h1>
 
-          <div class="usa-input member-card__input">
-            {{ Selector(form.workspace_role) }}
-          </div>
+        <div class="usa-input member-card__input">
+          {{ Selector(form.workspace_role) }}
+        </div>
 
-      </div>
-      <div class='member-card__details'>
-        <dl>
-          <div>
-            <dt>DOD ID:</dt>
-            <dd>{{ member.user.dod_id }}</dd>
-          </div>
-          <div>
-            <dt>Email:</dt>
-            <dd>{{ member.user.email }}</dd>
-          </div>
-        </dl>
-        <a href='#' class='icon-link'>edit account details</a>
-      </div>
     </div>
-
-    <div class="panel">
-      <div class="panel__heading panel__heading--tight">
-        <h2 class="h3">Manage Access <div class="subtitle">Grant access to an environment</div></h2>
-      </div>
+    <div class='member-card__details'>
+      <dl>
+        <div>
+          <dt>DOD ID:</dt>
+          <dd>{{ member.user.dod_id }}</dd>
+        </div>
+        <div>
+          <dt>Email:</dt>
+          <dd>{{ member.user.email }}</dd>
+        </div>
+      </dl>
+      <a href='#' class='icon-link'>edit account details</a>
     </div>
+  </div>
 
-    <div class='search-bar'>
-      <div class='usa-input search-input'>
-        <label for='project-search'>Search by project name</label>
-        <input type='search' id='project-search' name='project-search' placeholder="Search by project name"/>
-        <button type="submit">
-          <span class="hide">Search</span>
+  <div class="panel">
+    <div class="panel__heading panel__heading--tight">
+      <h2 class="h3">Manage Access <div class="subtitle">Grant access to an environment</div></h2>
+    </div>
+  </div>
+
+  <div class='search-bar'>
+    <div class='usa-input search-input'>
+      <label for='project-search'>Search by project name</label>
+      <input type='search' id='project-search' name='project-search' placeholder="Search by project name"/>
+      <button type="submit">
+        <span class="hide">Search</span>
+      </button>
+    </div>
+  </div>
+
+  {% for project in projects %}
+  <div is='toggler' default-visible class='block-list project-list-item'>
+    <template slot-scope='{ isVisible, toggle }'>
+      <header class='block-list__header'>
+      <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+          <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+          <template v-else>{{ Icon('caret_right') }}</template>
+          <h3 class="block-list__title">{{ project.name }}</h3>
         </button>
-      </div>
-    </div>
+        <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
+      </header>
+      <ul v-show='isVisible'>
+        {% for env in project.environments %}
 
-    {% for project in projects %}
-    <div is='toggler' default-visible class='block-list project-list-item'>
-      <template slot-scope='{ isVisible, toggle }'>
-        <header class='block-list__header'>
-        <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-            <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
-            <template v-else>{{ Icon('caret_right') }}</template>
-            <h3 class="block-list__title">{{ project.name }}</h3>
-          </button>
-          <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
-        </header>
-        <ul v-show='isVisible'>
-          {% for env in project.environments %}
+          {% set role = EnvironmentRole.get(member.user_id, env.id).role or 'no_access' %}
+          {% set label_class = 'label' %}
+          {% if role != 'no_access' %}
+            {% set label_class = 'label label--success' %}
+          {% endif %}
 
-            {% set role = EnvironmentRole.get(member.user_id, env.id).role or 'no access' %}
-            {% set label_class = 'label' %}
-            {% if role != 'no access' %}
-              {% set label_class = 'label label--success' %}
-            {% endif %}
 
-            {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
-                <div class='block-list'>
-                  <ul>
-                    {% for choice in form.environment_role.choices %}
-                    <li class='block-list__item block-list__item--selectable'>
-
-                      {% if choice[0] != ""  %}
-                        <input
-                          name='env_{{ env.name }}'
-                          type='radio'
-                          id="env_{{ env.name }}"
-                          value='{ "id": "{{ env.id }}", "role": "{{ choice[0] }}" }'
-                          checked='{{ role  == choice[0] }}'
-                        />
-                        <label for="env_{{ env.name }}">
-                          {% if choice[1].description %}
-                            <dl>
-                              <dt>{{ choice[1].name }}</dt>
-                              <dd>{{ choice[1].description }}</dd>
-                            </dl>
-                          {% else %}
-                            {{ choice[1].name }}
-                          {% endif %}
-                        </label>
-                        {% endif %}
-                    </li>
-                    {% endfor %}
-                  </ul>
-                </div>
-                <div class='block-list__footer'>
-                  <div class='action-group'>
-                    <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-                    <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal')">No Access</a>
-                  </div>
-                </div>
-            {% endcall %}
-
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
+        <li class='block-list__item'>
+          <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>
+          <div class='project-list-item__environment'>
+            <span class='project-list-item__environment__link'>
               {{ env.name }}
             </span>
 
             <div class='project-list-item__environment__actions'>
               <div>{{ form.data["environment_role"] }}</div>
 
-              <span class="{{ label_class }}">{{ role }}</span>
+              <span class="{{ label_class }}" v-html="value"></span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
+              {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
+                  <div class='block-list'>
+                    <ul>
+                      {% for choice in form.environment_role.choices %}
+                      <li class='block-list__item block-list__item--selectable'>
+
+                        {% if choice[0] != ""  %}
+                          <input
+                            name='env_{{ env.name }}_{{ project.id }}'
+                            v-on:change="change"
+                            type='radio'
+                            id="env_{{ env.id }}_{{ choice[0] }}"
+                            value='{ "id": "{{ env.id }}", "role": "{{ choice[0] }}" }'
+                            {% if role == choice[0] %}
+                              checked='checked'
+                            {% endif %}
+                          />
+                          <label for="env_{{ env.id }}_{{ choice[0] }}">
+                            {% if choice[1].description %}
+                              <dl>
+                                <dt>{{ choice[1].name }}</dt>
+                                <dd>{{ choice[1].description }}</dd>
+                              </dl>
+                            {% else %}
+                              {{ choice[1].name }}
+                            {% endif %}
+                          </label>
+                          {% endif %}
+                      </li>
+                      {% endfor %}
+                    </ul>
+                    <div class='block-list__footer'>
+                      <div class='action-group'>
+                        <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
+                        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal')">Cancel</a>
+                      </div>
+                    </div>
+                  </div>
+              {% endcall %}
             </div>
+          </div>
+          </edit-workspace-member>
+        </li>
 
-          {% endfor %}
-        </ul>
-      </template>
-    </div>
-    {% endfor %}
+        {% endfor %}
+      </ul>
+    </template>
+  </div>
+  {% endfor %}
 
-    <div class='action-group'>
-      <button class='action-group__action usa-button usa-button-big'>
-        {% if is_new_member %}Create{% else %}Save{% endif %}
-      </button>
-      <a href='#' class='action-group__action icon-link'>
-        {{ Icon('x') }}
-        <span>Cancel</span>
-      </a>
-    </div>
+  <div class='action-group'>
+    <button class='action-group__action usa-button usa-button-big'>
+      {% if is_new_member %}Create{% else %}Save{% endif %}
+    </button>
+    <a href='#' class='action-group__action icon-link'>
+      {{ Icon('x') }}
+      <span>Cancel</span>
+    </a>
+  </div>
 
   </form>
-</edit-workspace-member>
 
 
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -86,7 +86,6 @@
             <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">Cancel</a>
           </div>
         </div>
-      </div>
     {% endcall %}
 
     <div is='toggler' default-visible class='block-list project-list-item'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -86,7 +86,7 @@
 
                         {% if choice[0] != ""  %}
                           <input
-                            name='env_{{ env.id }}'
+                            name='radio_input_{{ env.id }}'
                             v-on:change='change'
                             type='radio'
                             id="env_{{ env.id }}_{{ choice[0] }}"
@@ -109,10 +109,11 @@
                       </li>
                       {% endfor %}
                     </ul>
+                    <input type='hidden' name='env_{{ env.id }}' v-bind:value='new_role'/>
                     <div class='block-list__footer'>
                       <div class='action-group'>
                         <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-                        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal'); cancel('{{ role }}', value);" value="{{ value if value == role else role }}" >Cancel</a>
+                        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal'); cancel();" value="{{ value if value == role else role }}" >Cancel</a>
                       </div>
                     </div>
                   </div>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -76,7 +76,7 @@
             <div class='project-list-item__environment__actions'>
               <div>{{ form.data["environment_role"] }}</div>
 
-              <span v-bind:class="label_class" v-html:on=displayName(value)></span>
+              <span v-bind:class="label_class" v-html:on=displayName></span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
               {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
                   <div class='block-list'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -51,43 +51,6 @@
       </div>
     </div>
 
-
-    {% call Modal(name='rolesModal', dismissable=False) %}
-        <div class='block-list'>
-          <ul>
-            {% for choice in form.environment_role.choices %}
-            <li class='block-list__item block-list__item--selectable'>
-              {% if choice[0] != ""  %}
-                <input
-                  name='environment_role'
-                  type='radio'
-                  id="environment_role_{{ choice[0] }}"
-                  value='{{ choice[0] }}'
-                  checked='{{ value == choice[0] }}'
-                />
-                <label for="environment_role_{{ choice[0] }}">
-                  {% if choice[1].description %}
-                    <dl>
-                      <dt>{{ choice[1].name }}</dt>
-                      <dd>{{ choice[1].description }}</dd>
-                    </dl>
-                  {% else %}
-                    {{ choice[1].name }}
-                  {% endif %}
-                </label>
-                {% endif %}
-            </li>
-            {% endfor %}
-          </ul>
-        </div>
-        <div class='block-list__footer'>
-          <div class='action-group'>
-            <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-            <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">Cancel</a>
-          </div>
-        </div>
-    {% endcall %}
-
     {% for project in projects %}
     <div is='toggler' default-visible class='block-list project-list-item'>
       <template slot-scope='{ isVisible, toggle }'>
@@ -101,11 +64,48 @@
         </header>
         <ul v-show='isVisible'>
           {% for env in project.environments %}
+            {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
+                <div class='block-list'>
+                  <ul>
+                    {% for choice in form.environment_role.choices %}
+                    <li class='block-list__item block-list__item--selectable'>
+                      {% if choice[0] != ""  %}
+                        <input
+                          name='environment_role'
+                          type='radio'
+                          id="environment_role_{{ choice[0] }}"
+                          value='{{ choice[0] }}'
+                          checked='{{ value == choice[0] }}'
+                        />
+                        <label for="environment_role_{{ choice[0] }}">
+                          {% if choice[1].description %}
+                            <dl>
+                              <dt>{{ choice[1].name }}</dt>
+                              <dd>{{ choice[1].description }}</dd>
+                            </dl>
+                          {% else %}
+                            {{ choice[1].name }}
+                          {% endif %}
+                        </label>
+                        {% endif %}
+                    </li>
+                    {% endfor %}
+                  </ul>
+                </div>
+                <div class='block-list__footer'>
+                  <div class='action-group'>
+                    <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
+                    <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal')">No Access</a>
+                  </div>
+                </div>
+            {% endcall %}
+
           <li class='block-list__item project-list-item__environment'>
             <span class='project-list-item__environment'>
               {{ env.name }}
             </span>
             <div class='project-list-item__environment__actions'>
+              <input type="hidden" name="{{ env.id }}">
               {% set role = 'no access' %}
               {% set label = 'label' %}
               {% for er in member.user.environment_roles %}
@@ -114,8 +114,10 @@
                   {% set label = 'label label--success' %}
                 {% endif %}
               {% endfor %}
-              <span class="{{ label }}">{{ role }}</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+              <span class="label {{ label }}">{{ role }}</span>
+              <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
             </div>
+
           {% endfor %}
         </ul>
       </template>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -3,223 +3,185 @@
 {% from "components/icon.html" import Icon %}
 {% from "components/modal.html" import Modal %}
 {% from "components/selector.html" import Selector %}
+{% from "components/options_input.html" import OptionsInput %}
 
 {% block content %}
 
-<form method="POST" action="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=member.user_id) }}" autocomplete="false">
-  {{ form.csrf_token }}
+<edit-workspace-member inline-template v-bind:initial-data='{{ form.data|tojson }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>
+  <form method="POST" action="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=member.user_id) }}" autocomplete="false">
+    {{ form.csrf_token }}
 
-  <div class='panel member-card'>
-    <div class='member-card__header'>
-      <h1 class='member-card__heading'>{{ member.user.full_name }}</h1>
+    <div class='panel member-card'>
+      <div class='member-card__header'>
+        <h1 class='member-card__heading'>{{ member.user.full_name }}</h1>
 
-        <div class="usa-input member-card__input">
-          {{ Selector(form.workspace_role) }}
-        </div>
+          <div class="usa-input member-card__input">
+            {{ Selector(form.workspace_role) }}
+          </div>
 
-    </div>
-    <div class='member-card__details'>
-      <dl>
-        <div>
-          <dt>DOD ID:</dt>
-          <dd>{{ member.user.dod_id }}</dd>
-        </div>
-        <div>
-          <dt>Email:</dt>
-          <dd>{{ member.user.email }}</dd>
-        </div>
-      </dl>
-      <a href='#' class='icon-link'>edit account details</a>
-    </div>
-  </div>
-
-  <div class="panel">
-    <div class="panel__heading panel__heading--tight">
-      <h2 class="h3">Manage Access <div class="subtitle">Grant access to an environment</div></h2>
-    </div>
-  </div>
-
-  <div class='search-bar'>
-    <div class='usa-input search-input'>
-      <label for='project-search'>Search by project name</label>
-      <input type='search' id='project-search' name='project-search' placeholder="Search by project name"/>
-      <button type="submit">
-        <span class="hide">Search</span>
-      </button>
-    </div>
-  </div>
-
-  {% call Modal(name='rolesModal', dismissable=False) %}
-  <div class="block-list">
-    <header class="block-list__header">
-      <h2 class="block-list__title">
-        Environment access for {{ member.user.full_name }}
-        <div class='subtitle'>Project Name - Environment Name</div>
-      </h2>
-    </header>
-
-    <ul>
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='developer' />
-        <label for='developer'>
-          <dl>
-            <dt>Developer</dt>
-            <dd>Configures cloud-based IaaS and PaaS computing, networking, and storage services.</dd>
-          </dl>
-        </label>
-      </li>
-
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='database_admin' />
-        <label for='database_admin'>
-          <dl>
-            <dt>Database Administrator</dt>
-            <dd>Configures cloud-based database services.</dd>
-          </dl>
-        </label>
-      </li>
-
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='devops' />
-        <label for='devops'>
-          <dl>
-            <dt>DevOps</dt>
-            <dd>Provisions, deprovisions, and deploys cloud-based IaaS and PaaS computing, networking, and storage services, including pre-configured machine images.</dd>
-          </dl>
-        </label>
-      </li>
-
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='billing_admin' />
-        <label for='billing_admin'>
-          <dl>
-            <dt>Billing Administrator</dt>
-            <dd>Views cloud resource usage, budget reports, and invoices; Tracks budgets, including spend reports, cost planning and projections, and sets limits based on cloud service usage.</dd>
-          </dl>
-        </label>
-      </li>
-
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='security_admin' />
-        <label for='security_admin'>
-          <dl>
-            <dt>Security Administrator</dt>
-            <dd>Accesses information security and control tools of cloud resources which include viewing cloud resource usage logging, user roles and permissioning history.</dd>
-          </dl>
-        </label>
-      </li>
-
-      <li class='block-list__item block-list__item--selectable'>
-        <input type='radio' name='radio' id='financial_auditor' />
-        <label for='financial_auditor'>
-          <dl>
-            <dt>Financial Auditor</dt>
-            <dd>Views cloud resource usage and budget reports.</dd>
-          </dl>
-        </label>
-      </li>
-    </ul>
-
-    <div class='block-list__footer'>
-      <div class='action-group'>
-        <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">No Access</a>
+      </div>
+      <div class='member-card__details'>
+        <dl>
+          <div>
+            <dt>DOD ID:</dt>
+            <dd>{{ member.user.dod_id }}</dd>
+          </div>
+          <div>
+            <dt>Email:</dt>
+            <dd>{{ member.user.email }}</dd>
+          </div>
+        </dl>
+        <a href='#' class='icon-link'>edit account details</a>
       </div>
     </div>
 
-  </div>
+    <div class="panel">
+      <div class="panel__heading panel__heading--tight">
+        <h2 class="h3">Manage Access <div class="subtitle">Grant access to an environment</div></h2>
+      </div>
+    </div>
 
-  {% endcall %}
-
-  <div is='toggler' default-visible class='block-list project-list-item'>
-    <template slot-scope='props'>
-      <header class='block-list__header'>
-      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
-          <template v-else>{{ Icon('caret_right') }}</template>
-          <h3 class="block-list__title">Code.mil</h3>
+    <div class='search-bar'>
+      <div class='usa-input search-input'>
+        <label for='project-search'>Search by project name</label>
+        <input type='search' id='project-search' name='project-search' placeholder="Search by project name"/>
+        <button type="submit">
+          <span class="hide">Search</span>
         </button>
-        <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
-      </header>
-      <ul v-show='props.isVisible'>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Development
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Sandbox
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Production
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label label--success">Billing</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-      </ul>
-    </template>
-  </div>
+      </div>
+    </div>
+      {{ Selector(form.environment_role) }}
 
-  <div is="toggler" class='block-list project-list-item'>
-    <template slot-scope='props'>
-      <header class='block-list__header'>
-      <button type='button' v-on:click='props.toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-          <template v-if='props.isVisible'>{{ Icon('caret_down') }}</template>
-          <template v-else>{{ Icon('caret_right') }}</template>
-          <h3 class="block-list__title">Digital Dojo</h3>
-        </button>
-        <span class="label">no access</span>
-      </header>
-      <ul v-show='props.isVisible'>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Development
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Sandbox
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-        <li class='block-list__item project-list-item__environment'>
-          <span class='project-list-item__environment'>
-            Production
-          </span>
-          <div class='project-list-item__environment__actions'>
-            <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-          </div>
-        </li>
-      </ul>
-    </template>
-  </div>
+    {% call Modal(name='rolesModal', dismissable=False) %}
+      <div class='block-list'>
+        <ul>
+          {% for choice in form.environment_role.choices %}
+          <li class='block-list__item block-list__item--selectable'>
 
-  <div class='action-group'>
-    <button class='action-group__action usa-button usa-button-big'>
-      {% if is_new_member %}Create{% else %}Save{% endif %}
-    </button>
-    <a href='#' class='action-group__action icon-link'>
-      {{ Icon('x') }}
-      <span>Cancel</span>
-    </a>
-  </div>
+            {% if choice[0] != ""  %}
+              <input
+                name='env'
+                v-on:change='change'
+                type='radio'
+                id="env_{{ choice[0] }}"
+                value='{{ choice[0] }}'
+                {% if role == choice[0] %}
+                  checked='checked'
+                {% endif %}
+              />
+              <label for="env_{{ choice[0] }}">
+                {% if choice[1].description %}
+                  <dl>
+                    <dt>{{ choice[1].name }}</dt>
+                    <dd>{{ choice[1].description }}</dd>
+                  </dl>
+                {% else %}
+                  {{ choice[1].name }}
+                {% endif %}
+              </label>
+              {% endif %}
+          </li>
+          {% endfor %}
+        </ul>
+        <div class='block-list__footer'>
+          <div class='action-group'>
+            <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>
+            <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">Cancel</a>
+          </div>
+        </div>
+      </div>
+    {% endcall %}
 
-</form>
+    <div is='toggler' default-visible class='block-list project-list-item'>
+      <template slot-scope='{ isVisible, toggle }'>
+        <header class='block-list__header'>
+        <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+            <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+            <template v-else>{{ Icon('caret_right') }}</template>
+            <h3 class="block-list__title">Code.mil</h3>
+          </button>
+          <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
+        </header>
+        <ul v-show='isVisible'>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Development
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Sandbox
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Production
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label label--success">Billing</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+    </div>
+
+    <div is="toggler" class='block-list project-list-item'>
+      <template slot-scope='{ isVisible, toggle }'>
+        <header class='block-list__header'>
+        <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
+            <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
+            <template v-else>{{ Icon('caret_right') }}</template>
+            <h3 class="block-list__title">Digital Dojo</h3>
+          </button>
+          <span class="label">no access</span>
+        </header>
+        <ul v-show='isVisible'>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Development
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Sandbox
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+          <li class='block-list__item project-list-item__environment'>
+            <span class='project-list-item__environment'>
+              Production
+            </span>
+            <div class='project-list-item__environment__actions'>
+              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+            </div>
+          </li>
+        </ul>
+      </template>
+    </div>
+
+    <div class='action-group'>
+      <button class='action-group__action usa-button usa-button-big'>
+        {% if is_new_member %}Create{% else %}Save{% endif %}
+      </button>
+      <a href='#' class='action-group__action icon-link'>
+        {{ Icon('x') }}
+        <span>Cancel</span>
+      </a>
+    </div>
+
+  </form>
+</edit-workspace-member>
 
 
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -64,20 +64,28 @@
         </header>
         <ul v-show='isVisible'>
           {% for env in project.environments %}
+
+            {% set role = EnvironmentRole.get(member.user_id, env.id).role or 'no access' %}
+            {% set label_class = 'label' %}
+            {% if role != 'no access' %}
+              {% set label_class = 'label label--success' %}
+            {% endif %}
+
             {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
                 <div class='block-list'>
                   <ul>
                     {% for choice in form.environment_role.choices %}
                     <li class='block-list__item block-list__item--selectable'>
+
                       {% if choice[0] != ""  %}
                         <input
-                          name='environment_role'
+                          name='env_{{ env.name }}'
                           type='radio'
-                          id="environment_role_{{ choice[0] }}"
-                          value='{{ choice[0] }}'
-                          checked='{{ value == choice[0] }}'
+                          id="env_{{ env.name }}"
+                          value='{ "id": "{{ env.id }}", "role": "{{ choice[0] }}" }'
+                          checked='{{ role  == choice[0] }}'
                         />
-                        <label for="environment_role_{{ choice[0] }}">
+                        <label for="env_{{ env.name }}">
                           {% if choice[1].description %}
                             <dl>
                               <dt>{{ choice[1].name }}</dt>
@@ -104,17 +112,11 @@
             <span class='project-list-item__environment'>
               {{ env.name }}
             </span>
+
             <div class='project-list-item__environment__actions'>
-              <input type="hidden" name="{{ env.id }}">
-              {% set role = 'no access' %}
-              {% set label = 'label' %}
-              {% for er in member.user.environment_roles %}
-                {% if er.get(member.user_id, env.id) %}
-                  {% set role = er.get(member.user_id, env.id).role %}
-                  {% set label = 'label label--success' %}
-                {% endif %}
-              {% endfor %}
-              <span class="label {{ label }}">{{ role }}</span>
+              <div>{{ form.data["environment_role"] }}</div>
+
+              <span class="{{ label_class }}">{{ role }}</span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
             </div>
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -52,88 +52,80 @@
   {% call Modal(name='rolesModal', dismissable=False) %}
   <div class="block-list">
     <header class="block-list__header">
-      <div>
-        <h2 class="block-list__title">
-          Environment access for Danny Knight
-          <div class='subtitle'>Project Name - Environment Name</div>
-        </h2>
-        <div class="block-list__description">
-          <p>An environment role determines the permissions a member of the workspace assumes when using the JEDI Cloud.</p>
-          <p>A member may have different environment roles across different projects. A member can only have one assigned environment role in a given environment.</p>
-        </div>
-      </div>
+      <h2 class="block-list__title">
+        Environment access for {{ member.user.full_name }}
+        <div class='subtitle'>Project Name - Environment Name</div>
+      </h2>
     </header>
 
-    <form method="post" action="">
-      <ul>
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>Developer</dt>
-              <dd>Configures cloud-based IaaS and PaaS computing, networking, and storage services.</dd>
-            </dl>
-          </label>
-        </li>
+    <ul>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='developer' />
+        <label for='developer'>
+          <dl>
+            <dt>Developer</dt>
+            <dd>Configures cloud-based IaaS and PaaS computing, networking, and storage services.</dd>
+          </dl>
+        </label>
+      </li>
 
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>Database Administrator</dt>
-              <dd>Configures cloud-based database services.</dd>
-            </dl>
-          </label>
-        </li>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='database_admin' />
+        <label for='database_admin'>
+          <dl>
+            <dt>Database Administrator</dt>
+            <dd>Configures cloud-based database services.</dd>
+          </dl>
+        </label>
+      </li>
 
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>DevOps</dt>
-              <dd>Provisions, deprovisions, and deploys cloud-based IaaS and PaaS computing, networking, and storage services, including pre-configured machine images.</dd>
-            </dl>
-          </label>
-        </li>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='devops' />
+        <label for='devops'>
+          <dl>
+            <dt>DevOps</dt>
+            <dd>Provisions, deprovisions, and deploys cloud-based IaaS and PaaS computing, networking, and storage services, including pre-configured machine images.</dd>
+          </dl>
+        </label>
+      </li>
 
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>Billing Administrator</dt>
-              <dd>Views cloud resource usage, budget reports, and invoices; tracks budgets, including spend reports, cost planning and projections, and sets limits based on cloud service usage.</dd>
-            </dl>
-          </label>
-        </li>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='billing_admin' />
+        <label for='billing_admin'>
+          <dl>
+            <dt>Billing Administrator</dt>
+            <dd>Views cloud resource usage, budget reports, and invoices; Tracks budgets, including spend reports, cost planning and projections, and sets limits based on cloud service usage.</dd>
+          </dl>
+        </label>
+      </li>
 
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>Security Administrator</dt>
-              <dd>Accesses information security and control tools of cloud resources which include viewing cloud resource usage logging, user roles and permissioning history.</dd>
-            </dl>
-          </label>
-        </li>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='security_admin' />
+        <label for='security_admin'>
+          <dl>
+            <dt>Security Administrator</dt>
+            <dd>Accesses information security and control tools of cloud resources which include viewing cloud resource usage logging, user roles and permissioning history.</dd>
+          </dl>
+        </label>
+      </li>
 
-        <li class='block-list__item block-list__item--selectable'>
-          <input type='radio' name='radio' id='radio-' />
-          <label for='radio-'>
-            <dl>
-              <dt>Financial Auditor</dt>
-              <dd>Views cloud resource usage and budget reports.</dd>
-            </dl>
-          </label>
-        </li>
-      </ul>
+      <li class='block-list__item block-list__item--selectable'>
+        <input type='radio' name='radio' id='financial_auditor' />
+        <label for='financial_auditor'>
+          <dl>
+            <dt>Financial Auditor</dt>
+            <dd>Views cloud resource usage and budget reports.</dd>
+          </dl>
+        </label>
+      </li>
+    </ul>
 
-      <div class='block-list__footer'>
-        <div class='action-group'>
-          <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-          <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">No Access</a>
-        </div>
+    <div class='block-list__footer'>
+      <div class='action-group'>
+        <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>
+        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('rolesModal')">No Access</a>
       </div>
-    </form>
+    </div>
 
   </div>
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -65,11 +65,6 @@
         {% for env in project.environments %}
 
           {% set role = EnvironmentRole.get(member.user_id, env.id).role or 'no_access' %}
-          {% set label_class = 'label' %}
-          {% if role != 'no_access' %}
-            {% set label_class = 'label label--success' %}
-          {% endif %}
-
 
         <li class='block-list__item'>
           <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>
@@ -81,7 +76,7 @@
             <div class='project-list-item__environment__actions'>
               <div>{{ form.data["environment_role"] }}</div>
 
-              <span class="{{ label_class }}" v-html:on=readableName(value)></span>
+              <span v-bind:class="label_class" v-html:on=displayName(value)></span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
               {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
                   <div class='block-list'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -81,7 +81,7 @@
             <div class='project-list-item__environment__actions'>
               <div>{{ form.data["environment_role"] }}</div>
 
-              <span class="{{ label_class }}" v-html="value"></span>
+              <span class="{{ label_class }}" v-html:on=readableName(value)></span>
               <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
               {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
                   <div class='block-list'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -64,7 +64,7 @@
       <ul v-show='isVisible'>
         {% for env in project.environments %}
 
-          {% set role = EnvironmentRole.get(member.user_id, env.id).role %}
+          {% set role = EnvironmentRoles.get(member.user_id, env.id).role %}
 
         <li class='block-list__item'>
           <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -62,8 +62,8 @@
                   name='environment_role'
                   type='radio'
                   id="environment_role_{{ choice[0] }}"
-                  value='choice[0]'
-                  checked='value is choice[0]'
+                  value='{{ choice[0] }}'
+                  checked='{{ value == choice[0] }}'
                 />
                 <label for="environment_role_{{ choice[0] }}">
                   {% if choice[1].description %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -64,7 +64,7 @@
       <ul v-show='isVisible'>
         {% for env in project.environments %}
 
-          {% set role = EnvironmentRole.get(member.user_id, env.id).role or 'no_access' %}
+          {% set role = EnvironmentRole.get(member.user_id, env.id).role %}
 
         <li class='block-list__item'>
           <edit-workspace-member inline-template initial-data='{{ role }}' v-bind:choices='{{ form.environment_role.choices | tojson }}'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -50,39 +50,36 @@
         </button>
       </div>
     </div>
-      {{ Selector(form.environment_role) }}
+
 
     {% call Modal(name='rolesModal', dismissable=False) %}
-      <div class='block-list'>
-        <ul>
-          {% for choice in form.environment_role.choices %}
-          <li class='block-list__item block-list__item--selectable'>
-
-            {% if choice[0] != ""  %}
-              <input
-                name='env'
-                v-on:change='change'
-                type='radio'
-                id="env_{{ choice[0] }}"
-                value='{{ choice[0] }}'
-                {% if role == choice[0] %}
-                  checked='checked'
+        <div class='block-list'>
+          <ul>
+            {% for choice in form.environment_role.choices %}
+            <li class='block-list__item block-list__item--selectable'>
+              {% if choice[0] != ""  %}
+                <input
+                  name='environment_role'
+                  type='radio'
+                  id="environment_role_{{ choice[0] }}"
+                  value='choice[0]'
+                  checked='value is choice[0]'
+                />
+                <label for="environment_role_{{ choice[0] }}">
+                  {% if choice[1].description %}
+                    <dl>
+                      <dt>{{ choice[1].name }}</dt>
+                      <dd>{{ choice[1].description }}</dd>
+                    </dl>
+                  {% else %}
+                    {{ choice[1].name }}
+                  {% endif %}
+                </label>
                 {% endif %}
-              />
-              <label for="env_{{ choice[0] }}">
-                {% if choice[1].description %}
-                  <dl>
-                    <dt>{{ choice[1].name }}</dt>
-                    <dd>{{ choice[1].description }}</dd>
-                  </dl>
-                {% else %}
-                  {{ choice[1].name }}
-                {% endif %}
-              </label>
-              {% endif %}
-          </li>
-          {% endfor %}
-        </ul>
+            </li>
+            {% endfor %}
+          </ul>
+        </div>
         <div class='block-list__footer'>
           <div class='action-group'>
             <a v-on:click="closeModal('rolesModal')" class='action-group__action usa-button'>Select Access Role</a>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -88,83 +88,39 @@
         </div>
     {% endcall %}
 
+    {% for project in projects %}
     <div is='toggler' default-visible class='block-list project-list-item'>
       <template slot-scope='{ isVisible, toggle }'>
         <header class='block-list__header'>
         <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
             <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
             <template v-else>{{ Icon('caret_right') }}</template>
-            <h3 class="block-list__title">Code.mil</h3>
+            <h3 class="block-list__title">{{ project.name }}</h3>
           </button>
           <span><a href="#" class="icon-link icon-link--danger">revoke all access</a></span>
         </header>
         <ul v-show='isVisible'>
+          {% for env in project.environments %}
           <li class='block-list__item project-list-item__environment'>
             <span class='project-list-item__environment'>
-              Development
+              {{ env.name }}
             </span>
             <div class='project-list-item__environment__actions'>
-              <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
+              {% set role = 'no access' %}
+              {% set label = 'label' %}
+              {% for er in member.user.environment_roles %}
+                {% if er.get(member.user_id, env.id) %}
+                  {% set role = er.get(member.user_id, env.id).role %}
+                  {% set label = 'label label--success' %}
+                {% endif %}
+              {% endfor %}
+              <span class="{{ label }}">{{ role }}</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
             </div>
-          </li>
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
-              Sandbox
-            </span>
-            <div class='project-list-item__environment__actions'>
-              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-            </div>
-          </li>
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
-              Production
-            </span>
-            <div class='project-list-item__environment__actions'>
-              <span class="label label--success">Billing</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-            </div>
-          </li>
+          {% endfor %}
         </ul>
       </template>
     </div>
-
-    <div is="toggler" class='block-list project-list-item'>
-      <template slot-scope='{ isVisible, toggle }'>
-        <header class='block-list__header'>
-        <button v-on:click='toggle' class='icon-link icon-link--large icon-link--default spend-table__project__toggler'>
-            <template v-if='isVisible'>{{ Icon('caret_down') }}</template>
-            <template v-else>{{ Icon('caret_right') }}</template>
-            <h3 class="block-list__title">Digital Dojo</h3>
-          </button>
-          <span class="label">no access</span>
-        </header>
-        <ul v-show='isVisible'>
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
-              Development
-            </span>
-            <div class='project-list-item__environment__actions'>
-              <span class="label">no access </span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-            </div>
-          </li>
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
-              Sandbox
-            </span>
-            <div class='project-list-item__environment__actions'>
-              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-            </div>
-          </li>
-          <li class='block-list__item project-list-item__environment'>
-            <span class='project-list-item__environment'>
-              Production
-            </span>
-            <div class='project-list-item__environment__actions'>
-              <span class="label">no access</span><button v-on:click="openModal('rolesModal')" type="button" class="icon-link">set role</button>
-            </div>
-          </li>
-        </ul>
-      </template>
-    </div>
+    {% endfor %}
 
     <div class='action-group'>
       <button class='action-group__action usa-button usa-button-big'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -117,7 +117,7 @@
                     <div class='block-list__footer'>
                       <div class='action-group'>
                         <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-                        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal')">Cancel</a>
+                        <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal'); cancel('{{ role }}', value);" value="{{ value if value == role else role }}" >Cancel</a>
                       </div>
                     </div>
                   </div>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -91,11 +91,11 @@
 
                         {% if choice[0] != ""  %}
                           <input
-                            name='env_{{ env.name }}_{{ project.id }}'
-                            v-on:change="change"
+                            name='env_{{ env.id }}'
+                            v-on:change='change'
                             type='radio'
                             id="env_{{ env.id }}_{{ choice[0] }}"
-                            value='{ "id": "{{ env.id }}", "role": "{{ choice[0] }}" }'
+                            value='{{ choice[0] }}'
                             {% if role == choice[0] %}
                               checked='checked'
                             {% endif %}

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -29,8 +29,8 @@ def test_update_environment_roles():
 
     dev_env = project.environments[0]
     staging_env = project.environments[1]
-    Environments.add_member(owner, dev_env, workspace_user.user, role="devops")
-    Environments.add_member(owner, staging_env, workspace_user.user, role="developer")
+    Environments.add_member(dev_env, workspace_user.user, "devops")
+    Environments.add_member(staging_env, workspace_user.user, "developer")
 
     new_ids_and_roles = [
         {"id": dev_env.id, "role": "billing_admin"},

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -1,0 +1,45 @@
+import pytest
+from uuid import uuid4
+
+from atst.domain.environments import Environments
+from atst.domain.environment_roles import EnvironmentRoles
+from atst.domain.projects import Projects
+from atst.domain.workspaces import Workspaces
+from atst.domain.workspace_users import WorkspaceUsers
+from atst.domain.exceptions import NotFoundError
+
+from tests.factories import RequestFactory, UserFactory
+
+
+def test_update_environment_roles():
+    owner = UserFactory.create()
+    developer_data = {
+        "dod_id": "1234567890",
+        "first_name": "Test",
+        "last_name": "User",
+        "email": "test.user@mail.com",
+        "workspace_role": "developer",
+    }
+
+    workspace = Workspaces.create(RequestFactory.create(creator=owner))
+    workspace_user = Workspaces.create_member(owner, workspace, developer_data)
+    project = Projects.create(
+        owner, workspace, "my test project", "It's mine.", ["dev", "staging", "prod"]
+    )
+
+    dev_env = project.environments[0]
+    staging_env = project.environments[1]
+    Environments.add_member(owner, dev_env, workspace_user.user, role="devops")
+    Environments.add_member(owner, staging_env, workspace_user.user, role="developer")
+
+    new_ids_and_roles = [
+        {"id": dev_env.id, "role": "billing_admin"},
+        {"id": staging_env.id, "role": "developer"},
+    ]
+
+    Environments.update_environment_role(owner, new_ids_and_roles, workspace_user)
+    new_dev_env_role = EnvironmentRoles.get(workspace_user.user.id, dev_env.id)
+    staging_env_role = EnvironmentRoles.get(workspace_user.user.id, staging_env.id)
+
+    assert new_dev_env_role.role == "billing_admin"
+    assert staging_env_role.role == "developer"

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -169,7 +169,7 @@ def test_scoped_workspace_only_returns_a_users_projects_and_environments(
     )
     developer = UserFactory.from_atat_role("developer")
     dev_environment = Environments.add_member(
-        workspace_owner, new_project.environments[0], developer
+        new_project.environments[0], developer, "developer"
     )
 
     scoped_workspace = Workspaces.get(developer, workspace.id)

--- a/tests/models/test_environments.py
+++ b/tests/models/test_environments.py
@@ -14,5 +14,5 @@ def test_add_user_to_environment():
     )
     dev_environment = project.environments[0]
 
-    dev_environment = Environments.add_member(owner, dev_environment, developer)
+    dev_environment = Environments.add_member(dev_environment, developer, "developer")
     assert developer in dev_environment.users

--- a/tests/models/test_workspace_user.py
+++ b/tests/models/test_workspace_user.py
@@ -36,7 +36,7 @@ def test_has_environment_roles():
     project = Projects.create(
         owner, workspace, "my test project", "It's mine.", ["dev", "staging", "prod"]
     )
-    Environments.add_member(owner, project.environments[0], workspace_user.user)
+    Environments.add_member(project.environments[0], workspace_user.user, "developer")
     assert workspace_user.has_environment_roles
 
 

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -108,7 +108,7 @@ def test_update_member_environment_role(client, user_session):
     env1_id = project.environments[0].id
     env2_id = project.environments[1].id
     for env in project.environments:
-        Environments.add_member(owner, env, user, "developer")
+        Environments.add_member(env, user, "developer")
     user_session(owner)
     response = client.post(
         url_for(

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -2,6 +2,10 @@ from flask import url_for
 
 from tests.factories import UserFactory, WorkspaceFactory
 from atst.domain.workspaces import Workspaces
+from atst.domain.workspace_users import WorkspaceUsers
+from atst.domain.projects import Projects
+from atst.domain.environments import Environments
+from atst.domain.environment_roles import EnvironmentRoles
 from atst.models.workspace_user import WorkspaceUser
 
 
@@ -67,3 +71,56 @@ def test_update_workspace_name(client, user_session):
     )
     assert response.status_code == 200
     assert workspace.name == "a cool new name"
+
+
+def test_update_member_workspace_role(client, user_session):
+    owner = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(owner, workspace, "admin")
+    user = UserFactory.create()
+    member = WorkspaceUsers.add(user, workspace.id, "developer")
+    user_session(owner)
+    response = client.post(
+        url_for(
+            "workspaces.update_member", workspace_id=workspace.id, member_id=user.id
+        ),
+        data={"workspace_role": "security_auditor"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert member.role == "security_auditor"
+
+
+def test_update_member_environment_role(client, user_session):
+    owner = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(owner, workspace, "admin")
+
+    user = UserFactory.create()
+    member = WorkspaceUsers.add(user, workspace.id, "developer")
+    project = Projects.create(
+        owner,
+        workspace,
+        "Snazzy Project",
+        "A new project for me and my friends",
+        {"env1", "env2"},
+    )
+    env1_id = project.environments[0].id
+    env2_id = project.environments[1].id
+    for env in project.environments:
+        Environments.add_member(owner, env, user, "developer")
+    user_session(owner)
+    response = client.post(
+        url_for(
+            "workspaces.update_member", workspace_id=workspace.id, member_id=user.id
+        ),
+        data={
+            "workspace_role": "developer",
+            "env_" + str(env1_id): "security_auditor",
+            "env_" + str(env2_id): "devops",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert EnvironmentRoles.get(user.id, env1_id).role == "security_auditor"
+    assert EnvironmentRoles.get(user.id, env2_id).role == "devops"


### PR DESCRIPTION
## Description
 - Users with permissions to edit workspace users can now assign and update their workspace users' environment roles on each project (and each environment on the project).
 - Each environment has its own modal in order to capture environment role changes to multiple environments. This means that there will be a field on the posted form for every environment in each project that the user being editing is a member of.
 - When a new environment role is chosen, the displayed environment role is updated. Note that the environment role is not actually updated until the user presses `Save`. If a selection was made, pressing `Cancel` will change the display back to the original role. 
 - This PR also wires up the edit member template to use the user's real data instead of hardcoded example data.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/158072276
https://www.pivotaltracker.com/story/show/160298069

## Screenshots
![screen shot 2018-09-20 at 11 00 52 am](https://user-images.githubusercontent.com/42577527/45827460-7a85c880-bcc4-11e8-85e2-dd40654357cf.png)

![screen shot 2018-09-19 at 2 49 48 pm](https://user-images.githubusercontent.com/42577527/45774769-d9dbce00-bc1b-11e8-9ccb-cdc2109ba6f4.png)
