### PR TITLE
Filter by status and role

### DIFF
--- a/atst/models/workspace_user.py
+++ b/atst/models/workspace_user.py
@@ -67,8 +67,5 @@ class WorkspaceUser(object):
 
     def __repr__(self):
         return "<WorkspaceUser(user='{}', role='{}', workspace='{}', num_environment_roles='{}')>".format(
-            self.user.full_name,
-            self.role,
-            self.workspace.name,
-            self.num_environment_roles,
+            self.user_name, self.role, self.workspace.name, self.num_environment_roles
         )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -107,7 +107,7 @@ def workspace_members(workspace_id):
             "name": k.user_name,
             "status": k.status,
             "id": k.user_id,
-            "role": k.role,
+            "role": k.role_displayname,
             "num_env": k.num_environment_roles,
         }
         for k in workspace.members

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -113,7 +113,9 @@ def workspace_members(workspace_id):
             "id": k.user_id,
             "role": k.role_displayname,
             "num_env": k.num_environment_roles,
-            "edit_link": url_for("workspaces.view_member", workspace_id=workspace.id, member_id=k.user_id)
+            "edit_link": url_for(
+                "workspaces.view_member", workspace_id=workspace.id, member_id=k.user_id
+            ),
         }
         for k in workspace.members
     ]

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -113,6 +113,7 @@ def workspace_members(workspace_id):
             "id": k.user_id,
             "role": k.role_displayname,
             "num_env": k.num_environment_roles,
+            "edit_link": url_for("workspaces.view_member", workspace_id=workspace.id, member_id=k.user_id)
         }
         for k in workspace.members
     ]

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -103,7 +103,13 @@ def workspace_members(workspace_id):
         filter(lambda m: m.user_name == new_member_name, workspace.members), None
     )
     members_list = [
-        {"name": k.user_name, "role": k.role, "num_env": k.num_environment_roles}
+        {
+            "name": k.user_name,
+            "status": k.status,
+            "id": k.user_id,
+            "role": k.role,
+            "num_env": k.num_environment_roles,
+        }
         for k in workspace.members
     ]
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -1,4 +1,4 @@
-import re, json
+import re
 from datetime import date, timedelta
 
 from flask import (

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -1,4 +1,4 @@
-import re
+import re, json
 from datetime import date, timedelta
 
 from flask import (
@@ -102,9 +102,16 @@ def workspace_members(workspace_id):
     new_member = next(
         filter(lambda m: m.user_name == new_member_name, workspace.members), None
     )
+    members_list = [
+        {"name": k.user_name, "role": k.role, "num_env": k.num_environment_roles}
+        for k in workspace.members
+    ]
 
     return render_template(
-        "workspaces/members/index.html", workspace=workspace, new_member=new_member
+        "workspaces/members/index.html",
+        workspace=workspace,
+        members=members_list,
+        new_member=new_member,
     )
 
 

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -21,7 +21,11 @@ from atst.forms.project import NewProjectForm, ProjectForm
 from atst.forms.new_member import NewMemberForm
 from atst.forms.edit_member import EditMemberForm
 from atst.forms.workspace import WorkspaceForm
-from atst.forms.data import ENVIRONMENT_ROLES, ENV_ROLE_MODAL_DESCRIPTION
+from atst.forms.data import (
+    ENVIRONMENT_ROLES,
+    ENV_ROLE_MODAL_DESCRIPTION,
+    WORKSPACE_ROLE_DEFINITIONS,
+)
 from atst.domain.authz import Authorization
 from atst.models.permissions import Permissions
 from atst.domain.invitations import Invitations
@@ -116,6 +120,7 @@ def workspace_members(workspace_id):
     return render_template(
         "workspaces/members/index.html",
         workspace=workspace,
+        choices=WORKSPACE_ROLE_DEFINITIONS,
         members=members_list,
         new_member=new_member,
     )

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -9,6 +9,8 @@ export default {
   data: function () {
     return {
       searchValue: '',
+      status: '',
+      role: '',
       searchedList: [],
     }
   },
@@ -23,6 +25,18 @@ export default {
         member => member.name.toLowerCase()
         .includes(this.searchValue.toLowerCase())
       )
+
+      if (this.status) {
+        this.searchedList = this.searchedList.filter(
+          member => member.status === this.status
+        )
+      }
+
+      if (this.role) {
+        this.searchedList = this.searchedList.filter(
+            member => member.role.toLowerCase() === this.role
+        )
+      }
     },
   },
 }

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -14,39 +14,20 @@ export default {
     }
   },
 
