### PR TITLE
Fix nightly test deployment

### DIFF
--- a/atst/routes/workspaces/index.py
+++ b/atst/routes/workspaces/index.py
@@ -58,7 +58,9 @@ def workspace_reports(workspace_id):
     prev_month = current_month - timedelta(days=28)
     two_months_ago = prev_month - timedelta(days=28)
 
-    expiration_date = workspace.request.legacy_task_order.expiration_date
+    expiration_date = (
+        workspace.legacy_task_order and workspace.legacy_task_order.expiration_date
+    )
     if expiration_date:
         remaining_difference = expiration_date - today
         remaining_days = remaining_difference.days
@@ -71,7 +73,7 @@ def workspace_reports(workspace_id):
         workspace_totals=Reports.workspace_totals(workspace),
         monthly_totals=Reports.monthly_totals(workspace),
         jedi_request=workspace.request,
-        legacy_task_order=workspace.request.legacy_task_order,
+        legacy_task_order=workspace.legacy_task_order,
         current_month=current_month,
         prev_month=prev_month,
         two_months_ago=two_months_ago,

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -108,7 +108,7 @@ def seed_db():
         )
 
         workspace = Workspaces.create(
-            request, name="{}'s workspace".format(user.first_name)
+            user, name="{}'s workspace".format(user.first_name)
         )
         for workspace_role in WORKSPACE_USERS:
             ws_role = Workspaces.create_member(user, workspace, workspace_role)


### PR DESCRIPTION
This PR fixes the failing nightly deployment to the test server: https://circleci.com/gh/dod-ccpo/atst/2922.

The script to seed sample data was using `Workspaces.create`, but passing in a request object instead of a user or using the new `Workspaces.create_from_request`. 

After updating the parameter, I noticed that the reports page would throw an error for a workspace without an associated request, so that is fixed here as well.