### PR TITLE
IE Budget Report page fixes

### DIFF
--- a/js/components/charts/budget_chart.js
+++ b/js/components/charts/budget_chart.js
@@ -34,6 +34,7 @@ export default {
   mounted: function () {
     this._setDisplayedMonths()
     this._setMetrics()
+    addEventListener('load', this._setMetrics)
     addEventListener('resize', this._setMetrics)
   },
 

--- a/styles/components/_empty_state.scss
+++ b/styles/components/_empty_state.scss
@@ -4,6 +4,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
+  max-width: 100%;
 
   @include media($medium-screen) {
     padding: 8rem ($gap * 4) 0;
@@ -28,6 +29,7 @@
   .empty-state__sub-message {
     @include h4;
     color: $color-gray;
+    max-width: 100%;
 
     @include media($large-screen) {
       @include h3;

--- a/styles/components/_global_layout.scss
+++ b/styles/components/_global_layout.scss
@@ -24,25 +24,10 @@
     max-width: $site-max-width;
     overflow-x: hidden;
     flex-grow: 1;
-
-    @include ie-only {
-      max-width: 85%;
-    }
+    -ms-flex-negative: 1;
 
     @include media($medium-screen) {
       margin: $gap * 2;
-    }
-
-    @include media($large-screen) {
-      @include ie-only {
-        max-width: 80%;
-      }
-    }
-
-    @include media($xlarge-screen) {
-      @include ie-only {
-        max-width: $site-max-width;
-      }
     }
   }
 }

--- a/styles/sections/_reports.scss
+++ b/styles/sections/_reports.scss
@@ -14,6 +14,10 @@
       flex-direction: row;
       flex-basis: 50%;
 
+      @include ie-only {
+        max-width: 50%;
+      }
+
       &:first-child {
         padding-left: 0;
       }
@@ -26,7 +30,10 @@
 
     .panel {
       padding: $gap * 2;
-      flex-grow: 1;
+
+      @include ie-only {
+        max-width: 100%;
+      }
 
 
       // Spending Summary
@@ -38,19 +45,33 @@
 
         .row {
           justify-content: space-between;
+
+          @include ie-only {
+            max-width: 100%;
+            flex-wrap: wrap;
+          }
         }
 
         .spend-summary__heading {
           @include h3;
           margin: 0 $gap 0 0;
+          -ms-flex-negative: 1;
         }
 
         .spend-summary__budget {
           margin: 0 0 0 $gap;
 
+          @include ie-only {
+            margin: $gap 0 0 0;
+          }
+
           > div {
             text-align: right;
             margin: 0 0 ($gap / 2) 0;
+
+            @include ie-only {
+              text-align: left;
+            }
 
             dd, dt {
               display: inline;

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -365,7 +365,9 @@
               <td class='table-cell--align-right previous-month'>{{ workspace_totals.get(prev_month_index, 0) | dollars }}</td>
               <td class='table-cell--align-right current-month'>{{ workspace_totals.get(current_month_index, 0) | dollars }}</td>
               <td class='table-cell--expand current-month meter-cell'>
-                <meter value='{{ workspace_totals.get(current_month_index, 0) }}' min='0' max='{{ workspace_totals.get(current_month_index, 0) }}'></meter>
+                <meter value='{{ workspace_totals.get(current_month_index, 0) }}' min='0' max='{{ workspace_totals.get(current_month_index, 0) }}'>
+                  <div class='meter__fallback' style='width: 100%'></div>
+                </meter>
               </td>
             </tr>
           </tbody>


### PR DESCRIPTION
Fixes a few things:

https://www.pivotaltracker.com/story/show/160794811
Fixes box layout at the top of the budget page, so they split 50/50 correctly

https://www.pivotaltracker.com/story/show/160794046
Fixes a problem with all layouts that prevented the global layout container from shrinking to fit the window. This was just most apparent on this screen, but was problem everywhere.

https://www.pivotaltracker.com/story/show/160795011
Adds a missing fallback meter bar

https://www.pivotaltracker.com/story/show/160794726
Restricts text width in EmptyState block, which was flowing off screen in IE