### PR TITLE
Fix report display for task order with no expiration date

### DIFF
--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -121,7 +121,7 @@ def workspace_reports(workspace_id):
         remaining_difference = expiration_date - today
         remaining_days = remaining_difference.days
     else:
-        remaining_days = 0
+        remaining_days = None
 
     return render_template(
         "workspaces/reports/index.html",

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -65,16 +65,26 @@
               <div>
                 <dt>Expires</dt>
                 <dd>
-                  <local-datetime
-                    timestamp='{{ expiration_date }}'
-                    format='MMMM D, YYYY'>
-                    </local-datetime>
+                  {% if expiration_date %}
+                    <local-datetime
+                      timestamp='{{ expiration_date }}'
+                      format='MMMM D, YYYY'>
+                      </local-datetime>
+                  {% else %}
+                      -
+                  {% endif %}
                 </dd>
               </div>
 
               <div>
                 <dt>Remaining</dt>
-                <dd>{{ remaining_days }} days</dd>
+                <dd>
+                  {% if remaining_days %}
+                    {{ remaining_days }} days
+                  {% else %}
+                    -
+                  {% endif %}
+                </dd>
               </div>
             </dl>
 

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -79,7 +79,7 @@
               <div>
                 <dt>Remaining</dt>
                 <dd>
-                  {% if remaining_days %}
+                  {% if remaining_days is not none %}
                     {{ remaining_days }} days
                   {% else %}
                     -


### PR DESCRIPTION
Update the budget report so that it displays a `-` instead of `Invalid Date` when the workspace's task order has no `expiration_date`.

![screen shot 2018-10-01 at 2 26 26 pm](https://user-images.githubusercontent.com/38955572/46307997-78eeb700-c586-11e8-8255-51489be9e791.png)
