### PR TITLE
Edit pe number #160627814

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -66,11 +66,7 @@ export default {
     validationError: 'Please enter a valid Program Treasury Code. Note that it should be a four digit or six digit number, optionally prefixed by one or more zeros.'
   },
   baCode: {
-    mask: val => {
-      if (val.length === 1) return [/\d/]
-      if (val.length === 2) return [/\d/, /\d/]
-      return [/\d/,/\d/,/[a-z,A-Z]/]
-    },
+    mask: false,
     match: /[0-9]{2}\w?$/,
     unmask: [],
     validationError: 'Please enter a valid BA Code. Note that it should be two digits, followed by an optional letter.'

--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -54,12 +54,8 @@ export default {
     validationError: 'Please enter a 10-digit DoD ID number'
   },
   peNumber: {
-    mask: val => {
-      if (val.length <= 7) return [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/[a-z,A-Z]/]
-      if (val.length === 8) return [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/[a-z,A-Z]/,/[a-z,A-Z]/]
-      return [/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/\d/,/[a-z,A-Z]/,/[a-z,A-Z]/,/[a-z,A-Z]/]
-    },
-    match: /(0\d)(0\d)(\d)(\d{2})([a-z,A-Z]{1,3})/,
+    mask: false,
+    match: /(0\d)(0\d)(\d{3})([a-z,A-Z]{1,3})/,
     unmask: ['_'],
     validationError: 'Please enter a valid PE number. Note that it should be 7 digits followed by 1-3 letters, and should have a zero as the first and third digits.'
   },


### PR DESCRIPTION
## Description
There was a bug in the PE Form Field when you typed in a PE number or BA Code with letters at the end then edited the beginning of the number, it would delete all of the letters at the end of the input. This was caused by the masking for the input. 
This PR removes the masking on the PE Number and BA Code to make the input fields more user friendly when editing. The input fields no longer use masking to guard against incorrect data inputs, now the fields rely on validations to ensure that users are entering the correct type of data.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/160627814