### PR TITLE
Adjust coverage and __repr__ method handling

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,16 +1,3 @@
 [run]
 omit = atst/routes/dev.py
 branch = True
-
-[report]
-
-# Regexes for lines to exclude from consideration
-exclude_lines =
-
-    # Have to re-enable the standard pragmas
-    pragma: no cover
-    pragma: no branch
-
-    # Don't complain about missing debug-only code:
-    def __repr__
-    

--- a/atst/models/audit_event.py
+++ b/atst/models/audit_event.py
@@ -33,7 +33,7 @@ class AuditEvent(Base, TimestampsMixin):
 
         connection.execute(self.__table__.insert(), **attrs)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<AuditEvent(name='{}', action='{}', id='{}')>".format(
             self.display_name, self.action, self.id
         )

--- a/atst/models/legacy_task_order.py
+++ b/atst/models/legacy_task_order.py
@@ -64,7 +64,7 @@ class LegacyTaskOrder(Base, mixins.TimestampsMixin):
             )
         )
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<LegacyTaskOrder(number='{}', verified='{}', budget='{}', expiration_date='{}', pdf='{}', id='{}')>".format(
             self.number,
             self.verified,

--- a/atst/models/pe_number.py
+++ b/atst/models/pe_number.py
@@ -9,7 +9,7 @@ class PENumber(Base):
     number = Column(String, primary_key=True)
     description = Column(String)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<PENumber(number='{}', description='{}')>".format(
             self.number, self.description
         )

--- a/atst/models/project.py
+++ b/atst/models/project.py
@@ -21,7 +21,7 @@ class Project(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     def displayname(self):
         return self.name
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<Project(name='{}', description='{}', workspace='{}', id='{}')>".format(
             self.name, self.description, self.workspace.name, self.id
         )

--- a/atst/models/request_internal_comment.py
+++ b/atst/models/request_internal_comment.py
@@ -16,7 +16,7 @@ class RequestInternalComment(Base, mixins.TimestampsMixin):
     request_id = Column(ForeignKey("requests.id", ondelete="CASCADE"), nullable=False)
     request = relationship("Request")
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<RequestInternalComment(text='{}', user='{}', request='{}', id='{}')>".format(
             self.text, self.user.full_name, self.request_id, self.id
         )

--- a/atst/models/request_revision.py
+++ b/atst/models/request_revision.py
@@ -79,7 +79,7 @@ class RequestRevision(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
     treasury_code = Column(String)
     ba_code = Column(String)
 
-    def __repr__(self):
+    def __repr__(self):  # pragma: no cover
         return "<RequestRevision(request='{}', id='{}')>".format(
             self.request_id, self.id
         )


### PR DESCRIPTION
This PR addresses the issues noted in card https://www.pivotaltracker.com/story/show/162718482

Summary: PyTest's coverage system allows one to add regex (e.g. "__repr__") which will be matched in determining what to exclude. There is limited documentation on how this affects coverage reporting. After several days of research and one test, I found that everything included in the "exclude_lines" block would be completely ignored in calculating coverage. This is bad because we still need to be able to indicate "no branch" or "no cover" to handle various individual situations. 

While the documentation indicates that you have to add back "standard pragmas," the practical effect is that those lines or branches are completely ignored (not just ignored from one calculation).

See me for any further explanation.