### PR TITLE
Add Audit Log events for environment role updates

### DIFF
--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -31,18 +31,18 @@ class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def history(self):
-        previous_state = mixins.AuditableMixin.get_history(self)
-        auditable_previous_state = {}
+        previous_state = self.get_changes()
+        change_set = {}
         if "role" in previous_state:
-            from_role = previous_state["role"]
+            from_role = previous_state["role"][0]
             to_role = self.role
-            auditable_previous_state["role"] = [from_role, to_role]
-        return auditable_previous_state
+            change_set["role"] = [from_role, to_role]
+        return change_set
 
     @property
     def event_details(self):
         return {
-            "updated_user": self.user.displayname,
+            "updated_user_name": self.user.displayname,
             "updated_user_id": str(self.user_id),
             "environment": self.environment.displayname,
             "environment_id": str(self.environment_id),

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -44,8 +44,8 @@ class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         return {
             "updated_user": self.user.displayname,
             "updated_user_id": str(self.user_id),
-            "env": self.environment.displayname,
-            "env_id": str(self.environment_id),
+            "environment": self.environment.displayname,
+            "environment_id": str(self.environment_id),
             "project": self.environment.project.name,
             "project_id": str(self.environment.project_id),
             "workspace": self.environment.project.workspace.name,

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -29,6 +29,29 @@ class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
             self.role, self.user.full_name, self.environment.name, self.id
         )
 
+    @property
+    def history(self):
+        previous_state = mixins.AuditableMixin.get_history(self)
+        auditable_previous_state = {}
+        if "role" in previous_state:
+            from_role = previous_state["role"]
+            to_role = self.role
+            auditable_previous_state["role"] = [from_role, to_role]
+        return auditable_previous_state
+
+    @property
+    def event_details(self):
+        return {
+            "updated_user": self.user.displayname,
+            "updated_user_id": str(self.user_id),
+            "env": self.environment.displayname,
+            "env_id": str(self.environment_id),
+            "project": self.environment.project.name,
+            "project_id": str(self.environment.project_id),
+            "workspace": self.environment.project.workspace.name,
+            "workspace_id": str(self.environment.project.workspace.id),
+        }
+
 
 Index(
     "environments_role_user_environment",

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -31,13 +31,7 @@ class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def history(self):
-        previous_state = self.get_changes()
-        change_set = {}
-        if "role" in previous_state:
-            from_role = previous_state["role"][0]
-            to_role = self.role
-            change_set["role"] = [from_role, to_role]
-        return change_set
+        return self.get_changes()
 
     @property
     def event_details(self):

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -10,7 +10,7 @@ class CSPRole(Enum):
     NONSENSE_ROLE = "nonsense_role"
 
 
-class EnvironmentRole(Base, mixins.TimestampsMixin):
+class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     __tablename__ = "environment_roles"
 
     id = types.Id()

--- a/atst/models/mixins/auditable.py
+++ b/atst/models/mixins/auditable.py
@@ -52,7 +52,8 @@ class AuditableMixin(object):
 
     @staticmethod
     def audit_update(mapper, connection, target):
-        target.create_audit_event(connection, target, ACTION_UPDATE)
+        if AuditableMixin.get_history(target):
+            target.create_audit_event(connection, target, ACTION_UPDATE)
 
     def get_changes(self):
         """

--- a/atst/models/mixins/auditable.py
+++ b/atst/models/mixins/auditable.py
@@ -17,8 +17,11 @@ class AuditableMixin(object):
         request_id = resource.auditable_request_id()
         resource_type = resource.auditable_resource_type()
         display_name = resource.auditable_displayname()
-        changed_state = resource.auditable_changed_state()
         event_details = resource.auditable_event_details()
+
+        changed_state = (
+            resource.auditable_changed_state() if action == ACTION_UPDATE else None
+        )
 
         audit_event = AuditEvent(
             user_id=user_id,
@@ -69,7 +72,9 @@ class AuditableMixin(object):
         for attr in attrs:
             history = getattr(inspect(self).attrs, attr.key).history
             if history.has_changes():
-                previous_state[attr.key] = [history.deleted.pop(), history.added.pop()]
+                deleted = history.deleted.pop() if history.deleted else None
+                added = history.added.pop() if history.added else None
+                previous_state[attr.key] = [deleted, added]
         return previous_state
 
     def auditable_changed_state(self):

--- a/atst/models/mixins/auditable.py
+++ b/atst/models/mixins/auditable.py
@@ -52,15 +52,12 @@ class AuditableMixin(object):
 
     @staticmethod
     def audit_update(mapper, connection, target):
-        if AuditableMixin.get_history(target):
+        if AuditableMixin.get_changes(target):
             target.create_audit_event(connection, target, ACTION_UPDATE)
 
     def get_changes(self):
         """
-        This function borrows largely from a gist:
-        https://gist.github.com/ngse/c20058116b8044c65d3fbceda3fdf423#file-audit_mixin-py-L106-L120
-
-        It returns a dictionary of the form {item: [from_value, to_value]},
+        This function returns a dictionary of the form {item: [from_value, to_value]},
         where 'item' is the attribute on the target that has been updated,
         'from_value' is the value of the attribute before it was updated,
         and 'to_value' is the current value of the attribute.

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -57,6 +57,7 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
             change_set["status"] = [from_status, to_status]
         return change_set
 
+
     @property
     def event_details(self):
         return {

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -57,7 +57,6 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
             change_set["status"] = [from_status, to_status]
         return change_set
 
-
     @property
     def event_details(self):
         return {

--- a/templates/audit_log.html
+++ b/templates/audit_log.html
@@ -33,15 +33,26 @@
                 <br>
               {% endif %}
 
-              {% if event.changed_state %}
-                from {{ event.changed_state.role[0] }} to {{ event.changed_state.role[1] }}
-                <br>
+                {% if event.event_details["environment"] %}
+                  <br>
+                  in Environment <code>{{ event.event_details["environment_id"] }}</code> ({{ event.event_details["environment"] }})
+                  <br>
+                  in Project <code>{{ event.event_details["project_id"] }}</code> ({{ event.event_details["project"] }})
+                  <br>
+                  in Workspace <code>{{ event.event_details["workspace_id"] }}</code> ({{ event.event_details["workspace"] }})
+                {% endif %}
+              <br>
               {% endif %}
 
               {% if event.workspace %}
                 in Workspace <code>{{ event.workspace_id }}</code> ({{ event.workspace.name }})
               {% elif event.request %}
                 on Request <code>{{ event.request_id }}</code> ({{ event.request.displayname }})
+              {% endif %}
+
+              {% if event.changed_state %}
+                from {{ event.changed_state.role[0] }} to {{ event.changed_state.role[1] }}
+                <br>
               {% endif %}
             </div>
           </article>

--- a/templates/audit_log.html
+++ b/templates/audit_log.html
@@ -30,8 +30,6 @@
 
               {% if event.event_details %}
                 for User <code>{{ event.event_details.updated_user_id }}</code> ({{ event.event_details.updated_user_name }})
-                <br>
-              {% endif %}
 
                 {% if event.event_details["environment"] %}
                   <br>
@@ -50,7 +48,7 @@
                 on Request <code>{{ event.request_id }}</code> ({{ event.request.displayname }})
               {% endif %}
 
-              {% if event.changed_state %}
+              {% if event.changed_state.role %}
                 from {{ event.changed_state.role[0] }} to {{ event.changed_state.role[1] }}
                 <br>
               {% endif %}

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -134,7 +134,8 @@ def test_update_workspace_role_role(workspace, workspace_owner):
         "workspace_role": "developer",
         "dod_id": "1234567890",
     }
-    member = Workspaces.create_member(workspace_owner, workspace, user_data)
+    WorkspaceRoleFactory._meta.sqlalchemy_session_persistence = "flush"
+    member = WorkspaceRoleFactory.create(workspace=workspace)
     role_name = "admin"
 
     updated_member = Workspaces.update_member(


### PR DESCRIPTION
## Description
The audit log now logs changes to users' environment roles. Additionally, only events with actual changes are logged, which means we will have fewer simultaneous events logged for a single update.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161790458

## Screenshots
![screen shot 2018-11-26 at 2 29 22 pm](https://user-images.githubusercontent.com/42577527/49043573-74ff9f80-f199-11e8-9cd3-6d63a9f5331c.png)
