### PR TITLE
Invite and Workspace Member Status

### DIFF
--- a/alembic/versions/e1081cf01780_adjust_invitation_status.py
+++ b/alembic/versions/e1081cf01780_adjust_invitation_status.py
@@ -1,0 +1,39 @@
+"""adjust invitation status
+
+Revision ID: e1081cf01780
+Revises: a9d8c6b6221c
+Create Date: 2018-11-01 12:24:10.970963
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from atst.models.invitation import Status
+from enum import Enum
+
+
+# revision identifiers, used by Alembic.
+revision = 'e1081cf01780'
+down_revision = 'a9d8c6b6221c'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    constraints = ", ".join(["'{}'::character varying::text".format(s.name) for s in Status])
+    conn.execute("ALTER TABLE invitations ALTER COLUMN status TYPE varchar(30)")
+    conn.execute("ALTER TABLE invitations DROP CONSTRAINT status")
+    conn.execute("ALTER TABLE invitations ADD CONSTRAINT status CHECK(status::text = ANY (ARRAY[{}]))".format(constraints))
+
+class PreviousStatus(Enum):
+    ACCEPTED = "accepted"
+    REVOKED = "revoked"
+    PENDING = "pending"
+    REJECTED = "rejected"
+
+def downgrade():
+    conn = op.get_bind()
+    constraints = ", ".join(["'{}'::character varying::text".format(s.name) for s in PreviousStatus])
+    conn.execute("ALTER TABLE invitations ALTER COLUMN status TYPE varchar(8)")
+    conn.execute("ALTER TABLE invitations DROP CONSTRAINT status")
+    conn.execute("ALTER TABLE invitations ADD CONSTRAINT status CHECK(status::text = ANY (ARRAY[{}]))".format(constraints))

--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -71,11 +71,11 @@ class Invitations(object):
 
         if invite.user.dod_id != user.dod_id:
             if invite.is_pending:
-                Invitations._update_status(invite, InvitationStatus.REJECTED)
+                Invitations._update_status(invite, InvitationStatus.REJECTED_WRONG_USER)
             raise WrongUserError(user, invite)
 
         elif invite.is_expired:
-            Invitations._update_status(invite, InvitationStatus.REJECTED)
+            Invitations._update_status(invite, InvitationStatus.REJECTED_EXPIRED)
             raise ExpiredError(invite)
 
         elif invite.is_accepted or invite.is_revoked or invite.is_rejected:

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -37,17 +37,25 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         )
 
     @property
+    def latest_invitation(self):
+        if self.invitations:
+            return self.invitations[-1]
+
+    @property
     def display_status(self):
-        import ipdb; ipdb.set_trace()
         if self.status == Status.ACTIVE:
             return "Active"
-        else:
-            if any(i.is_expired for i in self.invitations):
-                return "Invitation Expired"
-            elif any(i.is_rejected for i in self.invitations):
-                return "Invitation Rejected"
+        elif self.latest_invitation:
+            if self.latest_invitation.is_rejected_expired:
+                return "Invite expired"
+            elif self.latest_invitation.is_rejected_wrong_user:
+                return "Error on invite"
+            elif self.latest_invitation.is_expired:
+                return "Invite expired"
             else:
                 return "Pending"
+        else:
+            return "Unknown errors"
 
 
 Index(

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -38,6 +38,7 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def display_status(self):
+        import ipdb; ipdb.set_trace()
         if self.status == Status.ACTIVE:
             return "Active"
         else:

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -36,6 +36,18 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
             self.role.name, self.workspace.name, self.user_id, self.id
         )
 
+    @property
+    def display_status(self):
+        if self.status == Status.ACTIVE:
+            return "Active"
+        else:
+            if any(i.is_expired for i in self.invitations):
+                return "Invitation Expired"
+            elif any(i.is_rejected for i in self.invitations):
+                return "Invitation Rejected"
+            else:
+                return "Pending"
+
 
 Index(
     "workspace_role_user_workspace",

--- a/atst/models/workspace_user.py
+++ b/atst/models/workspace_user.py
@@ -35,7 +35,7 @@ class WorkspaceUser(object):
 
     @property
     def status(self):
-        return "active"
+        return self.workspace_role.display_status
 
     @property
     def num_environment_roles(self):

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -11,6 +11,7 @@ from atst.domain.users import Users
 from atst.domain.requests import Requests
 from atst.domain.workspaces import Workspaces
 from atst.domain.projects import Projects
+from atst.domain.workspace_users import WorkspaceUsers
 from atst.domain.exceptions import AlreadyExistsError
 from tests.factories import RequestFactory, TaskOrderFactory
 from atst.routes.dev import _DEV_USERS as DEV_USERS
@@ -74,7 +75,8 @@ def seed_db():
             request, name="{}'s workspace".format(user.first_name)
         )
         for workspace_user in WORKSPACE_USERS:
-            Workspaces.create_member(user, workspace, workspace_user)
+            ws_user = Workspaces.create_member(user, workspace, workspace_user)
+            WorkspaceUsers.enable(ws_user.workspace_role)
 
         Projects.create(
             user,

--- a/tests/domain/test_invitations.py
+++ b/tests/domain/test_invitations.py
@@ -55,7 +55,7 @@ def test_accept_expired_invitation():
 
 def test_accept_rejected_invite():
     user = UserFactory.create()
-    invite = InvitationFactory.create(user_id=user.id, status=Status.REJECTED)
+    invite = InvitationFactory.create(user_id=user.id, status=Status.REJECTED_EXPIRED)
     with pytest.raises(InvitationError):
         Invitations.accept(user, invite.token)
 

--- a/tests/models/test_workspace_user.py
+++ b/tests/models/test_workspace_user.py
@@ -1,8 +1,9 @@
 from atst.domain.environments import Environments
 from atst.domain.workspaces import Workspaces
 from atst.domain.projects import Projects
-from atst.models.workspace_user import WorkspaceUser
-from tests.factories import RequestFactory, UserFactory
+from atst.domain.workspace_users import WorkspaceUsers
+from atst.models.invitation import Status
+from tests.factories import RequestFactory, UserFactory, InvitationFactory, WorkspaceRoleFactory
 
 
 def test_has_no_environment_roles():
@@ -54,3 +55,10 @@ def test_role_displayname():
     workspace_user = Workspaces.create_member(owner, workspace, developer_data)
 
     assert workspace_user.role_displayname == "Developer"
+
+
+def test_status_when_member_has_pending_invitation():
+    workspace_role = WorkspaceRoleFactory.create(
+        invitations=[InvitationFactory.create(status=Status.ACCEPTED)]
+    )
+    assert workspace_role.display_status == "Accepted"

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -363,7 +363,9 @@ def test_member_accepts_invalid_invite(client, user_session):
         user=user, workspace=workspace, status=WorkspaceRoleStatus.PENDING
     )
     invite = InvitationFactory.create(
-        user_id=user.id, workspace_role_id=ws_role.id, status=InvitationStatus.REJECTED
+        user_id=user.id,
+        workspace_role_id=ws_role.id,
+        status=InvitationStatus.REJECTED_WRONG_USER,
     )
     user_session(user)
     response = client.get(url_for("workspaces.accept_invitation", token=invite.token))
@@ -411,7 +413,7 @@ def test_user_accepts_expired_invite(client, user_session):
     invite = InvitationFactory.create(
         user_id=user.id,
         workspace_role_id=ws_role.id,
-        status=InvitationStatus.REJECTED,
+        status=InvitationStatus.REJECTED_EXPIRED,
         expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
     )
     user_session(user)


### PR DESCRIPTION
A user's workspace status changes depending on whether they've accepted an invite or the invitation failed.

This takes care of two related PT stories:

1. Expire an invitation and show the correct workspace member status: https://www.pivotaltracker.com/story/show/161347144
2. Change user status when an invitation is accepted: https://www.pivotaltracker.com/story/show/161347593

<img width="1004" alt="screen shot 2018-11-01 at 1 49 55 pm" src="https://user-images.githubusercontent.com/38955503/47869318-0e2ad880-dddd-11e8-9ea4-7df2270eae36.png">
