### PR TITLE
be more generous in finding PDF attachment file name when rendering f…

### DIFF
--- a/atst/domain/workspace_roles.py
+++ b/atst/domain/workspace_roles.py
@@ -2,7 +2,9 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
 from atst.models.workspace_role import (
-    WorkspaceRole, Status as WorkspaceRoleStatus, MEMBER_STATUSES
+    WorkspaceRole,
+    Status as WorkspaceRoleStatus,
+    MEMBER_STATUSES,
 )
 from atst.models.user import User
 
@@ -12,8 +14,7 @@ from .exceptions import NotFoundError
 
 
 MEMBER_STATUS_CHOICES = [
-    dict(name=key, display_name=value)
-    for key, value in MEMBER_STATUSES.items()
+    dict(name=key, display_name=value) for key, value in MEMBER_STATUSES.items()
 ]
 
 

--- a/atst/forms/financial.py
+++ b/atst/forms/financial.py
@@ -219,7 +219,7 @@ class FinancialVerificationForm(CacheableForm):
         return self.task_order.number
 
     @property
-    def has_task_order_pdf(self):
+    def has_pdf_upload(self):
         return isinstance(self.task_order.pdf.data, FileStorage)
 
     @property

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -82,21 +82,21 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     @property
     def display_status(self):
         if self.status == Status.ACTIVE:
-            return MEMBER_STATUSES['active']
+            return MEMBER_STATUSES["active"]
         elif self.latest_invitation:
             if self.latest_invitation.is_revoked:
-                return MEMBER_STATUSES['revoked']
+                return MEMBER_STATUSES["revoked"]
             elif self.latest_invitation.is_rejected_wrong_user:
-                return MEMBER_STATUSES['error']
+                return MEMBER_STATUSES["error"]
             elif (
                 self.latest_invitation.is_rejected_expired
                 or self.latest_invitation.is_expired
             ):
-                return MEMBER_STATUSES['expired']
+                return MEMBER_STATUSES["expired"]
             else:
-                return MEMBER_STATUSES['pending']
+                return MEMBER_STATUSES["pending"]
         else:
-            return MEMBER_STATUSES['unknown']
+            return MEMBER_STATUSES["unknown"]
 
     @property
     def has_dod_id_error(self):

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -32,11 +32,16 @@ class FinancialVerificationBase(object):
         form = FinancialVerificationForm(obj=fv, formdata=_formdata)
 
         if not form.has_task_order_pdf:
-            try:
-                attachment = Attachment.get_for_resource("task_order", self.request.id)
-                form.task_order.pdf.data = attachment.filename
-            except NotFoundError:
-                pass
+            if isinstance(form.task_order.pdf.data, Attachment):
+                form.task_order.pdf.data = form.task_order.pdf.data.filename
+            else:
+                try:
+                    attachment = Attachment.get_for_resource(
+                        "task_order", self.request.id
+                    )
+                    form.task_order.pdf.data = attachment.filename
+                except NotFoundError:
+                    pass
 
         return form
 

--- a/atst/routes/requests/financial_verification.py
+++ b/atst/routes/requests/financial_verification.py
@@ -31,7 +31,7 @@ class FinancialVerificationBase(object):
         fv = FinancialVerification(request)
         form = FinancialVerificationForm(obj=fv, formdata=_formdata)
 
-        if not form.has_task_order_pdf:
+        if not form.has_pdf_upload:
             if isinstance(form.task_order.pdf.data, Attachment):
                 form.task_order.pdf.data = form.task_order.pdf.data.filename
             else:


### PR DESCRIPTION
…inancial verification form

This should fix https://www.pivotaltracker.com/n/projects/2160940/stories/162270400.

The problem we're seeing right now is that multiple requests reference the same task order entity (i.e., the mock "valid" one). We look up what PDF filename to display based on the request ID saved as part of the attachment record, so only one of the many requests referencing the valid TO can get the PDF filename. I fixed it here by being more generous in how we get the filename, but this is just a band-aid. We need TO numbers to be unique to the request.