### PR TITLE
Show environment role name in audit log

### DIFF
--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -34,10 +34,15 @@ class EnvironmentRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         return self.get_changes()
 
     @property
+    def displayname(self):
+        return self.role
+
+    @property
     def event_details(self):
         return {
             "updated_user_name": self.user.displayname,
             "updated_user_id": str(self.user_id),
+            "role": self.role,
             "environment": self.environment.displayname,
             "environment_id": str(self.environment_id),
             "project": self.environment.project.name,

--- a/templates/audit_log/events/environment_role.html
+++ b/templates/audit_log/events/environment_role.html
@@ -1,7 +1,13 @@
 {% extends 'audit_log/events/_base.html' %}
 
 {% block content %}
+  {% if event.changed_state.role %}
+    from role "{{ event.changed_state.role[0] }}" to "{{ event.changed_state.role[1] }}"
+    <br>
+  {% endif %}
+
   for User <code>{{ event.event_details.updated_user_id }}</code> ({{ event.event_details.updated_user_name }})
+
   {% if event.event_details["environment"] %}
     <br>
     in Environment <code>{{ event.event_details["environment_id"] }}</code> ({{ event.event_details["environment"] }})


### PR DESCRIPTION
Previously, we were not showing the name of the environment role in the audit log. This PR fixes that oversight. 

The following screenshot shows an example of deleting, updating, and creating an environment role:

![image](https://user-images.githubusercontent.com/40774582/50167146-7ca4f680-02b6-11e9-8e26-2a7e3687d714.png)
