### PR TITLE
Use `term-missing` to show uncovered lines in coverage report

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,4 +2,4 @@
 norecursedirs = .venv .git node_modules
 env =
   D:FLASK_ENV=test
-addopts = --ignore=tests/acceptance/ --cov=atst --cov-report term --cov-fail-under 90
+addopts = --ignore=tests/acceptance/ --cov=atst --cov-report term-missing --cov-fail-under 90


### PR DESCRIPTION
This will make it easier for figure out what is actually missing from test coverage.