### PR TITLE
Fix link to github repo in buildinfo.json

### DIFF
--- a/script/generate_build_info.sh
+++ b/script/generate_build_info.sh
@@ -57,7 +57,7 @@ GITHUB_COMMIT_URL="${GITHUB_BASE_URL}/commit/${GIT_SHA}"
 APP_CONTAINER_CREATE_DATE=$(date '+%Y-%m-%d')
 APP_CONTAINER_CREATE_TIME=$(date '+%H:%M:%S')
 
-echo "Generating public/buildinfo.json ..."
+echo "Generating ${STATIC_DIR}/buildinfo.json ..."
 cat > ${STATIC_DIR}/buildinfo.json <<ENDJSON
 {
   "build_info" : {
@@ -86,7 +86,7 @@ cat > ${STATIC_DIR}/buildinfo.json <<ENDJSON
 }
 ENDJSON
 
-echo "Generating public/buildinfo.html ..."
+echo "Generating ${STATIC_DIR}/buildinfo.html ..."
 cat > ${STATIC_DIR}/buildinfo.html <<ENDHTML
 <HTML>
 <HEAD>

--- a/script/generate_build_info.sh
+++ b/script/generate_build_info.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# script/generate_build_info: Generates buildinfo.html and buildinfo.json and 
+# script/generate_build_info: Generates buildinfo.html and buildinfo.json and
 #                             places them in a publically accessable static asset
 #                             folder
 
@@ -36,7 +36,7 @@ echo "Gathering info from git..."
 COMMIT_AUTHOR=$(git log -1 --pretty=%aN)
 COMMIT_AUTHOR_EMAIL=$(git log -1 --pretty=%aE)
 GIT_SHA=$(git rev-parse HEAD)
-# Escape all double quotes in commit message and switch newlines for \n 
+# Escape all double quotes in commit message and switch newlines for \n
 # (for JSON compatability)
 COMMIT_MESSAGE_JSON=$(git log -1 --pretty=format:%B | sed -e 's#\([^\\]\)"#\1\\"#g' | awk 1 ORS='\\n')
 # Escape all < and > characters in commit message and trade newlines for <BR/> tags
@@ -44,7 +44,7 @@ COMMIT_MESSAGE_HTML=$(git log -1 --pretty=format:%B | sed -e 's#>#&gt;#g' | sed 
 
 # Assemble https based git repo url
 GIT_REPO=$(git config --get remote.origin.url | cut -d ':' -f 2)
-GIT_URL="https://github.com/${GIT_REPO}"
+GIT_URL="https:${GIT_REPO}"
 # Drop the trailing .git for generating github links
 GITHUB_BASE_URL="${GIT_URL%.git}"
 GITHUB_COMMIT_URL="${GITHUB_BASE_URL}/commit/${GIT_SHA}"

--- a/script/generate_build_info.sh
+++ b/script/generate_build_info.sh
@@ -43,8 +43,13 @@ COMMIT_MESSAGE_JSON=$(git log -1 --pretty=format:%B | sed -e 's#\([^\\]\)"#\1\\"
 COMMIT_MESSAGE_HTML=$(git log -1 --pretty=format:%B | sed -e 's#>#&gt;#g' | sed -e 's#<#&lt;#g' | awk 1 ORS='<BR/>')
 
 # Assemble https based git repo url
-GIT_REPO=$(git config --get remote.origin.url | cut -d ':' -f 2)
-GIT_URL="https:${GIT_REPO}"
+GIT_REMOTE_URL=$(git config --get remote.origin.url)
+if [[ ${GIT_REMOTE_URL} =~ "@" ]]
+then
+    GIT_URL="https://github.com/$(echo "${GIT_REMOTE_URL}" | cut -d ':' -f 2)"
+else
+    GIT_URL="${GIT_REMOTE_URL}"
+fi
 # Drop the trailing .git for generating github links
 GITHUB_BASE_URL="${GIT_URL%.git}"
 GITHUB_COMMIT_URL="${GITHUB_BASE_URL}/commit/${GIT_SHA}"

--- a/script/generate_build_info.sh
+++ b/script/generate_build_info.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 #
 # script/generate_build_info: Generates buildinfo.html and buildinfo.json and
-#                             places them in a publically accessable static asset
+#                             places them in a publicly accessable static asset
 #                             folder
 
 source "$(dirname "${0}")"/../script/include/global_header.inc.sh


### PR DESCRIPTION
The current buildinfo (https://www.atat.codes/static/buildinfo.html) links to the commit with an extra `https://github.com/`, for example: `https://github.com///github.com/dod-ccpo/atst/commit/2bbb859ad8c92ece65807457c56107a58e5f500c`. This change should make a valid link.