### PR TITLE
update requests

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -322,11 +322,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
-                "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
+                "sha256:99dcfdaaeb17caf6e526f32b6a7b780461512ab3f1d992187801694cba42770c",
+                "sha256:a84b8c9ab6239b578f22d1c21d51b696dcfe004032bb80ea832398d6909d7279"
             ],
             "index": "pypi",
-            "version": "==2.19.1"
+            "version": "==2.20.0"
         },
         "rq": {
             "hashes": [


### PR DESCRIPTION
This updates `requests` to 2.20.0, which addresses [CVE-2018-18074](https://nvd.nist.gov/vuln/detail/CVE-2018-18074). 

EDIT
<strike>Apparently `pipenv` won't even let you try to update one dependency in isolation. [It's a whole thing.](https://github.com/pypa/pipenv/issues/966) Because of this, I've updated all our Pipfile dependencies. Everything still passes.</strike>

Okay, just manually updated the `Pipfile.lock` so we only update requests. Ignore my comments below.

