### PR TITLE
Update template variable request to jedi_request for financial verifi…

### DIFF
--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -38,7 +38,7 @@ def financial_verification(request_id=None):
     return render_template(
         "requests/financial_verification.html",
         f=form,
-        request=request,
+        jedi_request=request,
         review_comment=request.review_comment,
         extended=is_extended(request),
     )
@@ -50,7 +50,7 @@ def update_financial_verification(request_id):
     existing_request = Requests.get(g.current_user, request_id)
     form = financial_form(existing_request, post_data)
     rerender_args = dict(
-        request=existing_request, f=form, extended=is_extended(existing_request)
+        jedi_request=existing_request, f=form, extended=is_extended(existing_request)
     )
 
     if form.validate():

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -9,7 +9,7 @@
 
 {% include 'requests/review_menu.html' %}
 
-{% if request.is_pending_financial_verification and not f.errors and not extended %}
+{% if jedi_request.is_pending_financial_verification and not f.errors and not extended %}
   {{ Alert('Pending Financial Verification', fragment="fragments/pending_financial_verification.html") }}
 {% endif %}
 
@@ -35,7 +35,7 @@
   {% endif %}
 
   {% if f.is_missing_task_order_number %}
-    {% set extended_url = url_for('requests.financial_verification', request_id=request.id, extended=True) %}
+    {% set extended_url = url_for('requests.financial_verification', request_id=jedi_request.id, extended=True) %}
     {% call Alert('Task Order not found in EDA', level='warning') %}
         We could not find your Task Order in our system of record, EDA. Please confirm that you have entered it correctly.<br>
         <a class="usa-button" href="{{ extended_url }}">Enter Task Order information manually</a>
@@ -44,9 +44,9 @@
 
   {% block form_action %}
     {% if extended %}
-      <form method='POST' action="{{ url_for('requests.financial_verification', request_id=request.id, extended=True) }}" autocomplete="off" enctype="multipart/form-data">
+      <form method='POST' action="{{ url_for('requests.financial_verification', request_id=jedi_request.id, extended=True) }}" autocomplete="off" enctype="multipart/form-data">
     {% else %}
-      <form method='POST' action="{{ url_for('requests.financial_verification', request_id=request.id) }}" autocomplete="off">
+    <form method='POST' action="{{ url_for('requests.financial_verification', request_id=jedi_request.id) }}" autocomplete="off">
     {% endif %}
   {% endblock %}
 
@@ -65,7 +65,7 @@
 
     <div class="panel__heading">
       <h1>Financial Verification</h1>
-      <div class="subtitle" id="financial-verification"><h2>Request: {{ request.displayname }}</h2></div>
+      <div class="subtitle" id="financial-verification"><h2>Request: {{ jedi_request.displayname }}</h2></div>
     </div>
 
     <div class="panel__content">

--- a/templates/requests/review_menu.html
+++ b/templates/requests/review_menu.html
@@ -1,5 +1,5 @@
-{% set pending_url=url_for('requests.view_request_details', request_id=request.id) %}
-{% set financial_url=url_for('requests.financial_verification', request_id=request.id) %}
+{% set pending_url=url_for('requests.view_request_details', request_id=jedi_request.id) %}
+{% set financial_url=url_for('requests.financial_verification', request_id=jedi_request.id) %}
 <div class="progress-menu progress-menu--two">
   <ul>
     <li class="progress-menu__item progress-menu__item--complete">


### PR DESCRIPTION
…cation review menu (thanks to Leigh!)

This fixes a bug where the URLs for the request details and financial verification were not being rendered correctly in the financial verification tabs at the top of the page. The fin ver templates were still using `request` as the variable name instead of `jedi_request`, which is what we're using in other templates. Leigh found and fixed.