### PR TITLE
set environment for tests so that tests use their own queue

### DIFF
--- a/config/test.ini
+++ b/config/test.ini
@@ -1,4 +1,5 @@
 [default]
+ENVIRONMENT = test
 PGDATABASE = atat_test
 CRL_DIRECTORY = tests/fixtures/crl
 WTF_CSRF_ENABLED = false


### PR DESCRIPTION
We were seeing a small bug in the tests because they were relying on `atat_dev` as their queue. This meant that if the queue worker was running at the same time you ran tests, it would try to perform any jobs enqueued by the tests so that assertions about the number of enqueued jobs would fail. This change just specifies the `ENVIRONMENT` for the tests so that the constructed queue name is `atat_test`.