### PR TITLE
Parse clin data

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -29,7 +29,7 @@ class TaskOrders(object):
         to_data = TaskOrders._client().get_contract(order_number, status="y")
         if to_data:
             # TODO: we need to determine exactly what we're getting and storing from the EDA client
-            return TaskOrders.create(number=to_data["contract_no"], source=Source.EDA)
+            return TaskOrders.create(source=Source.EDA, **to_data)
 
         else:
             raise NotFoundError("task_order")

--- a/atst/eda_client.py
+++ b/atst/eda_client.py
@@ -35,7 +35,10 @@ class EDAXMLHandler:
                 ".//ItemOtherAmounts[AmountDescription='Not to Exceed Amount (Funding)']/Amount"
             )
             if number_el is not None and amount_details is not None:
-                self.clins[number_el.text] = float(amount_details.text)
+                try:
+                    self.clins[number_el.text] = float(amount_details.text)
+                except ValueError:
+                    continue
 
 
 class EDAClientBase(object):

--- a/atst/eda_client.py
+++ b/atst/eda_client.py
@@ -28,14 +28,14 @@ class EDAXMLHandler:
     def _line_items(self):
         return self.element_tree.findall(".//LineItem[LineItemType='CLIN']/../../..")
 
-    def _parse_clin_data(self):
-        for line_item in self._line_items:
-            number = line_item.find(".//LineItemBase").text
-            amount_details = line_item.find(".//ItemOtherAmounts[AmountDescription='Not to Exceed Amount (Funding)']/Amount")
-            self.clins[number] = float(amount_details.text)
-
     def parse(self):
-        self._parse_clin_data()
+        for line_item in self._line_items:
+            number_el = line_item.find(".//LineItemBase")
+            amount_details = line_item.find(
+                ".//ItemOtherAmounts[AmountDescription='Not to Exceed Amount (Funding)']/Amount"
+            )
+            if number_el is not None and amount_details is not None:
+                self.clins[number_el.text] = float(amount_details.text)
 
 
 class EDAClientBase(object):

--- a/atst/eda_client.py
+++ b/atst/eda_client.py
@@ -116,18 +116,13 @@ class MockEDAClient(EDAClientBase):
     def get_contract(self, contract_number, status):
         if contract_number == self.MOCK_CONTRACT_NUMBER and status == "y":
             return {
-                "aco_mod": "01",
-                "admin_dodaac": None,
-                "cage_code": "1U305",
-                "contract_no": "DCA10096D0052",
-                "delivery_order": "0084",
-                "duns_number": None,
-                "issue_date": "20000228",
-                "issue_dodaac": None,
-                "location": "https://docsrv1.nit.disa.mil:443/eda/enforcer/C0414345.PDF?ver=1.4&loc=Y29udHJhY3RzL29nZGVuL3ZlbmRvci8xOTk4LzA5LzE0L0MwNDE0MzQ1LlBERg==&sourceurl=aHR0cHM6Ly9lZGE0Lm5pdC5kaXNhLm1pbC9wbHMvdXNlci9uZXdfYXBwLkdldF9Eb2M_cFRhYmxlX0lEPTImcFJlY29yZF9LZXk9OEE2ODExNjM2RUY5NkU2M0UwMzQwMDYwQjBCMjgyNkM=&uid=6CFC2B2322E86FD5E054002264936E3C&qid=19344159&signed=G&qdate=20180529194407GMT&token=6xQICrrrfIMciEJSpXmfsAYrToM=",
-                "pay_dodaac": None,
-                "pco_mod": "02",
-                "amount": 2_000_000,
+                "number": "DCA10096D0052",
+                "clin_0001": 500,
+                "clin_0003": 600,
+                "clin_1001": 700,
+                "clin_1003": 800,
+                "clin_2001": 900,
+                "clin_2003": 1000,
             }
         else:
             return None
