### PR TITLE
Reports task order info #159975038

### DIFF
--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -216,3 +216,13 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def displayname(self):
         return self.latest_revision.name or self.id
+
+    @property
+    def contracting_officer_full_name(self):
+        if self.latest_revision.fname_co:
+            return "{} {}".format(self.latest_revision.fname_co, self.latest_revision.lname_co)
+
+    @property
+    def contracting_officer_email(self):
+        return self.latest_revision.email_co
+

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -220,9 +220,10 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def contracting_officer_full_name(self):
         if self.latest_revision.fname_co:
-            return "{} {}".format(self.latest_revision.fname_co, self.latest_revision.lname_co)
+            return "{} {}".format(
+                self.latest_revision.fname_co, self.latest_revision.lname_co
+            )
 
     @property
     def contracting_officer_email(self):
         return self.latest_revision.email_co
-

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -105,16 +105,20 @@ def workspace_reports(workspace_id):
     prev_month = current_month - timedelta(days=28)
     two_months_ago = prev_month - timedelta(days=28)
 
-    # lets just say it expires on Christmas... ho ho ho
-    expiration_date = date(2018, 12, 25)
-    remaining_difference = expiration_date - today
-    remaining_days = remaining_difference.days
+    expiration_date = workspace.request.task_order.expiration_date
+    if expiration_date:
+        remaining_difference = expiration_date - today
+        remaining_days = remaining_difference.days
+    else:
+        remaining_days = 0
 
     return render_template(
         "workspaces/reports/index.html",
         cumulative_budget=Reports.cumulative_budget(workspace),
         workspace_totals=Reports.workspace_totals(workspace),
         monthly_totals=Reports.monthly_totals(workspace),
+        jedi_request=workspace.request,
+        task_order=workspace.request.task_order,
         current_month=current_month,
         prev_month=prev_month,
         two_months_ago=two_months_ago,

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -21,23 +21,24 @@ WORKSPACE_USERS = [
         "last_name": "Knight",
         "email": "knight@mil.gov",
         "workspace_role": "developer",
-        "dod_id": "0000000001"
+        "dod_id": "0000000001",
     },
     {
         "first_name": "Mario",
         "last_name": "Hudson",
         "email": "hudson@mil.gov",
         "workspace_role": "ccpo",
-        "dod_id": "0000000002"
+        "dod_id": "0000000002",
     },
     {
         "first_name": "Louise",
         "last_name": "Greer",
         "email": "greer@mil.gov",
         "workspace_role": "admin",
-        "dod_id": "0000000003"
+        "dod_id": "0000000003",
     },
 ]
+
 
 def seed_db():
     users = []
@@ -65,8 +66,13 @@ def seed_db():
 
         request = requests[0]
         request.task_order = TaskOrderFactory.build()
+        request = Requests.update(
+            request.id, {"financial_verification": RequestFactory.mock_financial_data()}
+        )
 
-        workspace = Workspaces.create(request, name="{}'s workspace".format(user.first_name))
+        workspace = Workspaces.create(
+            request, name="{}'s workspace".format(user.first_name)
+        )
         for workspace_user in WORKSPACE_USERS:
             Workspaces.create_member(user, workspace, workspace_user)
 
@@ -75,7 +81,7 @@ def seed_db():
             workspace=workspace,
             name="First Project",
             description="This is our first project.",
-            environment_names=["dev", "staging", "prod"]
+            environment_names=["dev", "staging", "prod"],
         )
 
 

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -78,7 +78,7 @@
               </div>
             </dl>
 
-            <a href='#' class='icon-link'>
+            <a href='{{ url_for("workspaces.workspace", workspace_id=workspace.id) }}' class='icon-link'>
               Manage Task Order
             </a>
           </div>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -56,7 +56,7 @@
             <h2 class='to-summary__heading'>Task Order</h2>
             <dl class='to-summary__to-number'>
               <dt class='usa-sr-only'>Task Order Number</dt>
-              <dd>1234567890</dd>
+              <dd>{{ task_order.number }}</dd>
             </dl>
           </div>
 
@@ -87,8 +87,8 @@
         <dl class='to-summary__co'>
           <dt>Contracting Officer</dt>
           <dd>
-            Pietro Quirines
-            <a class='icon-link' href='mailto:email@email.com'>email@email.com</a>
+            {{ jedi_request.contracting_officer_full_name }}
+            <a class='icon-link' href='mailto:{{ jedi_request.contracting_officer_email }}'>{{ jedi_request.contracting_officer_email }}</a>
           </dd>
         </dl>
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -191,7 +191,9 @@ class TaskOrderFactory(Base):
     source = Source.MANUAL
     funding_type = FundingType.PROC
     funding_type_other = None
-    number = factory.Faker("md5")
+    number = factory.LazyFunction(
+        lambda: "".join(random.choices(string.ascii_uppercase + string.digits, k=13))
+    )
     expiration_date = factory.LazyFunction(
         lambda: datetime.date(
             datetime.date.today().year + random.randrange(1, 15), 1, 1

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,7 @@ import string
 import factory
 from uuid import uuid4
 import datetime
+from faker import Faker as _Faker
 
 from atst.forms.data import SERVICE_BRANCHES
 from atst.models.request import Request
@@ -158,6 +159,24 @@ class RequestFactory(Base):
             request=request, revision=request.latest_revision, new_status=status
         )
         return request
+
+    @classmethod
+    def mock_financial_data(cls):
+        fake = _Faker()
+        return {
+            "pe_id": "0101110F",
+            "fname_co": fake.first_name(),
+            "lname_co": fake.last_name(),
+            "email_co": fake.email(),
+            "office_co": fake.phone_number(),
+            "fname_cor": fake.first_name(),
+            "lname_cor": fake.last_name(),
+            "email_cor": fake.email(),
+            "office_cor": fake.phone_number(),
+            "uii_ids": "123abc",
+            "treasury_code": "00123456",
+            "ba_code": "02A",
+        }
 
 
 class PENumberFactory(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -196,7 +196,9 @@ class TaskOrderFactory(Base):
     )
     expiration_date = factory.LazyFunction(
         lambda: datetime.date(
-            datetime.date.today().year + random.randrange(1, 15), 1, 1
+            datetime.date.today().year + random.randrange(1, 5),
+            random.randrange(1, 12),
+            random.randrange(1, 28),
         )
     )
     clin_0001 = random.randrange(100, 100000)


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/159975038

This wires real data for the "Task Order" box on the reports page. Re-run the `seed_sample.py` script to get real data for the mock workspace.

**notes**
- I updated the `seed_sample.py` script to add real data for the financial section of a request if we're using to to make a workspace.
- After discussion, Hardik and I decided that "Manage Task Order" should link to the workspace settings form, since that's where users will eventually go to update the TO and other things related to the workspace.