### PR TITLE
Fix request listing for CCPO user

### DIFF
--- a/js/components/__tests__/requests_list.test.js
+++ b/js/components/__tests__/requests_list.test.js
@@ -55,5 +55,21 @@ describe('RequestsList', () => {
       const requestNames = displayedRequests.map(req => req.name)
       expect(requestNames).toEqual(['X Wing', 'TIE Fighter'])
     })
+
+    it('handles sorting with un-submitted requests', () => {
+      const unsubmittedRequest = {
+        name: 'Death Star',
+        status: 'Started',
+        last_submission_timestamp: null
+      }
+      const wrapper = shallowMount(RequestsList, {
+        propsData: {
+          requests: [unsubmittedRequest, ...requests],
+          isExtended: true
+        }
+      })
+      const displayedRequests = wrapper.vm.filteredRequests
+      expect(displayedRequests).toEqual([requests[1], requests[0], unsubmittedRequest])
+    })
   })
 })

--- a/js/components/requests_list.js
+++ b/js/components/requests_list.js
@@ -1,7 +1,7 @@
 import LocalDatetime from '../components/local_datetime'
 import { formatDollars } from '../lib/dollars'
 import { parse } from 'date-fns'
-import { compose, partial, indexBy, prop, sortBy, reverse, pipe } from 'ramda'
+import { compose, partial, indexBy, prop, propOr, sortBy, reverse, pipe } from 'ramda'
 
 export default {
   name: 'requests-list',
@@ -32,7 +32,7 @@ export default {
   data: function () {
     const defaultSort = (sort, requests) => sortBy(prop(sort.columnName), requests)
     const dateSort = (sort, requests) => {
-      const parseDate = compose(partial(parse), prop(sort.columnName))
+      const parseDate = compose(partial(parse), propOr(sort.columnName, ''))
       return sortBy(parseDate, requests)
     }
 

--- a/templates/requests/index.html
+++ b/templates/requests/index.html
@@ -137,7 +137,14 @@
               <a class='icon-link icon-link--large' :href="r.edit_link">!{ r.name }</a>
               <span v-if="r.action_required" class="label label--info">Action Required</span>
             </th>
-            <td><local-datetime :timestamp="r.last_submission_timestamp" format="M/D/YYYY"></td>
+            <td>
+              <local-datetime
+                v-if="r.last_submission_timestamp"
+                :timestamp="r.last_submission_timestamp"
+                format="M/D/YYYY">
+              </local-datetime>
+              <span v-else>—<span>
+            </td>
           {% if extended_view %}
               <td><local-datetime :timestamp="r.last_edited_timestamp" format="M/D/YYYY"></td>
               <td>!{ r.full_name }</td>


### PR DESCRIPTION
There was a bug when sorting the requests by submission time when there were unsubmitted requests. After setting the default sort order to be the request submission time, this became more obvious and broke the page for the CCPO user.

Now, one can sort by the submission timestamp. Also, a `—` will be displayed for unsubmitted requests. Previously we were erroneously showing `12/31/1969` as the submission date for unsubmitted requests.

![image](https://user-images.githubusercontent.com/40774582/49239642-3d7b3800-f3d1-11e8-8718-1794a01992ff.png)
