### PR TITLE
Revert "Tests ignore object representation"

### DIFF
--- a/atst/models/audit_event.py
+++ b/atst/models/audit_event.py
@@ -33,7 +33,7 @@ class AuditEvent(Base, TimestampsMixin):
 
         connection.execute(self.__table__.insert(), **attrs)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<AuditEvent(name='{}', action='{}', id='{}')>".format(
             self.display_name, self.action, self.id
         )

--- a/atst/models/invitation.py
+++ b/atst/models/invitation.py
@@ -46,7 +46,7 @@ class Invitation(Base, TimestampsMixin, AuditableMixin):
 
     email = Column(String, nullable=False)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<Invitation(user='{}', workspace_role='{}', id='{}', email='{}')>".format(
             self.user_id, self.workspace_role_id, self.id, self.email
         )

--- a/atst/models/pe_number.py
+++ b/atst/models/pe_number.py
@@ -9,7 +9,7 @@ class PENumber(Base):
     number = Column(String, primary_key=True)
     description = Column(String)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<PENumber(number='{}', description='{}')>".format(
             self.number, self.description
         )

--- a/atst/models/project.py
+++ b/atst/models/project.py
@@ -21,7 +21,7 @@ class Project(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     def displayname(self):
         return self.name
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<Project(name='{}', description='{}', workspace='{}', id='{}')>".format(
             self.name, self.description, self.workspace.name, self.id
         )

--- a/atst/models/request.py
+++ b/atst/models/request.py
@@ -245,7 +245,7 @@ class Request(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         else:
             return None
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<Request(status='{}', name='{}', creator='{}', is_approved='{}', time_created='{}', id='{}')>".format(
             self.status_displayname,
             self.displayname,

--- a/atst/models/request_internal_comment.py
+++ b/atst/models/request_internal_comment.py
@@ -16,7 +16,7 @@ class RequestInternalComment(Base, mixins.TimestampsMixin):
     request_id = Column(ForeignKey("requests.id", ondelete="CASCADE"), nullable=False)
     request = relationship("Request")
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<RequestInternalComment(text='{}', user='{}', request='{}', id='{}')>".format(
             self.text, self.user.full_name, self.request_id, self.id
         )

--- a/atst/models/request_review.py
+++ b/atst/models/request_review.py
@@ -37,7 +37,7 @@ class RequestReview(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     def full_name_ccpo(self):
         return "{} {}".format(self.fname_ccpo, self.lname_ccpo)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<RequestReview(status='{}', comment='{}', reviewer='{}', id='{}')>".format(
             self.status.log_name, self.comment, self.full_name_reviewer, self.id
         )

--- a/atst/models/request_revision.py
+++ b/atst/models/request_revision.py
@@ -79,7 +79,7 @@ class RequestRevision(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     treasury_code = Column(String)
     ba_code = Column(String)
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<RequestRevision(request='{}', id='{}')>".format(
             self.request_id, self.id
         )

--- a/atst/models/request_status_event.py
+++ b/atst/models/request_status_event.py
@@ -56,7 +56,7 @@ class RequestStatusEvent(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         else:
             return self.displayname
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<RequestStatusEvent(log_name='{}', request='{}', id='{}')>".format(
             self.log_name, self.request_id, self.id
         )

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -64,7 +64,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
             )
         )
 
-    def __repr__(self):  # pragma: no cover
+    def __repr__(self):
         return "<TaskOrder(number='{}', verified='{}', budget='{}', expiration_date='{}', pdf='{}', id='{}')>".format(
             self.number,
             self.verified,


### PR DESCRIPTION
Reverts dod-ccpo/atst#479

The same adjustment to test coverage is accomplished more elegantly with https://github.com/dod-ccpo/atst/pull/483