### PR TITLE
Hide DEV login button for demo

### DIFF
--- a/templates/login.html
+++ b/templates/login.html
@@ -17,7 +17,7 @@
 
           <a class="usa-button usa-button-big login-banner__button" href='{{ redirect_url }}'><span>Sign in with CAC</span></a>
 
-          {% if g.dev %}
+          {% if False %}
           <a class="usa-button usa-button-big usa-button-secondary" href='{{ url_for("dev.login_dev", **request.args) }}'><span>DEV Login</span></a>
           {% endif %}
         </div>


### PR DESCRIPTION
Tiny change to temporarily hide the login dev button while we demo the site. We could change the deployed site to be production mode instead of the dev environment, but we need the dev environment to allow viewing the styleguide.