### PR TITLE
Set focus when no workspace role is selected

### DIFF
--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -84,7 +84,11 @@ export default {
 
     onShow: function () {
       setTimeout(() => { // timeout is a hack to make focus work in Chrome
-        this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
+        if (this.$refs.choices.find(choice => choice.selected)) {
+          this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
+        } else {
+          this.$refs.choices[0].$refs.input[0].focus()
+        }
       }, 100)
     },
 

--- a/js/components/selector.js
+++ b/js/components/selector.js
@@ -84,8 +84,9 @@ export default {
 
     onShow: function () {
       setTimeout(() => { // timeout is a hack to make focus work in Chrome
-        if (this.$refs.choices.find(choice => choice.selected)) {
-          this.$refs.choices.find(choice => choice.selected).$refs.input[0].focus()
+        const selected = this.$refs.choices.find(choice => choice.selected)
+        if (selected) {
+          selected.$refs.input[0].focus()
         } else {
           this.$refs.choices[0].$refs.input[0].focus()
         }


### PR DESCRIPTION
## Description
Fixes a bug where there was an error appearing in the console because no workspace role was selected, so it was throwing an error when setting the focus. I fixed this by adding in conditional logic so now if there is a role selected, that has focus, and if none is selected, the first option in the list has focus.

## Pivotal Tracker
[https://www.pivotaltracker.com/story/show/161560976](https://www.pivotaltracker.com/story/show/161560976)

## Screenshots
<img width="1551" alt="screen shot 2018-12-03 at 4 11 01 pm" src="https://user-images.githubusercontent.com/43828539/49401802-35473380-f716-11e8-8693-4c577ef06452.png">

_Look ma, no errors!_
