### PR TITLE
Aardvark beluga #160300247

### DIFF
--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -151,8 +151,9 @@ REPORT_FIXTURE_MAP = {
         "cumulative": CUMULATIVE_BUDGET_BELUGA,
         "monthly": MONTHLY_SPEND_BELUGA,
         "budget": 70_000,
-    }
+    },
 }
+
 
 def _sum_monthly_spend(data):
     return sum(
@@ -164,46 +165,63 @@ def _sum_monthly_spend(data):
         ]
     )
 
+
+def _derive_project_totals(data):
+    project_totals = {}
+    for project, environments in data.items():
+        project_spend = [
+            (month, spend)
+            for env in environments.values()
+            for month, spend in env.items()
+        ]
+        project_totals[project] = {
+            month: sum([spend[1] for spend in spends])
+            for month, spends in groupby(sorted(project_spend), lambda x: x[0])
+        }
+
+    return project_totals
+
+
+def _derive_workspace_totals(project_totals):
+    monthly_spend = [
+        (month, spend)
+        for project in project_totals.values()
+        for month, spend in project.items()
+    ]
+    workspace_totals = {}
+    for month, spends in groupby(sorted(monthly_spend), lambda m: m[0]):
+        workspace_totals[month] = sum([spend[1] for spend in spends])
+
+    return workspace_totals
+
+
 class Reports:
     @classmethod
     def workspace_totals(cls, workspace):
-        if workspace.name in REPORT_FIXTURE_MAP.keys():
+        if workspace.name in REPORT_FIXTURE_MAP:
             budget = REPORT_FIXTURE_MAP[workspace.name]["budget"]
             spent = _sum_monthly_spend(REPORT_FIXTURE_MAP[workspace.name]["monthly"])
         elif workspace.request and workspace.request.task_order:
             ws_to = workspace.request.task_order
             budget = ws_to.budget
+            # spent will be derived from CSP data
             spent = 0
         else:
             budget = 0
             spent = 0
 
-        # spent will be derived from CSP data
         return {"budget": budget, "spent": spent}
 
     @classmethod
-    def monthly_totals(cls, alternate):
-        data = MONTHLY_SPEND_BELUGA if alternate else MONTHLY_SPEND_AARDVARK
-        project_totals = {}
-        for project, environments in data.items():
-            project_spend = [
-                (month, spend)
-                for env in environments.values()
-                for month, spend in env.items()
-            ]
-            project_totals[project] = {
-                month: sum([spend[1] for spend in spends])
-                for month, spends in groupby(sorted(project_spend), lambda x: x[0])
-            }
-
-        monthly_spend = [
-            (month, spend)
-            for project in project_totals.values()
-            for month, spend in project.items()
-        ]
-        workspace_totals = {}
-        for month, spends in groupby(sorted(monthly_spend), lambda m: m[0]):
-            workspace_totals[month] = sum([spend[1] for spend in spends])
+    def monthly_totals(cls, workspace):
+        if workspace.name in REPORT_FIXTURE_MAP:
+            data = REPORT_FIXTURE_MAP[workspace.name]["monthly"]
+            project_totals = _derive_project_totals(data)
+            workspace_totals = _derive_workspace_totals(project_totals)
+        else:
+            data = {}
+            project_totals = {}
+            workspace_totals = {}
 
         return {
             "environments": data,
@@ -212,9 +230,10 @@ class Reports:
         }
 
     @classmethod
-    def cumulative_budget(cls, alternate):
-        return {
-            "months": CUMULATIVE_BUDGET_BELUGA
-            if alternate
-            else CUMULATIVE_BUDGET_AARDVARK
-        }
+    def cumulative_budget(cls, workspace):
+        if workspace.name in REPORT_FIXTURE_MAP:
+            months = REPORT_FIXTURE_MAP[workspace.name]["cumulative"]
+        else:
+            months = {}
+
+        return {"months": months}

--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -141,18 +141,45 @@ CUMULATIVE_BUDGET_BELUGA = {
     "09/2018": {"spend": 14500, "cumulative": 19338},
 }
 
+REPORT_FIXTURE_MAP = {
+    "aardvark": {
+        "cumulative": CUMULATIVE_BUDGET_AARDVARK,
+        "monthly": MONTHLY_SPEND_AARDVARK,
+        "budget": 500_000,
+    },
+    "beluga": {
+        "cumulative": CUMULATIVE_BUDGET_BELUGA,
+        "monthly": MONTHLY_SPEND_BELUGA,
+        "budget": 70_000,
+    }
+}
+
+def _sum_monthly_spend(data):
+    return sum(
+        [
+            spend
+            for project in data.values()
+            for env in project.values()
+            for spend in env.values()
+        ]
+    )
 
 class Reports:
     @classmethod
     def workspace_totals(cls, workspace):
