### PR TITLE
Dummy help page

### DIFF
--- a/atst/domain/auth.py
+++ b/atst/domain/auth.py
@@ -8,6 +8,7 @@ UNPROTECTED_ROUTES = [
     "dev.login_dev",
     "atst.login_redirect",
     "atst.unauthorized",
+    "atst.helpdocs",
     "static",
 ]
 

--- a/atst/domain/requests/requests.py
+++ b/atst/domain/requests/requests.py
@@ -225,8 +225,8 @@ class Requests(object):
         return Requests._add_review(user, request, review_data)
 
     @classmethod
-    def update_internal_comments(cls, user, request, comment_text):
+    def add_internal_comment(cls, user, request, comment_text):
         Authorization.check_can_approve_request(user)
-        request.internal_comments = RequestInternalComment(text=comment_text, user=user)
-        request = RequestsQuery.add_and_commit(request)
+        comment = RequestInternalComment(request=request, text=comment_text, user=user)
+        RequestsQuery.add_and_commit(comment)
         return request

--- a/atst/forms/internal_comment.py
+++ b/atst/forms/internal_comment.py
@@ -1,5 +1,5 @@
 from wtforms.fields import TextAreaField
-from wtforms.validators import Optional
+from wtforms.validators import InputRequired
 
 from .forms import ValidatedForm
 
@@ -7,6 +7,7 @@ from .forms import ValidatedForm
 class InternalCommentForm(ValidatedForm):
     text = TextAreaField(
         "CCPO Internal Notes",
+        default="",
         description="Add comments or notes for internal CCPO reference and follow-up here.<strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
-        validators=[Optional()],
+        validators=[InputRequired()],
     )

--- a/atst/forms/internal_comment.py
+++ b/atst/forms/internal_comment.py
@@ -8,6 +8,6 @@ class InternalCommentForm(ValidatedForm):
     text = TextAreaField(
         "CCPO Internal Notes",
         default="",
-        description="Add comments or notes for internal CCPO reference and follow-up here.<strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
+        description="Add comments or notes for internal CCPO reference and follow-up here. <strong>These comments <em>will not</em> be visible to the person making the JEDI request.</strong>",
         validators=[InputRequired()],
     )

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -45,7 +45,7 @@ class Request(Base, mixins.TimestampsMixin):
         "RequestRevision", back_populates="request", order_by="RequestRevision.sequence"
     )
 
-    internal_comments = relationship("RequestInternalComment", uselist=False)
+    internal_comments = relationship("RequestInternalComment")
 
     @property
     def latest_revision(self):
@@ -166,10 +166,6 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def reviews(self):
         return [status.review for status in self.status_events if status.review]
-
-    @property
-    def internal_comments_text(self):
-        return self.internal_comments.text if self.internal_comments else ""
 
     @property
     def is_pending_financial_verification(self):

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -216,3 +216,13 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def displayname(self):
         return self.latest_revision.name or self.id
+
+    @property
+    def contracting_officer_full_name(self):
+        if self.latest_revision.fname_co:
+            return "{} {}".format(self.latest_revision.fname_co, self.latest_revision.lname_co)
+
+    @property
+    def contracting_officer_email(self):
+        return self.latest_revision.email_co
+

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -220,9 +220,10 @@ class Request(Base, mixins.TimestampsMixin):
     @property
     def contracting_officer_full_name(self):
         if self.latest_revision.fname_co:
-            return "{} {}".format(self.latest_revision.fname_co, self.latest_revision.lname_co)
+            return "{} {}".format(
+                self.latest_revision.fname_co, self.latest_revision.lname_co
+            )
 
     @property
     def contracting_officer_email(self):
         return self.latest_revision.email_co
-

--- a/atst/models/request_internal_comment.py
+++ b/atst/models/request_internal_comment.py
@@ -14,3 +14,4 @@ class RequestInternalComment(Base, mixins.TimestampsMixin):
     user = relationship("User")
 
     request_id = Column(ForeignKey("requests.id", ondelete="CASCADE"), nullable=False)
+    request = relationship("Request")

--- a/atst/models/workspace_user.py
+++ b/atst/models/workspace_user.py
@@ -41,8 +41,8 @@ class WorkspaceUser(object):
         return "active"
 
     @property
