### PR TITLE
Handle new-project submission with Enter key

### DIFF
--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -16,7 +16,8 @@ export default {
     initialData: {
       type: Object,
       default: () => ({})
-    }
+    },
+    modalName: String
   },
 
   data: function () {
@@ -86,10 +87,10 @@ export default {
       return names.every((n, index) => names.indexOf(n) === index)
     },
 
-    handleSubmit: function (modalName, event) {
+    handleSubmit: function (event) {
       if (!this.readyToSubmit) {
         event.preventDefault()
-        this.validateAndOpenModal(modalName)
+        this.validateAndOpenModal(this.modalName)
       }
     },
 

--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -85,6 +85,13 @@ export default {
       return names.every((n, index) => names.indexOf(n) === index)
     },
 
+    handleSubmit: function (modalName, event) {
+      if (!this.readyToSubmit) {
+        event.preventDefault()
+        this.validateAndOpenModal(modalName)
+      }
+    },
+
     validateAndOpenModal: function (modalName) {
       let isValid = this.$children.reduce((previous, newVal) => {
         // display textInput error if it is not valid

--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -40,6 +40,7 @@ export default {
       errors: [],
       environments,
       name,
+      readyToSubmit: false
     }
   },
 
@@ -106,6 +107,7 @@ export default {
       isValid = this.errors.length == 0 && isValid
 
       if (isValid) {
+        this.readyToSubmit = true
         this.openModal(modalName)
       }
     }

--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -90,7 +90,7 @@ export default {
     handleSubmit: function (event) {
       if (!this.readyToSubmit) {
         event.preventDefault()
-        this.validateAndOpenModal(this.modalName)
+        this.validateAndOpenModal()
       }
     },
 
@@ -99,7 +99,7 @@ export default {
       this.closeModal(this.modalName)
     },
 
-    validateAndOpenModal: function (modalName) {
+    validateAndOpenModal: function () {
       let isValid = this.$children.reduce((previous, newVal) => {
         // display textInput error if it is not valid
         if (!newVal.showValid) {
@@ -114,7 +114,7 @@ export default {
 
       if (isValid) {
         this.readyToSubmit = true
-        this.openModal(modalName)
+        this.openModal(this.modalName)
       }
     }
   }

--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -94,6 +94,11 @@ export default {
       }
     },
 
+    handleCancelSubmit: function () {
+      this.readyToSubmit = false
+      this.closeModal(this.modalName)
+    },
+
     validateAndOpenModal: function (modalName) {
       let isValid = this.$children.reduce((previous, newVal) => {
         // display textInput error if it is not valid

--- a/templates/fragments/edit_project_form.html
+++ b/templates/fragments/edit_project_form.html
@@ -23,7 +23,7 @@
 
       <div class='action-group'>
         <button type='submit' class='action-group__action usa-button' tabindex='0'>{{ action_text }} Project</button>
-        <button type='button' v-on:click="closeModal('{{ modalName }}')" class='icon-link action-group__action' tabindex='0'>Cancel</button>
+        <button type='button' v-on:click="handleCancelSubmit" class='icon-link action-group__action' tabindex='0'>Cancel</button>
       </div>
     {% endcall %}
 

--- a/templates/fragments/edit_project_form.html
+++ b/templates/fragments/edit_project_form.html
@@ -3,13 +3,13 @@
 {% from "components/text_input.html" import TextInput %}
 {% from "components/alert.html" import Alert %}
 
-<new-project inline-template v-bind:initial-data='{{ form.data|tojson }}'>
+<new-project inline-template v-bind:initial-data='{{ form.data|tojson }}' modal-name='{{ modalName }}'>
   {% set new_project = project is not defined %}
   {% set form_action = url_for('workspaces.create_project', workspace_id=workspace.id) if new_project else url_for('workspaces.edit_project', workspace_id=workspace.id, project_id=project.id) %}
   {% set action_text = 'Create' if new_project else 'Update' %}
   {% set title_text = 'Add a new project' if new_project else 'Edit {} project'.format(project.name) %}
 
-  <form method="POST" action="{{ form_action }}" v-on:submit="handleSubmit('{{ modalName }}', $event)">
+  <form method="POST" action="{{ form_action }}" v-on:submit="handleSubmit">
     {% call Modal(name=modalName, dismissable=False) %}
       <h1>{{ action_text }} project !{ name }</h1>
 

--- a/templates/fragments/edit_project_form.html
+++ b/templates/fragments/edit_project_form.html
@@ -9,7 +9,7 @@
   {% set action_text = 'Create' if new_project else 'Update' %}
   {% set title_text = 'Add a new project' if new_project else 'Edit {} project'.format(project.name) %}
 
-  <form method="POST" action="{{ form_action }}" >
+  <form method="POST" action="{{ form_action }}" v-on:submit="handleSubmit('{{ modalName }}', $event)">
     {% call Modal(name=modalName, dismissable=False) %}
       <h1>{{ action_text }} project !{ name }</h1>
 
@@ -75,7 +75,7 @@
       </div>
 
       <div class="action-group">
-        <button v-on:click="validateAndOpenModal('{{ modalName }}')" class="usa-button usa-button-primary" tabindex="0" type="button">{{ action_text }} Project</button>
+        <button class="usa-button usa-button-primary" tabindex="0" type="button">{{ action_text }} Project</button>
       </div>
 
     </div>

--- a/templates/fragments/edit_project_form.html
+++ b/templates/fragments/edit_project_form.html
@@ -75,7 +75,7 @@
       </div>
 
       <div class="action-group">
-        <button class="usa-button usa-button-primary" tabindex="0" type="button">{{ action_text }} Project</button>
+        <button class="usa-button usa-button-primary" tabindex="0" type="submit">{{ action_text }} Project</button>
       </div>
 
     </div>


### PR DESCRIPTION
This fixes the way form submission is handled in the new-project form. Rather than handling on-click of the submit button, submission is handled on-submit of the form itself. This allows the "Enter" button (or any other method of submitting the form) to trigger the modal properly.

Also sets a `readyToSubmit` flag to decide whether to prevent the default submission and show the modal, or allow the submission.

Fixes https://www.pivotaltracker.com/story/show/160940008
