### PR TITLE
Always use the front-end validation message

### DIFF
--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -69,8 +69,7 @@
       <input type='hidden' v-bind:value='rawValue' name='{{ field.name }}' />
 
       <template v-if='showError'>
-        <span v-if='initialErrors' v-for='error in initialErrors' class='usa-input__message' v-html='error'></span>
-        <span v-if='!initialErrors' class='usa-input__message' v-html='validationError'></span>
+        <span class='usa-input__message' v-html='validationError'></span>
       </template>
 
     </div>


### PR DESCRIPTION
This modifies the TextInput macro/component to only display the front-end defined error message. Even when a server-side error is present, the more detailed front-end message will be displayed.

Addresses https://www.pivotaltracker.com/story/show/160627446