### PR TITLE
Remove option to revoke from expired workspace invitation

### DIFF
--- a/atst/models/invitation.py
+++ b/atst/models/invitation.py
@@ -87,3 +87,7 @@ class Invitation(Base, TimestampsMixin, AuditableMixin):
     @property
     def user_name(self):
         return self.workspace_role.user.full_name
+
+    @property
+    def is_revokable(self):
+        return self.is_pending and not self.is_expired

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -40,7 +40,7 @@
         <a href='{{ url_for("users.user") }}' class='icon-link'>edit account details</a>
       {% endif %}
       <div>
-      {% if member.latest_invitation.is_pending %}
+      {% if member.latest_invitation.is_revokable %}
         {{ ConfirmationButton(
               "Revoke Invitation",
               url_for("workspaces.revoke_invitation", workspace_id=workspace.id, token=member.latest_invitation.token),

--- a/tests/models/test_invitation.py
+++ b/tests/models/test_invitation.py
@@ -1,0 +1,23 @@
+import pytest
+import datetime
+
+from atst.models.invitation import Invitation, Status
+
+from tests.factories import InvitationFactory
+
+
+def test_expired_invite_is_not_revokable():
+    invite = InvitationFactory.create(
+        expiration_time=datetime.datetime.now() - datetime.timedelta(minutes=60)
+    )
+    assert not invite.is_revokable
+
+
+def test_unexpired_invite_is_revokable():
+    invite = InvitationFactory.create()
+    assert invite.is_revokable
+
+
+def test_invite_is_not_revokable_if_invite_is_not_pending():
+    invite = InvitationFactory.create(status=Status.ACCEPTED)
+    assert not invite.is_revokable


### PR DESCRIPTION
## Description
Prior to this PR, the Revoke Invitation button would appear if an invite is in the pending state. Since the state of the invite never changes when it expires, the button was still showing for expired invites.
This issue was solved by adding the property is_revokable to Invitation and checking for that in the edit member template instead of whether or not the invite is pending. 

## Pivotal
[https://www.pivotaltracker.com/story/show/161933129](https://www.pivotaltracker.com/story/show/161933129)