### PR TITLE
Reduce alerts on financial form

### DIFF
--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -156,7 +156,6 @@ class FinancialForm(BaseFinancialForm):
         return "task_order_number" in self.errors and len(self.errors) == 1
 
 
-
 class ExtendedFinancialForm(BaseFinancialForm):
     def validate(self, *args, **kwargs):
         if self.funding_type.data == "OTHER":

--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -151,6 +151,11 @@ class FinancialForm(BaseFinancialForm):
     def is_missing_task_order_number(self):
         return "task_order_number" in self.errors
 
+    @property
+    def is_only_missing_task_order_number(self):
+        return "task_order_number" in self.errors and len(self.errors) == 1
+
+
 
 class ExtendedFinancialForm(BaseFinancialForm):
     def validate(self, *args, **kwargs):

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -9,7 +9,7 @@
 
 {% include 'requests/review_menu.html' %}
 
-{% if request.is_pending_financial_verification %}
+{% if request.is_pending_financial_verification and not f.errors and not extended %}
   {{ Alert('Pending Financial Verification', fragment="fragments/pending_financial_verification.html") }}
 {% endif %}
 

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -22,7 +22,7 @@
 
   {% if extended %}
     {{ Alert('Manually enter Task Order information',
-      message="Additional field are displayed below, where you can manually enter financial information as documented in your Task Order.",
+      message="Additional fields are displayed below, where you can manually enter financial information as documented in your Task Order.",
       level='warning',
       actions=[
         {

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -23,7 +23,14 @@
   {% if extended %}
     {{ Alert('Manually enter Task Order information',
       message="Additional field are displayed below, where you can manually enter financial information as documented in your Task Order.",
-      level='warning'
+      level='warning',
+      actions=[
+        {
+          'href': url_for('atst.helpdocs'),
+          'label': 'Learn more about the JEDI Cloud Task Order and the Financial Verification process.',
+          'icon': 'help'
+        }
+      ]
     ) }}
   {% endif %}
 

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -21,8 +21,8 @@
 <div class="col">
 
   {% if extended %}
-    {{ Alert('Task Order not found in EDA',
-      message="We could not find your Task Order in the EDA, our system of record. Please confirm that you have entered the information correctly and resubmit or click on the button below to enter the TO manually.",
+    {{ Alert('Manually enter Task Order information',
+      message="Additional field are displayed below, where you can manually enter financial information as documented in your Task Order.",
       level='warning'
     ) }}
   {% endif %}

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -47,7 +47,7 @@
   {% block form %}
     {% autoescape false %}
 
-    {% if f.errors %}
+    {% if f.errors and not f.is_only_missing_task_order_number %}
       {{ Alert('There were some errors',
         message="<p>Please see below.</p>",
         level='error'


### PR DESCRIPTION
This cleans up the alerts display on the financial verification form.

- The blue info alert only shows when there are no errors, or the extended form is not showing.
- The red error alert only shows if the missing TO isn't the only error
- The extended TO alert content is modified to reflect the instructions more clearly, rather than just duplicating the missing TO message. Also, helpdocs link is added to this alert.

![screen shot 2018-10-02 at 8 40 10 am](https://user-images.githubusercontent.com/40467269/46349039-eb12da80-c61e-11e8-8250-873903bf22af.png)

![screen shot 2018-10-02 at 8 40 17 am](https://user-images.githubusercontent.com/40467269/46349047-efd78e80-c61e-11e8-943a-b7bbe3ba2601.png)
