### PR TITLE
Set currently logged in user on all routes

### DIFF
--- a/atst/domain/auth.py
+++ b/atst/domain/auth.py
@@ -17,14 +17,11 @@ def apply_authentication(app):
     @app.before_request
     # pylint: disable=unused-variable
     def enforce_login():
-
-        if not _unprotected_route(request):
-            user = get_current_user()
-            if user:
-                g.current_user = user
-
-            else:
-                return redirect(url_for("atst.root"))
+        user = get_current_user()
+        if user:
+            g.current_user = user
+        elif not _unprotected_route(request):
+            return redirect(url_for("atst.root"))
 
 
 def get_current_user():


### PR DESCRIPTION
Previously, we would only set `g.current_user` for protected routes. Recent changes to the header in the public routes, however, were expecting this to be set all the time. Now, you'll still see your user name in the header of public routes, if logged in, instead of a "Login" button:

![image](https://user-images.githubusercontent.com/40774582/46108668-9568a900-c1ac-11e8-9d40-30d43e6cb9e6.png)

Previously, the top right would always show "Login", even if the user was already logged in.