-    def has_environment_roles(self):
-        num_environment_roles = (
+    def num_environment_roles(self):
+        return (
             db.session.query(EnvironmentRole)
             .join(EnvironmentRole.environment)
             .join(Environment.project)
@@ -51,4 +51,7 @@ class WorkspaceUser(object):
             .filter(EnvironmentRole.user_id == self.user_id)
             .count()
         )
-        return num_environment_roles > 0
+
+    @property
+    def has_environment_roles(self):
+        return self.num_environment_roles > 0

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -13,6 +13,9 @@ bp = Blueprint("atst", __name__)
 @bp.route("/")
 def root():
     return render_template("root.html")
+@bp.route("/help")
+def helpdocs():
+    return render_template("help/index.html")
 
 
 @bp.route("/home")

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -12,7 +12,9 @@ bp = Blueprint("atst", __name__)
 
 @bp.route("/")
 def root():
-    return render_template("root.html")
+    return render_template("login.html")
+
+
 @bp.route("/help")
 def helpdocs():
     return render_template("help/index.html")

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -14,8 +14,6 @@ from atst.domain.exceptions import NotFoundError
 from atst.forms.ccpo_review import CCPOReviewForm
 from atst.forms.internal_comment import InternalCommentForm
 
-from datetime import date
-
 
 def map_ccpo_authorizing(user):
     return {"fname_ccpo": user.first_name, "lname_ccpo": user.last_name}
@@ -32,20 +30,6 @@ def render_approval(request, form=None, internal_comment_form=None):
 
     if not internal_comment_form:
         internal_comment_form = InternalCommentForm()
-
-    # Dummy internal comments
-    comments = [
-        {
-            "time_created": date(2018, 9, 18),
-            "full_name_commenter": "Darth Vader",
-            "message": "We'll have no more of this Obi-Wan Kenobi jibberish...and don't talk to me about your mission, either. You're fortunate he doesn't blast you into a million pieces right here. ",
-        },
-        {
-            "time_created": date(2018, 9, 20),
-            "full_name_commenter": "Grand Moff Tarkin",
-            "message": "We'll have no more of this Obi-Wan Kenobi jibberish...and don't talk to me about your mission, either. You're fortunate he doesn't blast you into a million pieces right here. ",
-        },
-    ]
 
     return render_template(
         "requests/approval.html",

--- a/atst/routes/requests/approval.py
+++ b/atst/routes/requests/approval.py
@@ -30,7 +30,7 @@ def render_approval(request, form=None):
         mo_data = map_ccpo_authorizing(g.current_user)
         form = CCPOReviewForm(data=mo_data)
 
-    internal_comment_form = InternalCommentForm(text=request.internal_comments_text)
+    internal_comment_form = InternalCommentForm()
 
     # Dummy internal comments
     comments = [
@@ -54,7 +54,7 @@ def render_approval(request, form=None):
         current_status=request.status.value,
         f=form or CCPOReviewForm(),
         internal_comment_form=internal_comment_form,
-        comments=comments,
+        comments=request.internal_comments,
     )
 
 
@@ -101,10 +101,10 @@ def task_order_pdf_download(request_id):
 
 @requests_bp.route("/requests/internal_comments/<string:request_id>", methods=["POST"])
 def create_internal_comment(request_id):
-    # form = InternalCommentForm(http_request.form)
-    # if form.validate():
-    #     request = Requests.get(g.current_user, request_id)
-    #     Requests.update_internal_comments(g.current_user, request, form.data["text"])
+    form = InternalCommentForm(http_request.form)
+    if form.validate():
+        request = Requests.get(g.current_user, request_id)
+        Requests.add_internal_comment(g.current_user, request, form.data.get("text"))
     return redirect(
         url_for("requests.approval", request_id=request_id, _anchor="ccpo-notes")
     )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -105,16 +105,20 @@ def workspace_reports(workspace_id):
     prev_month = current_month - timedelta(days=28)
     two_months_ago = prev_month - timedelta(days=28)
 
-    # lets just say it expires on Christmas... ho ho ho
-    expiration_date = date(2018, 12, 25)
-    remaining_difference = expiration_date - today
-    remaining_days = remaining_difference.days
+    expiration_date = workspace.request.task_order.expiration_date
+    if expiration_date:
+        remaining_difference = expiration_date - today
+        remaining_days = remaining_difference.days
+    else:
+        remaining_days = 0
 
     return render_template(
         "workspaces/reports/index.html",
         cumulative_budget=Reports.cumulative_budget(workspace),
         workspace_totals=Reports.workspace_totals(workspace),
         monthly_totals=Reports.monthly_totals(workspace),
+        jedi_request=workspace.request,
+        task_order=workspace.request.task_order,
         current_month=current_month,
         prev_month=prev_month,
         two_months_ago=two_months_ago,

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -21,23 +21,24 @@ WORKSPACE_USERS = [
         "last_name": "Knight",
         "email": "knight@mil.gov",
         "workspace_role": "developer",
-        "dod_id": "0000000001"
+        "dod_id": "0000000001",
     },
     {
         "first_name": "Mario",
         "last_name": "Hudson",
         "email": "hudson@mil.gov",
         "workspace_role": "ccpo",
-        "dod_id": "0000000002"
+        "dod_id": "0000000002",
     },
     {
         "first_name": "Louise",
         "last_name": "Greer",
         "email": "greer@mil.gov",
         "workspace_role": "admin",
-        "dod_id": "0000000003"
+        "dod_id": "0000000003",
     },
 ]
+
 
 def seed_db():
     users = []
@@ -65,8 +66,13 @@ def seed_db():
 
         request = requests[0]
         request.task_order = TaskOrderFactory.build()
+        request = Requests.update(
+            request.id, {"financial_verification": RequestFactory.mock_financial_data()}
+        )
 
-        workspace = Workspaces.create(request, name="{}'s workspace".format(user.first_name))
+        workspace = Workspaces.create(
+            request, name="{}'s workspace".format(user.first_name)
+        )
         for workspace_user in WORKSPACE_USERS:
             Workspaces.create_member(user, workspace, workspace_user)
 
@@ -75,7 +81,7 @@ def seed_db():
             workspace=workspace,
             name="First Project",
             description="This is our first project.",
-            environment_names=["dev", "staging", "prod"]
+            environment_names=["dev", "staging", "prod"],
         )
 
 

--- a/styles/components/_footer.scss
+++ b/styles/components/_footer.scss
@@ -4,15 +4,27 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
+  align-items: center;
+  padding: $gap * 2;
 
-  h5,
-  .browser-support {
-    margin: 0;
-    padding: $gap * 2;
+  .app-footer__info {
+    flex-grow: 1;
+
+    .app-footer__info__title {
+      display: inline-block;
+      padding: 0;
+      margin: 0 $gap 0 0;
+      //margin: ($gap * 2);
+    }
+
+    .app-footer__info__link {
+      margin: (-$gap * 2) (-$gap);
+    }
   }
 
-  .browser-support {
+  .app-footer__browser-support {
     color: $color-gray;
+    margin: 0;
     text-align: right;
     dt, dd {
       @include h5;

--- a/styles/components/_topbar.scss
+++ b/styles/components/_topbar.scss
@@ -24,6 +24,14 @@
         margin-left: $gap;
       }
 
+      &.topbar__link--home {
+        padding-left: $gap/2;
+
+        .topbar__link-label {
+          padding-left: $gap;
+        }
+      }
+
       &.topbar__link--shield {
         width: $icon-bar-width;
         justify-content: center;
@@ -52,7 +60,7 @@
       justify-content: flex-end;
       -ms-flex-pack: start;
 
-      .topbar__link {
+      .topbar__link--workspace {
         &:first-child {
           margin-right: auto;
         }
@@ -72,6 +80,35 @@
             background-color: $color-primary-darker;
           }
         }
+      }
+    }
+  }
+
+
+  &.topbar--public {
+    background-color: $color-primary;
+
+    .topbar__navigation {
+      justify-content: flex-end;
+    }
+
+    .topbar__link {
+      color: $color-white;
+
+      .topbar__link-icon {
+        @include icon-style-inverted;
+      }
+
+      &.topbar__link--home {
+        padding-left: $gap;
+      }
+
+      &:first-child {
+        margin-right: auto;
+      }
+
+      &:hover {
+        background-color: $color-primary-darker;
       }
     }
   }

--- a/styles/components/_topbar.scss
+++ b/styles/components/_topbar.scss
@@ -90,6 +90,7 @@
 
     .topbar__navigation {
       justify-content: flex-end;
+      -ms-flex-pack: justify;
     }
 
     .topbar__link {

--- a/templates/base_public.html
+++ b/templates/base_public.html
@@ -24,7 +24,7 @@
       </a>
 
       {% if g.current_user %}
-        <a href="/" class="topbar__link">
+        <a href="{{ url_for('atst.home') }}" class="topbar__link">
           <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>
           {{ Icon('avatar', classes='topbar__link-icon') }}
         </a>
@@ -48,7 +48,7 @@
     <div class='app-footer__info'>
       <h5 class='app-footer__info__title'>Joint Enterprise Defense Infrastructure</h5>
 
-      <a href='/help' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
+      <a href='{{ url_for('atst.helpdocs') }}' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
         {{ Icon('help') }}
         <span>JEDI Help</span>
       </a>

--- a/templates/base_public.html
+++ b/templates/base_public.html
@@ -1,0 +1,67 @@
+{% from "components/icon.html" import Icon %}
+
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}JEDI Cloud{% endblock %}</title>
+  {% assets "css" %}
+    <link rel="stylesheet" href="{{ ASSET_URL }}" type="text/css">
+  {% endassets %}
+  <link rel="icon" type="image/x-icon" href="/static/img/favicon.ico">
+</head>
+<body>
+
+<div id='app-root'>
+
+  <header class="topbar topbar--public">
+    <nav class="topbar__navigation">
+      <a href="{{ url_for('atst.home') }}" class="topbar__link topbar__link--home">
+        {{ Icon('shield', classes='topbar__link-icon') }}
+        <span class="topbar__link-label">JEDI Cloud</span>
+      </a>
+
+      {% if g.current_user %}
+        <a href="/" class="topbar__link">
+          <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>
+          {{ Icon('avatar', classes='topbar__link-icon') }}
+        </a>
+
+        <a href="{{ url_for('atst.logout') }}" class="topbar__link" title='Log out of JEDI Cloud'>
+          {{ Icon('logout', classes='topbar__link-icon') }}
+        </a>
+      {% else %}
+        <a href="{{ url_for('atst.home') }}" class="topbar__link" title='Log in'>
+          <span class="topbar__link-label">Log in</span>
+          {{ Icon('avatar', classes='topbar__link-icon') }}
+        </a>
+      {% endif %}
+
+    </nav>
+  </header>
+
+  {% block content %}{% endblock %}
+
+  <footer class='app-footer'>
+    <div class='app-footer__info'>
+      <h5 class='app-footer__info__title'>Joint Enterprise Defense Infrastructure</h5>
+
+      <a href='/help' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
+        {{ Icon('help') }}
+        <span>JEDI Help</span>
+      </a>
+    </div>
+
+    <dl class='app-footer__browser-support'>
+      <dt>JEDI Cloud supported on these web browsers</dt>
+      <dd>Chrome</dd><dd>Firefox</dd><dd>Safari</dd><dd>Edge</dd><dd>IE11 on Windows 10</dd><dd>IE10 on Windows 7</dd>
+  </footer>
+
+</div>
+
+</body>
+</html>
+
+

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -4,7 +4,7 @@
   <div class='app-footer__info'>
     <h5 class='app-footer__info__title'>Joint Enterprise Defense Infrastructure</h5>
 
-    <a href='/help' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
+    <a href='{{ url_for('atst.helpdocs') }}' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
       {{ Icon('help') }}
       <span>JEDI Help</span>
     </a>

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,3 +1,12 @@
+{% from "components/icon.html" import Icon %}
+
 <footer class='app-footer'>
-  <h5>Joint Enterprise Defense Infrastructure</h5>
+  <div class='app-footer__info'>
+    <h5 class='app-footer__info__title'>Joint Enterprise Defense Infrastructure</h5>
+
+    <a href='/help' class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
+      {{ Icon('help') }}
+      <span>JEDI Help</span>
+    </a>
+  </div>
 </footer>

--- a/templates/fragments/pending_ccpo_acceptance_alert.html
+++ b/templates/fragments/pending_ccpo_acceptance_alert.html
@@ -1,3 +1,5 @@
+{% from "components/icon.html" import Icon %}
+
 <p>
   We will review and respond to your request in 3 business days. You’ll be notified via email or phone.
 </p>
@@ -6,6 +8,10 @@
   While your request is being reviewed, your next step is to create a Task Order associated with JEDI Cloud. Please contact a Contracting Officer (KO), Contracting Officer Representative (COR), or a Financial Manager to help with this step.
 </p>
 
-<p>
-  Learn more about the JEDI Cloud Task Order and the Financial Verification process.
-</p>
+<div class='alert__actions'>
+  <a href='/help' class='icon-link'>
+    {{ Icon('help') }}
+    Learn more about the JEDI Cloud Task Order and the Financial Verification process.
+  </a>
+</div>
+

--- a/templates/fragments/pending_ccpo_approval_modal.html
+++ b/templates/fragments/pending_ccpo_approval_modal.html
@@ -30,6 +30,9 @@
   Once the Task Order has been created, you will be asked to provide details about the task order in the Financial Verification step.
 </p>
 
-<p>
-  Learn more about the JEDI Cloud Task Order and the Financial Verification process.
-</p>
+<div class='alert__actions'>
+  <a href='/help' class='icon-link'>
+    {{ Icon('help') }}
+    Learn more about the JEDI Cloud Task Order and the Financial Verification process.
+  </a>
+</div>

--- a/templates/fragments/pending_ccpo_approval_modal.html
+++ b/templates/fragments/pending_ccpo_approval_modal.html
@@ -1,3 +1,5 @@
+{% from "components/icon.html" import Icon %}
+
 <h1>
   Request submitted. Approval pending.
 </h1>

--- a/templates/fragments/pending_financial_verification.html
+++ b/templates/fragments/pending_financial_verification.html
@@ -1,3 +1,5 @@
+{% from "components/icon.html" import Icon %}
+
 <p>
   The next step is to create a Task Order associated with JEDI Cloud.
   Please contact a Contracting Officer (KO), Contracting Officer

--- a/templates/fragments/pending_financial_verification.html
+++ b/templates/fragments/pending_financial_verification.html
@@ -7,6 +7,11 @@
   Once the Task Order has been created, you will be asked to provide
   details about the task order in the Financial Verification step.
 </p>
-<p>
-  <i>Learn more</i> about the JEDI Cloud Task Order and the Financial Verification process.
-</p>
+
+<div class='alert__actions'>
+  <a href='/help' class='icon-link'>
+    {{ Icon('help') }}
+    Learn more about the JEDI Cloud Task Order and the Financial Verification process.
+  </a>
+</div>
+

--- a/templates/help/index.html
+++ b/templates/help/index.html
@@ -1,0 +1,57 @@
+{% extends "base_public.html" %}
+{% from "components/sidenav_item.html" import SidenavItem %}
+{% from "components/alert.html" import Alert %}
+
+{% block title %}Help | JEDI Cloud{% endblock %}
+
+{% block content %}
+  <div class='global-layout'>
+    <div class='global-navigation sidenav'>
+      <ul>
+        {{ SidenavItem("Help Topic",
+          href="/help",
+          active=g.matchesPath('/help'),
+          subnav=[
+            {"label":"Sub Topic", "href":"/help", "active": False},
+            {"label":"Sub Topic", "href":"/help", "active": False},
+            {"label":"Another Sub Topic", "href":"/help", "active": False},
+          ]
+        )}}
+
+
+        {{ SidenavItem("Another Help Topic",
+          href="/help",
+          active=False
+        )}}
+
+        {{ SidenavItem("One More Help Topic",
+          href="/help",
+          active=False
+        )}}
+      </ul>
+    </div>
+
+
+    <div class='global-panel-container'>
+      {{ Alert('Sample Content',
+        message='This is a sample help page intended to demonstrate the layout of a JEDI Cloud help documentation page.',
+      ) }}
+
+      <div class='panel'>
+        <div class='panel__heading panel__heading--divider'>
+          <h1>
+            <div class='h4'>JEDI Cloud Help Documentation</div>
+            <span class='h1'>Help Topic</span>
+          </h1>
+        </div>
+
+        <div class='panel__content'>
+          <p>So you see, since we're a small operation, we don't fall into the...uh...jurisdiction of the Empire. So you're part of the mining guild then? No, not actually. Our operation is small enough not to be noticed...which is advantageous for everybody since our customers are anxious to avoid attracting attention to themselves. Aren't you afraid the Empire's going to find out about this little operation and shut you down? That's always been a danger looming like a shadow over everything we've built here. But things have developed that will insure security. I've just made a deal that will keep the Empire out of here forever. We would be honored if you would join us. I had no choice. They arrived right before you did. I'm sorry. I'm sorry, too.</p>
+          <p>Now will you move along, little fella? We're got a lot of work to do. No! No, no! Stay and help you, I will. Find your friend, hmm? I'm not looking for a friend, I'm looking for a Jedi Master. Oohhh. Jedi Master. Yoda. You seek Yoda. You know him? Mmm. Take you to him, I will. Yes, yes. But now, we must eat. Come. Good food. Come. Come, come. Stay here and watch after the camp, Artoo.</p>
+          <p>Well done. Hold them in the security tower - and keep it quiet. Move. What do you think you're doing? We're getting out of here. I knew all along it had to be a mistake. Do you think that after what you did to Han we're going to trust you? I had no choice... What are you doing? Trust him, trust him! Oh, so we understand, don't we, Chewie? He had no choice. I'm just trying to help... We don't need any of your help. H-a-a-a... What? It sounds like Han. There's still a chance to save Han...I mean, at the East Platform... Chewie. I'm terribly sorry about all this. After all, he's only a Wookiee.</p>
+        </div>
+      </div>
+    </div>
+
+  </div>
+{% endblock %}

--- a/templates/login.html
+++ b/templates/login.html
@@ -1,20 +1,10 @@
 {% from "components/alert.html" import Alert %}
 
-<!DOCTYPE html>
-<html>
-<head>
-  <meta charset="utf-8">
-  <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block title %}JEDI Cloud{% endblock %}</title>
-  {% assets "css" %}
-    <link rel="stylesheet" href="{{ ASSET_URL }}" type="text/css">
-  {% endassets %}
-  <link rel="icon" type="image/x-icon" href="/static/img/favicon.ico">
-</head>
-<body>
+{% extends "base_public.html" %}
 
-<div id='app-root'>
+{% block title %}Sign in | JEDI Cloud{% endblock %}
+
+{% block content %}
 
   <div class='global-layout login-layout'>
     <div class='global-panel-container login-container'>
@@ -38,7 +28,7 @@
             {
               'label': 'Learn More',
               'icon': 'help',
-              'href': '/'
+              'href': '/help'
             }
           ]
         ) }}
