### PR TITLE
Workspace member buttons #162641480

### DIFF
--- a/atst/domain/workspaces/workspaces.py
+++ b/atst/domain/workspaces/workspaces.py
@@ -146,7 +146,10 @@ class Workspaces(object):
 
     @classmethod
     def can_revoke_access_for(cls, workspace, workspace_role):
-        return workspace_role.user != workspace.owner
+        return (
+            workspace_role.user != workspace.owner
+            and workspace_role.status == WorkspaceRoleStatus.ACTIVE
+        )
 
     @classmethod
     def revoke_access(cls, user, workspace_id, workspace_role_id):

--- a/atst/models/invitation.py
+++ b/atst/models/invitation.py
@@ -77,7 +77,10 @@ class Invitation(Base, TimestampsMixin, AuditableMixin):
 
     @property
     def is_expired(self):
-        return datetime.datetime.now(self.expiration_time.tzinfo) > self.expiration_time
+        return (
+            datetime.datetime.now(self.expiration_time.tzinfo) > self.expiration_time
+            and not self.status == Status.ACCEPTED
+        )
 
     @property
     def workspace(self):

--- a/atst/models/invitation.py
+++ b/atst/models/invitation.py
@@ -83,6 +83,14 @@ class Invitation(Base, TimestampsMixin, AuditableMixin):
         )
 
     @property
+    def is_inactive(self):
+        return self.is_expired or self.status in [
+            Status.REJECTED_WRONG_USER,
+            Status.REJECTED_EXPIRED,
+            Status.REVOKED,
+        ]
+
+    @property
     def workspace(self):
         if self.workspace_role:
             return self.workspace_role.workspace

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -152,12 +152,7 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     @property
     def can_resend_invitation(self):
         return not self.is_active and (
-            self.latest_invitation
-            and (
-                self.latest_invitation.is_rejected
-                or self.latest_invitation.is_expired
-                or self.latest_invitation.is_revoked
-            )
+            self.latest_invitation and self.latest_invitation.is_inactive
         )
 
 

--- a/atst/models/workspace_role.py
+++ b/atst/models/workspace_role.py
@@ -118,6 +118,10 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         return self.role.display_name
 
     @property
+    def is_active(self):
+        return self.status == Status.ACTIVE
+
+    @property
     def num_environment_roles(self):
         return (
             db.session.query(EnvironmentRole)
@@ -147,8 +151,13 @@ class WorkspaceRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def can_resend_invitation(self):
-        return self.latest_invitation and (
-            self.latest_invitation.is_rejected or self.latest_invitation.is_expired
+        return not self.is_active and (
+            self.latest_invitation
+            and (
+                self.latest_invitation.is_rejected
+                or self.latest_invitation.is_expired
+                or self.latest_invitation.is_revoked
+            )
         )
 
 

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -304,9 +304,11 @@ def test_can_create_workspaces_with_matching_names():
     Workspaces.create(RequestFactory.create(), name=workspace_name)
 
 
-def test_can_revoke_workspace_access():
+def test_can_revoke_workspace_access_for_active_member():
     workspace = WorkspaceFactory.create()
-    workspace_role = WorkspaceRoleFactory.create(workspace=workspace)
+    workspace_role = WorkspaceRoleFactory.create(
+        workspace=workspace, status=WorkspaceRoleStatus.ACTIVE
+    )
     Workspaces.revoke_access(workspace.owner, workspace.id, workspace_role.id)
     assert Workspaces.for_user(workspace_role.user) == []
 
@@ -314,7 +316,9 @@ def test_can_revoke_workspace_access():
 def test_can_revoke_access():
     workspace = WorkspaceFactory.create()
     owner_role = workspace.roles[0]
-    workspace_role = WorkspaceRoleFactory.create(workspace=workspace)
+    workspace_role = WorkspaceRoleFactory.create(
+        workspace=workspace, status=WorkspaceRoleStatus.ACTIVE
+    )
 
     assert Workspaces.can_revoke_access_for(workspace, workspace_role)
     assert not Workspaces.can_revoke_access_for(workspace, owner_role)

--- a/tests/domain/test_workspaces.py
+++ b/tests/domain/test_workspaces.py
@@ -304,7 +304,7 @@ def test_can_create_workspaces_with_matching_names():
     Workspaces.create(RequestFactory.create(), name=workspace_name)
 
 
-def test_can_revoke_workspace_access_for_active_member():
+def test_able_to_revoke_workspace_access_for_active_member():
     workspace = WorkspaceFactory.create()
     workspace_role = WorkspaceRoleFactory.create(
         workspace=workspace, status=WorkspaceRoleStatus.ACTIVE
@@ -324,7 +324,7 @@ def test_can_revoke_access():
     assert not Workspaces.can_revoke_access_for(workspace, owner_role)
 
 
-def test_cant_revoke_owner_workspace_access():
+def test_unable_to_revoke_owner_workspace_access():
     workspace = WorkspaceFactory.create()
     owner_workspace_role = workspace.roles[0]
 


### PR DESCRIPTION
## Description
This fixes a bug where the buttons on the workspace member pages were appearing when the should not. Now the buttons should only appear as follows:

**Remove Workspace Access** - Active Users
**Revoke Invitation** - Pending Invites
**Resend Invitation** - Expired and Revoked Invites

## Pivotal
[https://www.pivotaltracker.com/story/show/162641480](https://www.pivotaltracker.com/story/show/162641480)