-  mounted: function () {
-    // this.searchedList = this.members
-  },
-
   computed: {
     searchedList: function () {
       return this.members.filter(
-        member => this.status ? member.status === this.status : true
+        member => this.status ?
+          member.status === this.status | this.status === 'all'
+          : true
       ).filter(
-          member => this.role ? member.role.toLowerCase() === this.role : true
+        member => this.role ?
+          member.role.toLowerCase() === this.role | this.role === 'all'
+          : true
       ).filter(
         member => this.searchValue ? member.name.toLowerCase()
           .includes(this.searchValue.toLowerCase()) : true
       )
     }
-  },
-
-  // watch: {
-  //   status: function (status) {
-  //     this.searchedList = this.searchedList.filter(
-  //       member => member.status === status
-  //     )
-  //   },
-  //   role: function (role) {
-  //     this.searchedList = this.searchedList.filter(
-  //       member => member.role.toLowerCase() === role
-  //     )
-  //   }
-  // },
-
-  methods: {
-    search: function () {
-      console.log("search")
-    },
   },
 }

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -11,32 +11,42 @@ export default {
       searchValue: '',
       status: '',
       role: '',
-      searchedList: [],
     }
   },
 
   mounted: function () {
-    this.searchedList = this.members
+    // this.searchedList = this.members
   },
+
+  computed: {
+    searchedList: function () {
+      return this.members.filter(
+        member => this.status ? member.status === this.status : true
+      ).filter(
+          member => this.role ? member.role.toLowerCase() === this.role : true
+      ).filter(
+        member => this.searchValue ? member.name.toLowerCase()
+          .includes(this.searchValue.toLowerCase()) : true
+      )
+    }
+  },
+
+  // watch: {
+  //   status: function (status) {
+  //     this.searchedList = this.searchedList.filter(
+  //       member => member.status === status
+  //     )
+  //   },
+  //   role: function (role) {
+  //     this.searchedList = this.searchedList.filter(
+  //       member => member.role.toLowerCase() === role
+  //     )
+  //   }
+  // },
 
   methods: {
     search: function () {
-      this.searchedList = this.members.filter(
-        member => member.name.toLowerCase()
-        .includes(this.searchValue.toLowerCase())
-      )
-
-      if (this.status) {
-        this.searchedList = this.searchedList.filter(
-          member => member.status === this.status
-        )
-      }
-
-      if (this.role) {
-        this.searchedList = this.searchedList.filter(
-            member => member.role.toLowerCase() === this.role
-        )
-      }
+      console.log("search")
     },
   },
 }

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -1,0 +1,29 @@
+
+export default {
+  name: 'members-list',
+
+  template: '#search-template',
+
+  props: {
+    members: Array,
+  },
+
+  data: function () {
+    return {
+      searchValue: '',
+      searchedList: [],
+    }
+  },
+
+  mounted: function () {
+    // console.log(this.members)
+  },
+
+  methods: {
+    search: function () {
+      console.log(this.members)
+      this.searchedList = this.members.filter(member => member.name.includes(this.searchValue))
+      console.log(this.searchedList)
+    },
+  },
+}

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -4,6 +4,7 @@ export default {
 
   props: {
     members: Array,
+    choices: Array,
   },
 
   data: function () {
@@ -21,13 +22,19 @@ export default {
           member.status === this.status | this.status === 'all'
           : true
       ).filter(
-        member => this.role ?
-          member.role.toLowerCase() === this.role | this.role === 'all'
+        member => this.role ? (
+          this.getRoleFromDisplayName(member.role) === this.role | this.role === 'all')
           : true
       ).filter(
         member => this.searchValue ? member.name.toLowerCase()
           .includes(this.searchValue.toLowerCase()) : true
       )
     }
+  },
+
+  methods: {
+    getRoleFromDisplayName: function (role) {
+      return this.choices.find(choice => choice.display_name === role).name
+    },
   },
 }

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -16,14 +16,15 @@ export default {
   },
 
   mounted: function () {
-    // console.log(this.members)
+    this.searchedList = this.members
   },
 
   methods: {
     search: function () {
-      console.log(this.members)
-      this.searchedList = this.members.filter(member => member.name.includes(this.searchValue))
-      console.log(this.searchedList)
+      this.searchedList = this.members.filter(
+        member => member.name.toLowerCase()
+        .includes(this.searchValue.toLowerCase())
+      )
     },
   },
 }

