### PR TITLE
Show acceptance modal on requests index

### DIFF
--- a/templates/requests/index.html
+++ b/templates/requests/index.html
@@ -25,6 +25,16 @@
     </div>
   {% endcall %}
 
+  {% call Modal(name='pendingCCPOAcceptance', dismissable=True) %}
+    <h1>Request submitted!</h1>
+
+    {% include 'fragments/pending_ccpo_acceptance_alert.html' %}
+
+    <div class='action-group'>
+      <a v-on:click="closeModal('pendingCCPOAcceptance')" class='action-group__action usa-button'>Close</a>
+    </div>
+  {% endcall %}
+
 {% if num_action_required %}
   {% set title -%}
     Action required on {{ num_action_required }} requests.

--- a/templates/requests/index.html
+++ b/templates/requests/index.html
@@ -17,6 +17,7 @@
   {% endcall %}
 
   {% call Modal(name='pendingCCPOApproval', dismissable=True) %}
+    <h1>Financial Verification submitted!</h1>
 
     {% include 'fragments/pending_ccpo_approval_modal.html' %}
 


### PR DESCRIPTION
When a request is submitted and not automatically approved, we should show the "pending acceptance" modal:

![image](https://user-images.githubusercontent.com/40774582/46297710-57340680-c56b-11e8-9bda-d660b7ebf55b.png)
