### PR TITLE
Hook up internal request comments

### DIFF
--- a/atst/domain/requests/requests.py
+++ b/atst/domain/requests/requests.py
@@ -225,8 +225,8 @@ class Requests(object):
         return Requests._add_review(user, request, review_data)
 
     @classmethod
-    def update_internal_comments(cls, user, request, comment_text):
+    def add_internal_comment(cls, user, request, comment_text):
         Authorization.check_can_approve_request(user)
-        request.internal_comments = RequestInternalComment(text=comment_text, user=user)
-        request = RequestsQuery.add_and_commit(request)
+        comment = RequestInternalComment(request=request, text=comment_text, user=user)
+        RequestsQuery.add_and_commit(comment)
         return request

--- a/atst/forms/internal_comment.py
+++ b/atst/forms/internal_comment.py
@@ -1,5 +1,5 @@
 from wtforms.fields import TextAreaField
-from wtforms.validators import Optional
+from wtforms.validators import InputRequired
 
 from .forms import ValidatedForm
 
@@ -7,6 +7,7 @@ from .forms import ValidatedForm
 class InternalCommentForm(ValidatedForm):
     text = TextAreaField(
         "CCPO Internal Notes",
+        default="",
         description="Add comments or notes for internal CCPO reference and follow-up here.<strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
-        validators=[Optional()],
+        validators=[InputRequired()],
     )

--- a/atst/forms/internal_comment.py
+++ b/atst/forms/internal_comment.py
@@ -8,6 +8,6 @@ class InternalCommentForm(ValidatedForm):
     text = TextAreaField(
         "CCPO Internal Notes",
         default="",
-        description="Add comments or notes for internal CCPO reference and follow-up here.<strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
+        description="Add comments or notes for internal CCPO reference and follow-up here. <strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
         validators=[InputRequired()],
     )

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -45,7 +45,7 @@ class Request(Base, mixins.TimestampsMixin):
         "RequestRevision", back_populates="request", order_by="RequestRevision.sequence"
     )
 
-    internal_comments = relationship("RequestInternalComment", uselist=False)
+    internal_comments = relationship("RequestInternalComment")
 
     @property
     def latest_revision(self):
@@ -166,10 +166,6 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def reviews(self):
         return [status.review for status in self.status_events if status.review]
-
-    @property
-    def internal_comments_text(self):
-        return self.internal_comments.text if self.internal_comments else ""
 
     @property
     def is_pending_financial_verification(self):

--- a/atst/models/request_internal_comment.py
+++ b/atst/models/request_internal_comment.py
@@ -14,3 +14,4 @@ class RequestInternalComment(Base, mixins.TimestampsMixin):
     user = relationship("User")
 
     request_id = Column(ForeignKey("requests.id", ondelete="CASCADE"), nullable=False)
+    request = relationship("Request")

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -14,8 +14,6 @@ from atst.domain.exceptions import NotFoundError
 from atst.forms.ccpo_review import CCPOReviewForm
 from atst.forms.internal_comment import InternalCommentForm
 
-from datetime import date
-
 
 def map_ccpo_authorizing(user):
     return {"fname_ccpo": user.first_name, "lname_ccpo": user.last_name}
@@ -32,20 +30,6 @@ def render_approval(request, form=None, internal_comment_form=None):
 
     if not internal_comment_form:
         internal_comment_form = InternalCommentForm()
