### PR TITLE
Fix revoke/resend invitations in IE

### DIFF
--- a/js/components/__tests__/__snapshots__/confirmation_popover.test.js.snap
+++ b/js/components/__tests__/__snapshots__/confirmation_popover.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ConfirmationPopover matches snapshot 1`] = `<v-popover placement="top-start"><template></template> <button type="button" class="tooltip-target">Do something dangerous</button></v-popover>`;

--- a/js/components/__tests__/__snapshots__/confirmation_popover.test.js.snap
+++ b/js/components/__tests__/__snapshots__/confirmation_popover.test.js.snap
@@ -1,3 +1,3 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ConfirmationPopover matches snapshot 1`] = `<v-popover placement="top-start"><template></template> <button type="button" class="tooltip-target">Do something dangerous</button></v-popover>`;
+exports[`ConfirmationPopover matches snapshot 1`] = `<v-popover-stub placement="top-start" delay="0" offset="0" trigger="click" container="body" popperoptions="[object Object]" popoverclass="vue-popover-theme" popoverbaseclass="tooltip popover" popoverinnerclass="tooltip-inner popover-inner" popoverwrapperclass="wrapper" popoverarrowclass="tooltip-arrow popover-arrow" autohide="true" handleresize="true"><template></template> <button type="button" class="tooltip-target">Do something dangerous</button></v-popover-stub>`;

--- a/js/components/__tests__/confirmation_popover.test.js
+++ b/js/components/__tests__/confirmation_popover.test.js
@@ -1,11 +1,15 @@
-import { shallowMount } from '@vue/test-utils'
+import { createLocalVue, shallowMount } from '@vue/test-utils'
+import VTooltip from 'v-tooltip'
 
 import ConfirmationPopover from '../confirmation_popover'
 
