### PR TITLE
Add format check to test script

### DIFF
--- a/script/test
+++ b/script/test
@@ -18,5 +18,8 @@ PYTHON_FILES="./app.py ./atst/** ./config"
 # Enable Python testing
 RUN_PYTHON_TESTS="true"
 
+# Check python formatting
+source ./script/format check
+
 # Run the shared test script
 source ./script/include/run_test


### PR DESCRIPTION
Pivotal card https://www.pivotaltracker.com/story/show/162481690

The CircleCI build checks file formatting, but the test script did not. This change adds the checker, so that both types of test runs match.