### PR TITLE
Fix Environment Name Render Issue with Apostrophes

### DIFF
--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -81,6 +81,7 @@
           {% for env in project.environments %}
 
             {% set role = EnvironmentRoles.get(member.user_id, env.id).role %}
+            {% set env_modal_name = (env.id|string) + 'RolesModal' %}
 
           <li class='block-list__item'>
             <edit-environment-role inline-template initial-data='{{ role or "" }}' v-bind:choices='{{ choices | tojson }}' v-bind:project-id="'{{ project.id }}'">
@@ -91,8 +92,8 @@
 
               <div class='project-list-item__environment__actions'>
                 <span v-bind:class="label_class" v-html:on=displayName></span>
-                <button v-on:click="openModal('{{ env.name }}RolesModal')" type="button" class="icon-link">set role</button>
-                {% call Modal(name=env.name + 'RolesModal', dismissable=False) %}
+                <button v-on:click="openModal('{{env_modal_name}}')" type="button" class="icon-link">set role</button>
+                {% call Modal(name=env_modal_name, dismissable=False) %}
                     <div class='block-list'>
                       <div class='block-list__header'>
                         <div>
@@ -129,8 +130,8 @@
                       <input type='hidden' name='env_{{ env.id }}' v-bind:value='newRole'/>
                       <div class='block-list__footer'>
                         <div class='action-group'>
-                          <a v-on:click="closeModal('{{ env.name }}RolesModal')" class='action-group__action usa-button'>Select Access Role</a>
-                          <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{ env.name }}RolesModal'); cancel();" value="{{ value if value == role else role }}" >Cancel</a>
+                          <a v-on:click="closeModal('{{env_modal_name}}')" class='action-group__action usa-button'>Select Access Role</a>
+                          <a class='action-group__action icon-link icon-link--danger' v-on:click="closeModal('{{env_modal_name}}'); cancel();" value="{{ value if value == role else role }}" >Cancel</a>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Description
The edit member page would not render if a project had an environment name with an apostrophe. Instead of using the environment's name to call the Modal, we now use the environment's ID to avoid this rendering issue.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161560295

## Screenshots
![screen shot 2018-10-30 at 10 02 04 am](https://user-images.githubusercontent.com/42577527/47723458-f27fd080-dc2a-11e8-8360-beca9a5bcbed.png)
