### PR TITLE
Run JS tests in "script/test"

### DIFF
--- a/script/test
+++ b/script/test
@@ -18,6 +18,9 @@ PYTHON_FILES="./app.py ./atst/** ./config"
 # Enable Python testing
 RUN_PYTHON_TESTS="true"
 
+# Enable Javascript testing
+RUN_JS_TESTS="true"
+
 # Check python formatting
 source ./script/format check
 


### PR DESCRIPTION
Currently, the JS tests are run only in the `script/cibuild` script but not in the `script/test` script. This means JS tests would run on CircleCI (and appropriately fail builds), but would not be run locally when running the test script.