### PR TITLE
fix task order number display

### DIFF
--- a/atst/models/workspace.py
+++ b/atst/models/workspace.py
@@ -35,7 +35,7 @@ class Workspace(Base, TimestampsMixin):
 
     @property
     def task_order(self):
-        return {"number": "task-order-number"}
+        return self.request.task_order
 
     @property
     def members(self):


### PR DESCRIPTION
Fixes this PT bug: https://www.pivotaltracker.com/story/show/160667796

The workspace model had a mocked-out `task_order` property before, which meant that we showed fake data in the workspaces index view. This makes that property return the task order for the associated request.