### PR TITLE
Empty state for workspace reports should show existing projects

### DIFF
--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -215,16 +215,18 @@ class Reports:
     @classmethod
     def monthly_totals(cls, workspace):
         if workspace.name in REPORT_FIXTURE_MAP:
-            data = REPORT_FIXTURE_MAP[workspace.name]["monthly"]
-            project_totals = _derive_project_totals(data)
-            workspace_totals = _derive_workspace_totals(project_totals)
+            environments = REPORT_FIXTURE_MAP[workspace.name]["monthly"]
         else:
-            data = {}
-            project_totals = {}
-            workspace_totals = {}
+            environments = {
+                project.name: {env.name: {} for env in project.environments}
+                for project in workspace.projects
+            }
+
+        project_totals = _derive_project_totals(environments)
+        workspace_totals = _derive_workspace_totals(project_totals)
 
         return {
-            "environments": data,
+            "environments": environments,
             "projects": project_totals,
             "workspace": workspace_totals,
         }

--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from itertools import groupby
 
 
@@ -237,7 +236,6 @@ class Reports:
         if workspace.name in REPORT_FIXTURE_MAP:
             months = REPORT_FIXTURE_MAP[workspace.name]["cumulative"]
         else:
-            this_month = datetime.today().strftime("%m/%Y")
-            months = {this_month: {"spend": 0, "cumulative": 0}}
+            months = {}
 
         return {"months": months}

--- a/atst/domain/reports.py
+++ b/atst/domain/reports.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from itertools import groupby
 
 
@@ -236,6 +237,7 @@ class Reports:
         if workspace.name in REPORT_FIXTURE_MAP:
             months = REPORT_FIXTURE_MAP[workspace.name]["cumulative"]
         else:
-            months = {}
+            this_month = datetime.today().strftime("%m/%Y")
+            months = {this_month: {"spend": 0, "cumulative": 0}}
 
         return {"months": months}

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -103,7 +103,7 @@
   {% set two_months_ago_index = two_months_ago.strftime('%m/%Y') %}
   {% set reports_url = url_for("workspaces.workspace_reports", workspace_id=workspace.id) %}
 
-  {% if not monthly_totals['environments'] %}
+  {% if not workspace.projects %}
 
     {% set can_create_projects = user_can(permissions.ADD_APPLICATION_IN_WORKSPACE) %}
     {% set message = 'This Workspace has no Cloud Environments setup, hence there is no spending data to report. Create a Project with some Cloud Environments to get started.'

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -335,6 +335,9 @@
               {{ month.strftime('%B %Y') }}
             </option>
           {% endfor %}
+          {% if not cumulative_budget["months"] %}
+            <option>{{ current_month.strftime('%B %Y') }}</option>
+          {% endif %}
         </select>
       </div>
 


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/160732667

We only show the empty state for the reports page if the workspace has no projects. I also updated the reporting methods so that the projects and environments for a workspace are displayed even if there's no spend.