### PR TITLE
Raise unhandled exception in debug mode

### DIFF
--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -1,4 +1,4 @@
-from flask import render_template
+from flask import render_template, current_app
 import werkzeug.exceptions as werkzeug_exceptions
 
 import atst.domain.exceptions as exceptions
@@ -27,6 +27,8 @@ def make_error_pages(app):
     # pylint: disable=unused-variable
     def exception(e):
         log_error(e)
+        if current_app.debug:
+            raise e
         return (
             render_template("error.html", message="An Unexpected Error Occurred"),
             500,


### PR DESCRIPTION
When an error occurs, the error is handled by the `exception` error handler and shows the generic "An error occurred" page.

In local development, however, it's nice to see what the error was and show the flask debugging page.