### PR TITLE
display error alert for users who had DOD ID conflict when accepting …

### DIFF
--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -57,6 +57,10 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         else:
             return "Unknown errors"
 
+    @property
+    def has_dod_id_error(self):
+        return self.latest_invitation and self.latest_invitation.is_rejected_wrong_user
+
 
 Index(
     "workspace_role_user_workspace",

--- a/atst/models/workspace_user.py
+++ b/atst/models/workspace_user.py
@@ -38,6 +38,10 @@ class WorkspaceUser(object):
         return self.workspace_role.display_status
 
     @property
+    def has_dod_id_error(self):
+        return self.workspace_role.has_dod_id_error
+
+    @property
     def num_environment_roles(self):
         return (
             db.session.query(EnvironmentRole)

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -4,8 +4,13 @@
 {% from "components/modal.html" import Modal %}
 {% from "components/selector.html" import Selector %}
 {% from "components/options_input.html" import OptionsInput %}
+{% from "components/alert.html" import Alert %}
 
 {% block content %}
+
+{% if member.has_dod_id_error %}
+  {{ Alert('CAC ID Error', message='The member attempted to accept this invite, but their CAC ID did not match the CAC ID you specified on the invite. Please confirm that the DOD ID is accurate.', level='error') }}
+{% endif %}
 
 <form method="POST" action="{{ url_for('workspaces.update_member', workspace_id=workspace.id, member_id=member.user_id) }}" autocomplete="false">
   {{ form.csrf_token }}


### PR DESCRIPTION
…workspace invitation

For https://www.pivotaltracker.com/story/show/161347944

If a user tries to follow a workspace invitation link and there is a DOD ID mismatch, the MO now sees an alert to that effect on the member details page.

The status updates for the user were handled on a previous PR, and the "re-invite" functionality should be handled on a separate [PT story](https://www.pivotaltracker.com/n/projects/2160940/stories/161347134).