### PR TITLE
Fix manual fin ver #161560975

### DIFF
--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -133,7 +133,9 @@ class UpdateFinancialVerification(FinancialVerificationBase):
         if not self.pe_validator.validate(self.request, form.pe_id):
             should_submit = False
 
-        if not self.task_order_validator.validate(form.task_order.number):
+        if not self.is_extended and not self.task_order_validator.validate(
+            form.task_order.number
+        ):
             should_submit = False
 
         if should_update:

--- a/tests/routes/test_financial_verification.py
+++ b/tests/routes/test_financial_verification.py
@@ -122,6 +122,17 @@ def test_update_fv_extended(fv_data, e_fv_data):
     assert update_fv.execute()
 
 
+def test_update_fv_extended_does_not_validate_task_order(fv_data, e_fv_data):
+    request = RequestFactory.create()
+    user = UserFactory.create()
+    data = {**fv_data, **e_fv_data, "task_order-number": "abc123"}
+    update_fv = UpdateFinancialVerification(
+        TrueValidator, TaskOrderNumberValidator(), user, request, data, is_extended=True
+    )
+
+    assert update_fv.execute()
+
+
 def test_update_fv_missing_extended_data(fv_data):
     request = RequestFactory.create()
     user = UserFactory.create()


### PR DESCRIPTION
## Description
This PR fixes a regression that required a valid TO number to submit an extended financial verification form. Everything is now validating as it should, and only checks for the presence of a TO number when submitting an extended fin ver form.

## Pivotal Tracker
[https://www.pivotaltracker.com/story/show/161560975](https://www.pivotaltracker.com/story/show/161560975)