### PR TITLE
Hook up the "Add Environment Access" link when adding a member

### DIFF
--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -89,7 +89,14 @@ def show_workspace(workspace_id):
 @bp.route("/workspaces/<workspace_id>/members")
 def workspace_members(workspace_id):
     workspace = Workspaces.get_with_members(g.current_user, workspace_id)
-    return render_template("workspaces/members/index.html", workspace=workspace)
+    new_member_name = http_request.args.get("newMemberName")
+    new_member = next(
+        filter(lambda m: m.user_name == new_member_name, workspace.members), None
+    )
+
+    return render_template(
+        "workspaces/members/index.html", workspace=workspace, new_member=new_member
+    )
 
 
 @bp.route("/workspaces/<workspace_id>/reports")

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -20,11 +20,10 @@
 
 {% else %}
 
-{% set new_member_name = request.args.get("newMemberName") %}
-{% if new_member_name %}
+{% if new_member %}
     {% set message -%}
-      <p>{{ new_member_name }} was successfully invited via email to this workspace. They do not yet have access to any environments.</p>
-      <p><a href="#">Add environment access.</a></p>
+      <p>{{ new_member.user_name }} was successfully invited via email to this workspace. They do not yet have access to any environments.</p>
+      <p><a href="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=new_member.user_id) }}">Add environment access.</a></p>
     {%- endset %}
 
   {{ Alert('Member added successfully',


### PR DESCRIPTION
After adding a member to a workspace, an alert is shown with a link to add environment access that previously did nothing. Now, it will link to the edit workspace member page:

![image](https://user-images.githubusercontent.com/40774582/46040579-b367d800-c0de-11e8-9e58-aa95eef2c60b.png)
