### PR TITLE
prepopulate remaining user data on request form

### DIFF
--- a/atst/routes/requests/jedi_request_flow.py
+++ b/atst/routes/requests/jedi_request_flow.py
@@ -63,6 +63,11 @@ class JEDIRequestFlow(object):
             "fname_request": user.first_name,
             "lname_request": user.last_name,
             "email_request": user.email,
+            "phone_number": user.phone_number,
+            "service_branch": user.service_branch,
+            "designation": user.designation,
+            "citizenship": user.citizenship,
+            "date_latest_training": user.date_latest_training,
         }
 
     @property

--- a/tests/routes/test_request_new.py
+++ b/tests/routes/test_request_new.py
@@ -1,3 +1,4 @@
+import datetime
 import re
 from tests.factories import (
     RequestFactory,
@@ -93,9 +94,18 @@ def test_creator_info_is_autopopulated_for_existing_request(
 
     response = client.get("/requests/new/2/{}".format(request.id))
     body = response.data.decode()
-    assert "initial-value='{}'".format(user.first_name) in body
-    assert "initial-value='{}'".format(user.last_name) in body
-    assert "initial-value='{}'".format(user.email) in body
+    prepopulated_values = [
+        "first_name",
+        "last_name",
+        "email",
+        "phone_number",
+        "date_latest_training",
+    ]
+    for attr in prepopulated_values:
+        value = getattr(user, attr)
+        if isinstance(value, datetime.date):
+            value = value.strftime("%m/%d/%Y")
+        assert "initial-value='{}'".format(value) in body
 
 
 def test_creator_info_is_autopopulated_for_new_request(


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/161022161

This pre-populates the "information about you" section of the request with all available user information.

I was planning to do a refactor of the `JEDIRequestFlow` class on this PR, but I don't think it's calling out for it on closer examination. We can revisit that later if it becomes necessary. 