### PR TITLE
Update Workspace user_count exclude disabled users

### DIFF
--- a/atst/models/workspace.py
+++ b/atst/models/workspace.py
@@ -31,7 +31,7 @@ class Workspace(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def user_count(self):
-        return len(self.users)
+        return len(self.members)
 
     @property
     def legacy_task_order(self):

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -337,3 +337,14 @@ def test_disabled_members_dont_show_up(session):
 
     # should only return workspace owner and ACTIVE member
     assert len(workspace.members) == 2
+
+
+def test_does_not_count_disabled_members(session):
+    workspace = WorkspaceFactory.create()
+    WorkspaceRoleFactory.create(workspace=workspace, status=WorkspaceRoleStatus.ACTIVE)
+    WorkspaceRoleFactory.create(workspace=workspace)
+    WorkspaceRoleFactory.create(
+        workspace=workspace, status=WorkspaceRoleStatus.DISABLED
+    )
+
+    assert workspace.user_count == 3


### PR DESCRIPTION
## Description
Now, when a user is removed from a workspace the user count on the workspace index page is updated to reflect the change.

## Pivotal
[https://www.pivotaltracker.com/story/show/162648520](https://www.pivotaltracker.com/story/show/162648520)