### PR TITLE
Update UAT environment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,6 +206,9 @@ workflows:
       - build_and_push_image:
           requires:
             - test
+          filters:
+            branches:
+              only: master
       - deploy:
           requires:
             - build_and_push_image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -206,9 +206,6 @@ workflows:
       - build_and_push_image:
           requires:
             - test
-          filters:
-            branches:
-              only: master
       - deploy:
           requires:
             - build_and_push_image

--- a/atst/app.py
+++ b/atst/app.py
@@ -102,7 +102,7 @@ def map_config(config):
         ),
         "REQUIRE_CRLS": config.getboolean("default", "REQUIRE_CRLS"),
         "RQ_REDIS_URL": config["default"]["REDIS_URI"],
-        "RQ_QUEUES": ["atat_{}".format(ENV.lower())],
+        "RQ_QUEUES": [config["default"]["RQ_QUEUES"]],
     }
 
 

--- a/config/base.ini
+++ b/config/base.ini
@@ -16,6 +16,7 @@ PGUSER = postgres
 PORT=8000
 REDIS_URI = redis://localhost:6379
 REQUIRE_CRLS = true
+RQ_QUEUES = atat_%(ENVIRONMENT)s
 SECRET = change_me_into_something_secret
 SECRET_KEY = change_me_into_something_secret
 SESSION_COOKIE_NAME=atat

--- a/deploy/kubernetes/uat/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-envvars-configmap.yml
@@ -8,3 +8,4 @@ data:
   FLASK_ENV: dev
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini
+  RQ_QUEUES: atat-uat

--- a/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
@@ -1,0 +1,8 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: atst-worker-envvars
+  namespace: atat-uat
+data:
+  REQUIRE_CRLS: "False"

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:76854ac
+          image: registry.atat.codes:443/atst-prod:3a01b36d
           resources:
             requests:
                memory: "2500Mi"
@@ -124,6 +124,51 @@ spec:
         - name: uwsgi-socket-dir
           emptyDir:
             medium: Memory
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: atst
+  name: atst-worker
+  namespace: atat-uat
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: atst
+    spec:
+      securityContext:
+        fsGroup: 101
+      containers:
+        - name: atst-worker
+          image: registry.atat.codes:443/atst-prod:3a01b36d
+          args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
+          resources:
+            requests:
+               memory: "500Mi"
+          envFrom:
+          - configMapRef:
+              name: atst-envvars
+          - configMapRef:
+              name: atst-worker-envvars
+          volumeMounts:
+            - name: atst-config
+              mountPath: "/opt/atat/atst/atst-overrides.ini"
+              subPath: atst-overrides.ini
+      imagePullSecrets:
+        - name: regcred
+      volumes:
+        - name: atst-config
+          secret:
+            secretName: atst-config-ini
+            items:
+            - key: override.ini
+              path: atst-overrides.ini
+              mode: 0644
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -24,7 +24,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:3a01b36d
+          image: registry.atat.codes:443/atst-prod:a9fc2bd2
           resources:
             requests:
                memory: "2500Mi"
@@ -145,7 +145,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:3a01b36d
+          image: registry.atat.codes:443/atst-prod:a9fc2bd2
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:


### PR DESCRIPTION
This PR updates the UAT env with the latest changes to our deployment including:

* the cron job to sync CRLs will now be running
* the container image has been update to the latest code
* the flask-rq worker deployment has been added

This branch also allows specifying the `RQ_QUEUES` via an environment variable so that the UAT env and the staging env can continue to use the same Redis resource without conflicting use of RQ.

These changes have already been applied to the `atat-uat` namespace on the cluster.