### PR TITLE
Deploy RQ worker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           command: echo "export GIT_SHA=$(git rev-parse --short HEAD)" >> $BASH_ENV
       - run:
           name: "Generate the Target Image Name"
-          command: echo "export IMAGE_NAME=\"${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${GIT_SHA}-circleci\"" >> $BASH_ENV
+          command: echo "export IMAGE_NAME=\"${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${GIT_SHA}\"" >> $BASH_ENV
       - run:
           name: "Start a Fresh Container"
           command: docker run -d --entrypoint='/bin/sh' -ti --name ${CONTAINER_NAME} alpine:3.8
@@ -190,7 +190,7 @@ jobs:
           command: echo "export GIT_SHA=$(git rev-parse --short HEAD)" >> $BASH_ENV
       - run:
           name: "Generate the Target Image Name"
-          command: echo "export IMAGE_NAME=\"${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${GIT_SHA}-circleci\"" >> $BASH_ENV
+          command: echo "export IMAGE_NAME=\"${ATAT_DOCKER_REGISTRY_URL}/${PROD_IMAGE_NAME}:${GIT_SHA}\"" >> $BASH_ENV
       - run:
           name: "Update Kubernetes Deployment"
           command: ./deploy/kubernetes/atst-update-deploy.sh

--- a/atst/app.py
+++ b/atst/app.py
@@ -28,7 +28,6 @@ from atst.queue import queue
 
 
 ENV = os.getenv("FLASK_ENV", "dev")
-REQUIRE_CRLS = os.getenv("REQUIRE_CRLS", "True")
 
 
 def make_app(config):
@@ -47,7 +46,7 @@ def make_app(config):
     app.config.update({"SESSION_REDIS": app.redis})
 
     make_flask_callbacks(app)
-    if REQUIRE_CRLS == "True":
+    if app.config.get("REQUIRE_CRLS"):
         make_crl_validator(app)
     register_filters(app)
     make_eda_client(app)
@@ -101,6 +100,7 @@ def map_config(config):
         "PERMANENT_SESSION_LIFETIME": config.getint(
             "default", "PERMANENT_SESSION_LIFETIME"
         ),
+        "REQUIRE_CRLS": config.getboolean("default", "REQUIRE_CRLS"),
         "RQ_REDIS_URL": config["default"]["REDIS_URI"],
         "RQ_QUEUES": ["atat_{}".format(ENV.lower())],
     }

--- a/atst/app.py
+++ b/atst/app.py
@@ -28,6 +28,7 @@ from atst.queue import queue
 
 
 ENV = os.getenv("FLASK_ENV", "dev")
+REQUIRE_CRLS = os.getenv("REQUIRE_CRLS", "True")
 
 
 def make_app(config):
@@ -46,7 +47,8 @@ def make_app(config):
     app.config.update({"SESSION_REDIS": app.redis})
 
     make_flask_callbacks(app)
-    make_crl_validator(app)
+    if REQUIRE_CRLS == "True":
+        make_crl_validator(app)
     register_filters(app)
     make_eda_client(app)
     make_upload_storage(app)

--- a/config/base.ini
+++ b/config/base.ini
@@ -15,6 +15,7 @@ PGPORT = 5432
 PGUSER = postgres
 PORT=8000
 REDIS_URI = redis://localhost:6379
+REQUIRE_CRLS = true
 SECRET = change_me_into_something_secret
 SECRET_KEY = change_me_into_something_secret
 SESSION_COOKIE_NAME=atat

--- a/deploy/kubernetes/atst-update-deploy.sh
+++ b/deploy/kubernetes/atst-update-deploy.sh
@@ -45,12 +45,14 @@ kubectl config current-context
 
 # Update the ATST deployment
 kubectl -n atat set image deployment.apps/atst atst="${IMAGE_NAME}"
+kubectl -n atat set image deployment.apps/atst-worker atst-worker="${IMAGE_NAME}"
 
 # Wait for deployment to finish
 if ! timeout -t "${MAX_DEPLOY_WAIT}" -s INT kubectl -n atat rollout status deployment/atst
 then
     # Deploy did not finish before max wait time; abort and rollback the deploy
     kubectl -n atat rollout undo deployment/atst