-        if workspace.request and workspace.request.task_order:
+        if workspace.name in REPORT_FIXTURE_MAP.keys():
+            budget = REPORT_FIXTURE_MAP[workspace.name]["budget"]
+            spent = _sum_monthly_spend(REPORT_FIXTURE_MAP[workspace.name]["monthly"])
+        elif workspace.request and workspace.request.task_order:
             ws_to = workspace.request.task_order
             budget = ws_to.budget
+            spent = 0
         else:
             budget = 0
+            spent = 0
 
         # spent will be derived from CSP data
-        return {"budget": budget, "spent": 0}
+        return {"budget": budget, "spent": spent}
 
     @classmethod
     def monthly_totals(cls, alternate):

--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -142,12 +142,12 @@ CUMULATIVE_BUDGET_BELUGA = {
 }
 
 REPORT_FIXTURE_MAP = {
-    "aardvark": {
+    "Aardvark": {
         "cumulative": CUMULATIVE_BUDGET_AARDVARK,
         "monthly": MONTHLY_SPEND_AARDVARK,
         "budget": 500_000,
     },
-    "beluga": {
+    "Beluga": {
         "cumulative": CUMULATIVE_BUDGET_BELUGA,
         "monthly": MONTHLY_SPEND_BELUGA,
         "budget": 70_000,

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -1,4 +1,5 @@
 import re
+import datetime
 from flask import current_app as app
 from werkzeug.datastructures import FileStorage
 
@@ -72,6 +73,10 @@ def formattedDate(value, formatter="%m/%d/%Y"):
         return "-"
 
 
+def dateFromString(value, formatter="%m/%Y"):
+    return datetime.datetime.strptime(value, formatter)
+
+
 def register_filters(app):
     app.jinja_env.filters["iconSvg"] = iconSvg
     app.jinja_env.filters["dollars"] = dollars
@@ -82,3 +87,4 @@ def register_filters(app):
     app.jinja_env.filters["findFilter"] = findFilter
     app.jinja_env.filters["renderList"] = renderList
     app.jinja_env.filters["formattedDate"] = formattedDate
+    app.jinja_env.filters["dateFromString"] = dateFromString

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -98,7 +98,6 @@ def workspace_reports(workspace_id):
         "view workspace reports",
     )
 
-    alternate_reports = http_request.args.get("alternate")
     today = date.today()
     month = http_request.args.get("month", today.month)
     year = http_request.args.get("year", today.year)
@@ -113,9 +112,9 @@ def workspace_reports(workspace_id):
 
     return render_template(
         "workspaces/reports/index.html",
-        cumulative_budget=Reports.cumulative_budget(alternate_reports),
+        cumulative_budget=Reports.cumulative_budget(workspace),
         workspace_totals=Reports.workspace_totals(workspace),
-        monthly_totals=Reports.monthly_totals(alternate_reports),
+        monthly_totals=Reports.monthly_totals(workspace),
         current_month=current_month,
         prev_month=prev_month,
         two_months_ago=two_months_ago,

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -301,8 +301,21 @@
     <div class='spend-table__header'>
       <h2 class='spend-table__title'>Total spend per month </h2>
 
-      <select name='month' id='month' class='spend-table__month-select'>
-        <option value='03/2019'>{{ current_month.strftime('%B %Y') }}</option>
+      <select name='month' id='month' onchange='location = this.value' class='spend-table__month-select'>
+        {% for m in cumulative_budget["months"] %}
+          {% set month = m | dateFromString %}
+          <option
+            {% if month.month == current_month.month and month.year == current_month.year %}
+              selected='selected'
+            {% endif %}
+            value='{{ url_for("workspaces.workspace_reports",
+                              workspace_id=workspace.id,
+                              month=month.month,
+                              year=month.year) }}'
+          >
+            {{ month.strftime('%B %Y') }}
+          </option>
+        {% endfor %}
       </select>
     </div>
 


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/160300247

This wires the backend so that it will return our mock report data if a workspace is named "Beluga" or "Aardvark". To test this, just change your workspace name to one of the two.

**note**

The ACs also say:

> And I can choose to view a different month in the "Total spend per month" report

so I wired up the month-selector in the "Total spend" section in the following way:

- You can select any of the months we have cumulative data for
- It will reset the window location to that page (report with month and year query params), the same way the "Cumulative Budget" report above will when you click a month.

This is sort of a weird old HTML hack, but it works.