### PR TITLE
Add branch coverage flag

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,2 +1,3 @@
 [run]
 omit = atst/routes/dev.py
+branch = True


### PR DESCRIPTION
This code adds branch coverage stats to the Python testing. We've been consistently above 90% coverage (increasing from 90.17% to 90.30% over the 6 days that I've been tracking the numbers manually) **including** branch coverage. Given that I'm currently working on correcting some of the missing statement coverage and partial branch coverage, this number will continue to increase (if only incrementally at the moment). I'm very comfortable that 90% remains a reasonable baseline for coverage.

@dandds and @patricksmithdds I'll look to both of you for help if we need to do something to add this check to CircleCI.