### PR TITLE
Task order validations

### DIFF
--- a/atst/forms/forms.py
+++ b/atst/forms/forms.py
@@ -16,6 +16,9 @@ class ValidatedForm(FlaskForm):
         _data.pop("csrf_token", None)
         return _data
 
+    def validate_without_flash(self, *args, **kwargs):
+        return super().validate(*args, **kwargs)
+
     def validate(self, *args, **kwargs):
         valid = super().validate(*args, **kwargs)
         if not valid:

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -8,9 +8,9 @@ from wtforms.fields import (
     TextAreaField,
     FileField,
 )
+from wtforms.validators import Required, StopValidation, Length
 from wtforms.fields.html5 import DateField, TelField
 from wtforms.widgets import ListWidget, CheckboxInput
-from wtforms.validators import Required, Length
 
 from atst.forms.validators import IsNumber, PhoneNumber, RequiredIfNot
 
@@ -26,28 +26,44 @@ from .data import (
 from atst.utils.localization import translate
 
 
+def OptionalAsDraft():
+    def _requiredUnlessDraft(form, field):
+        if form.is_draft.data:
+            field.errors[:] = []
+            raise StopValidation()
+
+    return _requiredUnlessDraft
+
+
 class AppInfoForm(CacheableForm):
+    is_draft = BooleanField("Is draft", default=False)
     portfolio_name = StringField(
         translate("forms.task_order.portfolio_name_label"),
         description=translate("forms.task_order.portfolio_name_description"),
+        validators=[OptionalAsDraft(), Required()],
     )
     scope = TextAreaField(
         translate("forms.task_order.scope_label"),
         description=translate("forms.task_order.scope_description"),
+        validators=[OptionalAsDraft(), Required()],
     )
     defense_component = SelectField(
-        translate("forms.task_order.defense_component_label"), choices=SERVICE_BRANCHES
+        translate("forms.task_order.defense_component_label"),
+        choices=SERVICE_BRANCHES,
+        validators=[OptionalAsDraft()],
     )
     app_migration = RadioField(
         translate("forms.task_order.app_migration.label"),
         description=translate("forms.task_order.app_migration.description"),
         choices=APP_MIGRATION,
         default="",
+        validators=[OptionalAsDraft()],
     )
     native_apps = RadioField(
         translate("forms.task_order.native_apps_label"),
         description=translate("forms.task_order.native_apps_description"),
         choices=[("yes", "Yes"), ("no", "No"), ("not_sure", "Not Sure")],
+        validators=[OptionalAsDraft()],
     )
     complexity = SelectMultipleField(
         translate("forms.task_order.complexity.label"),
@@ -56,6 +72,7 @@ class AppInfoForm(CacheableForm):
         default="",
         widget=ListWidget(prefix_label=False),
         option_widget=CheckboxInput(),
+        validators=[OptionalAsDraft(), Required()],
     )
     complexity_other = StringField(translate("forms.task_order.complexity_other_label"))
     dev_team = SelectMultipleField(
@@ -65,6 +82,7 @@ class AppInfoForm(CacheableForm):
         default="",
         widget=ListWidget(prefix_label=False),
         option_widget=CheckboxInput(),
+        validators=[OptionalAsDraft(), Required()],
     )
     dev_team_other = StringField(translate("forms.task_order.dev_team_other_label"))
     team_experience = RadioField(
@@ -72,28 +90,44 @@ class AppInfoForm(CacheableForm):
         description=translate("forms.task_order.team_experience.description"),
         choices=TEAM_EXPERIENCE,
         default="",
+        validators=[OptionalAsDraft()],
     )
 
 
 class FundingForm(CacheableForm):
+    is_draft = BooleanField("Is draft", default=False)
     performance_length = SelectField(
         translate("forms.task_order.performance_length.label"),
         choices=PERIOD_OF_PERFORMANCE_LENGTH,
+        validators=[OptionalAsDraft()],
     )
     start_date = DateField(
-        translate("forms.task_order.start_date_label"), format="%m/%d/%Y"
+        translate("forms.task_order.start_date_label"),
+        format="%m/%d/%Y",
+        validators=[OptionalAsDraft()],
     )
     end_date = DateField(
-        translate("forms.task_order.end_date_label"), format="%m/%d/%Y"
+        translate("forms.task_order.end_date_label"),
+        format="%m/%d/%Y",
+        validators=[OptionalAsDraft()],
     )
     pdf = FileField(
         translate("forms.task_order.pdf_label"),
         description=translate("forms.task_order.pdf_description"),
+        validators=[OptionalAsDraft()],
     )
-    clin_01 = IntegerField(translate("forms.task_order.clin_01_label"))
-    clin_02 = IntegerField(translate("forms.task_order.clin_02_label"))
-    clin_03 = IntegerField(translate("forms.task_order.clin_03_label"))
-    clin_04 = IntegerField(translate("forms.task_order.clin_04_label"))
+    clin_01 = IntegerField(
+        translate("forms.task_order.clin_01_label"), validators=[OptionalAsDraft()]
+    )
+    clin_02 = IntegerField(
+        translate("forms.task_order.clin_02_label"), validators=[OptionalAsDraft()]
+    )
+    clin_03 = IntegerField(
+        translate("forms.task_order.clin_03_label"), validators=[OptionalAsDraft()]
+    )
+    clin_04 = IntegerField(
+        translate("forms.task_order.clin_04_label"), validators=[OptionalAsDraft()]
+    )
 
 
 class UnclassifiedFundingForm(FundingForm):
@@ -107,17 +141,26 @@ class UnclassifiedFundingForm(FundingForm):
 
 
 class OversightForm(CacheableForm):
+    is_draft = BooleanField("Is draft", default=False)
     ko_first_name = StringField(
-        translate("forms.task_order.oversight_first_name_label")
+        translate("forms.task_order.oversight_first_name_label"),
+        validators=[OptionalAsDraft(), Required()],
     )
-    ko_last_name = StringField(translate("forms.task_order.oversight_last_name_label"))
-    ko_email = StringField(translate("forms.task_order.oversight_email_label"))
+    ko_last_name = StringField(
+        translate("forms.task_order.oversight_last_name_label"),
+        validators=[OptionalAsDraft(), Required()],
+    )
+    ko_email = StringField(
+        translate("forms.task_order.oversight_email_label"),
+        validators=[OptionalAsDraft(), Required()],
+    )
     ko_phone_number = TelField(
-        translate("forms.task_order.oversight_phone_label"), validators=[PhoneNumber()]
+        translate("forms.task_order.oversight_phone_label"),
+        validators=[OptionalAsDraft(), PhoneNumber()],
     )
     ko_dod_id = StringField(
         translate("forms.task_order.oversight_dod_id_label"),
-        validators=[Required(), Length(min=10), IsNumber()],
+        validators=[OptionalAsDraft(), Required(), Length(min=10), IsNumber()],
     )
 
     am_cor = BooleanField(translate("forms.task_order.oversight_am_cor_label"))
@@ -128,11 +171,16 @@ class OversightForm(CacheableForm):
     cor_email = StringField(translate("forms.task_order.oversight_email_label"))
     cor_phone_number = TelField(
         translate("forms.task_order.oversight_phone_label"),
-        validators=[RequiredIfNot("am_cor"), PhoneNumber()],
+        validators=[OptionalAsDraft(), RequiredIfNot("am_cor"), PhoneNumber()],
     )
     cor_dod_id = StringField(
         translate("forms.task_order.oversight_dod_id_label"),
-        validators=[RequiredIfNot("am_cor"), Length(min=10), IsNumber()],
+        validators=[
+            OptionalAsDraft(),
+            RequiredIfNot("am_cor"),
+            Length(min=10),
+            IsNumber(),
+        ],
     )
 
     so_first_name = StringField(
@@ -141,11 +189,12 @@ class OversightForm(CacheableForm):
     so_last_name = StringField(translate("forms.task_order.oversight_last_name_label"))
     so_email = StringField(translate("forms.task_order.oversight_email_label"))
     so_phone_number = TelField(
-        translate("forms.task_order.oversight_phone_label"), validators=[PhoneNumber()]
+        translate("forms.task_order.oversight_phone_label"),
+        validators=[OptionalAsDraft(), PhoneNumber()],
     )
     so_dod_id = StringField(
         translate("forms.task_order.oversight_dod_id_label"),
-        validators=[Required(), Length(min=10), IsNumber()],
+        validators=[OptionalAsDraft(), Required(), Length(min=10), IsNumber()],
     )
 
     ko_invite = BooleanField(

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -97,8 +97,9 @@ class ShowTaskOrderWorkflow:
 
         if self.task_order:
             for section in screen_info:
-                if TaskOrders.is_section_complete(self.task_order, section["section"]):
-                    section["complete"] = True
+                section["complete"] = TaskOrders.section_completion_status(
+                    self.task_order, section["section"]
+                )
 
         return screen_info
 

--- a/js/components/savedraft.js
+++ b/js/components/savedraft.js
@@ -1,0 +1,23 @@
+export default {
+  name: 'save_as_draft',
+
+  props: {
+    is_draft_initial: Boolean
+  },
+
+  data: function() {
+    return {
+      is_draft: this.is_draft_initial
+    }
+  },
+
+  updated: function() {
+    document.getElementById('form').submit();
+  },
+
+  methods: {
+    save: function() {
+      this.is_draft = true;
+    }
+  }
+}

--- a/js/index.js
+++ b/js/index.js
@@ -28,6 +28,7 @@ import MembersList from './components/members_list'
 import LocalDatetime from './components/local_datetime'
 import RequestsList from './components/requests_list'
 import ConfirmationPopover from './components/confirmation_popover'
+import savedraft from './components/savedraft'
 
 Vue.config.productionTip = false
 
@@ -41,6 +42,7 @@ const app = new Vue({
     toggler,
     optionsinput,
     multicheckboxinput,
+    savedraft,
     textinput,
     checkboxinput,
     DetailsOfUse,

--- a/styles/components/_forms.scss
+++ b/styles/components/_forms.scss
@@ -116,3 +116,10 @@
   }
 }
 
+
+.usa-button-save-draft {
+  height: 4.4rem;
+  line-height: 4.4rem;
+  padding-bottom: 0;
+  padding-top: 0;
+}

--- a/styles/components/_progress_menu.scss
+++ b/styles/components/_progress_menu.scss
@@ -101,6 +101,13 @@
       padding: 1px 2px;
     }
 
+    &--draft:before {
+      background: $color-gold;
+      border: none;
+      font-size: $h6-font-size;
+      mask-image: url('#{$asset-path}/icons/alert.svg');
+    }
+
     &--incomplete:before {
       border: 2px solid $color-gray-light;
     }

--- a/templates/task_orders/_new.html
+++ b/templates/task_orders/_new.html
@@ -10,9 +10,9 @@
 
   {% block form_action %}
     {% if task_order_id %}
-      <form method='POST' action="{{ url_for('task_orders.new', screen=current, task_order_id=task_order_id) }}" autocomplete="off">
+      <form id="form" method='POST' action="{{ url_for('task_orders.new', screen=current, task_order_id=task_order_id) }}" autocomplete="off">
     {% else %}
-      <form method='POST' action="{{ url_for('task_orders.update', screen=current, portfolio_id=portfolio_id) }}" autocomplete="off">
+      <form id="form" method='POST' action="{{ url_for('task_orders.update', screen=current, portfolio_id=portfolio_id) }}" autocomplete="off">
     {% endif %}
   {% endblock %}
 
@@ -40,7 +40,13 @@
 
       <div class='action-group'>
         <input type='submit' class='usa-button usa-button-primary' value='Save & Continue' />
-        <input class='usa-button usa-button-secondary' value='Save Draft' />
+
+        <savedraft inline-template v-bind:is_draft_initial="false">
+          <div>
+            <div class="usa-button usa-button-secondary usa-button-save-draft" v-on:click="save">Save Draft</div>
+            <input name="is_draft" type="hidden" value="true" v-if="is_draft" />
+          </div>
+        </savedraft>
       </div>
 
     {% endblock %}

--- a/templates/task_orders/new/menu.html
+++ b/templates/task_orders/new/menu.html
@@ -1,8 +1,10 @@
 <div class="progress-menu progress-menu--four">
   <ul>
     {% for s in screens %}
-      {% if s.complete %}
+      {% if s.complete == 'complete' %}
         {% set step_indicator = 'complete' %}
+      {% elif s.complete == 'draft' %}
+        {% set step_indicator = 'draft' %}
       {% elif loop.index == current %}
         {% set step_indicator = 'active' %}
       {% else %}

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -147,7 +147,9 @@
         </tr>
         <tr>
           <td><h4 class='task-order-form__heading funding-summary__td'>{{ "task_orders.new.review.clin_3"| translate }}</h4></td>
-          <td class="table-cell--align-right">{{ '${:,.2f}'.format(task_order.clin_03) }}</td>
+          {% if task_order.clin_03 %}
+            <td class="table-cell--align-right">{{ '${:,.2f}'.format(task_order.clin_03) }}</td>
+          {% endif %}
         </tr>
         <tr>
             <td><h4 class="task-order-form__heading funding-summary__td{% if not config.CLASSIFIED %} inactive{% endif %}">

--- a/tests/forms/test_app_info.py
+++ b/tests/forms/test_app_info.py
@@ -1,0 +1,43 @@
+import pytest
+
+from atst.forms.task_order import AppInfoForm
+from tests.factories import TaskOrderFactory
+
+
+def test_validations_pass_for_valid_form():
+    form_data = TaskOrderFactory.dictionary()
+    form_data["portfolio_name"] = "Dummy"
+
+    form = AppInfoForm(form_data)
+
+    assert form.validate()
+
+
+def test_validations_fail_for_invalid_form():
+    form = AppInfoForm({})
+
+    assert not form.validate()
+
+    errors = form.errors
+
+    def assert_field_is_required(field, errors):
+        assert "This field is required." in errors[field]
+
+    def assert_none_is_not_valid_choice(field, errors):
+        assert "Not a valid choice" in errors[field]
+
+    assert_field_is_required("complexity", errors)
+    assert_field_is_required("dev_team", errors)
+    assert_field_is_required("portfolio_name", errors)
+    assert_field_is_required("scope", errors)
+
+    assert_none_is_not_valid_choice("app_migration", errors)
+    assert_none_is_not_valid_choice("defense_component", errors)
+    assert_none_is_not_valid_choice("native_apps", errors)
+    assert_none_is_not_valid_choice("team_experience", errors)
+
+
+def test_validations_skipped_for_draft():
+    form = AppInfoForm({"is_draft": True})
+
+    assert form.validate()


### PR DESCRIPTION
This PR implements the ["Save as Draft" feature](https://www.pivotaltracker.com/story/show/162772188).

When clicking "Save as Draft" we set a hidden field via the vue component called `is_draft` to `True`. This field is only an attribute and it does not get saved to the database. When running the `validate()` on a form when the `is_draft` attribute is set to `True` we run through the validations we run the first validation (`OptionalAsDraft()`) which returns a status as `valid=True` for that field and halts all further validations down the chain.

**NOTE**: `OptionalAsDraft()` must be the first validation to run.

When we want to check the completion status we run the method `section_completion_status()` which replaces `is_section_complete()` and this method now returns the form steps completion state of either `["complete", "draft", "incomplete"]`.

The form steps component now uses the `section_completion_status` to display either complete, draft, incomplete in the timeline at the top.

The method `all_sections_complete()` has also been changed to make use of `section_completion_status()`.