### PR TITLE
Fix environment listing for user

### DIFF
--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -44,7 +44,7 @@ class Environments(object):
             .join(EnvironmentRole)
             .join(Project)
             .filter(EnvironmentRole.user_id == user.id)
-            .filter(Project.id == Environment.project_id)
+            .filter(Environment.project_id == project.id)
             .all()
         )
 

--- a/templates/navigation/workspace_navigation.html
+++ b/templates/navigation/workspace_navigation.html
@@ -16,25 +16,29 @@
       ]
     ) }}
 
-    {{ SidenavItem(
-      "Members",
-      href=url_for("workspaces.workspace_members", workspace_id=workspace.id),
-      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/members'),
-      subnav=None if not user_can(permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE) else [
-        {
-          "label": "Add New Member",
-          "href": url_for("workspaces.new_member", workspace_id=workspace.id),
-          "active": request.url_rule.rule.startswith('/workspaces/<workspace_id>/members/new'),
-          "icon": "plus"
-        }
-      ]
-    ) }}
+    {% if user_can(permissions.VIEW_WORKSPACE_MEMBERS) %}
+      {{ SidenavItem(
+        "Members",
+        href=url_for("workspaces.workspace_members", workspace_id=workspace.id),
+        active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/members'),
+        subnav=None if not user_can(permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE) else [
+          {
+            "label": "Add New Member",
+            "href": url_for("workspaces.new_member", workspace_id=workspace.id),
+            "active": request.url_rule.rule.startswith('/workspaces/<workspace_id>/members/new'),
+            "icon": "plus"
+          }
+        ]
+      ) }}
+    {% endif %}
 
-    {{ SidenavItem(
-      "Budget Report",
-      href=url_for("workspaces.workspace_reports", workspace_id=workspace.id),
-      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/reports')
-    ) }}
+    {% if user_can(permissions.VIEW_USAGE_DOLLARS) %}
+      {{ SidenavItem(
+        "Budget Report",
+        href=url_for("workspaces.workspace_reports", workspace_id=workspace.id),
+        active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/reports')
+      ) }}
+    {% endif %}
 
     {% if user_can(permissions.EDIT_WORKSPACE_INFORMATION) %}
       {{ SidenavItem(

--- a/templates/workspaces/projects/index.html
+++ b/templates/workspaces/projects/index.html
@@ -25,10 +25,12 @@
     <div class='block-list project-list-item'>
       <header class='block-list__header'>
         <h2 class='block-list__title'>{{ project.name }} ({{ project.environments|length }} environments)</h2>
-        <a class='icon-link' href='{{ url_for("workspaces.edit_project", workspace_id=workspace.id, project_id=project.id) }}'>
-          {{ Icon('edit') }}
-          <span>edit</span>
-        </a>
+        {% if user_can(permissions.RENAME_APPLICATION_IN_WORKSPACE) %}
+          <a class='icon-link' href='{{ url_for("workspaces.edit_project", workspace_id=workspace.id, project_id=project.id) }}'>
+            {{ Icon('edit') }}
+            <span>edit</span>
+          </a>
+        {% endif %}
       </header>
       <ul>
         {% for environment in project.environments %}

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -4,11 +4,19 @@ from uuid import uuid4
 from atst.domain.environments import Environments
 from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.projects import Projects
+from atst.domain.roles import Roles
 from atst.domain.workspaces import Workspaces
 from atst.domain.workspace_users import WorkspaceUsers
 from atst.domain.exceptions import NotFoundError
+from atst.models.environment_role import EnvironmentRole
 
-from tests.factories import RequestFactory, UserFactory
+from tests.factories import (
+    RequestFactory,
+    UserFactory,
+    WorkspaceFactory,
+    EnvironmentFactory,
+    ProjectFactory,
+)
 
 
 def test_update_environment_roles():
@@ -43,3 +51,24 @@ def test_update_environment_roles():
 
     assert new_dev_env_role.role == "billing_admin"
     assert staging_env_role.role == "developer"
+
+
+def test_get_scoped_environments(db):
+    developer = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    workspace_user = Workspaces.add_member(workspace, developer, "developer")
+    project1 = ProjectFactory.create(workspace=workspace)
+    project2 = ProjectFactory.create(workspace=workspace)
+    env1 = EnvironmentFactory.create(project=project1, name="project1 dev")
+    env2 = EnvironmentFactory.create(project=project1, name="project1 staging")
+    env3 = EnvironmentFactory.create(project=project2, name="project2 dev")
+    env4 = EnvironmentFactory.create(project=project2, name="project2 staging")
+    db.session.add(EnvironmentRole(user=developer, environment=env1, role="developer"))
+    db.session.add(EnvironmentRole(user=developer, environment=env4, role="developer"))
+    db.session.commit()
+
+    project1_envs = Environments.for_user(developer, project1)
+    assert [env.name for env in project1_envs] == ["project1 dev"]
+
+    project2_envs = Environments.for_user(developer, project2)
+    assert [env.name for env in project2_envs] == ["project2 staging"]

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -6,11 +6,13 @@ import datetime
 from faker import Faker as _Faker
 
 from atst.forms.data import SERVICE_BRANCHES
+from atst.models.environment import Environment
 from atst.models.request import Request
 from atst.models.request_revision import RequestRevision
 from atst.models.request_review import RequestReview
 from atst.models.request_status_event import RequestStatusEvent, RequestStatus
 from atst.models.pe_number import PENumber
+from atst.models.project import Project
 from atst.models.task_order import TaskOrder, Source, FundingType
 from atst.models.user import User
 from atst.models.role import Role
@@ -217,3 +219,17 @@ class WorkspaceFactory(Base):
     request = factory.SubFactory(RequestFactory)
     # name it the same as the request ID by default
     name = factory.LazyAttribute(lambda w: w.request.id)
+
+
+class ProjectFactory(Base):
+    class Meta:
+        model = Project
+
+    workspace = factory.SubFactory(WorkspaceFactory)
+    name = factory.Faker("name")
+    description = "A test project"
+
+
+class EnvironmentFactory(Base):
+    class Meta:
+        model = Environment


### PR DESCRIPTION
This PR addresses three things:

1. A [bug](https://www.pivotaltracker.com/story/show/160836122) that appeared to show a user more environments than they have access to. This was actually due to a missing filter when fetching environments for a project (causing _all_ environments a user has access to to be returned for each project).
2. Hides the workspace nav items that the user does not have access to (viewing workspace members, viewing the budget report).
3. Hides the "edit" button for projects that the user cannot edit.
