### PR TITLE
Update .coveragerc to handle exceptions

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,16 @@
 [run]
 omit = atst/routes/dev.py
 branch = True
+
+[report]
+
+# Regexes for lines to exclude from consideration
+exclude_lines =
+
+    # Have to re-enable the standard pragmas
+    pragma: no cover
+    pragma: no branch
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    


### PR DESCRIPTION
This change follows the pattern established in https://coverage.readthedocs.io/en/v4.5.x/config.html# for adjusting the .coveragerc to exclude regex patterns that we agree can be ignored in test coverage. As our first, I added `__repr__`, since we agreed to exclude it recently.

This has an impact on the current coverage calculation but I'm seeing 90.79% coverage after this change, so it has no negative impact on coverage or our current goal.

PT card https://www.pivotaltracker.com/story/show/162513732