### PR TITLE
Invited user #160301892

### DIFF
--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -70,6 +70,8 @@ class Invitations(object):
         invite = Invitations._get(token)
 
         if invite.user.dod_id != user.dod_id:
+            if invite.is_pending:
+                Invitations._update_status(invite, InvitationStatus.REJECTED)
             raise WrongUserError(user, invite)
 
         elif invite.is_expired:

--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -8,6 +8,15 @@ from atst.domain.workspace_users import WorkspaceUsers
 from .exceptions import NotFoundError
 
 
+class WrongUserError(Exception):
+    def __init__(self, user, invite):
+        self.user = user
+        self.invite = invite
+
+    @property
+    def message(self):
+        return "User {} with DOD ID {} does not match expected DOD ID {} for invitation {}".format(self.user.id, self.user.dod_id, self.invite.user.dod_id, self.invite.id)
+
 class InvitationError(Exception):
     def __init__(self, invite):
         self.invite = invite
@@ -45,8 +54,11 @@ class Invitations(object):
         return invite
 
     @classmethod
-    def accept(cls, token):
+    def accept(cls, user, token):
         invite = Invitations._get(token)
+
+        if invite.user.dod_id != user.dod_id:
+            raise WrongUserError(user, invite)
 
         if invite.is_expired:
             invite.status = InvitationStatus.REJECTED

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -2,6 +2,7 @@ import urllib.parse as url
 from flask import Blueprint, render_template, g, redirect, session, url_for, request
 
 from flask import current_app as app
+from jinja2.exceptions import TemplateNotFound
 import pendulum
 import os
 
@@ -10,6 +11,7 @@ from atst.domain.users import Users
 from atst.domain.authnid import AuthenticationContext
 from atst.domain.audit_log import AuditLog
 from atst.domain.auth import logout as _logout
+from werkzeug.exceptions import NotFound
 
 
 bp = Blueprint("atst", __name__)
@@ -77,7 +79,10 @@ def styleguide():
 
 @bp.route("/<path:path>")
 def catch_all(path):
-    return render_template("{}.html".format(path))
+    try:
+        return render_template("{}.html".format(path))
+    except TemplateNotFound:
+        raise NotFound()
 
 
 def _make_authentication_context():

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -3,7 +3,7 @@ from flask_wtf.csrf import CSRFError
 import werkzeug.exceptions as werkzeug_exceptions
 
 import atst.domain.exceptions as exceptions
-from atst.domain.invitations import InvitationError
+from atst.domain.invitations import InvitationError, WrongUserError as InvitationWrongUserError
 
 
 def make_error_pages(app):
@@ -43,12 +43,13 @@ def make_error_pages(app):
         )
 
     @app.errorhandler(InvitationError)
+    @app.errorhandler(InvitationWrongUserError)
     # pylint: disable=unused-variable
     def invalid_invitation(e):
         log_error(e)
         return (
             render_template(
-                "error.html", message="The invitation link you clicked is invalid."
+                "error.html", message="The link you followed is invalid."
             ),
             404,
         )

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -3,27 +3,35 @@ from flask_wtf.csrf import CSRFError
 import werkzeug.exceptions as werkzeug_exceptions
 
 import atst.domain.exceptions as exceptions
-from atst.domain.invitations import InvitationError, WrongUserError as InvitationWrongUserError
+from atst.domain.invitations import (
+    InvitationError,
+    ExpiredError as InvitationExpiredError,
+    WrongUserError as InvitationWrongUserError,
+)
+
+
+def log_error(e):
+    error_message = e.message if hasattr(e, "message") else str(e)
+    current_app.logger.error(error_message)
+
+
+def handle_error(e, message="Not Found", code=404):
+    log_error(e)
+    return render_template("error.html", message=message), code
 
 
 def make_error_pages(app):
-    def log_error(e):
-        error_message = e.message if hasattr(e, "message") else str(e)
-        app.logger.error(error_message)
-
     @app.errorhandler(werkzeug_exceptions.NotFound)
     @app.errorhandler(exceptions.NotFoundError)
     @app.errorhandler(exceptions.UnauthorizedError)
     # pylint: disable=unused-variable
     def not_found(e):
-        log_error(e)
-        return render_template("error.html", message="Not Found"), 404
+        return handle_error(e)
 
     @app.errorhandler(exceptions.UnauthenticatedError)
     # pylint: disable=unused-variable
     def unauthorized(e):
-        log_error(e)
-        return render_template("error.html", message="Log in Failed"), 401
+        return handle_error(e, message="Log in Failed", code=401)
 
     @app.errorhandler(CSRFError)
     # pylint: disable=unused-variable
