### PR TITLE
Fix budget chart projection line

### DIFF
--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -75,7 +75,8 @@ export default {
           this.spendPath += this.spendPath === '' ? 'M' : ' L'
           this.spendPath += cumulativePoint
           lastSpendPoint = cumulativePoint
-        } else {
+
+        } else if (lastSpendPoint !== '') {
           this.projectedPath += this.projectedPath === '' ? `M${lastSpendPoint} L` : ' L'
           this.projectedPath += cumulativePoint
         }


### PR DESCRIPTION
Refine else condition when adding points to the projection path, so it doesn't accidentally catch un-budgeted months BEFORE spending starts.