### PR TITLE
Sample data fix

### DIFF
--- a/atst/domain/workspace_roles.py
+++ b/atst/domain/workspace_roles.py
@@ -97,7 +97,10 @@ class WorkspaceRoles(object):
             new_workspace_role.role = role
         except NoResultFound:
             new_workspace_role = WorkspaceRole(
-                user=user, role_id=role.id, workspace_id=workspace_id
+                user=user,
+                role_id=role.id,
+                workspace_id=workspace_id,
+                status=WorkspaceRoleStatus.PENDING,
             )
 
         user.workspace_roles.append(new_workspace_role)

--- a/script/remove_sample_data.py
+++ b/script/remove_sample_data.py
@@ -101,11 +101,6 @@ def remove_sample_data(all_users=False):
             .filter(AuditEvent.request_id.in_([r.id for r in requests]))
             .all()
         )
-        request_audit = (
-            db.session.query(AuditEvent)
-            .filter(AuditEvent.request_id.in_([r.id for r in requests]))
-            .all()
-        )
         events = [ev for r in requests for ev in r.status_events]
         revisions = [rev for r in requests for rev in r.revisions]
         workspaces = [r.workspace for r in requests if r.workspace]
@@ -115,6 +110,7 @@ def remove_sample_data(all_users=False):
             .all()
         )
         workspace_roles = [role for workspace in workspaces for role in workspace.roles]
+        invites = [invite for role in workspace_roles for invite in role.invitations]
         projects = [p for workspace in workspaces for p in workspace.projects]
         environments = (
             db.session.query(Environment)
@@ -127,6 +123,7 @@ def remove_sample_data(all_users=False):
             roles,
             environments,
             projects,
+            invites,
             workspace_roles,
             ws_audit,
             events,

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -112,6 +112,7 @@ def seed_db():
         )
         for workspace_role in WORKSPACE_USERS:
             ws_role = Workspaces.create_member(user, workspace, workspace_role)
+            db.session.refresh(ws_role)
             WorkspaceRoles.enable(ws_role)
 
         for workspace_role in WORKSPACE_INVITED_USERS:


### PR DESCRIPTION
The sample data scripts broke for a couple reasons:

- The script for removing sample data was not removing invitations associated to workspace roles, causing errors
- Workspace roles did not have a default status when first created, which causes errors in audit log events when we try to update the status