### PR TITLE
Hide Budget Report link from developers of workspaces

### DIFF
--- a/atst/domain/roles.py
+++ b/atst/domain/roles.py
@@ -119,7 +119,6 @@ WORKSPACE_ROLES = [
         "description": "Views only the projects and environments they are granted access to. Can also view members associated with each environment.",
         "permissions": [
             Permissions.VIEW_USAGE_REPORT,
-            Permissions.VIEW_USAGE_DOLLARS,
             Permissions.VIEW_WORKSPACE,
             Permissions.VIEW_APPLICATION_IN_WORKSPACE,
         ],

--- a/atst/domain/users.py
+++ b/atst/domain/users.py
@@ -28,11 +28,11 @@ class Users(object):
         return user
 
     @classmethod
-    def create(cls, atat_role_name=None, **kwargs):
+    def create(cls, dod_id, atat_role_name=None, **kwargs):
         atat_role = Roles.get(atat_role_name)
 
         try:
-            user = User(atat_role=atat_role, **kwargs)
+            user = User(dod_id=dod_id, atat_role=atat_role, **kwargs)
             db.session.add(user)
             db.session.commit()
         except IntegrityError:
@@ -46,7 +46,7 @@ class Users(object):
         try:
             user = Users.get_by_dod_id(dod_id)
         except NotFoundError:
-            user = Users.create(dod_id=dod_id, **kwargs)
+            user = Users.create(dod_id, **kwargs)
             db.session.add(user)
             db.session.commit()
 

--- a/tests/domain/test_users.py
+++ b/tests/domain/test_users.py
@@ -8,13 +8,13 @@ DOD_ID = "my_dod_id"
 
 
 def test_create_user():
-    user = Users.create("developer", dod_id=DOD_ID)
+    user = Users.create(DOD_ID, "developer")
     assert user.atat_role.name == "developer"
 
 
 def test_create_user_with_nonexistent_role():
     with pytest.raises(NotFoundError):
-        Users.create("nonexistent", dod_id=DOD_ID)
+        Users.create(DOD_ID, "nonexistent")
 
 
 def test_get_or_create_nonexistent_user():
@@ -29,37 +29,37 @@ def test_get_or_create_existing_user():
 
 
 def test_get_user():
-    new_user = Users.create("developer", dod_id=DOD_ID)
+    new_user = Users.create(DOD_ID, "developer")
     user = Users.get(new_user.id)
     assert user.id == new_user.id
 
 
 def test_get_nonexistent_user():
-    Users.create("developer", dod_id=DOD_ID)
+    Users.create(DOD_ID, "developer")
     with pytest.raises(NotFoundError):
         Users.get(uuid4())
 
 
 def test_get_user_by_dod_id():
-    new_user = Users.create("developer", dod_id=DOD_ID)
+    new_user = Users.create(DOD_ID, "developer")
     user = Users.get_by_dod_id(DOD_ID)
     assert user == new_user
 
 
 def test_update_user():
-    new_user = Users.create("developer", dod_id=DOD_ID)
+    new_user = Users.create(DOD_ID, "developer")
     updated_user = Users.update(new_user.id, "ccpo")
 
     assert updated_user.atat_role.name == "ccpo"
 
 
 def test_update_nonexistent_user():
-    Users.create("developer", dod_id=DOD_ID)
+    Users.create(DOD_ID, "developer")
     with pytest.raises(NotFoundError):
         Users.update(uuid4(), "ccpo")
 
 
 def test_update_existing_user_with_nonexistent_role():
-    new_user = Users.create("developer", dod_id=DOD_ID)
+    new_user = Users.create(DOD_ID, "developer")
     with pytest.raises(NotFoundError):
         Users.update(new_user.id, "nonexistent")

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -9,6 +9,30 @@ from atst.domain.environment_roles import EnvironmentRoles
 from atst.models.workspace_user import WorkspaceUser
 
 
+def test_user_with_permission_has_budget_report_link(client, user_session):
+    user = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(user, workspace, "owner")
+
+    user_session(user)
+    response = client.get("/workspaces/{}/projects".format(workspace.id))
+    assert (
+        'href="/workspaces/{}/reports"'.format(workspace.id).encode() in response.data
+    )
+
+
+def test_user_without_permission_has_no_budget_report_link(client, user_session):
+    user = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(user, workspace, "developer")
+    user_session(user)
+    response = client.get("/workspaces/{}/projects".format(workspace.id))
+    assert (
+        'href="/workspaces/{}/reports"'.format(workspace.id).encode()
+        not in response.data
+    )
+
+
 def test_user_with_permission_has_add_project_link(client, user_session):
     user = UserFactory.create()
     workspace = WorkspaceFactory.create()


### PR DESCRIPTION
## Description
Developers of a workspace should not have permission to see Budget Reports. The `VIEW_USAGE_DOLLARS` permission was still on the developer role, which was incorrect. This PR removes that permission and adds two tests. 

While working on this bug, I found that some recent changes to the `User` model affected the use of `Users.create()` in an unintuitive way. The attribute `dod_id` can no longer be `null`, so I updated the method to make this change more obvious. 

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/160894086

## Screenshots
![screen shot 2018-10-01 at 5 16 34 pm](https://user-images.githubusercontent.com/42577527/46316436-26b99000-c59e-11e8-98a5-4243d19c7275.png)
