### PR TITLE
Lock dod id

### DIFF
--- a/alembic/versions/c222327c3963_stop_updates_of_dod_id.py
+++ b/alembic/versions/c222327c3963_stop_updates_of_dod_id.py
@@ -1,0 +1,46 @@
+"""stop updates of dod id
+
+Revision ID: c222327c3963
+Revises: 02d11579a581
+Create Date: 2018-12-12 10:23:00.773973
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'c222327c3963'
+down_revision = '02d11579a581'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    connection = op.get_bind()
+    connection.execute("""
+CREATE OR REPLACE FUNCTION lock_dod_id()
+RETURNS TRIGGER
+AS $$
+BEGIN
+    IF NEW.dod_id != OLD.dod_id THEN
+        RAISE EXCEPTION 'DOD ID cannot be updated';
+    END IF;
+
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER lock_dod_id
+BEFORE UPDATE ON users
+FOR EACH ROW
+    EXECUTE PROCEDURE lock_dod_id();
+    """)
+
+
+def downgrade():
+    connection = op.get_bind()
+    connection.execute("""
+DROP TRIGGER IF EXISTS lock_dod_id ON users;
+DROP FUNCTION IF EXISTS lock_dod_id();
+    """)

--- a/tests/models/test_user.py
+++ b/tests/models/test_user.py
@@ -1,4 +1,5 @@
 import pytest
+from sqlalchemy.exc import InternalError
 
 from atst.models.user import User
 
@@ -15,3 +16,11 @@ def test_profile_complete_with_missing_info(missing_field):
     user = UserFactory.create()
     setattr(user, missing_field, None)
     assert not user.profile_complete
+
+
+def test_cannot_update_dod_id(session):
+    user = UserFactory.create()
+    user.dod_id = "23403498202"
+    session.add(user)
+    with pytest.raises(InternalError):
+        session.commit()


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/162589566

For security reasons, a user's DOD ID should be "write once." I've added a Postgres trigger to ensure it can't be updated after a user is created.

Practically, I like having a unit test to confirm this behavior is present. It seems weird to have a Python test for something entirely outside the application code, though, so if you have a better idea I'm open to it.