### PR TITLE
Show "Remove Workspace Access" button

### DIFF
--- a/atst/domain/workspace_roles.py
+++ b/atst/domain/workspace_roles.py
@@ -29,7 +29,7 @@ class WorkspaceRoles(object):
                 .one()
             )
         except NoResultFound:
-            workspace_role = None
+            raise NotFoundError("workspace_role")
 
         return workspace_role
 

--- a/atst/routes/workspaces/members.py
+++ b/atst/routes/workspaces/members.py
@@ -106,6 +106,7 @@ def view_member(workspace_id, member_id):
     projects = Projects.get_all(g.current_user, member, workspace)
     form = EditMemberForm(workspace_role=member.role_name)
     editable = g.current_user == member.user
+    can_revoke_access = Workspaces.can_revoke_access_for(workspace, member)
     return render_template(
         "workspaces/members/edit.html",
         workspace=workspace,
@@ -116,6 +117,7 @@ def view_member(workspace_id, member_id):
         env_role_modal_description=ENV_ROLE_MODAL_DESCRIPTION,
         EnvironmentRoles=EnvironmentRoles,
         editable=editable,
+        can_revoke_access=can_revoke_access,
     )
 
 

--- a/templates/workspaces/members/edit.html
+++ b/templates/workspaces/members/edit.html
@@ -57,7 +57,6 @@
         {{ ConfirmationButton (
               "Remove Workspace Access",
               url_for("workspaces.revoke_access", workspace_id=workspace.id, member_id=member.id),
-              form.csrf_token,
               confirm_msg="Are you sure? This will remove this user from the workspace.",
         )}}
       {% endif %}

--- a/tests/routes/workspaces/test_members.py
+++ b/tests/routes/workspaces/test_members.py
@@ -1,6 +1,6 @@
 from flask import url_for
 
-from tests.factories import UserFactory, WorkspaceFactory
+from tests.factories import UserFactory, WorkspaceFactory, WorkspaceRoleFactory
 from atst.domain.workspaces import Workspaces
 from atst.domain.workspace_roles import WorkspaceRoles
 from atst.domain.projects import Projects
@@ -189,3 +189,45 @@ def test_revoke_member_access(client, user_session):
     )
     assert response.status_code == 302
     assert WorkspaceRoles.get_by_id(member.id).num_environment_roles == 0
+
+
+def test_shows_revoke_button(client, user_session):
+    workspace = WorkspaceFactory.create()
+    user = UserFactory.create()
+    member = WorkspaceRoleFactory.create(user=user, workspace=workspace)
+    Projects.create(
+        workspace.owner,
+        workspace,
+        "Snazzy Project",
+        "A new project for me and my friends",
+        {"env1"},
+    )
+    user_session(workspace.owner)
+    response = client.get(
+        url_for(
+            "workspaces.view_member",
+            workspace_id=workspace.id,
+            member_id=member.user.id,
+        )
+    )
+    assert "Remove Workspace Access" in response.data.decode()
+
+
+def test_does_not_show_revoke_button(client, user_session):
+    workspace = WorkspaceFactory.create()
+    Projects.create(
+        workspace.owner,
+        workspace,
+        "Snazzy Project",
+        "A new project for me and my friends",
+        {"env1"},
+    )
+    user_session(workspace.owner)
+    response = client.get(
+        url_for(
+            "workspaces.view_member",
+            workspace_id=workspace.id,
+            member_id=workspace.owner.id,
+        )
+    )
+    assert "Remove Workspace Access" not in response.data.decode()

--- a/tests/routes/workspaces/test_members.py
+++ b/tests/routes/workspaces/test_members.py
@@ -195,13 +195,6 @@ def test_shows_revoke_button(client, user_session):
     workspace = WorkspaceFactory.create()
     user = UserFactory.create()
     member = WorkspaceRoleFactory.create(user=user, workspace=workspace)
-    Projects.create(
-        workspace.owner,
-        workspace,
-        "Snazzy Project",
-        "A new project for me and my friends",
-        {"env1"},
-    )
     user_session(workspace.owner)
     response = client.get(
         url_for(
@@ -215,13 +208,6 @@ def test_shows_revoke_button(client, user_session):
 
 def test_does_not_show_revoke_button(client, user_session):
     workspace = WorkspaceFactory.create()
-    Projects.create(
-        workspace.owner,
-        workspace,
-        "Snazzy Project",
-        "A new project for me and my friends",
-        {"env1"},
-    )
     user_session(workspace.owner)
     response = client.get(
         url_for(


### PR DESCRIPTION
A bad rebase led to the "Remove Workspace Access" button not being shown. This is the fix, along with two new tests.