-
-    # Dummy internal comments
-    comments = [
-        {
-            "time_created": date(2018, 9, 18),
-            "full_name_commenter": "Darth Vader",
-            "message": "We'll have no more of this Obi-Wan Kenobi jibberish...and don't talk to me about your mission, either. You're fortunate he doesn't blast you into a million pieces right here. ",
-        },
-        {
-            "time_created": date(2018, 9, 20),
-            "full_name_commenter": "Grand Moff Tarkin",
-            "message": "We'll have no more of this Obi-Wan Kenobi jibberish...and don't talk to me about your mission, either. You're fortunate he doesn't blast you into a million pieces right here. ",
-        },
-    ]
 
     return render_template(
         "requests/approval.html",

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -30,7 +30,7 @@ def render_approval(request, form=None):
         mo_data = map_ccpo_authorizing(g.current_user)
         form = CCPOReviewForm(data=mo_data)
 
-    internal_comment_form = InternalCommentForm(text=request.internal_comments_text)
+    internal_comment_form = InternalCommentForm()
 
     # Dummy internal comments
     comments = [
@@ -54,7 +54,7 @@ def render_approval(request, form=None):
         current_status=request.status.value,
         f=form or CCPOReviewForm(),
         internal_comment_form=internal_comment_form,
-        comments=comments,
+        comments=request.internal_comments,
     )
 
 
@@ -101,10 +101,10 @@ def task_order_pdf_download(request_id):
 
 @requests_bp.route("/requests/internal_comments/<string:request_id>", methods=["POST"])
 def create_internal_comment(request_id):
-    # form = InternalCommentForm(http_request.form)
-    # if form.validate():
-    #     request = Requests.get(g.current_user, request_id)
-    #     Requests.update_internal_comments(g.current_user, request, form.data["text"])
+    form = InternalCommentForm(http_request.form)
+    if form.validate():
+        request = Requests.get(g.current_user, request_id)
+        Requests.add_internal_comment(g.current_user, request, form.data.get("text"))
     return redirect(
         url_for("requests.approval", request_id=request_id, _anchor="ccpo-notes")
     )

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -32,11 +32,6 @@
 
     </section>
 
-    {{ Alert('Comments and comment form are fake!',
-      message="<p>Please note, the comments and comment form below are just mocked out. Submitting it will do nothing. These will be hooked up to real functionality shortly. </p><p><strong>Engineer: please remove this alert when you do your thing.</strong></p>",
-      level='warning'
-    ) }}
-
     <section class='internal-notes' id='ccpo-notes'>
       <form method="POST" action="{{ url_for('requests.create_internal_comment', request_id=request.id) }}">
         <div class='panel'>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -8,7 +8,7 @@
 
 <article class='col col--grow request-approval'>
 
-{% if f.errors %}
+{% if review_form.errors or internal_comment_form.errors %}
   {{ Alert('There were some errors',
     message="<p>Please see below.</p>",
     level='error'
@@ -88,7 +88,7 @@
 
     <section class='request-approval__review'>
       <form method="POST" action="{{ url_for("requests.submit_approval", request_id=request.id) }}" autocomplete="off">
-        {{ f.csrf_token }}
+        {{ review_form.csrf_token }}
 
         <ccpo-approval inline-template>
           <div>
@@ -165,7 +165,7 @@
                   <h3>Message to Requestor <span class='subtitle'>(optional)</span></h3>
                   <div v-if='approving' key='approving' v-cloak>
                     {{ TextInput(
-                      f.comment,
+                      review_form.comment,
                       label='Approval comments or notes',
                       description='Provide any comments or notes regarding the approval of this request. <strong>This message will be shared with the person making the JEDI request.</strong>.',
                       paragraph=True,
@@ -175,7 +175,7 @@
 
                   <div v-else key='denying' v-cloak>
                     {{ TextInput(
-                      f.comment,
+                      review_form.comment,
                       label='Revision instructions or notes',
                       paragraph=True,
                       noMaxWidth=True
@@ -194,21 +194,21 @@
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.fname_mao, placeholder="First name of mission authorizing official") }}
+                      {{ TextInput(review_form.fname_mao, placeholder="First name of mission authorizing official") }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.lname_mao, placeholder="Last name of mission authorizing official") }}
+                      {{ TextInput(review_form.lname_mao, placeholder="Last name of mission authorizing official") }}
                     </div>
                   </div>
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.email_mao, placeholder="name@mail.mil", validation='email') }}
+                      {{ TextInput(review_form.email_mao, placeholder="name@mail.mil", validation='email') }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.phone_mao, placeholder="(123) 456-7890", validation='usPhone') }}
+                      {{ TextInput(review_form.phone_mao, placeholder="(123) 456-7890", validation='usPhone') }}
                     </div>
                   </div>
 
@@ -218,11 +218,11 @@
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.fname_ccpo, placeholder="First name of CCPO authorizing official") }}
+                      {{ TextInput(review_form.fname_ccpo, placeholder="First name of CCPO authorizing official") }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.lname_ccpo, placeholder="Last name of CCPO authorizing official") }}
+                      {{ TextInput(review_form.lname_ccpo, placeholder="Last name of CCPO authorizing official") }}
                     </div>
                   </div>
                 </div>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -51,8 +51,8 @@
                 <li>
                   <article class='comment-log__log-item'>
                     <div>
-                      <h3 class='comment-log__log-item__header'>{{ comment.full_name_commenter }}</h3>
-                      <p>{{ comment.message }}</p>
+                      <h3 class='comment-log__log-item__header'>{{ comment.user.full_name }}</h3>
+                      <p>{{ comment.text }}</p>
                     </div>
                     {% set timestamp=comment.time_created | formattedDate("%Y-%m-%d %H:%M:%S %Z") %}
                     <footer class='comment-log__log-item__timestamp'>

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -223,10 +223,13 @@ def test_request_changes_to_financial_verification_info():
     assert current_review.fname_mao == review_data["fname_mao"]
 
 
-def test_update_internal_comments():
+def test_add_internal_comment():
     request = RequestFactory.create()
     ccpo = UserFactory.from_atat_role("ccpo")
 
-    request = Requests.update_internal_comments(ccpo, request, "this is my comment")
+    assert len(request.internal_comments) == 0
 
-    assert request.internal_comments.text == "this is my comment"
+    request = Requests.add_internal_comment(ccpo, request, "this is my comment")
+
+    assert len(request.internal_comments) == 1
+    assert request.internal_comments[0].text == "this is my comment"

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -129,6 +129,23 @@ def test_ccpo_user_can_comment_on_request(client, user_session):
     assert request.internal_comments[0].text == comment_text
 
 
+def test_ccpo_user_can_comment_on_request(client, user_session):
+    user = UserFactory.from_atat_role("ccpo")
+    user_session(user)
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
+    )
+    assert len(request.internal_comments) == 0
+
+    comment_form_data = {"text": ""}
+    response = client.post(
+        url_for("requests.create_internal_comment", request_id=request.id),
+        data=comment_form_data,
+    )
+    assert response.status_code == 200
+    assert len(request.internal_comments) == 0
+
+
 def test_other_user_cannot_comment_on_request(client, user_session):
     user = UserFactory.create()
     user_session(user)

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -129,7 +129,7 @@ def test_ccpo_user_can_comment_on_request(client, user_session):
     assert request.internal_comments[0].text == comment_text
 
 
-def test_ccpo_user_can_comment_on_request(client, user_session):
+def test_comment_text_is_required(client, user_session):
     user = UserFactory.from_atat_role("ccpo")
     user_session(user)
     request = RequestFactory.create_with_status(


### PR DESCRIPTION
This PR hooks up the internal comment form & log on the request approval screen:

![image](https://user-images.githubusercontent.com/40774582/45969678-66163880-c002-11e8-8bcd-db151d78acb2.png)

The form requires a non-empty comment and will show an error if the field is blank:

![image](https://user-images.githubusercontent.com/40774582/45969699-78907200-c002-11e8-896f-f18997250440.png)
