### PR TITLE
control error display for options input component

### DIFF
--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -2,8 +2,22 @@ export default {
   name: 'optionsinput',
 
   props: {
-    name: String
+    name: String,
+    initialErrors: {
+      type: Array,
+      default: () => []
+    },
   },
+
+
+  data: function () {
+    return {
+      showError: (this.initialErrors && this.initialErrors.length) || false,
+      showValid: false,
+      validationError: this.initialErrors.join(' ')
+    }
+  },
+
 
   methods: {
     onInput: function (e) {
@@ -11,6 +25,8 @@ export default {
         value: e.target.value,
         name: this.name
       })
+      this.showError = false
+      this.showValid = true
     }
   }
 }

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -12,9 +12,10 @@ export default {
 
 
   data: function () {
+    const showError = (this.initialErrors && this.initialErrors.length) || false
     return {
-      showError: (this.initialErrors && this.initialErrors.length) || false,
-      showValid: !!this.initialValue,
+      showError: showError,
+      showValid: !showError && !!this.initialValue,
       validationError: this.initialErrors.join(' ')
     }
   },

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -7,13 +7,14 @@ export default {
       type: Array,
       default: () => []
     },
+    initialValue: String,
   },
 
 
   data: function () {
     return {
       showError: (this.initialErrors && this.initialErrors.length) || false,
-      showValid: false,
+      showValid: !!this.initialValue,
       validationError: this.initialErrors.join(' ')
     }
   },

--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -46,13 +46,13 @@
   fieldset {
     input[type='radio'] {
       + label::before {
-        box-shadow: 0 0 0 1px $color-white, 0 0 0 3px $color-red;
+        box-shadow: 0 0 0 1px $color-white, 0 0 0 3px $state-color;
       }
     }
 
     input[type='checkbox'] {
       + label::before {
-        box-shadow: 0 0 0 2px $color-red;
+        box-shadow: 0 0 0 2px $state-color;
       }
     }
   }

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -2,8 +2,13 @@
 {% from "components/tooltip.html" import Tooltip %}
 
 {% macro OptionsInput(field, tooltip, inline=False) -%}
-  <optionsinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
-    <div class='usa-input {% if field.errors %}usa-input--error{% endif %}'>
+  <optionsinput
+    name='{{ field.name }}'
+    inline-template
+    {% if field.errors %}v-bind:initial-errors='{{ field.errors | list }}'{% endif %}
+    key='{{ field.name }}'>
+    <div
+      v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">
 
       <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
@@ -16,18 +21,15 @@
             <span class='usa-input__help'>{{ field.description | safe }}</span>
           {% endif %}
 
-          {% if field.errors %}
-            {{ Icon('alert',classes="icon-validation") }}
-          {% endif %}
+          <span v-show='showError'>{{ Icon('alert',classes="icon-validation") }}</span>
+          <span v-show='showValid'>{{ Icon('ok',classes="icon-validation") }}</span>
         </legend>
 
         {{ field() }}
 
-        {% if field.errors %}
-          {% for error in field.errors %}
-            <span class='usa-input__message'>{{ error }}</span>
-          {% endfor %}
-        {% endif %}
+        <template v-if='showError'>
+          <span class='usa-input__message' v-html='validationError'></span>
+        </template>
 
       </fieldset>
     </div>

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -6,6 +6,7 @@
     name='{{ field.name }}'
     inline-template
     {% if field.errors %}v-bind:initial-errors='{{ field.errors | list }}'{% endif %}
+    {% if field.data and field.data != "None" %}v-bind:initial-value="'{{ field.data }}'"{% endif %}
     key='{{ field.name }}'>
     <div
       v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/161717158

This expands our `optioninput` Vue component so that it can dismiss errors when a user marks a choice. I think that the only validation error these can have is that nothing has been marked (because they're required), so any kind of input update should be valid. I also made a small adjustment to our sass so that radio buttons and checkboxes get the correct validation color.