### PR TITLE
Fix arrow for sort by role on Members List 

### DIFF
--- a/js/components/members_list.js
+++ b/js/components/members_list.js
@@ -86,7 +86,8 @@ export default {
       {
         displayName: 'Workspace Role',
         attr: 'role',
-        sortFunc: alphabeticalSort
+        sortFunc: alphabeticalSort,
+        width: "20%"
       },
     ]
 

--- a/js/components/members_list.js
+++ b/js/components/members_list.js
@@ -87,7 +87,6 @@ export default {
         displayName: 'Workspace Role',
         attr: 'role',
         sortFunc: alphabeticalSort,
-        width: "20%"
       },
     ]
 

--- a/styles/elements/_tables.scss
+++ b/styles/elements/_tables.scss
@@ -63,6 +63,7 @@
       th, td {
         @include block-list-header;
         display: table-cell;
+        white-space: nowrap;
       }
     }
   }


### PR DESCRIPTION
## Description
When sorting by `Workspace Role`, the arrow should display in-line with the title of the column. The arrow was spilling over to a second line before this PR.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161753255

## Screenshots
![screen shot 2018-12-04 at 10 34 58 am](https://user-images.githubusercontent.com/42577527/49453249-c0750780-f7b0-11e8-93aa-8f6b5f69e6d5.png)
![screen shot 2018-12-04 at 10 35 06 am](https://user-images.githubusercontent.com/42577527/49453250-c0750780-f7b0-11e8-887d-f24b440de4bf.png)
