### PR TITLE
Remove Styleguide From Navigation

### DIFF
--- a/templates/navigation/global_navigation.html
+++ b/templates/navigation/global_navigation.html
@@ -2,17 +2,6 @@
 
 <div class="global-navigation sidenav {% if workspace %}global-navigation__context--workspace{% endif %}">
   <ul>
-    {% if g.dev %}
-      {{ SidenavItem("Styleguide",
-        href="/styleguide",
-        icon="visible",
-        active=g.matchesPath('/styleguide'),
-        subnav=[
-          {"label":"Subnav 1", "href":"/styleguide?subnav1", "icon": "plus", "active": g.matchesPath('/styleguide?subnav1')},
-          {"label":"Subnav 2", "href":"/styleguide?subnav2", "active": g.matchesPath('/styleguide?subnav2')},
-        ]) }}
-    {% endif %}
-
     {{ SidenavItem("Requests",
       href="/requests",
       icon="document",


### PR DESCRIPTION
## Description
The Styleguide displayed on the side navigation was confusing to test users, so we removed it.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161597085

## Screenshots
![screen shot 2018-11-27 at 9 24 06 am](https://user-images.githubusercontent.com/42577527/49088504-68c22380-f227-11e8-8e85-fa9b6d9bb63b.png)
