### PR TITLE
Revoke invitation #160300315

### DIFF
--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -99,3 +99,8 @@ class Invitations(object):
         db.session.commit()
 
         return invite
+
+    @classmethod
+    def revoke(cls, token):
+        invite = Invitations._get(token)
+        return Invitations._update_status(invite, InvitationStatus.REVOKED)

--- a/atst/domain/workspaces/workspaces.py
+++ b/atst/domain/workspaces/workspaces.py
@@ -51,6 +51,18 @@ class Workspaces(object):
         return workspace
 
     @classmethod
+    def get_for_update_member(cls, user, workspace_id):
+        workspace = WorkspacesQuery.get(workspace_id)
+        Authorization.check_workspace_permission(
+            user,
+            workspace,
+            Permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE,
+            "update a workspace member",
+        )
+
+        return workspace
+
+    @classmethod
     def get_by_request(cls, request):
         return WorkspacesQuery.get_by_request(request)
 

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -51,7 +51,9 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         if self.status == Status.ACTIVE:
             return "Active"
         elif self.latest_invitation:
-            if self.latest_invitation.is_rejected_expired:
+            if self.latest_invitation.is_revoked:
+                return "Revoked"
+            elif self.latest_invitation.is_rejected_expired:
                 return "Invite expired"
             elif self.latest_invitation.is_rejected_wrong_user:
                 return "Error on invite"

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -357,10 +357,26 @@ def update_member(workspace_id, member_id):
         )
 
 
-@bp.route("/workspaces/invitation/<token>", methods=["GET"])
+@bp.route("/workspaces/invitations/<token>", methods=["GET"])
 def accept_invitation(token):
     invite = Invitations.accept(g.current_user, token)
 
     return redirect(
         url_for("workspaces.show_workspace", workspace_id=invite.workspace.id)
+    )
+
+
+@bp.route("/workspaces/<workspace_id>/invitations/<token>/revoke", methods=["POST"])
+def revoke_invitation(workspace_id, token):
+    workspace = Workspaces.get(g.current_user, workspace_id)
+    Authorization.check_workspace_permission(
+        g.current_user,
+        workspace,
+        Permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE,
+        "revoke member invitation",
+    )
+    invite = Invitations.revoke(token)
+
+    return redirect(
+        url_for("workspaces.show_workspace", workspace_id=workspace.id)
     )

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -375,8 +375,6 @@ def revoke_invitation(workspace_id, token):
         Permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE,
         "revoke member invitation",
     )
-    invite = Invitations.revoke(token)
+    Invitations.revoke(token)
 
-    return redirect(
-        url_for("workspaces.show_workspace", workspace_id=workspace.id)
-    )
+    return redirect(url_for("workspaces.workspace_members", workspace_id=workspace.id))

--- a/atst/routes/workspaces.py
+++ b/atst/routes/workspaces.py
@@ -368,13 +368,7 @@ def accept_invitation(token):
 
 @bp.route("/workspaces/<workspace_id>/invitations/<token>/revoke", methods=["POST"])
 def revoke_invitation(workspace_id, token):
-    workspace = Workspaces.get(g.current_user, workspace_id)
-    Authorization.check_workspace_permission(
-        g.current_user,
-        workspace,
-        Permissions.ASSIGN_AND_UNASSIGN_ATAT_ROLE,
-        "revoke member invitation",
-    )
+    workspace = Workspaces.get_for_update_member(g.current_user, workspace_id)
     Invitations.revoke(token)
 
     return redirect(url_for("workspaces.workspace_members", workspace_id=workspace.id))

--- a/templates/components/confirmation_button.html
+++ b/templates/components/confirmation_button.html
@@ -1,9 +1,10 @@
-{% macro ConfirmationButton(btn_text, action, confirm_msg="Are you sure?", confirm_btn="Confirm", cancel_btn="Cancel") -%}
+{% macro ConfirmationButton(btn_text, action, csrf_token, confirm_msg="Are you sure?", confirm_btn="Confirm", cancel_btn="Cancel") -%}
   <v-popover placement='top-start'>
     <template slot="popover">
       <p>{{ confirm_msg }}</p>
       <div class='action-group'>
         <form method="POST" action="{{ action }}">
