### PR TITLE
Always set initial text input value when field data is not None

### DIFF
--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -17,7 +17,7 @@
     validation='{{ validation }}'
     {% if paragraph %}paragraph='true'{% endif %}
     {% if noMaxWidth %}no-max-width='true'{% endif %}
-    {% if initial_value or field.data %}initial-value='{{ initial_value or field.data }}'{% endif %}
+    {% if initial_value or field.data is not none %}initial-value='{{ initial_value or field.data }}'{% endif %}
     {% if field.errors %}v-bind:initial-errors='{{ field.errors }}'{% endif %}
     key='{{ field.name }}'
     inline-template>


### PR DESCRIPTION
Fixes an issue where $0 entries for CLIN values were not being rendered. Now, they will be shown appropriately:

![image](https://user-images.githubusercontent.com/40774582/46032060-9de7b380-c0c8-11e8-8bd2-105dcc15f661.png)
