### PR TITLE
Fix project creation

### DIFF
--- a/templates/workspaces/projects/new.html
+++ b/templates/workspaces/projects/new.html
@@ -57,7 +57,8 @@
           <li v-for="(environment, i) in environments" class="block-list__item project-edit__env-list-item">
             <div class="usa-input">
               <label :for="'environment_names-' + i">Environment Name</label>
-              <input type="text" :name="'environment_names-' + i" :id="'environment_names-' + i" v-model="environment.name" placeholder="e.g. Development, Staging, Production">
+              <input type="text" :id="'environment_names-' + i" v-model="environment.name" placeholder="e.g. Development, Staging, Production"/>
+              <input type="hidden" :name="'environment_names-' + i" v-model="environment.name"/>
             </div>
             <button v-on:click="removeEnvironment(i)" v-if="environments.length > 1" type="button" class='project-edit__env-list-item__remover'>
               {{ Icon('trash') }}


### PR DESCRIPTION
This PR fixes a bug that prevented creating new projects. The root cause was tracked down to https://github.com/dod-ccpo/atst/commit/c0719ce85f93c4a7721cee509f9e2d53531f38ea by @leigh-mil.

We're using ally.js for modals, and when the modal is opened other elements on the page are disabled. Since the form is submitted when the "Create" button is clicked and browsers do not submit disabled form fields, the form was not submitting environment names when creating a project.

This workaround creates hidden inputs to track the environment names. Since they're hidden, they are not disabled by ally.js, so the fields are properly submitted.

This should be the only form affected, since this is the only form submitted via a modal button.