### PR TITLE
Clarify revoked name

### DIFF
--- a/atst/domain/workspace_roles.py
+++ b/atst/domain/workspace_roles.py
@@ -1,7 +1,9 @@
 from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
-from atst.models.workspace_role import WorkspaceRole, Status as WorkspaceRoleStatus
+from atst.models.workspace_role import (
+    WorkspaceRole, Status as WorkspaceRoleStatus, MEMBER_STATUSES
+)
 from atst.models.user import User
 
 from .roles import Roles
@@ -9,13 +11,9 @@ from .users import Users
 from .exceptions import NotFoundError
 
 
-MEMBER_STATUSES = [
-    {"name": "active", "display_name": "Active"},
-    {"name": "revoked", "display_name": "Revoked"},
-    {"name": "expired", "display_name": "Invite expired"},
-    {"name": "error", "display_name": "Error on invite"},
-    {"name": "pending", "display_name": "Pending"},
-    {"name": "unknown", "display_name": "Unknown errors"},
+MEMBER_STATUS_CHOICES = [
+    dict(name=key, display_name=value)
+    for key, value in MEMBER_STATUSES.items()
 ]
 
 

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -13,6 +13,16 @@ from atst.models.environment import Environment
 from atst.models.role import Role
 
 
+MEMBER_STATUSES = {
+    "active": "Active",
+    "revoked": "Revoked",
+    "expired": "Invite expired",
+    "error": "Error on invite",
+    "pending": "Pending",
+    "unknown": "Unknown errors",
+}
+
+
 class Status(Enum):
     ACTIVE = "active"
     DISABLED = "disabled"
@@ -72,21 +82,21 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     @property
     def display_status(self):
         if self.status == Status.ACTIVE:
-            return "Active"
+            return MEMBER_STATUSES['active']
         elif self.latest_invitation:
             if self.latest_invitation.is_revoked:
-                return "Revoked"
+                return MEMBER_STATUSES['revoked']
             elif self.latest_invitation.is_rejected_wrong_user:
-                return "Error on invite"
+                return MEMBER_STATUSES['error']
             elif (
                 self.latest_invitation.is_rejected_expired
                 or self.latest_invitation.is_expired
             ):
-                return "Invite expired"
+                return MEMBER_STATUSES['expired']
             else:
-                return "Pending"
+                return MEMBER_STATUSES['pending']
         else:
-            return "Unknown errors"
+            return MEMBER_STATUSES['unknown']
 
     @property
     def has_dod_id_error(self):

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -15,7 +15,7 @@ from atst.models.role import Role
 
 MEMBER_STATUSES = {
     "active": "Active",
-    "revoked": "Revoked",
+    "revoked": "Invite revoked",
     "expired": "Invite expired",
     "error": "Error on invite",
     "pending": "Pending",

--- a/atst/routes/workspaces/members.py
+++ b/atst/routes/workspaces/members.py
@@ -7,7 +7,7 @@ from atst.routes.workspaces.invitations import send_invite_email
 from atst.domain.exceptions import AlreadyExistsError
 from atst.domain.projects import Projects
 from atst.domain.workspaces import Workspaces
-from atst.domain.workspace_roles import WorkspaceRoles, MEMBER_STATUSES
+from atst.domain.workspace_roles import WorkspaceRoles, MEMBER_STATUS_CHOICES
 from atst.domain.environments import Environments
 from atst.domain.environment_roles import EnvironmentRoles
 from atst.forms.new_member import NewMemberForm
@@ -48,7 +48,7 @@ def workspace_members(workspace_id):
         "workspaces/members/index.html",
         workspace=workspace,
         role_choices=WORKSPACE_ROLE_DEFINITIONS,
-        status_choices=MEMBER_STATUSES,
+        status_choices=MEMBER_STATUS_CHOICES,
         members=members_list,
         new_member=new_member,
         resent_invitation_to=resent_invitation_to,


### PR DESCRIPTION
Previously, we were displaying the status of a workspace member whose invitation was revoked as "Revoked". It's clearer to specify that only their invite was revoked by displaying "Invite revoked" instead.

![image](https://user-images.githubusercontent.com/40774582/49183126-1cabd780-f32a-11e8-947a-fa5b7a1e2b1a.png)
