### PR TITLE
fixes error on workspaces index page when request is missing from wor…

### DIFF
--- a/atst/models/workspace.py
+++ b/atst/models/workspace.py
@@ -37,7 +37,7 @@ class Workspace(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
 
     @property
     def legacy_task_order(self):
-        return self.request.legacy_task_order
+        return self.request.legacy_task_order if self.request else None
 
     @property
     def members(self):


### PR DESCRIPTION
…kspace

@patricksmithdds noticed a bug where the workspaces index page threw errors. This is because the template called `legacy_task_order` on the workspace, which threw errors if there was no `request` entity for the workspace.