@@ -46,12 +54,13 @@ def make_error_pages(app):
     @app.errorhandler(InvitationWrongUserError)
     # pylint: disable=unused-variable
     def invalid_invitation(e):
-        log_error(e)
-        return (
-            render_template(
-                "error.html", message="The link you followed is invalid."
-            ),
-            404,
+        return handle_error(e, message="The link you followed is invalid.", code=404)
+
+    @app.errorhandler(InvitationExpiredError)
+    # pylint: disable=unused-variable
+    def invalid_invitation(e):
+        return handle_error(
+            e, message="The invitation you followed has expired.", code=404
         )
 
     return app

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -361,8 +361,6 @@ def update_member(workspace_id, member_id):
 
 @bp.route("/workspaces/invitation/<token>", methods=["GET"])
 def accept_invitation(token):
-    # TODO: check that the current_user DOD ID matches the user associated with
-    # the invitation
     invite = Invitations.accept(g.current_user, token)
 
     return redirect(

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -363,7 +363,7 @@ def update_member(workspace_id, member_id):
 def accept_invitation(token):
     # TODO: check that the current_user DOD ID matches the user associated with
     # the invitation
-    invite = Invitations.accept(token)
+    invite = Invitations.accept(g.current_user, token)
 
     return redirect(
         url_for("workspaces.show_workspace", workspace_id=invite.workspace.id)

--- a/templates/error.html
+++ b/templates/error.html
@@ -10,6 +10,10 @@
     <h1>An error occurred.</h1>
 {% endif %}
 
+{% if g.current_user %}
+  <p>Return <a href="{{ url_for("atst.home") }}">home</a>.</p>
+{% endif %}
+
 </main>
 
 {% endblock %}

--- a/tests/domain/test_invitations.py
+++ b/tests/domain/test_invitations.py
@@ -75,6 +75,16 @@ def test_wrong_user_accepts_invitation():
         Invitations.accept(wrong_user, invite.token)
 
 
+def test_user_cannot_accept_invitation_accepted_by_wrong_user():
+    user = UserFactory.create()
+    wrong_user = UserFactory.create()
+    invite = InvitationFactory.create(user_id=user.id)
+    with pytest.raises(WrongUserError):
+        Invitations.accept(wrong_user, invite.token)
+    with pytest.raises(InvitationError):
+        Invitations.accept(user, invite.token)
+
+
 def test_accept_invitation_twice():
     workspace = WorkspaceFactory.create()
     user = UserFactory.create()

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -355,3 +355,19 @@ def test_user_who_has_not_accepted_workspace_invite_cannot_view(client, user_ses
     user_session(user)
     response = client.get("/workspaces/{}/projects".format(workspace.id))
     assert response.status_code == 404
+
+
+def test_user_accepts_invite_with_wrong_dod_id(client, user_session):
+    workspace = WorkspaceFactory.create()
+    user = UserFactory.create()
+    different_user = UserFactory.create()
+    ws_role = WorkspaceRoleFactory.create(
+        user=user, workspace=workspace, status=WorkspaceRoleStatus.PENDING
+    )
+    invite = InvitationFactory.create(
+        user_id=user.id, workspace_role_id=ws_role.id
+    )
+    user_session(different_user)
+    response = client.get(url_for("workspaces.accept_invitation", token=invite.token))
+
+    assert response.status_code == 404

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -327,7 +327,7 @@ def test_existing_member_accepts_valid_invite(client, user_session):
     assert len(Workspaces.for_user(user)) == 1
 
 
-def test_new_member_accepts_valid_invite(client, user_session):
+def test_new_member_accepts_valid_invite(monkeypatch, client, user_session):
     workspace = WorkspaceFactory.create()
     user_info = UserFactory.dictionary()
 
@@ -340,6 +340,9 @@ def test_new_member_accepts_valid_invite(client, user_session):
     user = Users.get_by_dod_id(user_info["dod_id"])
     token = user.invitations[0].token
 
+    monkeypatch.setattr(
+        "atst.domain.auth.should_redirect_to_user_profile", lambda *args: False
+    )
     user_session(user)
     response = client.get(url_for("workspaces.accept_invitation", token=token))
 


### PR DESCRIPTION
This adds additional use-cases for users accepting a workspace invitation, per this PT story: https://www.pivotaltracker.com/story/show/160301892

**notes**
- The ACs initially asked for a modal with explanatory text when a user has an invalid or expired invite. After discussion, I've implemented it as a regular error page, since that's in line with how we've been handling other kinds of errors. I added a link to "home" on the error page so users have somewhere to go after trying to accept and expired invite.
- Unrelated to the story, but I added some exception handling to the glob route so that missing template exceptions get re-raised as 404s instead of 500s (since this is where legitimate 404s will happen, as opposed to our authorization-based 404s).