### PR TITLE
Prevent toggler from submitting form

### DIFF
--- a/js/components/toggler.js
+++ b/js/components/toggler.js
@@ -25,6 +25,7 @@ export default {
 
   methods: {
     toggle: function (e) {
+      e.preventDefault()
       this.isVisible = !this.isVisible
     }
   }


### PR DESCRIPTION
## Description
When the user clicked the carrot next to project names to collapse the list of environments, the form was being submitted and the user would be redirected to the view members page. This PR prevents the toggler from submitting the form so that it works as expected.