+    kubectl -n atat rollout undo deployment/atst-worker
     # Exit with a non-zero return code
     exit 2
 fi

--- a/deploy/kubernetes/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-worker-envvars-configmap.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atst-worker-envvars
+  namespace: atat
+data:
+  REQUIRE_CRLS: "False"

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:b1042cad
+          image: registry.atat.codes:443/atst-prod:5550eed2
           resources:
             requests:
                memory: "2500Mi"
@@ -145,7 +145,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:b1042cad
+          image: registry.atat.codes:443/atst-prod:5550eed2
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:76854ac
+          image: registry.atat.codes:443/atst-prod:47fa38b
           resources:
             requests:
                memory: "2500Mi"
@@ -124,6 +124,49 @@ spec:
         - name: uwsgi-socket-dir
           emptyDir:
             medium: Memory
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: atst
+  name: atst-worker
+  namespace: atat
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: atst
+    spec:
+      securityContext:
+        fsGroup: 101
+      containers:
+        - name: atst-worker
+          image: registry.atat.codes:443/atst-prod:47fa38b
+          args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
+          resources:
+            requests:
+               memory: "2500Mi"
+          envFrom:
+          - configMapRef:
+              name: atst-envvars
+          volumeMounts:
+            - name: atst-config
+              mountPath: "/opt/atat/atst/atst-overrides.ini"
+              subPath: atst-overrides.ini
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: atst-config
+          secret:
+            secretName: atst-config-ini
+            items:
+            - key: override.ini
+              path: atst-overrides.ini
+              mode: 0644
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:47fa38b
+          image: registry.atat.codes:443/atst-prod:6c56d03c
           resources:
             requests:
                memory: "2500Mi"
@@ -145,11 +145,11 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:47fa38b
+          image: registry.atat.codes:443/atst-prod:6c56d03c
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:
-               memory: "2500Mi"
+               memory: "500Mi"
           envFrom:
           - configMapRef:
               name: atst-envvars

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -153,6 +153,8 @@ spec:
           envFrom:
           - configMapRef:
               name: atst-envvars
+          - configMapRef:
+              name: atst-worker-envvars
           volumeMounts:
             - name: atst-config
               mountPath: "/opt/atat/atst/atst-overrides.ini"

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:6c56d03c
+          image: registry.atat.codes:443/atst-prod:b1042cad
           resources:
             requests:
                memory: "2500Mi"
@@ -145,7 +145,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:6c56d03c
+          image: registry.atat.codes:443/atst-prod:b1042cad
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:

--- a/script/rq_worker
+++ b/script/rq_worker
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# script/rq_worker: Launch the Flask-RQ worker
+
+source "$(dirname "${0}")"/../script/include/global_header.inc.sh
+
+# Before starting the server, apply any pending migrations to the DB
+migrate_db
+
+# Launch the worker
+run_command "flask rq worker"


### PR DESCRIPTION
This PR updates the Kubernetes config to include a second deployment to run the RQ worker. Running it as a separate deployment will allow us to scale it up/down in the future, independently of the web service.

I had initially planned on building two different docker images, each with a different `CMD` -- one to run the `wsgi_server` and one to run the new `rq_worker` script. Then, I found that we can specify `args` in the container configuration in Kubernetes to override the `CMD` from the container, which is a bit simpler.

The `atst-worker` deployment is configured similar to the `atst` deployment, but does not add any of the NGINX configuration. I also added an environment variable, `REQUIRE_CRLS`, that can be set to `False` to skip loading all the CRLs, since they require a lot of memory and are not needed for the RQ worker.

These changes are currently deployed to the k8s cluster and I was able to test with the `/test-email` dev route. The test message was then displayed on the `/messages` page and the logs from the worker indicated success:

```
20:23:29 atat_dev: _send_mail(['test@example.com'], 'test', 'test') (be42560a-3cc2-42ba-bc9a-2879fb80530a)
20:23:29 atat_dev: Job OK (be42560a-3cc2-42ba-bc9a-2879fb80530a)
20:23:29 Result is kept for 500 seconds
```