### PR TITLE
Fix a bug that was crashing the requests index

### DIFF
--- a/atst/routes/requests/index.py
+++ b/atst/routes/requests/index.py
@@ -60,7 +60,7 @@ class RequestsIndex(object):
     def _workspace_link_for_request(self, request):
         if request.is_approved:
             return url_for(
-                "workspaces.workspace_projects", workspace_id=request.workspace_id
+                "workspaces.workspace_projects", workspace_id=request.workspace.id
             )
         else:
             return None

--- a/tests/routes/test_requests_index.py
+++ b/tests/routes/test_requests_index.py
@@ -9,6 +9,8 @@ def test_action_required_mission_owner():
     creator = UserFactory.create()
     requests = RequestFactory.create_batch(5, creator=creator)
     Requests.submit(requests[0])
+    Requests.approve_and_create_workspace(requests[1])
+
     context = RequestsIndex(creator).execute()
 
     assert context["requests"][0]["action_required"] == False
@@ -18,6 +20,7 @@ def test_action_required_ccpo():
     creator = UserFactory.create()
     requests = RequestFactory.create_batch(5, creator=creator)
     Requests.submit(requests[0])
+    Requests.approve_and_create_workspace(requests[1])
 
     ccpo = UserFactory.from_atat_role("ccpo")
     context = RequestsIndex(ccpo).execute()


### PR DESCRIPTION
When a user navigated to the requests index with at least one approved request, it was crashing because of a typo. `request.workspace_id` should have been `request.workspace.id`.