@@ -47,16 +37,6 @@
     </div>
   </div>
 
-  <footer class='app-footer'>
-    <h5>Joint Enterprise Defense Infrastructure</h5>
-    <dl class='browser-support'>
-      <dt>JEDI Cloud supported on these web browsers</dt>
-      <dd>Chrome</dd><dd>Firefox</dd><dd>Safari</dd><dd>Edge</dd><dd>IE11 on Windows 10</dd><dd>IE10 on Windows 7</dd>
-  </footer>
-
-</div>
-
-</body>
-</html>
+{% endblock %}
 
 

--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -20,7 +20,7 @@
         </a>
       {% endif %}
 
-      <a href="/" class="topbar__link">
+      <a href="{{ url_for('atst.home') }}" class="topbar__link">
         <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>
         {{ Icon('avatar', classes='topbar__link-icon') }}
       </a>

--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -2,15 +2,23 @@
 
 <header class="topbar">
   <nav class="topbar__navigation">
-    <a href="{{ url_for('atst.home') }}" class="topbar__link topbar__link--shield" title="JEDI Cloud Home">
-      {{ Icon('shield', classes='topbar__link-icon') }}
-    </a>
+    {% if not workspace %}
+      <a href="{{ url_for('atst.home') }}" class="topbar__link topbar__link--home">
+        {{ Icon('shield', classes='topbar__link-icon') }}
+        <span class="topbar__link-label">JEDI Cloud</span>
+      </a>
+    {% else %}
+      <a href="{{ url_for('atst.home') }}" class="topbar__link topbar__link--shield" title="JEDI Cloud Home">
+        {{ Icon('shield', classes='topbar__link-icon') }}
+      </a>
+    {% endif %}
 
     <div class="topbar__context {% if workspace %}topbar__context--workspace{% endif %}">
