### PR TITLE
Add validator to user form for consistent validation

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -9,6 +9,12 @@ export default {
     unmask: [],
     validationError: 'Please enter a response'
   },
+  requiredField: {
+    mask: false,
+    match: /.+/,
+    unmask: [],
+    validationError: 'This field is required'
+  },
   integer: {
     mask: createNumberMask({ prefix: '', allowDecimal: false }),
     match: /^[1-9]\d*$/,

--- a/templates/fragments/edit_user_form.html
+++ b/templates/fragments/edit_user_form.html
@@ -9,11 +9,11 @@
     <div class='panel__content'>
       <div class='form-row'>
         <div class='form-col form-col--half'>
-          {{ TextInput(form.first_name) }}
+          {{ TextInput(form.first_name, validation='requiredField') }}
         </div>
 
         <div class='form-col form-col--half'>
-          {{ TextInput(form.last_name) }}
+          {{ TextInput(form.last_name, validation='requiredField') }}
         </div>
       </div>
 


### PR DESCRIPTION
## Description
This fixes a bug where the validation for first and last name in the edit user form did not give validation feedback until the user saved the form. 
Now when a user shifts focus out of the first or last name fields with invalid data, the validation message appears.

## Pivotal
[https://www.pivotaltracker.com/story/show/162222631](https://www.pivotaltracker.com/story/show/162222631)

## Screenshots
<img width="1552" alt="screen shot 2018-11-28 at 3 27 16 pm" src="https://user-images.githubusercontent.com/43828539/49180325-4f51d200-f322-11e8-952c-67bc25bc366f.png">
