### PR TITLE
Dropdown selector keyboard accessibility

### DIFF
--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -1,10 +1,41 @@
 import { VPopover } from 'v-tooltip'
 
+const SelectorInput = {
+  name: 'SelectorInput',
+  props: {
+    name: String,
+    value: String,
+    label: String,
+    description: String,
+    selected: Boolean,
+    handleChange: Function,
+    handleEnter: Function
+  },
+
+  computed: {
+    id: function () {
+      return `${this.name}_${this.value}`
+    }
+  },
+
+  methods: {
+    onChange: function (e) {
+      this.handleChange(this.value)
+    },
+
+    onEnter: function (e) {
+      this.handleEnter()
+    }
+  }
+}
+
+
 export default {
   name: 'selector',
 
   components: {
-    VPopover
+    VPopover,
+    SelectorInput
   },
 
   props: {
@@ -20,7 +51,8 @@ export default {
   data: function () {
     return {
       value: this.initialChoice || null,
-      showError: (this.initialErrors && this.initialErrors.length) || false
+      showError: (this.initialErrors && this.initialErrors.length) || false,
+      usingKeyboard: false
     }
   },
 
@@ -38,32 +70,29 @@ export default {
   },
 
   methods: {
+
     change: function (value) {
-      console.log('change', value)
       this.value = value
       this.showError = false
-      setTimeout(() => this.$refs.popover.hide(), 300)
+      if (!this.usingKeyboard) {
+        setTimeout(() => this.$refs.popover.hide(), 300)
+      }
     },
 
-    handleClickOption: function (e) {
-      console.log('click', e)
-      this.change(e.target.value)
-    },
-
-    handleSwitchOption: function (e) {
-      console.log('switch', e)
-      this.value = e.target.value
+    enter: function () {
+      this.$refs.popover.hide()
     },
 
     handleEnterOption: function (e) {
-      console.log('enter', e)
-      e.stopPropagation()
       this.change(e.target.value)
-      return false
+      this.usingKeyboard = false
+      this.$refs.popover.hide()
     },
 
     handleButtonArrowDown: function (e) {
+      this.usingKeyboard = true
       this.$refs.popover.show()
+      this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
     }
   },
 }

--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -38,10 +38,32 @@ export default {
   },
 
   methods: {
-    change: function (e) {
-      this.value = e.target.value
+    change: function (value) {
+      console.log('change', value)
+      this.value = value
       this.showError = false
       setTimeout(() => this.$refs.popover.hide(), 300)
+    },
+
+    handleClickOption: function (e) {
+      console.log('click', e)
+      this.change(e.target.value)
+    },
+
+    handleSwitchOption: function (e) {
+      console.log('switch', e)
+      this.value = e.target.value
+    },
+
+    handleEnterOption: function (e) {
+      console.log('enter', e)
+      e.stopPropagation()
+      this.change(e.target.value)
+      return false
+    },
+
+    handleButtonArrowDown: function (e) {
+      this.$refs.popover.show()
     }
   },
 }

--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -9,7 +9,8 @@ const SelectorInput = {
     description: String,
     selected: Boolean,
     handleChange: Function,
-    handleEnter: Function
+    handleEnter: Function,
+    handleEsc: Function
   },
 
   computed: {
@@ -25,6 +26,10 @@ const SelectorInput = {
 
     onEnter: function (e) {
       this.handleEnter()
+    },
+
+    onEsc: function (e) {
+      this.handleEsc()
     }
   }
 }
@@ -51,6 +56,7 @@ export default {
   data: function () {
     return {
       value: this.initialChoice || null,
+      currentChoice: this.initialChoice || null,
       showError: (this.initialErrors && this.initialErrors.length) || false,
       usingKeyboard: false
     }
@@ -74,17 +80,27 @@ export default {
     change: function (value) {
       this.value = value
       this.showError = false
-      if (!this.usingKeyboard) {
-        setTimeout(() => this.$refs.popover.hide(), 300)
-      }
+    },
+
+    onShow: function () {
+      setTimeout(() => { // timeout is a hack to make focus work in Chrome
+        this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
+      }, 100)
     },
 
     enter: function () {
       this.$refs.popover.hide()
     },
 
+    esc: function () {
+      this.value = this.currentChoice
+      this.usingKeyboard = false
+      this.$refs.popover.hide()
+    },
+
     handleEnterOption: function (e) {
       this.change(e.target.value)
+      this.currentChoice = e.target.value
       this.usingKeyboard = false
       this.$refs.popover.hide()
     },
@@ -92,7 +108,6 @@ export default {
     handleButtonArrowDown: function (e) {
       this.usingKeyboard = true
       this.$refs.popover.show()
-      this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
     }
   },
 }

--- a/styles/elements/_block_lists.scss
+++ b/styles/elements/_block_lists.scss
@@ -70,7 +70,7 @@
 
 @mixin block-list-selectable-label {
   margin: 0;
-  max-width: none;
+  max-width: 100%;
   display: flex;
   flex-direction: row-reverse;
   align-items: center;
@@ -126,6 +126,10 @@
     > div {
       display: flex;
       flex-direction: row-reverse;
+
+      @include ie-only {
+        width: 100%;
+      }
 
       > label {
         @include block-list-selectable-label;

--- a/styles/elements/_block_lists.scss
+++ b/styles/elements/_block_lists.scss
@@ -105,21 +105,26 @@
   @include block-list-item;
 
   &.block-list__item--selectable {
-    > label {
-      margin: 0;
-      max-width: none;
+    > div {
       display: flex;
       flex-direction: row-reverse;
-      align-items: center;
-      justify-content: space-between;
-      &::before {
-        flex-shrink: 0;
-        margin-right: 0;
-        margin-left: $gap * 2;
-      }
 
-      &:hover {
-        color: $color-primary;
+      > label {
+        margin: 0;
+        max-width: none;
+        display: flex;
+        flex-direction: row-reverse;
+        align-items: center;
+        justify-content: space-between;
+        &::before {
+          flex-shrink: 0;
+          margin-right: 0;
+          margin-left: $gap * 2;
+        }
+
+        &:hover {
+          color: $color-primary;
+        }
       }
     }
 

--- a/styles/elements/_block_lists.scss
+++ b/styles/elements/_block_lists.scss
@@ -68,6 +68,24 @@
   }
 }
 
+@mixin block-list-selectable-label {
+  margin: 0;
+  max-width: none;
+  display: flex;
+  flex-direction: row-reverse;
+  align-items: center;
+  justify-content: space-between;
+  &::before {
+    flex-shrink: 0;
+    margin-right: 0;
+    margin-left: $gap * 2;
+  }
+
+  &:hover {
+    color: $color-primary;
+  }
+}
+
 
 .block-list {
   @include block-list;
@@ -110,22 +128,12 @@
       flex-direction: row-reverse;
 
       > label {
-        margin: 0;
-        max-width: none;
-        display: flex;
-        flex-direction: row-reverse;
-        align-items: center;
-        justify-content: space-between;
-        &::before {
-          flex-shrink: 0;
-          margin-right: 0;
-          margin-left: $gap * 2;
-        }
-
-        &:hover {
-          color: $color-primary;
-        }
+        @include block-list-selectable-label;
       }
+    }
+
+    > label {
+      @include block-list-selectable-label;
     }
 
     input:checked {

--- a/templates/components/selector.html
+++ b/templates/components/selector.html
@@ -26,7 +26,7 @@
         class='selector__button'
         type='button'
         v-html='label'
-        v-on:keyup.down='handleButtonArrowDown'
+        v-on:keydown.down.prevent.stop='handleButtonArrowDown'
         v-tooltip='{ container:false }'>
       </button>
 
@@ -41,28 +41,45 @@
       <template slot='popover'>
         <div class='block-list'>
           <ul>
-            <li v-for='choice in choices' class='block-list__item block-list__item--selectable'>
+            <li v-for='(choice, index) in choices' class='block-list__item block-list__item--selectable'>
               <template v-if='choice[0] !== ""'>
-                <input
-                  tabindex='0'
-                  type='radio'
+
+                <selector-input
                   name="{{ field.name }}"
-                  v-bind:id="'{{ field.name }}_' + choice[0]"
+                  ref='choices'
                   v-bind:value='choice[0]'
-                  v-bind:checked='value === choice[0]'
-                  v-on:click='handleClickOption'
-                  v-on:keyup.enter='handleEnterOption'
-                  v-on:keyup.down='handleSwitchOption'
-                  v-on:keyup.up='handleSwitchOption'/>
-                <label v-bind:for="'{{ field.name }}_' + choice[0]">
-                  <template v-if='choice[1].description'>
-                    <dl>
-                      <dt v-html='choice[1].name'></dt>
-                      <dd v-html='choice[1].description'></dd>
-                    </dl>
-                  </template>
-                  <span v-else v-html='choice[1].name'>
-                </label>
+                  v-bind:label='choice[1].name'
+                  v-bind:description='choice[1].description'
+                  v-bind:selected='value === choice[0]'
+                  v-bind:handle-change='change'
+                  v-bind:handle-enter='enter'
+                  inline-template>
+
+                  <div>
+                    <input
+                      ref='input'
+                      tabindex='0'
+                      type='radio'
+                      v-bind:name='name'
+                      v-bind:id='id'
+                      v-bind:value='value'
+                      v-bind:checked='selected'
+                      v-on:change='onChange'
+                      v-on:keydown.enter.prevent.stop='onEnter'/>
+
+                    <label v-bind:for='id'>
+                      <template v-if='description'>
+                        <dl>
+                          <dt v-html='label'></dt>
+                          <dd v-html='description'></dd>
+                        </dl>
+                      </template>
+                      <span v-else v-html='label'>
+                    </label>
+                  </div>
+
+                </selector-input>
+
               </template>
             </li>
           </ul>

--- a/templates/components/selector.html
+++ b/templates/components/selector.html
@@ -22,7 +22,13 @@
         <span v-show='showError'>{{ Icon('alert',classes="icon-validation") }}</span>
       </legend>
 
-      <button class='selector__button' type='button' v-html='label'></button>
+      <button
+        class='selector__button'
+        type='button'
+        v-html='label'
+        v-on:keyup.down='handleButtonArrowDown'
+        v-tooltip='{ container:false }'>
+      </button>
 
       <span v-show='showError'>{{ Icon('alert',classes="icon-validation") }}</span>
 
@@ -38,11 +44,16 @@
             <li v-for='choice in choices' class='block-list__item block-list__item--selectable'>
               <template v-if='choice[0] !== ""'>
                 <input
+                  tabindex='0'
                   type='radio'
+                  name="{{ field.name }}"
                   v-bind:id="'{{ field.name }}_' + choice[0]"
                   v-bind:value='choice[0]'
                   v-bind:checked='value === choice[0]'
-                  v-on:change='change'/>
+                  v-on:click='handleClickOption'
+                  v-on:keyup.enter='handleEnterOption'
+                  v-on:keyup.down='handleSwitchOption'
+                  v-on:keyup.up='handleSwitchOption'/>
                 <label v-bind:for="'{{ field.name }}_' + choice[0]">
                   <template v-if='choice[1].description'>
                     <dl>

--- a/templates/components/selector.html
+++ b/templates/components/selector.html
@@ -11,7 +11,7 @@
   inline-template>
 
   <fieldset v-bind:class="['selector usa-input', { 'usa-input--error': initialErrors }]">
-    <v-popover v-bind:container='false' ref='popover'>
+    <v-popover v-bind:container='false' ref='popover' v-on:show='onShow'>
       <legend>
         <div class="usa-input__title">{{ field.label | striptags }}</div>
 
@@ -27,6 +27,7 @@
         type='button'
         v-html='label'
         v-on:keydown.down.prevent.stop='handleButtonArrowDown'
+        v-on:keydown.up.prevent.stop='handleButtonArrowDown'
         v-tooltip='{ container:false }'>
       </button>
 
@@ -53,6 +54,7 @@
                   v-bind:selected='value === choice[0]'
                   v-bind:handle-change='change'
                   v-bind:handle-enter='enter'
+                  v-bind:handle-esc='esc'
                   inline-template>
 
                   <div>
@@ -64,8 +66,10 @@
                       v-bind:id='id'
                       v-bind:value='value'
                       v-bind:checked='selected'
+                      v-bind:autofocus='selected'
                       v-on:change='onChange'
-                      v-on:keydown.enter.prevent.stop='onEnter'/>
+                      v-on:keydown.enter.prevent.stop='onEnter'
+                      v-on:keydown.esc.prevent.stop='onEsc'/>
 
                     <label v-bind:for='id'>
                       <template v-if='description'>


### PR DESCRIPTION
This fixes the custom dropdown Selector component to allow keyboard accessibility. It mimics (as closely as possible) the native keyboard behavior of a normal HTML select.

See: https://www.pivotaltracker.com/story/show/160353685

When focused, the down-arrow key expands the popup. The up/down-arrow keys allow you to select through the different options. The enter key then closes the popup. The behavior is subtly different when using a mouse: clicking the radio option will automatically close the popup (after a small delay).

Some learnings as a result of trying to achieve this behavior:

As it turns out, when the keyboard is used to select a radio button, the browser considers this a click, and a Mouse Event is triggered. Therefore its very difficult to know the difference between a mouse selecting a radio button, and a keyboard doing so.

I attempted various things to achieve this, but what ended up working best was a simple `usingKeyboard` flag that is set when the down-arrow is initially used to open the selector popup. This prevents the popup from closing until you manually do so with the enter key. There is a very narrow use case where someone opens the selector with a mouse, but chooses the radio with the keyboard, in which case it will appear to close as soon as you change it once. I couldn't figure any way to avoid this.

Also, one attempt included refactoring the options as a separate Vue component. I thought this might make it possible to listen to events differently. It didn't, and this refactoring was probably unnecessary. I didn't bother un-refactoring because: why waste time, it doesn't really hurt anything, and it ended up being a good lesson in Vue architecture.