-      {% set topbar_link = url_for("workspaces.show_workspace", workspace_id=workspace.id) if workspace else url_for("atst.home") %}
-      <a href="{{ topbar_link }}" class="topbar__link">
-        <span class="topbar__link-label">{{ ("Workspace " + workspace.name) if workspace else "JEDI Cloud" }}</span>
-      </a>
+      {% if workspace %}
+        <a href="{{ url_for("workspaces.show_workspace", workspace_id=workspace.id) }}" class="topbar__link topbar__link--workspace">
+          <span class="topbar__link-label">{{ ("Workspace " + workspace.name) }}</span>
+        </a>
+      {% endif %}
 
       <a href="/" class="topbar__link">
         <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -32,11 +32,6 @@
 
     </section>
 
-    {{ Alert('Comments and comment form are fake!',
-      message="<p>Please note, the comments and comment form below are just mocked out. Submitting it will do nothing. These will be hooked up to real functionality shortly. </p><p><strong>Engineer: please remove this alert when you do your thing.</strong></p>",
-      level='warning'
-    ) }}
-
     <section class='internal-notes' id='ccpo-notes'>
       <form method="POST" action="{{ url_for('requests.create_internal_comment', request_id=request.id) }}">
         <div class='panel'>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -8,7 +8,7 @@
 
 <article class='col col--grow request-approval'>
 
