### PR TITLE
Redirect to login page when CSRF error occurs

### DIFF
--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -25,6 +25,7 @@ def make_error_pages(app):
         return render_template("error.html", message="Log in Failed"), 401
 
     @app.errorhandler(CSRFError)
+    # pylint: disable=unused-variable
     def session_expired(e):
         log_error(e)
         return redirect(url_for("atst.root", sessionExpired=True, next=request.path))

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -1,4 +1,5 @@
-from flask import render_template, current_app
+from flask import render_template, current_app, url_for, redirect, request
+from flask_wtf.csrf import CSRFError
 import werkzeug.exceptions as werkzeug_exceptions
 
 import atst.domain.exceptions as exceptions
@@ -22,6 +23,11 @@ def make_error_pages(app):
     def unauthorized(e):
         log_error(e)
         return render_template("error.html", message="Log in Failed"), 401
+
+    @app.errorhandler(CSRFError)
+    def session_expired(e):
+        log_error(e)
+        return redirect(url_for("atst.root", sessionExpired=True, next=request.path))
 
     @app.errorhandler(Exception)
     # pylint: disable=unused-variable

--- a/templates/login.html
+++ b/templates/login.html
@@ -11,6 +11,12 @@
       <div class='col'>
 
         <div class='login-banner'>
+          {% if request.args.get("sessionExpired") %}
+            {{ Alert('Session Expired',
+                message='Your session expired due to inactivity. Please log in again to continue.',
+                level='error'
+            ) }}
+          {% endif %}
           <h1 class="login-banner__heading">Access the JEDI Cloud</h1>
 
           <img class="login-banner__logo" src="{{url_for('static', filename='img/ccpo-logo.svg')}}" alt="Cloud Computing Program Office Logo">

--- a/tests/routes/test_errors.py
+++ b/tests/routes/test_errors.py
@@ -1,10 +1,9 @@
-
 def test_csrf_error(app, client):
     app.config.update({"WTF_CSRF_ENABLED": True})
 
     response = client.post(
         "/requests/new/1",
-        headers={ "Content-Type": "application/x-www-form-urlencoded" },
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
         data="csrf_token=invalid_token",
         follow_redirects=True,
     )

--- a/tests/routes/test_errors.py
+++ b/tests/routes/test_errors.py
@@ -1,6 +1,14 @@
-def test_csrf_error(app, client):
-    app.config.update({"WTF_CSRF_ENABLED": True})
+import pytest
 
+
+@pytest.fixture
+def csrf_enabled_app(app):
+    app.config.update({"WTF_CSRF_ENABLED": True})
+    yield app
+    app.config.update({"WTF_CSRF_ENABLED": False})
+
+
+def test_csrf_error(csrf_enabled_app, client):
     response = client.post(
         "/requests/new/1",
         headers={"Content-Type": "application/x-www-form-urlencoded"},

--- a/tests/routes/test_errors.py
+++ b/tests/routes/test_errors.py
@@ -1,0 +1,14 @@
+
+def test_csrf_error(app, client):
+    app.config.update({"WTF_CSRF_ENABLED": True})
+
+    response = client.post(
+        "/requests/new/1",
+        headers={ "Content-Type": "application/x-www-form-urlencoded" },
+        data="csrf_token=invalid_token",
+        follow_redirects=True,
+    )
+
+    body = response.data.decode()
+    assert "Session Expired" in body
+    assert "Log in Required" in body


### PR DESCRIPTION
When the session times out and a form is submitted (if a user sits on the page for more than 10 minutes before submitting), a CSRF exception is raised. Previously, we didn't catch that and showed a generic error page. Now, we'll redirect to the login page with a message that their session expired:

![image](https://user-images.githubusercontent.com/40774582/47055720-d9851300-d186-11e8-83e7-040e48c7d058.png)

After logging in, the user will be taken back to the page they were on.