### PR TITLE
Update Role factory to prevent unique constraint violations during testing

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -27,7 +27,7 @@ class RoleFactory(Base):
     class Meta:
         model = Role
 
-    name = factory.Faker("job")
+    name = factory.Faker("name")
     description = "This is a test role."
     permissions = []
 


### PR DESCRIPTION
Tests have been failing occasionally because of a duplicate `Role.name`. The issue was that the `job` faker was sometimes generating duplicates. I switched the faker to `name`, which is hopefully random enough to avoid these failures.