-{% if f.errors %}
+{% if review_form.errors or internal_comment_form.errors %}
   {{ Alert('There were some errors',
     message="<p>Please see below.</p>",
     level='error'
@@ -88,7 +88,7 @@
 
     <section class='request-approval__review'>
       <form method="POST" action="{{ url_for("requests.submit_approval", request_id=request.id) }}" autocomplete="off">
-        {{ f.csrf_token }}
+        {{ review_form.csrf_token }}
 
         <ccpo-approval inline-template>
           <div>
@@ -165,7 +165,7 @@
                   <h3>Message to Requestor <span class='subtitle'>(optional)</span></h3>
                   <div v-if='approving' key='approving' v-cloak>
                     {{ TextInput(
-                      f.comment,
+                      review_form.comment,
                       label='Approval comments or notes',
                       description='Provide any comments or notes regarding the approval of this request. <strong>This message will be shared with the person making the JEDI request.</strong>.',
                       paragraph=True,
@@ -175,7 +175,7 @@
 
                   <div v-else key='denying' v-cloak>
                     {{ TextInput(
-                      f.comment,
+                      review_form.comment,
                       label='Revision instructions or notes',
                       paragraph=True,
                       noMaxWidth=True
@@ -194,21 +194,21 @@
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.fname_mao, placeholder="First name of mission authorizing official") }}
+                      {{ TextInput(review_form.fname_mao, placeholder="First name of mission authorizing official") }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.lname_mao, placeholder="Last name of mission authorizing official") }}
+                      {{ TextInput(review_form.lname_mao, placeholder="Last name of mission authorizing official") }}
                     </div>
                   </div>
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.email_mao, placeholder="name@mail.mil", validation='email') }}
+                      {{ TextInput(review_form.email_mao, placeholder="name@mail.mil", validation='email') }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.phone_mao, placeholder="(123) 456-7890", validation='usPhone') }}
+                      {{ TextInput(review_form.phone_mao, placeholder="(123) 456-7890", validation='usPhone') }}
                     </div>
                   </div>
 
