### PR TITLE
financial verification routes refactor

### DIFF
--- a/atst/domain/requests/query.py
+++ b/atst/domain/requests/query.py
@@ -1,8 +1,10 @@
 from sqlalchemy import exists, and_, exc, text
+from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
 from atst.domain.common import Query
 from atst.models.request import Request
+from atst.domain.exceptions import NotFoundError
 
 
 class RequestsQuery(Query):

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -7,8 +7,8 @@ from atst.forms.financial import FinancialForm, ExtendedFinancialForm
 
 
 class FinancialVerification:
-    def __init__(self, user, request_id, extended=False, post_data=None):
-        self.request = Requests.get(user, request_id)
+    def __init__(self, request, extended=False, post_data=None):
+        self.request = request
         self._extended = extended
         self._post_data = post_data
         self._form = None
@@ -91,9 +91,8 @@ class FinancialVerification:
 
 @requests_bp.route("/requests/verify/<string:request_id>", methods=["GET"])
 def financial_verification(request_id):
-    finver = FinancialVerification(
-        g.current_user, request_id, extended=http_request.args.get("extended")
-    )
+    request = Requests.get(g.current_user, request_id)
+    finver = FinancialVerification(request, extended=http_request.args.get("extended"))
 
     return render_template(
         "requests/financial_verification.html",
@@ -106,11 +105,9 @@ def financial_verification(request_id):
 
 @requests_bp.route("/requests/verify/<string:request_id>", methods=["POST"])
 def update_financial_verification(request_id):
+    request = Requests.get(g.current_user, request_id)
     finver = FinancialVerification(
-        g.current_user,
-        request_id,
-        extended=http_request.args.get("extended"),
-        post_data=http_request.form,
+        request, extended=http_request.args.get("extended"), post_data=http_request.form
     )
 
     finver.validate()

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -6,32 +6,20 @@ from atst.domain.requests import Requests
 from atst.forms.financial import FinancialForm, ExtendedFinancialForm
 
 
-def task_order_data(task_order):
-    data = task_order.to_dictionary()
-    data["task_order_number"] = task_order.number
-    data["funding_type"] = task_order.funding_type.value
-    return data
-
-
-def is_extended(request):
-    return (
-        http_request.args.get("extended")
-        or request.is_pending_financial_verification_changes
-    )
-
-
-def financial_form(request, data):
-    if is_extended(request):
-        return ExtendedFinancialForm(data=data)
-    else:
-        return FinancialForm(data=data)
-
-
 class FinancialVerification:
     def __init__(self, user, request_id=None, extended=False, post_data=None):
         self.request = Requests.get(user, request_id)
         self._extended = extended
         self.post_data = post_data
+        self._form = None
+        self.reset()
+
+    def reset(self):
+        self.updateable = False
+        self.valid = False
+        self.workspace = None
+        if self._form:
+            self._form.reset()
 
     @property
     def is_extended(self):
@@ -53,23 +41,59 @@ class FinancialVerification:
 
     @property
     def _form_data(self):
-        form_data = self.request.body.get("financial_verification", {})
-        form_data.update(self._task_order_data)
+        if self.post_data:
+            return self.post_data
+        else:
+            form_data = self.request.body.get("financial_verification", {})
+            form_data.update(self._task_order_data)
 
-        return form_data
+            return form_data
 
     @property
     def form(self):
-        if self.is_extended:
-            return ExtendedFinancialForm(self._form_data)
+        if not self._form:
+            if self.is_extended:
+                self._form = ExtendedFinancialForm(data=self._form_data)
+            else:
+                self._form = FinancialForm(data=self._form_data)
+
+        return self._form
+
+    def validate(self):
+        if self.form.validate():
+            self.updateable = True
+            self.valid = self.form.perform_extra_validation(
+                self.request.body.get("financial_verification")
+            )
         else:
-            return FinancialForm(self._form_data)
+            self.updateable = False
+            self.valid = False
+
+        return self.valid
+
+    @property
+    def pending(self):
+        return self.request.is_pending_ccpo_approval
+
+    def finalize(self):
+        if self.updateable:
+            self.request = Requests.update_financial_verification(
+                self.request.id, self.form.data
+            )
+
+        if self.valid:
+            self.request = Requests.submit_financial_verification(self.request)
+
+            if self.request.is_financially_verified:
+                self.workspace = Requests.approve_and_create_workspace(self.request)
 
 
 @requests_bp.route("/requests/verify/<string:request_id>", methods=["GET"])
 def financial_verification(request_id):
     finver = FinancialVerification(
-        g.current_user, request_id=request_id, extended=http_request.args.get("extended")
+        g.current_user,
+        request_id=request_id,
+        extended=http_request.args.get("extended"),
     )
 
     return render_template(
@@ -83,40 +107,32 @@ def financial_verification(request_id):
 
 @requests_bp.route("/requests/verify/<string:request_id>", methods=["POST"])
 def update_financial_verification(request_id):
-    post_data = http_request.form
-    existing_request = Requests.get(g.current_user, request_id)
-    form = financial_form(existing_request, post_data)
-    rerender_args = dict(
-        jedi_request=existing_request, f=form, extended=is_extended(existing_request)
+    finver = FinancialVerification(
+        g.current_user,
+        request_id=request_id,
+        extended=http_request.args.get("extended"),
+        post_data=http_request.form,
     )
 
-    if form.validate():
-        valid = form.perform_extra_validation(
-            existing_request.body.get("financial_verification")
-        )
-        updated_request = Requests.update_financial_verification(request_id, form.data)
-        if valid:
-            submitted_request = Requests.submit_financial_verification(updated_request)
-            if submitted_request.is_financially_verified:
-                new_workspace = Requests.approve_and_create_workspace(submitted_request)
-                return redirect(
-                    url_for(
-                        "workspaces.new_project",
-                        workspace_id=new_workspace.id,
-                        newWorkspace=True,
-                    )
-                )
-            else:
-                return redirect(
-                    url_for("requests.requests_index", modal="pendingCCPOApproval")
-                )
+    finver.validate()
 
-        else:
-            form.reset()
-            return render_template(
-                "requests/financial_verification.html", **rerender_args
+    finver.finalize()
+
+    if finver.workspace:
+        return redirect(
+            url_for(
+                "workspaces.new_project",
+                workspace_id=finver.workspace.id,
+                newWorkspace=True,
             )
-
+        )
+    elif finver.pending:
+        return redirect(url_for("requests.requests_index", modal="pendingCCPOApproval"))
     else:
-        form.reset()
-        return render_template("requests/financial_verification.html", **rerender_args)
+        finver.reset()
+        return render_template(
+            "requests/financial_verification.html",
+            jedi_request=finver.request,
+            f=finver.form,
+            extended=finver.is_extended,
+        )

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -32,7 +32,8 @@ class FinancialVerification:
     @property
     def _task_order_data(self):
         if self.request.task_order:
-            data = self.request.task_order.to_dictionary()
+            task_order = self.request.task_order
+            data = task_order.to_dictionary()
             data["task_order_number"] = task_order.number
             data["funding_type"] = task_order.funding_type.value
             return data

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -206,3 +206,23 @@ class TestFinancialVerification:
         assert finver_two.is_extended
         finver_three = self._service_object(extended=True)
         assert finver_three.is_extended
+
+    def test_is_pending_changes(self):
+        finver_one = self._service_object()
+        assert not finver_one.is_pending_changes
+        finver_two = self._service_object(
+            request=RequestFactory.create_with_status(
+                RequestStatus.CHANGES_REQUESTED_TO_FINVER
+            )
+        )
+        assert finver_two.is_pending_changes
+
+    def test_pending(self):
+        finver_one = self._service_object()
+        assert not finver_one.pending
+        finver_two = self._service_object(
+            request=RequestFactory.create_with_status(
+                RequestStatus.PENDING_CCPO_APPROVAL
+            )
+        )
+        assert finver_two.pending

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -176,12 +176,6 @@ def test_displays_ccpo_review_comment(user_session, client):
 
 
 class TestFinancialVerification:
-    @pytest.fixture(scope="function", autouse=True)
-    def apply_monkeypath(self, monkeypatch):
-        monkeypatch.setattr(
-            "atst.domain.requests.Requests.get", lambda *args: self.request
-        )
-
     def _service_object(self, request=None, extended=False, post_data={}):
         if not request:
             self.request = RequestFactory.create()
@@ -189,10 +183,7 @@ class TestFinancialVerification:
             self.request = request
 
         return FinancialVerification(
-            UserFactory.create(),
-            self.request.id,
-            extended=extended,
-            post_data=post_data,
+            self.request, extended=extended, post_data=post_data
         )
 
     def test_is_extended(self):


### PR DESCRIPTION
This refactors the logic of the financial verification routes into a service object, like we do for the request form and the requests index page. I think this will make incremental saving and more nuanced PDF handling, two upcoming PT stories, easier. It's basically done, it just needs some more unit tests for the service object class.

If @patricksmithdds @richard-dds or @montana-mil want it while I'm gone, be my guest.