### PR TITLE
UII IDs are optional for financial verification

### DIFF
--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -105,7 +105,6 @@ class BaseFinancialForm(ValidatedForm):
     uii_ids = NewlineListField(
         "Unique Item Identifier (UII)s related to your application(s) if you already have them.",
         description="If you have more than one UII, place each one on a new line.",
-        validators=[InputRequired()],
     )
 
     pe_id = StringField(


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/160796174

UII IDs are not required, per the PT story. There are no other validations on the field, so we can just remove the validators.