@@ -218,11 +218,11 @@
 
                   <div class='form-row'>
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.fname_ccpo, placeholder="First name of CCPO authorizing official") }}
+                      {{ TextInput(review_form.fname_ccpo, placeholder="First name of CCPO authorizing official") }}
                     </div>
 
                     <div class='form-col form-col--half'>
-                      {{ TextInput(f.lname_ccpo, placeholder="Last name of CCPO authorizing official") }}
+                      {{ TextInput(review_form.lname_ccpo, placeholder="Last name of CCPO authorizing official") }}
                     </div>
                   </div>
                 </div>

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -51,8 +51,8 @@
                 <li>
                   <article class='comment-log__log-item'>
                     <div>
-                      <h3 class='comment-log__log-item__header'>{{ comment.full_name_commenter }}</h3>
-                      <p>{{ comment.message }}</p>
+                      <h3 class='comment-log__log-item__header'>{{ comment.user.full_name }}</h3>
+                      <p>{{ comment.text }}</p>
                     </div>
                     {% set timestamp=comment.time_created | formattedDate("%Y-%m-%d %H:%M:%S %Z") %}
                     <footer class='comment-log__log-item__timestamp'>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -82,16 +82,21 @@
       <thead>
         <tr>
           <th scope="col" width="50%">Name</th>
