### PR TITLE
do not divide by zero

### DIFF
--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -36,7 +36,7 @@
 
         <div>
           <meter value='{{ spent }}' min='0' max='{{ budget }}' title='{{ spent | dollars }} Total spend to date'>
-            <div class='meter__fallback' style='width:{{ (spent / budget) * 100 }}%;'></div>
+            <div class='meter__fallback' style='width:{{ (spent / budget) * 100 if budget else 0 }}%;'></div>
           </meter>
 
           <dl class='spend-summary__spent'>


### PR DESCRIPTION
Don't do it.

This fixes the template bug for requests that have a budget of zero dollars (i.e., they don't have any CLIN data).