### PR TITLE
Prevent Vue from Loading Variables Before Evaluation

### DIFF
--- a/templates/audit_log/audit_log.html
+++ b/templates/audit_log/audit_log.html
@@ -3,23 +3,23 @@
 
 {% block content %}
 
+  <div v-cloak>
+    <section class="block-list">
+      <header class="block-list__header">
+        <h1 class="block-list__title">Activity History</h1>
+      </header>
 
-  <section v-cloak class="block-list">
-    <header class="block-list__header">
-      <h1 class="block-list__title">Activity History</h1>
-    </header>
-
-    <ul>
-      {% for event in audit_events %}
-        <li class="block-list__item">
-          {% autoescape false %}
-            {{ event | renderAuditEvent }}
-          {% endautoescape %}
-        </li>
-      {% endfor %}
-    </ul>
+      <ul>
+        {% for event in audit_events %}
+          <li class="block-list__item">
+            {% autoescape false %}
+              {{ event | renderAuditEvent }}
+            {% endautoescape %}
+          </li>
+        {% endfor %}
+      </ul>
+    </section>
 
     {{ Pagination(audit_events, 'atst.activity_history') }}
-
-  </section>
+  </div>
 {% endblock %}

--- a/templates/audit_log/audit_log.html
+++ b/templates/audit_log/audit_log.html
@@ -19,7 +19,7 @@
       {% endfor %}
     </ul>
 
-  </section>
+    {{ Pagination(audit_events, 'atst.activity_history') }}
 
-  {{ Pagination(audit_events, 'atst.activity_history') }}
+  </section>
 {% endblock %}

--- a/templates/audit_log/audit_log.html
+++ b/templates/audit_log/audit_log.html
@@ -4,7 +4,7 @@
 {% block content %}
 
 
-  <section class="block-list">
+  <section v-cloak class="block-list">
     <header class="block-list__header">
       <h1 class="block-list__title">Activity History</h1>
     </header>

--- a/templates/requests/index.html
+++ b/templates/requests/index.html
@@ -82,7 +82,7 @@
     </div>
   {% endif %}
 
-  <div class="col col--grow">
+  <div v-cloak class="col col--grow">
 
     {% if extended_view %}
       <form @submit.prevent class='search-bar'>
@@ -116,7 +116,7 @@
       </form>
     {% endif %}
 
-    <div class='responsive-table-wrapper'>
+    <div v-cloak class='responsive-table-wrapper'>
       <table v-if="filteredRequests.length">
         <thead>
           <tr>

--- a/templates/workspaces/index.html
+++ b/templates/workspaces/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class='col'>
+<div v-cloak class='col'>
   <table>
     <thead>
       <tr>

--- a/templates/workspaces/projects/index.html
+++ b/templates/workspaces/projects/index.html
@@ -22,7 +22,7 @@
 {% else %}
 
   {% for project in workspace.projects %}
-    <div class='block-list project-list-item'>
+    <div v-cloak class='block-list project-list-item'>
       <header class='block-list__header'>
         <h2 class='block-list__title'>{{ project.name }} ({{ project.environments|length }} environments)</h2>
         {% if user_can(permissions.RENAME_APPLICATION_IN_WORKSPACE) %}

--- a/templates/workspaces/reports/index.html
+++ b/templates/workspaces/reports/index.html
@@ -13,7 +13,7 @@
       {"label": "Learn More", "href": url_for('atst.helpdocs'), "icon": "info"}
     ]  ) }}
 
-  <div class='funding-summary-row'>
+  <div v-cloak class='funding-summary-row'>
 
     <div class='funding-summary-row__col'>
       <div class='panel spend-summary'>
@@ -131,6 +131,7 @@
   {% else %}
 
     <budget-chart
+      v-cloak
       budget={{ budget }}
       current-month='{{ current_month_index }}'
       expiration-date='{{ expiration_date }}'


### PR DESCRIPTION
## Description
When loading tables, charts, or longer lists, some Vue markup was flashing on screen. Using `v-cloak` on these Vue components prevents that behavior so that nothing loads until all the variables have been evaluated. 

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/162622309
https://www.pivotaltracker.com/story/show/161959592