-          <th scope="col" class='table-cell--shrink'>&nbsp;<span class="hide">Status Flag</span></th>
+          <th scope="col">Environments</th>
           <th scope="col">Status</th>
           <th scope="col">Workspace Role</th>
         </tr>
       </thead>
       <tbody>
         {% for m in workspace.members %}
+        {% set num_environment_roles = m.num_environment_roles %}
         <tr>
           <td><a href="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=m.user_id) }}" class="icon-link icon-link--large">{{ m.user_name }}</a></td>
-          <td class='table-cell--shrink'>{% if not m.has_environment_roles %} <span class="label label--info">No Environment Access</span> {% endif %}</td>
+          {% if num_environment_roles %}
+            <td class="table-cell--align-right">{{ num_environment_roles }}</td>
+          {% else %}
+            <td class='table-cell--shrink'><span class="label label--info">No Environment Access</span></td>
+          {% endif %}
           <td>{{ m.status }}</a></td>
           <td>{{ m.role }}</a></td>
         </tr>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -10,7 +10,7 @@
     message="<p>Track your monthly and cumulative expenditures for your workspace, projects, and environments below.</p>\
       <p>Please note that the projected spend is based on the <em>average expense over the last three completed months</em> and therefore does not account for future changes that might be made in scale or configuration of your cloud services.</p>",
     actions=[
-      {"label": "Learn More", "href": "/help", "icon": "info"}
+      {"label": "Learn More", "href": url_for('atst.helpdocs'), "icon": "info"}
     ]  ) }}
 
   <div class='funding-summary-row'>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -10,7 +10,7 @@
     message="<p>Track your monthly and cumulative expenditures for your workspace, projects, and environments below.</p>\
       <p>Please note that the projected spend is based on the <em>average expense over the last three completed months</em> and therefore does not account for future changes that might be made in scale or configuration of your cloud services.</p>",
     actions=[
-      {"label": "Learn More", "href": "/", "icon": "info"}
+      {"label": "Learn More", "href": "/help", "icon": "info"}
     ]  ) }}
 
   <div class='funding-summary-row'>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -78,7 +78,7 @@
               </div>
             </dl>
 
-            <a href='#' class='icon-link'>
+            <a href='{{ url_for("workspaces.workspace", workspace_id=workspace.id) }}' class='icon-link'>
               Manage Task Order
             </a>
           </div>

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -56,7 +56,7 @@
             <h2 class='to-summary__heading'>Task Order</h2>
             <dl class='to-summary__to-number'>
               <dt class='usa-sr-only'>Task Order Number</dt>
-              <dd>1234567890</dd>
+              <dd>{{ task_order.number }}</dd>
             </dl>
           </div>
 
@@ -87,8 +87,8 @@
         <dl class='to-summary__co'>
           <dt>Contracting Officer</dt>
           <dd>
-            Pietro Quirines
-            <a class='icon-link' href='mailto:email@email.com'>email@email.com</a>
+            {{ jedi_request.contracting_officer_full_name }}
+            <a class='icon-link' href='mailto:{{ jedi_request.contracting_officer_email }}'>{{ jedi_request.contracting_officer_email }}</a>
           </dd>
         </dl>
 

--- a/tests/domain/test_requests.py
+++ b/tests/domain/test_requests.py
@@ -223,10 +223,13 @@ def test_request_changes_to_financial_verification_info():
     assert current_review.fname_mao == review_data["fname_mao"]
 
 
-def test_update_internal_comments():
+def test_add_internal_comment():
     request = RequestFactory.create()
     ccpo = UserFactory.from_atat_role("ccpo")
 
-    request = Requests.update_internal_comments(ccpo, request, "this is my comment")
+    assert len(request.internal_comments) == 0
 
-    assert request.internal_comments.text == "this is my comment"
+    request = Requests.add_internal_comment(ccpo, request, "this is my comment")
+
+    assert len(request.internal_comments) == 1
+    assert request.internal_comments[0].text == "this is my comment"

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -191,7 +191,9 @@ class TaskOrderFactory(Base):
     source = Source.MANUAL
     funding_type = FundingType.PROC
     funding_type_other = None
