### PR TITLE
Fix task order funding submisssion

### DIFF
--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -85,6 +85,11 @@ class UnclassifiedFundingForm(FundingForm):
     clin_02 = IntegerField("CLIN 02: Classified (available soon)")
     clin_04 = IntegerField("CLIN 04: Classified (available soon)")
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.clin_02.data = "0"
+        self.clin_04.data = "0"
+
 
 class OversightForm(CacheableForm):
     ko_first_name = StringField("First Name")

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -108,10 +108,11 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
         self.task_order_id = task_order_id
         self._task_order = None
         self._section = TASK_ORDER_SECTIONS[screen - 1]
+        self._form = self._section["form"](self.form_data)
 
     @property
     def form(self):
-        return self._section["form"](self.form_data)
+        return self._form
 
     @property
     def workspace(self):

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from flask import (
     request as http_request,
     render_template,
@@ -90,7 +92,7 @@ class ShowTaskOrderWorkflow:
 
     @property
     def display_screens(self):
-        screen_info = TASK_ORDER_SECTIONS.copy()
+        screen_info = deepcopy(TASK_ORDER_SECTIONS)
 
         if self.task_order:
             for section in screen_info:

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -37,8 +37,10 @@
           <span class='usa-input__help'>{{ description | safe }}</span>
         {% endif %}
 
-        <span v-show='showError'>{{ Icon('alert',classes="icon-validation") }}</span>
-        <span v-show='showValid'>{{ Icon('ok',classes="icon-validation") }}</span>
+        {% if not disabled %}
+          <span v-show='showError'>{{ Icon('alert',classes="icon-validation") }}</span>
+          <span v-show='showValid'>{{ Icon('ok',classes="icon-validation") }}</span>
+        {% endif %}
 
       </label>
 

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -11,8 +11,6 @@
 
 {% block form %}
 
-{% include "fragments/flash.html" %}
-
 <h3>Basic Information</h3>
 {{ TextInput(form.portfolio_name, placeholder="The name of your office or organization") }}
 {{ TextInput(form.scope, paragraph=True) }}

--- a/templates/task_orders/new/funding.html
+++ b/templates/task_orders/new/funding.html
@@ -10,8 +10,6 @@
 
 {% block form %}
 
-{% include "fragments/flash.html" %}
-
 <funding inline-template v-bind:initial-data='{{ form.data|tojson }}'>
 <div>
   <!-- Get Funding Section           -->

--- a/templates/task_orders/new/oversight.html
+++ b/templates/task_orders/new/oversight.html
@@ -9,8 +9,6 @@
 
 {% block form %}
 
-{% include "fragments/flash.html" %}
-
 <!-- Oversight Section					 -->
 <h3>Contracting Officer (KO) Information</h3>
 {{ UserInfo(form.ko_first_name, form.ko_last_name, form.ko_email, form.ko_dod_id) }}

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -10,8 +10,6 @@
 
 {% block form %}
 
-{% include "fragments/flash.html" %}
-
 {% macro TOEditLink(screen=1) %}
 {% if task_order %}
   {{ EditLink(url_for("task_orders.new", screen=screen, task_order_id=task_order.id)) }}

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -70,6 +70,28 @@ def test_create_new_task_order(client, user_session):
     assert url_for("task_orders.new", screen=4) in response.headers["Location"]
 
 
+def test_task_order_form_shows_errors(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+
+    to = TaskOrderFactory.create()
+
+    task_order_data = TaskOrderFactory.dictionary()
+    funding_data = slice_data_for_section(task_order_data, "funding")
+    funding_data = serialize_dates(funding_data)
+    funding_data.update({"clin_01": "one milllllion dollars"})
+
+    response = client.post(
+        url_for("task_orders.update", screen=2, task_order_id=to.id),
+        data=funding_data,
+        follow_redirects=False,
+    )
+
+    body = response.data.decode()
+    assert "There were some errors" in body
+    assert "Not a valid integer" in body
+
+
 def test_show_task_order():
     workflow = ShowTaskOrderWorkflow()
     assert workflow.task_order is None


### PR DESCRIPTION
After disabling the classified CLIN fields, submitting the funding portion of the new task order would fail each time, but no errors were actually displayed. There was an issue with a form instance being created one too many times that was preventing the errors from displaying: https://github.com/dod-ccpo/atst/commit/3a5c55410c8ec9cdc336a4f16dd0eb208fe67d42

Once the errors were displayed, the form was complaining about invalid values for the disabled fields:

![image](https://user-images.githubusercontent.com/40774582/50865140-5e409100-1372-11e9-904e-cd686836227d.png)

This is fixed by setting a default value of $0 for those disabled fields: https://github.com/dod-ccpo/atst/commit/7b2e74f2f55501f46cfb10aa75137feb45edb655

I also disabled the green checkmark next to disabled fields, since that looked a little odd to me, so now the fields look like this:

![image](https://user-images.githubusercontent.com/40774582/50865130-57b21980-1372-11e9-8bc1-457ba87105c3.png)

Finally, I noticed an issue that sections were being marked as complete even though nothing was filled in yet. This was due to `list.copy` making a shallow copy of the form sections causing the completeness to be recorded application-wide. This is fixed by using `deepcopy` instead: https://github.com/dod-ccpo/atst/commit/b61a331ce6c2559354ba18ac57d9a2459d6fe2de