### PR TITLE
Show relevant details for invitation events in audit log

### DIFF
--- a/templates/audit_log/events/invitation.html
+++ b/templates/audit_log/events/invitation.html
@@ -4,5 +4,11 @@
   {% set accepted = event.changed_state.status and event.changed_state.status.1 == "ACCEPTED" %}
   {% if accepted %}
     accepted by {{ event.event_details.email }} (DOD <code>{{ event.event_details.dod_id }}</code>)
+    <br>
   {% endif %}
+  {% if event.action == "create" %}
+    invited {{ event.event_details.email }} (DOD <code>{{ event.event_details.dod_id }}</code>)
+    <br>
+  {% endif %}
+  in Workspace <code>{{ event.workspace_id }}</code> ({{ event.workspace.name }})
 {% endblock %}


### PR DESCRIPTION
Previously, we were not showing all the relevant details for invitation events in the audit log:

![image](https://user-images.githubusercontent.com/40774582/50859474-7360f400-1361-11e9-89ef-b47dbdf3540c.png)

We were, however, storing the information, so displaying it is just a matter of updating the template. Now, we see all relevant info:

![image](https://user-images.githubusercontent.com/40774582/50859425-575d5280-1361-11e9-9a5a-7fad45a2f309.png)
