### PR TITLE
Update "auto approve" to "auto accept" in request domain object

### DIFF
--- a/atst/domain/requests/requests.py
+++ b/atst/domain/requests/requests.py
@@ -27,7 +27,7 @@ def create_revision_from_request_body(body):
 
 
 class Requests(object):
-    AUTO_APPROVE_THRESHOLD = 1_000_000
+    AUTO_ACCEPT_THRESHOLD = 1_000_000
     ANNUAL_SPEND_THRESHOLD = 1_000_000
 
     @classmethod
@@ -63,7 +63,7 @@ class Requests(object):
     def submit(cls, request):
         request = Requests.set_status(request, RequestStatus.SUBMITTED)
 
-        if Requests.should_auto_approve(request):
+        if Requests.should_auto_accept(request):
             request = Requests.set_status(
                 request, RequestStatus.PENDING_FINANCIAL_VERIFICATION
             )
@@ -134,13 +134,13 @@ class Requests(object):
         return updated_request
 
     @classmethod
-    def should_auto_approve(cls, request):
+    def should_auto_accept(cls, request):
         try:
             dollar_value = request.body["details_of_use"]["dollar_value"]
         except KeyError:
             return False
 
-        return dollar_value < cls.AUTO_APPROVE_THRESHOLD
+        return dollar_value < cls.AUTO_ACCEPT_THRESHOLD
 
     _VALID_SUBMISSION_STATUSES = [
         RequestStatus.STARTED,

--- a/atst/domain/requests/requests.py
+++ b/atst/domain/requests/requests.py
@@ -72,7 +72,7 @@ class Requests(object):
                 request=request,
                 review_data={
                     "comment": "Auto-acceptance for dollar value below {}".format(
-                        dollars(Requests.AUTO_APPROVE_THRESHOLD)
+                        dollars(Requests.AUTO_ACCEPT_THRESHOLD)
                     )
                 },
             )

--- a/atst/forms/new_request.py
+++ b/atst/forms/new_request.py
@@ -35,7 +35,7 @@ class DetailsOfUseForm(ValidatedForm):
         except ValueError:
             annual_spend = 0
 
-        if annual_spend > Requests.AUTO_APPROVE_THRESHOLD:
+        if annual_spend > Requests.AUTO_ACCEPT_THRESHOLD:
             self.number_user_sessions.validators.append(InputRequired())
             self.average_daily_traffic.validators.append(InputRequired())
 

--- a/atst/forms/new_request.py
+++ b/atst/forms/new_request.py
@@ -35,7 +35,7 @@ class DetailsOfUseForm(ValidatedForm):
         except ValueError:
             annual_spend = 0
 
-        if annual_spend > Requests.AUTO_ACCEPT_THRESHOLD:
+        if annual_spend > Requests.ANNUAL_SPEND_THRESHOLD:
             self.number_user_sessions.validators.append(InputRequired())
             self.average_daily_traffic.validators.append(InputRequired())
 

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -162,7 +162,7 @@
                     {{ TextInput(
                       review_form.comment,
                       label='Approval comments or notes',
-                      description='Provide any comments or notes regarding the approval of this request. <strong>This message will be shared with the person making the JEDI request.</strong>.',
+                      description='Provide any comments or notes regarding the approval of this request. <strong>This message will be shared with the person making the JEDI request.</strong>',
                       paragraph=True,
                       noMaxWidth=True
                     ) }}

--- a/templates/requests/approval.html
+++ b/templates/requests/approval.html
@@ -101,7 +101,6 @@
                     <li>
                       <article class='approval-log__log-item'>
                         <div>
-                          {{ review.log_name }}
                           <h3 class='approval-log__log-item__header'>{{ review.status.log_name }} by {{ review.full_name_reviewer }}</h3>
                           {% if review.comment %}
                             <p>{{ review.comment }}</p>


### PR DESCRIPTION
We previously added a difference between "accept" and "approve" -- the acceptance is done when the request is submitted initially and the approval is down when the financial verification is reviewed. This PR changes the `Review.should_auto_approve` to `Review.should_auto_accept` and the `Review.AUTO_ACCEPT_THRESHOLD` to `Review.AUTO_APPROVE_THRESHOLD`. 

There's also a tiny clean-up in the accept/reject screen for CCPO and a change in the request form to use the correct constant.