### PR TITLE
Add UAT env and move to *.atat.code.mil (from *.atat.codes)

### DIFF
--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -7,14 +7,14 @@ metadata:
 data:
   nginx-config: |-
     server {
-        server_name www.atat.codes atat.codes;
+        server_name www.atat.code.mil atat.code.mil;
         listen 8442;
         listen [::]:8442 ipv6only=on;
         if ($http_x_forwarded_proto != 'https') {
             return 301 https://$host$request_uri;
         }
         location /login-redirect {
-            return 301 https://auth.atat.codes$request_uri;
+            return 301 https://auth.atat.code.mil$request_uri;
         }
         location /login-dev {
             try_files $uri @appbasicauth;
@@ -34,7 +34,7 @@ data:
         }
     }
     server {
-        server_name auth.atat.codes;
+        server_name auth.atat.code.mil;
         listen 8443 ssl;
         listen [::]:8443 ssl ipv6only=on;
         # SSL server certificate and private key
@@ -61,7 +61,7 @@ data:
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {
-            return 301 https://www.atat.codes$request_uri;
+            return 301 https://www.atat.code.mil$request_uri;
         }
         location /login-redirect {
             try_files $uri @app;

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -168,11 +168,12 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: 10m
 spec:
   tls:
-  - hosts:
-    - www.atat.codes
-    secretName: atst-ingress-tls
+  - secretName: atst-ingress-tls
+    hosts:
+    - atat.code.mil
+    - www.atat.code.mil
   rules:
-  - host: www.atat.codes
+  - host: www.atat.code.mil
     http:
       paths:
       - path: /

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:d8d05da
+          image: registry.atat.codes:443/atst-prod:76854ac
           resources:
             requests:
                memory: "2500Mi"

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:0696894
+          image: registry.atat.codes:443/atst-prod:d8d05da
           resources:
             requests:
                memory: "2500Mi"

--- a/deploy/kubernetes/uat/atst-configmap.yml
+++ b/deploy/kubernetes/uat/atst-configmap.yml
@@ -1,0 +1,15 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atst-config
+  namespace: atat-uat
+data:
+  uwsgi-config: |-
+    [uwsgi]
+    callable = app
+    module = app
+    socket = /var/run/uwsgi/uwsgi.socket
+    plugins = python3
+    virtualenv = /opt/atat/atst/.venv
+    chmod-socket = 666

--- a/deploy/kubernetes/uat/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-envvars-configmap.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atst-envvars
+  namespace: atat-uat
+data:
+  FLASK_ENV: dev
+  OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
+  UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini

--- a/deploy/kubernetes/uat/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/uat/atst-nginx-configmap.yml
@@ -14,7 +14,7 @@ data:
             return 301 https://$host$request_uri;
         }
         location /login-redirect {
-          return 301 https://auth-uat.atat.codes$request_uri;
+            return 301 https://auth-uat.atat.codes$request_uri;
         }
         location /login-dev {
             try_files $uri @appbasicauth;

--- a/deploy/kubernetes/uat/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/uat/atst-nginx-configmap.yml
@@ -1,0 +1,79 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atst-nginx
+  namespace: atat-uat
+data:
+  nginx-config: |-
+    server {
+        server_name uat.atat.codes;
+        listen 8442;
+        listen [::]:8442 ipv6only=on;
+        if ($http_x_forwarded_proto != 'https') {
+            return 301 https://$host$request_uri;
+        }
+        location /login-redirect {
+          return 301 https://auth-uat.atat.codes$request_uri;
+        }
+        location /login-dev {
+            try_files $uri @appbasicauth;
+        }
+        location / {
+            try_files $uri @app;
+        }
+        location @app {
+            include uwsgi_params;
+            uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+        }
+        location @appbasicauth {
+            include uwsgi_params;
+            uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+            auth_basic "Developer Access";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+        }
+    }
+    server {
+        server_name auth-uat.atat.codes;
+        listen 8443 ssl;
+        listen [::]:8443 ssl ipv6only=on;
+        # SSL server certificate and private key
+        ssl_certificate /etc/ssl/private/auth.atat.crt;
+        ssl_certificate_key /etc/ssl/private/auth.atat.key;
+        # Set SSL protocols, ciphers, and related options
+        ssl_protocols TLSv1.3 TLSv1.2;
+        ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
+        ssl_prefer_server_ciphers on;
+        ssl_ecdh_curve secp384r1;
+        ssl_dhparam /etc/ssl/dhparam.pem;
+        # SSL session options
+        ssl_session_timeout 4h;
+        ssl_session_cache shared:SSL:10m;   # 1mb = ~4000 sessions
+        ssl_session_tickets off;
+        # OCSP Stapling
+        ssl_stapling on;
+        ssl_stapling_verify on;
+        resolver 8.8.8.8 8.8.4.4;
+        # Request and validate client certificate
+        ssl_verify_client on;
+        ssl_verify_depth 10;
+        ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
+        # Guard against HTTPS -> HTTP downgrade
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
+        location / {
+            return 301 https://uat.atat.codes$request_uri;
+        }
+        location /login-redirect {
+            try_files $uri @app;
+        }
+        location @app {
+            include uwsgi_params;
+            uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+            uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
+            uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+        }
+    }

--- a/deploy/kubernetes/uat/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/uat/atst-nginx-configmap.yml
@@ -7,14 +7,14 @@ metadata:
 data:
   nginx-config: |-
     server {
-        server_name uat.atat.codes;
+        server_name uat.atat.code.mil;
         listen 8442;
         listen [::]:8442 ipv6only=on;
         if ($http_x_forwarded_proto != 'https') {
             return 301 https://$host$request_uri;
         }
         location /login-redirect {
-            return 301 https://auth-uat.atat.codes$request_uri;
+            return 301 https://auth-uat.atat.code.mil$request_uri;
         }
         location /login-dev {
             try_files $uri @appbasicauth;
@@ -34,7 +34,7 @@ data:
         }
     }
     server {
-        server_name auth-uat.atat.codes;
+        server_name auth-uat.atat.code.mil;
         listen 8443 ssl;
         listen [::]:8443 ssl ipv6only=on;
         # SSL server certificate and private key
@@ -61,7 +61,7 @@ data:
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {
-            return 301 https://uat.atat.codes$request_uri;
+            return 301 https://uat.atat.code.mil$request_uri;
         }
         location /login-redirect {
             try_files $uri @app;

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -168,11 +168,11 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-body-size: 10m
 spec:
   tls:
-  - hosts:
-    - uat.atat.codes
-    secretName: atst-uat-ingress-tls
+  - secretName: atst-uat-ingress-tls
+    hosts:
+    - uat.atat.code.mil
   rules:
-  - host: uat.atat.codes
+  - host: uat.atat.code.mil
     http:
       paths:
       - path: /

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:d8d05da
+          image: registry.atat.codes:443/atst-prod:76854ac
           resources:
             requests:
                memory: "2500Mi"

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -79,7 +79,7 @@ spec:
               mode: 0644
         - name: nginx-auth-tls
           secret:
-            secretName: auth-atst-ingress-tls
+            secretName: atst-auth-uat-ingress-tls
             items:
             - key: tls.crt
               path: auth.atat.crt

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -1,0 +1,181 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: atat-uat
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: atst
+  name: atst
+  namespace: atat-uat
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: atst
+    spec:
+      securityContext:
+        fsGroup: 101
+      containers:
+        - name: atst
+          image: registry.atat.codes:443/atst-prod:d8d05da
+          resources:
+            requests:
+               memory: "2500Mi"
+          envFrom:
+          - configMapRef:
+              name: atst-envvars
+          volumeMounts:
+            - name: atst-config
+              mountPath: "/opt/atat/atst/atst-overrides.ini"
+              subPath: atst-overrides.ini
+            - name: nginx-client-ca-bundle
+              mountPath: "/opt/atat/atst/ssl/server-certs/ca-chain.pem"
+              subPath: client-ca-bundle.pem
+            - name: uwsgi-config
+              mountPath: "/opt/atat/atst/uwsgi-config.ini"
+              subPath: uwsgi-config.ini
+            - name: uwsgi-socket-dir
+              mountPath: "/var/run/uwsgi"
+        - name: atst-nginx
+          image: nginx:alpine
+          ports:
+            - containerPort: 8442
+              name: http
+            - containerPort: 8443
+              name: https
+          volumeMounts:
+            - name: nginx-auth-tls
+              mountPath: "/etc/ssl/private"
+            - name: nginx-client-ca-bundle
+              mountPath: "/etc/ssl/client-ca-bundle.pem"
+              subPath: client-ca-bundle.pem
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d/atst.conf"
+              subPath: atst.conf
+            - name: nginx-dhparam
+              mountPath: "/etc/ssl/dhparam.pem"
+              subPath: dhparam.pem
+            - name: nginx-htpasswd
+              mountPath: "/etc/nginx/.htpasswd"
+              subPath: .htpasswd
+            - name: uwsgi-socket-dir
+              mountPath: "/var/run/uwsgi"
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: atst-config
+          secret:
+            secretName: atst-config-ini
+            items:
+            - key: override.ini
+              path: atst-overrides.ini
+              mode: 0644
+        - name: nginx-auth-tls
+          secret:
+            secretName: auth-atst-ingress-tls
+            items:
+            - key: tls.crt
+              path: auth.atat.crt
+              mode: 0644
+            - key: tls.key
+              path: auth.atat.key
+              mode: 0640
+        - name: nginx-client-ca-bundle
+          secret:
+            secretName: nginx-client-ca-bundle
+            items:
+            - key: client-ca-bundle.pem
+              path: client-ca-bundle.pem
+              mode: 0666
+        - name: nginx-config
+          configMap:
+            name: atst-nginx
+            items:
+            - key: nginx-config
+              path: atst.conf
+        - name: nginx-dhparam
+          secret:
+            secretName: dhparam-4096
+            items:
+            - key: dhparam.pem
+              path: dhparam.pem
+              mode: 0640
+        - name: nginx-htpasswd
+          secret:
+            secretName: atst-nginx-htpasswd
+            items:
+            - key: htpasswd
+              path: .htpasswd
+              mode: 0640
+        - name: uwsgi-config
+          configMap:
+            name: atst-config
+            items:
+            - key: uwsgi-config
+              path: uwsgi-config.ini
+              mode: 0644
+        - name: uwsgi-socket-dir
+          emptyDir:
+            medium: Memory
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: atst
+  name: atst
+  namespace: atat-uat
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: 8442
+  selector:
+    app: atst
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: atst
+  name: atst-auth
+  namespace: atat-uat
+spec:
+  type: NodePort
+  ports:
+  - name: https
+    protocol: TCP
+    nodePort: 32701
+    port: 8443
+  selector:
+    app: atst
+---
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: atst
+  namespace: atat-uat
+  annotations:
+    kubernetes.io/tls-acme: "true"
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/proxy-body-size: 10m
+spec:
+  tls:
+  - hosts:
+    - uat.atat.codes
+    secretName: atst-uat-ingress-tls
+  rules:
+  - host: uat.atat.codes
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: atst
+          servicePort: 80


### PR DESCRIPTION
This is all kubernetes config changes and has already been applied to the cluster. This PR accomplishes two things:

* adds a second namespace for a UAT environment (uat.atat.code.mil)
* moves www.atat.codes and auth.atat.codes to www.atat.code.mil and auth.atat.code.mil

Some notes:
* the UAT configuration contains a lot of duplication from the staging environment. In the future, it would be great to use some tool that allows tempated kubernetes configs so we can reuse the same template for both
* the UAT env re-uses the same postgres/redis instances that staging uses to reduce the amount of resources necessary
* these changes have already been applied to the cluster, so these are mostly artifacts of what exists
* one pain point was getting the correct certs for the domains using `kube-lego`. The load balancers were redirecting http:// requests to https:// which would raise an error due to invalid certs (which we were in the process of getting). I temporarily switched the LBs to http instead of https, let `kube-lego` get the certs, and then switched them back to https. Additionally, the auth services needed ingresses to be added temporarily in order for `kube-lego` to know it needed to fetch certs from them as well.