### PR TITLE
Fix workspace role selection on edit member page

### DIFF
--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -291,7 +291,7 @@ def view_member(workspace_id, member_id):
     )
     member = WorkspaceRoles.get(workspace_id, member_id)
     projects = Projects.get_all(g.current_user, member, workspace)
-    form = EditMemberForm(workspace_role=member.role)
+    form = EditMemberForm(workspace_role=member.role_name)
     editable = g.current_user == member.user
     return render_template(
         "workspaces/members/edit.html",

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -198,15 +198,27 @@ def test_create_member(client, user_session):
     assert len(queue.get_queue()) == queue_length + 1
 
 
+def test_view_member_shows_role(client, user_session):
+    user = UserFactory.create()
+    workspace = WorkspaceFactory.create()
+    Workspaces._create_workspace_role(user, workspace, "developer")
+    member = WorkspaceRoles.add(user, workspace.id, "developer")
+    user_session(workspace.owner)
+    response = client.get(
+        url_for("workspaces.view_member", workspace_id=workspace.id, member_id=user.id)
+    )
+    assert response.status_code == 200
+    assert "initial-choice='developer'".encode() in response.data
+
+
 def test_permissions_for_view_member(client, user_session):
     user = UserFactory.create()
     workspace = WorkspaceFactory.create()
     Workspaces._create_workspace_role(user, workspace, "developer")
     member = WorkspaceRoles.add(user, workspace.id, "developer")
     user_session(user)
-    response = client.post(
-        url_for("workspaces.view_member", workspace_id=workspace.id, member_id=user.id),
-        follow_redirects=True,
+    response = client.get(
+        url_for("workspaces.view_member", workspace_id=workspace.id, member_id=user.id)
     )
     assert response.status_code == 404
 


### PR DESCRIPTION
In consolidating over to the workspace role model (#427), the value passed in to the selector changed from a string to an object, causing the selection dropdown to not render at all:

![image](https://user-images.githubusercontent.com/40774582/48095094-d5766f00-e1e1-11e8-91e6-15bd6b70cd83.png)

This branch fixes that and adds a test to ensure the dropdown is shown:

![image](https://user-images.githubusercontent.com/40774582/48095118-e7f0a880-e1e1-11e8-9f5a-87d05bb9580e.png)