--- a/js/components/forms/members_list.js
+++ b/js/components/forms/members_list.js
@@ -2,8 +2,6 @@
 export default {
   name: 'members-list',
 
-  template: '#search-template',
-
   props: {
     members: Array,
   },

--- a/js/index.js
+++ b/js/index.js
@@ -20,6 +20,7 @@ import selector from './components/selector'
 import BudgetChart from './components/charts/budget_chart'
 import SpendTable from './components/tables/spend_table'
 import CcpoApproval from './components/forms/ccpo_approval'
+import MembersList from './components/forms/members_list'
 import LocalDatetime from './components/local_datetime'
 
 Vue.use(VTooltip)
@@ -41,6 +42,7 @@ const app = new Vue({
     BudgetChart,
     SpendTable,
     CcpoApproval,
+    MembersList,
     LocalDatetime,
     EditEnvironmentRole,
     EditProjectRoles,

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -48,7 +48,7 @@
 
 <members-list inline-template id="search-template" v-bind:members='{{ members | tojson}}'>
   <div>
-  <form class='search-bar' @submit.prevent="search">
+  <form class='search-bar' @submit.prevent>
     <div class='usa-input search-input'>
       <label for='members-search'>Search members by name</label>
       <input v-model='searchValue' type='search' id='members-search' name='members-search' placeholder="Search by name"/>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -52,15 +52,14 @@
     <div class='usa-input search-input'>
       <label for='members-search'>Search members by name</label>
       <input v-model='searchValue' type='search' id='members-search' name='members-search' placeholder="Search by name"/>
-      <button v-if='searchValue' type="button" @click='search'>
-        <span class="hide">Search</span>
-      </button>
+      <button type="button"></button>
     </div>
 
     <div class='usa-input filter-input'>
       <label for='filter-status'>Filter members by status</label>
       <select v-model="status" id="filter-status" name="filter-status">
-        <option value="" selected>Filter by status</option>
+        <option value="" selected disabled>Filter by status</option>
+        <option value="all">View All</option>
         <option value="active">Active</option>
         <option value="pending">Pending</option>
         <option value="denied">Denied</option>
@@ -70,7 +69,8 @@
     <div class='usa-input filter-input'>
       <label for='filter-role'>Filter members by role</label>
       <select v-model="role" id="filter-role" name="filter-role">
-        <option value="" selected>Filter by role</option>
+        <option value="" selected disabled>Filter by role</option>
+        <option value="all">View All</option>
         <option value="administrator">Administrator</option>
         <option value="ccpo">CCPO</option>
         <option value="developer">Developer</option>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -50,7 +50,7 @@
 
 <members-list id="search-template" v-bind:members='{{ members | tojson}}'>
   <div>
-  <form class='search-bar'>
+  <form class='search-bar' @submit.prevent="search">
     <div class='usa-input search-input'>
       <label for='members-search'>Search members by name</label>
       <input v-model='searchValue' type='search' id='members-search' name='members-search' placeholder="Search by name"/>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -45,11 +45,16 @@
   ) }}
 {% endif %}
 
