### PR TITLE
reference computed property directly in local-datetime component

### DIFF
--- a/js/components/local_datetime.js
+++ b/js/components/local_datetime.js
@@ -17,5 +17,5 @@ export default {
     }
   },
 
-  template: '<time v-bind:datetime="timestamp">{{ this.displayTime }}</time>'
+  template: '<time v-bind:datetime="timestamp">{{ displayTime }}</time>'
 }


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/story/show/161939714

Edge was throwing errors because we were referencing `this` in the `local-datetime` template. My understanding is that Vue components can reference computed properties directly, so I changed it to do that. I tested in my FF, Edge 18, and IE 10.