### PR TITLE
Fix input field to limit to 10 digits

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -48,8 +48,8 @@ export default {
     validationError: 'Please enter a 10-digit phone number'
   },
   phoneExt: {
-    mask: createNumberMask({ prefix: '', allowDecimal: false, allowLeadingZeroes: true, includeThousandsSeparator: false }),
-    match: /^\w{0,10}$/,
+    mask: createNumberMask({ prefix: '', allowDecimal: false, integerLimit: 10, allowLeadingZeroes: true, includeThousandsSeparator: false }),
+    match: /^\d{0,10}$/,
     unmask: [],
     validationError: 'Optional: Please enter up to 10 digits'
   },


### PR DESCRIPTION
## Description
This PR makes it so you cannot input more than 10 digits into the phone extension field. 

## Pivotal Tracker
[https://www.pivotaltracker.com/story/show/161268015](https://www.pivotaltracker.com/story/show/161268015)