+
+
+
+<members-list id="search-template" v-bind:members='{{ members | tojson}}'>
+  <div>
   <form class='search-bar'>
     <div class='usa-input search-input'>
       <label for='members-search'>Search members by name</label>
-      <input type='search' id='members-search' name='members-search' placeholder="Search by name"/>
-      <button type="submit">
+      <input v-model='searchValue' type='search' id='members-search' name='members-search' placeholder="Search by name"/>
+      <button type="button" @click='search'>
         <span class="hide">Search</span>
       </button>
     </div>
@@ -103,6 +108,8 @@
       </tbody>
     </table>
   </div>
+</div>
+</members-list>
 
 {% endif %}
 

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -71,9 +71,9 @@
       <select v-model="role" id="filter-role" name="filter-role">
         <option value="" selected disabled>Filter by role</option>
         <option value="all">View All</option>
-        <option value="administrator">Administrator</option>
-        <option value="ccpo">CCPO</option>
-        <option value="developer">Developer</option>
+        {% for role in choices %}
+          <option value='{{ role.name }}'>{{ role.display_name }}</option>
+        {% endfor %}
       </select>
     </div>
   </form>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -46,9 +46,7 @@
 {% endif %}
 
 
-
-
-<members-list id="search-template" v-bind:members='{{ members | tojson}}'>
+<members-list inline-template id="search-template" v-bind:members='{{ members | tojson}}'>
   <div>
   <form class='search-bar' @submit.prevent="search">
     <div class='usa-input search-input'>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -46,7 +46,7 @@
 {% endif %}
 
 
-<members-list inline-template id="search-template" v-bind:members='{{ members | tojson}}'>
+<members-list inline-template id="search-template" v-bind:members='{{ members | tojson}}' v-bind:choices='{{ choices | tojson}}'>
   <div>
   <form class='search-bar' @submit.prevent>
     <div class='usa-input search-input'>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -79,7 +79,7 @@
   </form>
 
   <div class='responsive-table-wrapper'>
-    <table>
+    <table v-if='searchedList && searchedList.length'>
       <thead>
         <tr>
           <th scope="col" width="50%">Name</th>
@@ -105,6 +105,15 @@
         </tr>
       </tbody>
     </table>
+    <div v-else>
+      {{ EmptyState(
+        'No members found.',
+        action_label=None,
+        action_href=None,
+        sub_message='Please try a different search.',
+        icon=None
+      ) }}
+    </div>
   </div>
 </div>
 </members-list>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -59,21 +59,21 @@
 
     <div class='usa-input filter-input'>
       <label for='filter-status'>Filter members by status</label>
-      <select id="filter-status" name="filter-status">
+      <select v-model="status" id="filter-status" name="filter-status">
         <option value="" selected disabled>Filter by status</option>
-        <option value="">Active</option>
-        <option value="">Pending</option>
-        <option value="">Denied</option>
+        <option value="active">Active</option>
+        <option value="pending">Pending</option>
+        <option value="denied">Denied</option>
       </select>
     </div>
 
     <div class='usa-input filter-input'>
       <label for='filter-role'>Filter members by role</label>
-      <select id="filter-role" name="filter-role">
+      <select v-model="role" id="filter-role" name="filter-role">
         <option value="" selected disabled>Filter by role</option>
-        <option value="">Admin</option>
-        <option value="">CCPO</option>
-        <option value="">Developer</option>
+        <option value="administrator">Administrator</option>
+        <option value="ccpo">CCPO</option>
+        <option value="developer">Developer</option>
       </select>
     </div>
   </form>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -52,7 +52,7 @@
     <div class='usa-input search-input'>
       <label for='members-search'>Search members by name</label>
       <input v-model='searchValue' type='search' id='members-search' name='members-search' placeholder="Search by name"/>
