### PR TITLE
Four Standard Environments Given When Creating a Project

### DIFF
--- a/js/components/forms/new_project.js
+++ b/js/components/forms/new_project.js
@@ -29,7 +29,7 @@ export default {
     const environments = (
       environment_names.length > 0
       ? environment_names
-      : [""]
+      : ["Development", "Testing", "Staging", "Production"]
     ).map(createEnvironment)
 
     return {


### PR DESCRIPTION
## Description
We want the user to be able to click through the entire setup of a workspace and have a functioning system. This PR adds four standard environments on the New Project page: "Development," Testing," "Staging," and "Production."

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161267715

## Screenshots
![screen shot 2018-11-08 at 10 36 13 am](https://user-images.githubusercontent.com/42577527/48209025-243b1a80-e342-11e8-8789-b543cdfb3d3f.png)