+          {{ csrf_token }}
           <button class='usa-button usa-button-primary' type='submit'>
             {{ confirm_btn }}
           </button>
@@ -13,6 +14,6 @@
         </button>
       </div>
     </template>
-    <button class="tooltip-target">{{ btn_text }}</button>
+    <button class="tooltip-target" type="button">{{ btn_text }}</button>
   </v-popover>
 {%- endmacro %}

--- a/templates/components/confirmation_button.html
+++ b/templates/components/confirmation_button.html
@@ -1,0 +1,18 @@
+{% macro ConfirmationButton(btn_text, action, confirm_msg="Are you sure?", confirm_btn="Confirm", cancel_btn="Cancel") -%}
+  <v-popover placement='top-start'>
+    <template slot="popover">
+      <p>{{ confirm_msg }}</p>
+      <div class='action-group'>
+        <form method="POST" action="{{ action }}">
+          <button class='usa-button usa-button-primary' type='submit'>
+            {{ confirm_btn }}
+          </button>
+        </form>
+        <button class='usa-button usa-button-secondary' v-close-popover>
+          {{ cancel_btn }}
+        </button>
+      </div>
+    </template>
+    <button class="tooltip-target">{{ btn_text }}</button>
+  </v-popover>
+{%- endmacro %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -5,6 +5,7 @@
 {% from "components/selector.html" import Selector %}
 {% from "components/options_input.html" import OptionsInput %}
 {% from "components/alert.html" import Alert %}
+{% from "components/confirmation_button.html" import ConfirmationButton %}
 
 {% block content %}
 
@@ -37,6 +38,13 @@
       </dl>
       {% if editable %}
         <a href='{{ url_for("users.user") }}' class='icon-link'>edit account details</a>
+      {% endif %}
+      {% if member.latest_invitation.is_pending %}
+        {{ ConfirmationButton(
+              "Revoke Invitation",
+              url_for("workspaces.revoke_invitation", workspace_id=workspace.id, token=member.latest_invitation.token),
+              form.csrf_token
+           ) }}
       {% endif %}
     </div>
   </div>

--- a/tests/domain/test_invitations.py
+++ b/tests/domain/test_invitations.py
@@ -93,3 +93,13 @@ def test_accept_invitation_twice():
     Invitations.accept(user, invite.token)
     with pytest.raises(InvitationError):
         Invitations.accept(user, invite.token)
+
+
+def test_revoke_invitation():
+    workspace = WorkspaceFactory.create()
+    user = UserFactory.create()
+    ws_role = WorkspaceRoleFactory.create(user=user, workspace=workspace)
+    invite = Invitations.create(ws_role, workspace.owner, user)
+    assert invite.is_pending
+    Invitations.revoke(invite.token)
+    assert invite.is_revoked

--- a/tests/routes/test_workspaces.py
+++ b/tests/routes/test_workspaces.py
@@ -435,7 +435,13 @@ def test_revoke_invitation(client, user_session):
         expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
     )
     user_session(workspace.owner)
-    response = client.post(url_for("workspaces.revoke_invitation", workspace_id=workspace.id, token=invite.token))
+    response = client.post(
+        url_for(
+            "workspaces.revoke_invitation",
+            workspace_id=workspace.id,
+            token=invite.token,
+        )
+    )
 
     assert response.status_code == 302
     assert invite.is_revoked


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160300315

This gives workspace owners and admins the ability to revoke a pending invitation.

I also added a new macro for a confirmation button component. The button presupposes that it's being used as the D in CRUD, so it's wrapped in its own small `form` element and needs a form action specified. This should prevent any form inheritance and submission confusion in the DOM.

The confirmation popup and copy could use a UI/UX pass if you have time, @luiscielak or @andrewcroce .

![screen shot 2018-11-07 at 9 46 49 am](https://user-images.githubusercontent.com/38955503/48138437-541aed00-e272-11e8-9b18-55a4bc37d440.png)
