### PR TITLE
Catch flask's NotFound error and return 404

### DIFF
--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -1,26 +1,32 @@
 from flask import render_template
+import werkzeug.exceptions as werkzeug_exceptions
 
 import atst.domain.exceptions as exceptions
 
 
 def make_error_pages(app):
+    def log_error(e):
+        error_message = e.message if hasattr(e, "message") else str(e)
+        app.logger.error(error_message)
+
+    @app.errorhandler(werkzeug_exceptions.NotFound)
     @app.errorhandler(exceptions.NotFoundError)
     @app.errorhandler(exceptions.UnauthorizedError)
     # pylint: disable=unused-variable
     def not_found(e):
-        app.logger.error(e.message)
+        log_error(e)
         return render_template("error.html", message="Not Found"), 404
 
     @app.errorhandler(exceptions.UnauthenticatedError)
     # pylint: disable=unused-variable
     def unauthorized(e):
-        app.logger.error(e.message)
+        log_error(e)
         return render_template("error.html", message="Log in Failed"), 401
 
     @app.errorhandler(Exception)
     # pylint: disable=unused-variable
     def exception(e):
-        app.logger.error(e.message)
+        log_error(e)
         return (
             render_template("error.html", message="An Unexpected Error Occurred"),
             500,


### PR DESCRIPTION
This fixes a bug where if a `NotFound` error was raised (particularly, when trying to access a static file that wasn't found), the app would return a 500 error because the `NotFound` exception did not have a `message` attribute (that's only for our custom errors).