-      <button type="button" @click='search'>
+      <button v-if='searchValue' type="button" @click='search'>
         <span class="hide">Search</span>
       </button>
     </div>
@@ -60,7 +60,7 @@
     <div class='usa-input filter-input'>
       <label for='filter-status'>Filter members by status</label>
       <select v-model="status" id="filter-status" name="filter-status">
-        <option value="" selected disabled>Filter by status</option>
+        <option value="" selected>Filter by status</option>
         <option value="active">Active</option>
         <option value="pending">Pending</option>
         <option value="denied">Denied</option>
@@ -70,7 +70,7 @@
     <div class='usa-input filter-input'>
       <label for='filter-role'>Filter members by role</label>
       <select v-model="role" id="filter-role" name="filter-role">
-        <option value="" selected disabled>Filter by role</option>
+        <option value="" selected>Filter by role</option>
         <option value="administrator">Administrator</option>
         <option value="ccpo">CCPO</option>
         <option value="developer">Developer</option>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -80,7 +80,6 @@
     </div>
   </form>
 
-
   <div class='responsive-table-wrapper'>
     <table>
       <thead>
@@ -91,20 +90,21 @@
           <th scope="col">Workspace Role</th>
         </tr>
       </thead>
+
       <tbody>
-        {% for m in workspace.members %}
-        {% set num_environment_roles = m.num_environment_roles %}
-        <tr>
-          <td><a href="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=m.user_id) }}" class="icon-link icon-link--large">{{ m.user_name }}</a></td>
-          {% if num_environment_roles %}
-            <td class="table-cell--align-right">{{ num_environment_roles }}</td>
-          {% else %}
-            <td class='table-cell--shrink'><span class="label label--info">No Environment Access</span></td>
-          {% endif %}
-          <td>{{ m.status }}</a></td>
-          <td>{{ m.role_displayname }}</a></td>
+        <tr v-for='member in searchedList'>
+          <td>
+            <a :href="'/workspaces/{{ workspace.id }}/members/'  + member.id + '/member_edit'" class="icon-link icon-link--large" v-html="member.name"></a>
+          </td>
+          <td class="table-cell--align-right" v-if='member.num_env'>
+            <span v-html="member.num_env"></span>
+          </td>
+          <td class='table-cell--shrink' v-else>
+            <span class="label label--info">No Environment Access</span>
+          </td>
+          <td v-html="member.status"></td>
+          <td v-html="member.role"></td>
         </tr>
-        {% endfor %}
       </tbody>
     </table>
   </div>

--- a/templates/workspaces/members/index.html
+++ b/templates/workspaces/members/index.html
@@ -92,7 +92,7 @@
       <tbody>
         <tr v-for='member in searchedList'>
           <td>
-            <a :href="'/workspaces/{{ workspace.id }}/members/'  + member.id + '/member_edit'" class="icon-link icon-link--large" v-html="member.name"></a>
+            <a :href="member.edit_link" class="icon-link icon-link--large" v-html="member.name"></a>
           </td>
           <td class="table-cell--align-right" v-if='member.num_env'>
             <span v-html="member.num_env"></span>


### PR DESCRIPTION
## Description
Users can now search for members by their names. Search is not cap-sensitive and happens as the user types. Members can also be filtered by `status` and/or `role`. 

Each of the filters and the search is additive. That is, each member in the results list respects each filter.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/159966589
https://www.pivotaltracker.com/story/show/159966584

## Screenshots
![screen shot 2018-10-26 at 1 38 31 pm](https://user-images.githubusercontent.com/42577527/47583129-79c7fe00-d924-11e8-9f51-b438fc1b1a57.png)
![screen shot 2018-10-26 at 1 37 48 pm](https://user-images.githubusercontent.com/42577527/47583128-79c7fe00-d924-11e8-96a8-1f85f462634b.png)


