### PR TITLE
do not set default kwarg for atat role when creating users

### DIFF
--- a/atst/domain/authnid/__init__.py
+++ b/atst/domain/authnid/__init__.py
@@ -31,7 +31,9 @@ class AuthenticationContext:
 
         except NotFoundError:
             email = self._get_user_email()
-            return Users.create(**{"email": email, **self.parsed_sdn})
+            return Users.create(
+                atat_role_name="default", email=email, **self.parsed_sdn
+            )
 
     def _get_user_email(self):
         try:

--- a/atst/domain/users.py
+++ b/atst/domain/users.py
@@ -28,7 +28,7 @@ class Users(object):
         return user
 
     @classmethod
-    def create(cls, atat_role_name="developer", **kwargs):
+    def create(cls, atat_role_name=None, **kwargs):
         atat_role = Roles.get(atat_role_name)
 
         try:

--- a/atst/domain/workspaces/workspaces.py
+++ b/atst/domain/workspaces/workspaces.py
@@ -85,6 +85,7 @@ class Workspaces(object):
             first_name=data["first_name"],
             last_name=data["last_name"],
             email=data["email"],
+            atat_role_name="default",
         )
         return Workspaces.add_member(workspace, new_user, data["workspace_role"])
 


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/160832928

@patricksmithdds and I discovered a bug from my early user creation code. We were setting the default ATAT roles for users to be "developer" when they first log in, which allows them to view all workspaces(!!). This fixes that specific problem.

More generally, we should have a longer conversation around authorization and permission management.