### PR TITLE
Add conditional logic to show Edit Account link

### DIFF
--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -255,6 +255,7 @@ def view_member(workspace_id, member_id):
     member = WorkspaceUsers.get(workspace_id, member_id)
     projects = Projects.get_all(g.current_user, member, workspace)
     form = EditMemberForm(workspace_role=member.role)
+    editable = g.current_user == member.user
     return render_template(
         "workspaces/members/edit.html",
         workspace=workspace,
@@ -264,6 +265,7 @@ def view_member(workspace_id, member_id):
         choices=ENVIRONMENT_ROLES,
         env_role_modal_description=ENV_ROLE_MODAL_DESCRIPTION,
         EnvironmentRoles=EnvironmentRoles,
+        editable=editable,
     )
 
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -31,7 +31,7 @@
         </div>
       </dl>
       {% if editable %}
-        <a href='#' class='icon-link'>edit account details</a>
+        <a href='{{ url_for("users.user") }}' class='icon-link'>edit account details</a>
       {% endif %}
     </div>
   </div>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -30,7 +30,9 @@
           <dd>{{ member.user.email }}</dd>
         </div>
       </dl>
-      <a href='#' class='icon-link'>edit account details</a>
+      {% if editable %}
+        <a href='#' class='icon-link'>edit account details</a>
+      {% endif %}
     </div>
   </div>
 


### PR DESCRIPTION
## Description
The workspace owner no longer has the edit account details link for each member of the workspace. The link still appears on the member edit page for the workspace owner.

## Pivotal Tracker
[https://www.pivotaltracker.com/story/show/161022031](https://www.pivotaltracker.com/story/show/161022031)

## Screenshots
<img width="1440" alt="screen shot 2018-10-26 at 3 26 29 pm" src="https://user-images.githubusercontent.com/43828539/47588242-8f90ef80-d933-11e8-8c0c-d4323b2d18e1.png">
