### PR TITLE
Update DOD ID validator to allow leading zeros

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -60,7 +60,7 @@ export default {
     validationError: 'Optional: Please enter up to 10 digits'
   },
   dodId: {
-    mask: createNumberMask({ prefix: '', allowDecimal: false, includeThousandsSeparator: false }),
+    mask: createNumberMask({ prefix: '', allowDecimal: false, allowLeadingZeroes: true, includeThousandsSeparator: false }),
     match: /^\d{10}$/,
     unmask: [],
     validationError: 'Please enter a 10-digit DoD ID number'


### PR DESCRIPTION
## Description
Updated validator for DOD ID so it will now allow DOD IDs that begin with zero.

## Pivotal Tracker
[https://www.pivotaltracker.com/story/show/162345371](https://www.pivotaltracker.com/story/show/162345371)