### PR TITLE
hide PDF link when PDF download is not available

### DIFF
--- a/templates/requests/_review.html
+++ b/templates/requests/_review.html
@@ -141,9 +141,13 @@
   </h2>
 
   <div>
-    <a href="{{ url_for("requests.task_order_pdf_download", request_id=request_id)}}" download>
-      Download the Task Order PDF
-    </a>
+    {% if jedi_request.task_order.pdf %}
+        <a href="{{ url_for("requests.task_order_pdf_download", request_id=request_id)}}" download>
+          Download the Task Order PDF
+        </a>
+    {% else %}
+      <p>No Task Order PDF attached.</p>
+    {% endif %}
   </div>
 
   <dl>


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/n/projects/2160940/stories/160757166

We should only show the link to the task order PDF if it's definitely available. Thanks to Leigh for the help.

![screen shot 2018-09-28 at 2 33 12 pm](https://user-images.githubusercontent.com/38955503/46226818-79d7dc80-c32b-11e8-80a4-8f076f6b68aa.png)
