### PR TITLE
Refactor factories to make test setup more declarative

### DIFF
--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -21,7 +21,7 @@ def test_update_environment_roles():
                     },
                     {
                         "name": "project1 staging",
-                        "members": [{"user": developer, "role_name": "developer"}]
+                        "members": [{"user": developer, "role_name": "developer"}],
                     },
                     {"name": "project1 prod"},
                 ],

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -1,14 +1,14 @@
 from atst.domain.environments import Environments
 from atst.domain.environment_roles import EnvironmentRoles
 
-from tests.factories import UserFactory, SuperWorkspaceFactory
+from tests.factories import UserFactory, WorkspaceFactory
 
 
 def test_update_environment_roles():
     owner = UserFactory.create()
     developer = UserFactory.from_atat_role("developer")
 
-    workspace = SuperWorkspaceFactory.create(
+    workspace = WorkspaceFactory.create(
         owner=owner,
         members=[{"user": developer, "role_name": "developer"}],
         projects=[
@@ -47,7 +47,7 @@ def test_update_environment_roles():
 
 def test_get_scoped_environments(db):
     developer = UserFactory.create()
-    workspace = SuperWorkspaceFactory.create(
+    workspace = WorkspaceFactory.create(
         members=[{"user": developer, "role_name": "developer"}],
         projects=[
             {

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -1,51 +1,42 @@
-import pytest
-from uuid import uuid4
-
 from atst.domain.environments import Environments
 from atst.domain.environment_roles import EnvironmentRoles
-from atst.domain.projects import Projects
-from atst.domain.roles import Roles
-from atst.domain.workspaces import Workspaces
-from atst.domain.workspace_users import WorkspaceUsers
-from atst.domain.exceptions import NotFoundError
-from atst.models.environment_role import EnvironmentRole
 
-from tests.factories import (
-    RequestFactory,
-    UserFactory,
-    WorkspaceFactory,
-    EnvironmentFactory,
-    ProjectFactory,
-    SuperWorkspaceFactory,
-)
+from tests.factories import UserFactory, SuperWorkspaceFactory
 
 
 def test_update_environment_roles():
     owner = UserFactory.create()
-    developer_data = {
-        "dod_id": "1234567890",
-        "first_name": "Test",
-        "last_name": "User",
-        "email": "test.user@mail.com",
-        "workspace_role": "developer",
-    }
+    developer = UserFactory.from_atat_role("developer")
 
-    workspace = Workspaces.create(RequestFactory.create(creator=owner))
-    workspace_user = Workspaces.create_member(owner, workspace, developer_data)
-    project = Projects.create(
-        owner, workspace, "my test project", "It's mine.", ["dev", "staging", "prod"]
+    workspace = SuperWorkspaceFactory.create(
+        owner=owner,
+        members=[{"user": developer, "role_name": "developer"}],
+        projects=[
+            {
+                "name": "project1",
+                "environments": [
+                    {
+                        "name": "project1 dev",
+                        "members": [{"user": developer, "role_name": "devlops"}],
+                    },
+                    {
+                        "name": "project1 staging",
+                        "members": [{"user": developer, "role_name": "developer"}]
+                    },
+                    {"name": "project1 prod"},
+                ],
+            }
+        ],
     )
 
-    dev_env = project.environments[0]
-    staging_env = project.environments[1]
-    Environments.add_member(dev_env, workspace_user.user, "devops")
-    Environments.add_member(staging_env, workspace_user.user, "developer")
-
+    dev_env = workspace.projects[0].environments[0]
+    staging_env = workspace.projects[0].environments[1]
     new_ids_and_roles = [
         {"id": dev_env.id, "role": "billing_admin"},
         {"id": staging_env.id, "role": "developer"},
     ]
 
+    workspace_user = workspace.members[0]
     Environments.update_environment_role(owner, new_ids_and_roles, workspace_user)
     new_dev_env_role = EnvironmentRoles.get(workspace_user.user.id, dev_env.id)
     staging_env_role = EnvironmentRoles.get(workspace_user.user.id, staging_env.id)
@@ -57,7 +48,6 @@ def test_update_environment_roles():
 def test_get_scoped_environments(db):
     developer = UserFactory.create()
     workspace = SuperWorkspaceFactory.create(
-        name="hey",
         members=[{"user": developer, "role_name": "developer"}],
         projects=[
             {

--- a/tests/domain/test_projects.py
+++ b/tests/domain/test_projects.py
@@ -19,15 +19,7 @@ def test_create_project_with_multiple_environments():
 def test_workspace_owner_can_view_environments():
     owner = UserFactory.create()
     workspace = WorkspaceFactory.create(
-        owner=owner,
-        projects=[
-            {
-                "environments": [
-                    {"name": "dev"},
-                    {"name": "prod"}
-                ]
-            }
-        ]
+        owner=owner, projects=[{"environments": [{"name": "dev"}, {"name": "prod"}]}]
     )
     project = Projects.get(owner, workspace, workspace.projects[0].id)
 

--- a/tests/domain/test_projects.py
+++ b/tests/domain/test_projects.py
@@ -1,5 +1,5 @@
 from atst.domain.projects import Projects
-from tests.factories import RequestFactory, UserFactory
+from tests.factories import RequestFactory, UserFactory, WorkspaceFactory
 from atst.domain.workspaces import Workspaces
 
 
@@ -18,12 +18,17 @@ def test_create_project_with_multiple_environments():
 
 def test_workspace_owner_can_view_environments():
     owner = UserFactory.create()
-    request = RequestFactory.create(creator=owner)
-    workspace = Workspaces.create(request)
-    _project = Projects.create(
-        owner, workspace, "My Test Project", "Test", ["dev", "prod"]
+    workspace = WorkspaceFactory.create(
+        owner=owner,
+        projects=[
+            {
+                "environments": [
+                    {"name": "dev"},
+                    {"name": "prod"}
+                ]
+            }
+        ]
     )
-
-    project = Projects.get(owner, workspace, _project.id)
+    project = Projects.get(owner, workspace, workspace.projects[0].id)
 
     assert len(project.environments) == 2

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -100,10 +100,15 @@ class RequestFactory(Base):
         new_status=RequestStatus.STARTED,
         revision=factory.LazyAttribute(lambda se: se.factory_parent.revisions[-1]),
     )
-    task_order = factory.SubFactory("tests.factories.TaskOrderFactory")
 
     class Params:
         initial_revision = None
+
+    @classmethod
+    def _adjust_kwargs(cls, **kwargs):
+        if kwargs.pop("with_task_order", False) and "task_order" not in kwargs:
+            kwargs["task_order"] = TaskOrderFactory.build()
+        return kwargs
 
     @classmethod
     def create_initial_status_event(cls, request):


### PR DESCRIPTION
Added some overrides to our factories' `_create` classmethods which allow them to take a bunch of kwargs. Now we can create entire workspaces in one call!

I'm not putting a WIP label on this since it could be considered done, but if you know of any other places in `tests/` that could use some refactoring, let me know.