@@ -180,7 +175,10 @@ class EDAClient(EDAClientBase):
         )
         if response.text.startswith("No data found"):
             return None
-        return ET.fromstring(response.text)
+
+        eda_data = {"number": contract_number}
+        eda_data.update(parse_eda_xml(response.text))
+        return eda_data
 
     def get_clins(self, record_key, clins, cage_code="", duns_number=""):
         response = self._get(

--- a/tests/fixtures/eda_contract.xml
+++ b/tests/fixtures/eda_contract.xml
@@ -1,0 +1,239 @@
+<ProcurementDocument>
+  <SchemaVersionUsed>2.5</SchemaVersionUsed>
+  <ProcurementInstrumentForm>DD 1155</ProcurementInstrumentForm>
+  <OriginatorDetails>
+    <InternalDocumentNumber>3244871</InternalDocumentNumber>
+    <DoDSystem>
+      <DITPRNumber>00000431</DITPRNumber>
+      <SystemAdministratorDoDAAC>704331</SystemAdministratorDoDAAC>
+    </DoDSystem>
+  </OriginatorDetails>
+  <AwardInstrument>
+    <ProcurementInstrumentHeader>
+      <ProcurementInstrumentIdentifier>
+        <ProcurementInstrumentOrigin>Department of Defense</ProcurementInstrumentOrigin>
+        <ProcurementInstrumentVehicle>Delivery Order</ProcurementInstrumentVehicle>
+        <NonDoDNumber>70433119F2644</NonDoDNumber>
+        <ProcurementInstrumentDescription>Represented Contract</ProcurementInstrumentDescription>
+      </ProcurementInstrumentIdentifier>
+      <ProcurementInstrumentIdentifier>
+        <ProcurementInstrumentOrigin>Department of Defense</ProcurementInstrumentOrigin>
+        <ProcurementInstrumentVehicle>Basic Ordering Agreement</ProcurementInstrumentVehicle>
+        <NonDoDNumber>W81K0419G0001</NonDoDNumber>
+        <ProcurementInstrumentDescription>Ordering Instrument</ProcurementInstrumentDescription>
+      </ProcurementInstrumentIdentifier>
+      <BasicInformation>
+        <ContingencyContract>false</ContingencyContract>
+        <DocumentPurpose>Original</DocumentPurpose>
+        <EmergencyRequestContract>false</EmergencyRequestContract>
+        <PricingArrangement>
+          <PricingArrangementBase>Firm Fixed Price</PricingArrangementBase>
+        </PricingArrangement>
+      </BasicInformation>
+      <ClauseInformation>
+        <RegulationURL>
+          http://farsite.hill.af.mil/reghtml/regs/far2afmcfars/fardfars/far/52_220.htm#P810_149596
+        </RegulationURL>
+        <ClauseDetails>
+          <RegulationOrSupplement>FAR</RegulationOrSupplement>
+          <ClauseNumber>52.222-50</ClauseNumber>
+          <ClauseTitle>Combating Trafficking in Persons.</ClauseTitle>
+          <ClauseEffectiveDate>2015-05</ClauseEffectiveDate>
+          <ClauseText>
+            <ClauseFullText>
+              [ lots of text ]
+            </ClauseFullText>
+          </ClauseText>
+          <Section>I</Section>
+        </ClauseDetails>
+        <ClauseDetails>
+          <RegulationOrSupplement>FAR</RegulationOrSupplement>
+          <ClauseNumber>52.245-1</ClauseNumber>
+          <ClauseTitle>Government Property.</ClauseTitle>
+          <ClauseEffectiveDate>2012-04</ClauseEffectiveDate>
+          <ClauseText>
+            <ClauseFullText>
+              [ lots of text ]
+            </ClauseFullText>
+          </ClauseText>
+          <Section>I</Section>
+        </ClauseDetails>
+      </ClauseInformation>
+      <ProcurementInstrumentDates>
+        <ProcurementInstrumentEffectiveDate>2016-02-04</ProcurementInstrumentEffectiveDate>
+        <ContractingOfficer>
+          <SignatureDate>2016-01-25</SignatureDate>
+          <SigneeDetails>
+            <Name>DALE WOLFE</Name>
+            <ContactMethod>
+              <MethodDescription>Telephone</MethodDescription>
+              <MethodValue>520-533-9132</MethodValue>
+            </ContactMethod>
+          </SigneeDetails>
+        </ContractingOfficer>
+      </ProcurementInstrumentDates>
+      <ProcurementInstrumentAddresses>
+        <AddressDescription>Contractor</AddressDescription>
+        <Address>
+          <OrganizationID>
+            <Cage>0Z7K0</Cage>
+            <DunsNumber>808152482</DunsNumber>
+          </OrganizationID>
+          <OrganizationNameAddress>
+            <OrganizationName>CACI TECHNOLOGIES, INC</OrganizationName>
+            <OrganizationAddress>
+              <FreeFormAddress>
+                <AddressLine1>6933 Gateway Ct</AddressLine1>
+                <AddressLine2>Manassas VA, 20109</AddressLine2>
+              </FreeFormAddress>
+            </OrganizationAddress>
+          </OrganizationNameAddress>
+        </Address>
+      </ProcurementInstrumentAddresses>
+      <ProcurementInstrumentAddresses>
+        <AddressDescription>Contract Issuing Office</AddressDescription>
+        <Address>
+          <OrganizationID>
+            <DoDAAC>704331</DoDAAC>
+          </OrganizationID>
+          <OrganizationNameAddress>
+            <OrganizationName>FEMA DISTRIBUTION CENTER</OrganizationName>
+            <OrganizationAddress>
+              <FreeFormAddress>
+                <AddressLine1>3870 S. SIDE INDUSTRIAL CTR</AddressLine1>
+                <AddressLine2>ATLANTA GA, 30354</AddressLine2>
+              </FreeFormAddress>
+            </OrganizationAddress>
+          </OrganizationNameAddress>
+        </Address>
+        <Contact>
+          <Name>GENE BARBER</Name>
+          <ContactMethod>
+            <MethodDescription>Telephone</MethodDescription>
+            <MethodValue>(202) 646-2727</MethodValue>
+          </ContactMethod>
+        </Contact>
+      </ProcurementInstrumentAddresses>
+      <ProcurementInstrumentAddresses>
+        <AddressDescription>Contract Administrative Office</AddressDescription>
+        <Address>
+          <OrganizationID>
+            <DoDAAC>704331</DoDAAC>
+          </OrganizationID>
+          <OrganizationNameAddress>
+            <OrganizationName>FEMA DISTRIBUTION CENTER</OrganizationName>
+            <OrganizationAddress>
+              <FreeFormAddress>
+                <AddressLine1>3870 S. SIDE INDUSTRIAL CTR</AddressLine1>
+                <AddressLine2>ATLANTA GA, 30354</AddressLine2>
+              </FreeFormAddress>
+            </OrganizationAddress>
+          </OrganizationNameAddress>
+        </Address>
+      </ProcurementInstrumentAddresses>
+      <ProcurementInstrumentAddresses>
+        <AddressDescription>Paying Office</AddressDescription>
+        <Address>
+          <OrganizationID>
+            <DoDAAC>HQ0131</DoDAAC>
+          </OrganizationID>
+          <OrganizationNameAddress>
+            <OrganizationName>DEFENSE FINANCE AND ACCOUNTING SVC</OrganizationName>
+            <OrganizationAddress>
+              <FreeFormAddress>
+                <AddressLine1>P.O. BOX 369016</AddressLine1>
+                <AddressLine2>COLUMBUS OH, 43236</AddressLine2>
+              </FreeFormAddress>
+            </OrganizationAddress>
+          </OrganizationNameAddress>
+        </Address>
+      </ProcurementInstrumentAddresses>
+      <ProcurementInstrumentAddresses>
+        <AddressDescription>Ship To</AddressDescription>
+        <Address>
+          <OrganizationID>
+            <DoDAAC>S0302A</DoDAAC>
+          </OrganizationID>
+          <OrganizationNameAddress>
+            <OrganizationName>DCMA PHOENIX</OrganizationName>
+            <OrganizationAddress>
+              <FreeFormAddress>
+                <AddressLine1>40 NORTH CENTRAL AVE, STE 400</AddressLine1>
+                <AddressLine2>TWO RENAISSANCE SQUARE</AddressLine2>
+                <AddressLine3>PHOENIX AZ, 85004</AddressLine3>
+              </FreeFormAddress>
+            </OrganizationAddress>
+          </OrganizationNameAddress>
+        </Address>
+      </ProcurementInstrumentAddresses>
+      <ProcurementInstrumentAmounts>
+        <OtherAmounts>
+          <AmountDescription>Header Only - Total Contract Value</AmountDescription>
+          <Amount>192000.00</Amount>
+        </OtherAmounts>
+      </ProcurementInstrumentAmounts>
+      <DeliveryDetails>
+        <DeliveryDates>
+          <DeliveryDescription>Delivery Requested By</DeliveryDescription>
+          <DeliveryDate>
+            <DateElement>2016-01-16</DateElement>
+          </DeliveryDate>
+        </DeliveryDates>
+      </DeliveryDetails>
+      <ReferenceNumber>
+        <ReferenceDescription>
+          Defense Priorities Allocation System (DPAS) Priority Rating
+        </ReferenceDescription>
+        <ReferenceValue>DO-A7</ReferenceValue>
+        <Section>A</Section>
+      </ReferenceNumber>
+      <Shipping>
+        <FoBDetails>
+          <PaymentMethod>Contractor</PaymentMethod>
+          <FoBPoint>Origin (after Loading)</FoBPoint>
+        </FoBDetails>
+      </Shipping>
+    </ProcurementInstrumentHeader>
+    <ContractLineItems>
+      <LineItems>
+        <LineItemIdentifier>
+          <DFARS>
+            <LineItem>
+              <LineItemType>CLIN</LineItemType>
+              <LineItemBase>0001</LineItemBase>
+            </LineItem>
+          </DFARS>
+        </LineItemIdentifier>
+        <LineItemBasicInformation>
+          <OptionLineItem>false</OptionLineItem>
+          <PricingArrangement>
+            <PricingArrangementBase>Cost No Fee</PricingArrangementBase>
+          </PricingArrangement>
+          <ProductServicesOrdered>
+            <ProductOrService>Real Property</ProductOrService>
+            <ProductServiceDescription>Radio Dishes</ProductServiceDescription>
+            <Quantity>3</Quantity>
+            <ItemUIDRequired>false</ItemUIDRequired>
+            <PriceBasis>Estimated</PriceBasis>
+            <UnitOfMeasure>Each</UnitOfMeasure>
+            <UnitPrice>64000.00</UnitPrice>
+            <ProductServiceData>
+              <DataDescription>Manufacturer's Part Number</DataDescription>
+              <DataValue>5L33M7730291DX081</DataValue>
+            </ProductServiceData>
+          </ProductServicesOrdered>
+        </LineItemBasicInformation>
+        <LineItemAmounts>
+          <ItemOtherAmounts>
+            <AmountDescription>Estimated Cost</AmountDescription>
+            <Amount>192000.00</Amount>
+          </ItemOtherAmounts>
+          <ItemOtherAmounts>
+            <AmountDescription>Not to Exceed Amount (Funding)</AmountDescription>
+            <Amount>200000.00</Amount>
+          </ItemOtherAmounts>
+        </LineItemAmounts>
+      </LineItems>
+    </ContractLineItems>
+  </AwardInstrument>
+</ProcurementDocument>

--- a/tests/test_eda_client.py
+++ b/tests/test_eda_client.py
@@ -24,3 +24,34 @@ def test_eda_xml_parser():
         eda_data = parse_eda_xml(contract.read())
         assert eda_data["clin_0001"] == 200_000.00
         assert not eda_data["clin_0003"]
+
+
+_EDA_XML_NO_NUMBER = """
+<ProcurementDocument>
+  <AwardInstrument>
+    <ContractLineItems>
+      <LineItems>
+        <LineItemIdentifier>
+          <DFARS>
+            <LineItem>
+              <LineItemType>CLIN</LineItemType>
+              <LineItemBase>0001</LineItemBase>
+            </LineItem>
+          </DFARS>
+        </LineItemIdentifier>
+        <LineItemAmounts>
+          <ItemOtherAmounts>
+            <AmountDescription>Not to Exceed Amount (Funding)</AmountDescription>
+            <Amount>not a number</Amount>
+          </ItemOtherAmounts>
+        </LineItemAmounts>
+      </LineItems>
+    </ContractLineItems>
+  </AwardInstrument>
+</ProcurementDocument>
+"""
+
+
+def test_eda_xml_parser_with_bad_xml():
+    eda_data = parse_eda_xml(_EDA_XML_NO_NUMBER)
+    assert eda_data["clin_0001"] is None

--- a/tests/test_eda_client.py
+++ b/tests/test_eda_client.py
@@ -22,5 +22,5 @@ def test_contract_not_found():
 def test_eda_xml_parser():
     with open("tests/fixtures/eda_contract.xml") as contract:
         eda_data = parse_eda_xml(contract.read())
-        assert eda_data["clin_0001"] == 200000.00
+        assert eda_data["clin_0001"] == 200_000.00
         assert not eda_data["clin_0003"]

--- a/tests/test_eda_client.py
+++ b/tests/test_eda_client.py
@@ -11,8 +11,7 @@ def test_list_contracts():
 
 def test_get_contract():
     result = mock_client.get_contract("DCA10096D0052", "y")
-    assert result["contract_no"] == "DCA10096D0052"
-    assert result["amount"] == 2_000_000
+    assert result["number"] == "DCA10096D0052"
 
 
 def test_contract_not_found():

--- a/tests/test_eda_client.py
+++ b/tests/test_eda_client.py
@@ -1,20 +1,27 @@
-from atst.eda_client import MockEDAClient
+from atst.eda_client import MockEDAClient, parse_eda_xml
 
 
-client = MockEDAClient()
+mock_client = MockEDAClient()
 
 
 def test_list_contracts():
-    results = client.list_contracts()
+    results = mock_client.list_contracts()
     assert len(results) == 3
 
 
 def test_get_contract():
-    result = client.get_contract("DCA10096D0052", "y")
+    result = mock_client.get_contract("DCA10096D0052", "y")
     assert result["contract_no"] == "DCA10096D0052"
     assert result["amount"] == 2_000_000
 
 
 def test_contract_not_found():
-    result = client.get_contract("abc", "y")
+    result = mock_client.get_contract("abc", "y")
     assert result is None
+
+
+def test_eda_xml_parser():
+    with open("tests/fixtures/eda_contract.xml") as contract:
+        eda_data = parse_eda_xml(contract.read())
+        assert eda_data["clin_0001"] == 200000.00
+        assert not eda_data["clin_0003"]


### PR DESCRIPTION
This is more work on the EDA chore: https://www.pivotaltracker.com/story/show/159969717

This adds a little parser for EDA XML. Right now, it can find and store CLIN values. Eventually, it could find and collect other useful data, like the expiration date.

*note*
The way it searches the document for CLIN totals is hard-coded around what we've seen. I still think we need to see a few more examples. I left some notes on the card.