-    number = factory.Faker("md5")
+    number = factory.LazyFunction(
+        lambda: "".join(random.choices(string.ascii_uppercase + string.digits, k=13))
+    )
     expiration_date = factory.LazyFunction(
         lambda: datetime.date(
             datetime.date.today().year + random.randrange(1, 15), 1, 1

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -3,6 +3,7 @@ import string
 import factory
 from uuid import uuid4
 import datetime
+from faker import Faker as _Faker
 
 from atst.forms.data import SERVICE_BRANCHES
 from atst.models.request import Request
@@ -158,6 +159,24 @@ class RequestFactory(Base):
             request=request, revision=request.latest_revision, new_status=status
         )
         return request
+
+    @classmethod
+    def mock_financial_data(cls):
+        fake = _Faker()
+        return {
+            "pe_id": "0101110F",
+            "fname_co": fake.first_name(),
+            "lname_co": fake.last_name(),
+            "email_co": fake.email(),
+            "office_co": fake.phone_number(),
+            "fname_cor": fake.first_name(),
+            "lname_cor": fake.last_name(),
+            "email_cor": fake.email(),
+            "office_cor": fake.phone_number(),
+            "uii_ids": "123abc",
+            "treasury_code": "00123456",
+            "ba_code": "02A",
+        }
 
 
 class PENumberFactory(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -196,7 +196,9 @@ class TaskOrderFactory(Base):
     )
     expiration_date = factory.LazyFunction(
         lambda: datetime.date(
-            datetime.date.today().year + random.randrange(1, 15), 1, 1
+            datetime.date.today().year + random.randrange(1, 5),
+            random.randrange(1, 12),
+            random.randrange(1, 28),
         )
     )
     clin_0001 = random.randrange(100, 100000)

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -129,6 +129,23 @@ def test_ccpo_user_can_comment_on_request(client, user_session):
     assert request.internal_comments[0].text == comment_text
 
 
+def test_ccpo_user_can_comment_on_request(client, user_session):
+    user = UserFactory.from_atat_role("ccpo")
+    user_session(user)
+    request = RequestFactory.create_with_status(
+        status=RequestStatus.PENDING_CCPO_ACCEPTANCE
+    )
+    assert len(request.internal_comments) == 0
+
+    comment_form_data = {"text": ""}
+    response = client.post(
+        url_for("requests.create_internal_comment", request_id=request.id),
+        data=comment_form_data,
+    )
+    assert response.status_code == 200
+    assert len(request.internal_comments) == 0
+
+
 def test_other_user_cannot_comment_on_request(client, user_session):
     user = UserFactory.create()
     user_session(user)

--- a/tests/routes/test_request_approval.py
+++ b/tests/routes/test_request_approval.py
@@ -129,7 +129,7 @@ def test_ccpo_user_can_comment_on_request(client, user_session):
     assert request.internal_comments[0].text == comment_text
 
 
-def test_ccpo_user_can_comment_on_request(client, user_session):
+def test_comment_text_is_required(client, user_session):
     user = UserFactory.from_atat_role("ccpo")
     user_session(user)
     request = RequestFactory.create_with_status(

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -6,6 +6,7 @@ from .mocks import DOD_SDN_INFO, DOD_SDN, FIXTURE_EMAIL_ADDRESS
 from atst.domain.users import Users
 from atst.domain.roles import Roles
 from atst.domain.exceptions import NotFoundError
+from atst.domain.auth import UNPROTECTED_ROUTES
 from .factories import UserFactory
 
 
@@ -68,6 +69,8 @@ def test_unsuccessful_login_redirect(client, monkeypatch):
 
 
 # checks that all of the routes in the app are protected by auth
+def is_unprotected(rule):
+    return rule.endpoint in UNPROTECTED_ROUTES
 
 
 def test_routes_are_protected(client, app):
@@ -75,7 +78,7 @@ def test_routes_are_protected(client, app):
         args = [1] * len(rule.arguments)
         mock_args = dict(zip(rule.arguments, args))
         _n, route = rule.build(mock_args)
-        if route in UNPROTECTED_ROUTES or "/static" in route:
+        if is_unprotected(rule) or "/static" in route:
             continue
 
         if "GET" in rule.methods:
@@ -89,7 +92,6 @@ def test_routes_are_protected(client, app):
             assert resp.headers["Location"] == "http://localhost/"
 
 
-UNPROTECTED_ROUTES = ["/", "/login-dev", "/login-redirect", "/unauthorized"]
 # this implicitly relies on the test config and test CRL in tests/fixtures/crl
 
 


### PR DESCRIPTION
This adds a single public '/help' route with some dummy navigation and content.
A handful of "learn more" links throughout are now directing to this page.

Also fixes a few layout issues with the topbar and footer.

Also makes a separate `base_public` template, which is inherited by public pages, such as login and help. The login route now has a separate template inheriting from this.

![help](https://user-images.githubusercontent.com/40467269/45976977-36712b80-c016-11e8-8f20-9b08392494eb.png)