+const localVue = createLocalVue()
+localVue.use(VTooltip)
 
 describe('ConfirmationPopover', () => {
   it('matches snapshot', () => {
     const wrapper = shallowMount(ConfirmationPopover, {
+      localVue,
       propsData: {
         action: '/some-url',
         btn_text: 'Do something dangerous',

--- a/js/components/__tests__/confirmation_popover.test.js
+++ b/js/components/__tests__/confirmation_popover.test.js
@@ -7,20 +7,26 @@ const localVue = createLocalVue()
 localVue.use(VTooltip)
 
 describe('ConfirmationPopover', () => {
-  it('matches snapshot', () => {
-    const wrapper = shallowMount(ConfirmationPopover, {
-      localVue,
-      propsData: {
-        action: '/some-url',
-        btn_text: 'Do something dangerous',
-        cancel_btn_text: 'Cancel',
-        confirm_btn_text: 'Confirm',
-        confirm_msg: 'Are you sure you want to do that?',
-        csrf_token: '42'
-      }
-    })
+  const wrapper = shallowMount(ConfirmationPopover, {
+    localVue,
+    propsData: {
+      action: '/some-url',
+      btn_text: 'Do something dangerous',
+      cancel_btn_text: 'Cancel',
+      confirm_btn_text: 'Confirm',
+      confirm_msg: 'Are you sure you want to do that?',
+      csrf_token: '42'
+    }
+  })
 
+  it('matches snapshot', () => {
     expect(wrapper).toMatchSnapshot()
+  })
+
+  it('renders form with hidden csrf input', () => {
+    const input = wrapper.find('input[type=hidden]')
+    expect(input.exists()).toBe(true)
+    expect(input.attributes('value')).toBe('42')
   })
 })
 

--- a/js/components/__tests__/confirmation_popover.test.js
+++ b/js/components/__tests__/confirmation_popover.test.js
@@ -1,0 +1,22 @@
+import { shallowMount } from '@vue/test-utils'
+
+import ConfirmationPopover from '../confirmation_popover'
+
+
+describe('ConfirmationPopover', () => {
+  it('matches snapshot', () => {
+    const wrapper = shallowMount(ConfirmationPopover, {
+      propsData: {
+        action: '/some-url',
+        btn_text: 'Do something dangerous',
+        cancel_btn_text: 'Cancel',
+        confirm_btn_text: 'Confirm',
+        confirm_msg: 'Are you sure you want to do that?',
+        csrf_token: '42'
+      }
+    })
+
+    expect(wrapper).toMatchSnapshot()
+  })
+})
+

--- a/js/components/confirmation_popover.js
+++ b/js/components/confirmation_popover.js
@@ -1,0 +1,32 @@
+export default {
+  name: 'confirmation-popover',
+
+  props: {
+    action: String,
+    btn_text: String,
+    cancel_btn_text: String,
+    confirm_btn_text: String,
+    confirm_msg: String,
+    csrf_token: String
+  },
+
+  template: `
+    <v-popover placement='top-start'>
+      <template slot="popover">
+        <p>{{ confirm_msg }}</p>
+        <div class='action-group'>
+          <form method="POST" v-bind:action="action">
+            <input id="csrf_token" name="csrf_token" type="hidden" v-bind:value="csrf_token">
+            <button class='usa-button usa-button-primary' type='submit'>
+              {{ confirm_btn_text }}
+            </button>
+          </form>
+          <button class='usa-button usa-button-secondary' v-close-popover>
+            {{ cancel_btn_text }}
+          </button>
+        </div>
+      </template>
+      <button class="tooltip-target" type="button">{{ btn_text }}</button>
+    </v-popover>
+  `
+}

--- a/js/index.js
+++ b/js/index.js
@@ -23,6 +23,7 @@ import CcpoApproval from './components/forms/ccpo_approval'
 import MembersList from './components/forms/members_list'
 import LocalDatetime from './components/local_datetime'
 import RequestsList from './components/forms/requests_list'
+import ConfirmationPopover from './components/confirmation_popover'
 
 Vue.config.productionTip = false
 
@@ -50,6 +51,7 @@ const app = new Vue({
     EditEnvironmentRole,
     EditProjectRoles,
     RequestsList,
+    ConfirmationPopover,
   },
 
   mounted: function() {

--- a/templates/components/confirmation_button.html
+++ b/templates/components/confirmation_button.html
@@ -1,19 +1,10 @@
-{% macro ConfirmationButton(btn_text, action, csrf_token, confirm_msg="Are you sure?", confirm_btn="Confirm", cancel_btn="Cancel") -%}
-  <v-popover placement='top-start'>
-    <template slot="popover">
-      <p>{{ confirm_msg }}</p>
-      <div class='action-group'>
-        <form method="POST" action="{{ action }}">
-          {{ csrf_token }}
-          <button class='usa-button usa-button-primary' type='submit'>
-            {{ confirm_btn }}
-          </button>
-        </form>
-        <button class='usa-button usa-button-secondary' v-close-popover>
-          {{ cancel_btn }}
-        </button>
-      </div>
-    </template>
-    <button class="tooltip-target" type="button">{{ btn_text }}</button>
-  </v-popover>
+{% macro ConfirmationButton(btn_text, action, confirm_msg="Are you sure?", confirm_btn="Confirm", cancel_btn="Cancel") -%}
+  <confirmation-popover
+    btn_text='{{ btn_text }}'
+    action='{{ action }}'
+    csrf_token='{{ csrf_token() }}'
+    confirm_msg='{{ confirm_msg }}'
+    confirm_btn_text='{{ confirm_btn }}'
+    cancel_btn_text='{{ cancel_btn }}'>
+  </confirmation-popover>
 {%- endmacro %}

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -44,14 +44,12 @@
         {{ ConfirmationButton(
               "Revoke Invitation",
               url_for("workspaces.revoke_invitation", workspace_id=workspace.id, token=member.latest_invitation.token),
-              form.csrf_token
            ) }}
       {% endif %}
       {% if member.can_resend_invitation %}
         {{ ConfirmationButton (
               "Resend Invitation",
               url_for("workspaces.resend_invitation", workspace_id=workspace.id, token=member.latest_invitation.token),
-              form.csrf_token,
               confirm_msg="Are you sure? This will send an email to invite the user to join this workspace."
         )}}
       {% endif %}


### PR DESCRIPTION
In IE, the revoke or resend invitation buttons were previously not working correctly. The buttons work by submitting a form to the appropriate URL. However, this form is nested inside another form (the edit member form), which is not valid HTML. 

The problem is actually a bit more subtle: when the popover element is rendered (when the relevant button is clicked), the displayed popover is added to the end of the DOM. This is outside the enclosing `form` element, so everything works as expected in Chrome/Firefox. IE, however, will strip the inner `form` element before the tooltip is shown. When the tooltip is shown, the "revoke" or "resend" buttons are not enclosed in any form, so they submit nothing.

The solution here is to move the inner `form` into a Vue template -- now, the form is never enclosed in the outer `form`, so no browsers will strip the `form` tag.