### PR TITLE
Fix project name

### DIFF
--- a/atst/filters.py
+++ b/atst/filters.py
@@ -76,6 +76,7 @@ def formattedDate(value, formatter="%m/%d/%Y"):
 def dateFromString(value, formatter="%m/%Y"):
     return datetime.datetime.strptime(value, formatter)
 
+
 def string(value):
     return app.jinja_env.filters["string"](value)
 

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -76,6 +76,9 @@ def formattedDate(value, formatter="%m/%d/%Y"):
 def dateFromString(value, formatter="%m/%Y"):
     return datetime.datetime.strptime(value, formatter)
 
+def string(value):
+    return app.jinja_env.filters["string"](value)
+
 
 def register_filters(app):
     app.jinja_env.filters["iconSvg"] = iconSvg
@@ -88,3 +91,4 @@ def register_filters(app):
     app.jinja_env.filters["renderList"] = renderList
     app.jinja_env.filters["formattedDate"] = formattedDate
     app.jinja_env.filters["dateFromString"] = dateFromString
+    app.jinja_env.globals.update(string=string)

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -77,10 +77,6 @@ def dateFromString(value, formatter="%m/%Y"):
     return datetime.datetime.strptime(value, formatter)
 
 
-def string(value):
-    return app.jinja_env.filters["string"](value)
-
-
 def register_filters(app):
     app.jinja_env.filters["iconSvg"] = iconSvg
     app.jinja_env.filters["dollars"] = dollars
@@ -92,4 +88,3 @@ def register_filters(app):
     app.jinja_env.filters["renderList"] = renderList
     app.jinja_env.filters["formattedDate"] = formattedDate
     app.jinja_env.filters["dateFromString"] = dateFromString
-    app.jinja_env.globals.update(string=string)

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -53,7 +53,7 @@
   </div>
 
   {% for project in projects %}
-  {% set revoke_modal_name = string(project.id) + 'RevokeModal' %}
+  {% set revoke_modal_name = (project.id|string) + 'RevokeModal' %}
   <edit-project-roles inline-template name="{{ project.name }}" id="{{ project.id }}">
     <div is='toggler' default-visible class='block-list project-list-item'>
       <template slot-scope='props'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -53,8 +53,8 @@
   </div>
 
   {% for project in projects %}
-  {% set revoke_modal_name = project.name + 'RevokeModal' %}
-  <edit-project-roles inline-template v-bind:name="'{{ project.name }}'" v-bind:id="'{{ project.id }}'">
+  {% set revoke_modal_name = string(project.id) + 'RevokeModal' %}
+  <edit-project-roles inline-template name="{{ project.name | string }}" id="{{ project.id }}">
     <div is='toggler' default-visible class='block-list project-list-item'>
       <template slot-scope='props'>
         <header class='block-list__header'>

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -54,7 +54,7 @@
 
   {% for project in projects %}
   {% set revoke_modal_name = string(project.id) + 'RevokeModal' %}
-  <edit-project-roles inline-template name="{{ project.name | string }}" id="{{ project.id }}">
+  <edit-project-roles inline-template name="{{ project.name }}" id="{{ project.id }}">
     <div is='toggler' default-visible class='block-list project-list-item'>
       <template slot-scope='props'>
         <header class='block-list__header'>


### PR DESCRIPTION
The project name was being used to generate an ID for the access-revocation modal. This was causing an error when it had an apostrophe in the name.

This changes it to use the project ID instead of the name, since it's a safer string. Also cleans up the props attributes, removing unnecessary `v-bind:`s and quotes.

Adds a global template function for casting to string.