### PR TITLE
Simple task order view

### DIFF
--- a/atst/routes/workspaces/__init__.py
+++ b/atst/routes/workspaces/__init__.py
@@ -6,6 +6,7 @@ from . import index
 from . import projects
 from . import members
 from . import invitations
+from . import task_orders
 from atst.domain.exceptions import UnauthorizedError
 from atst.domain.workspaces import Workspaces
 from atst.domain.authz import Authorization

--- a/atst/routes/workspaces/task_orders.py
+++ b/atst/routes/workspaces/task_orders.py
@@ -1,0 +1,20 @@
+from flask import g, render_template
+
+from . import workspaces_bp
+from atst.domain.task_orders import TaskOrders
+from atst.domain.workspaces import Workspaces
+
+
+@workspaces_bp.route("/workspaces/<workspace_id>/task_orders")
+def workspace_task_orders(workspace_id):
+    workspace = Workspaces.get(g.current_user, workspace_id)
+    return render_template("workspaces/task_orders/index.html", workspace=workspace)
+
+
+@workspaces_bp.route("/workspaces/<workspace_id>/task_order/<task_order_id>")
+def view_task_order(workspace_id, task_order_id):
+    workspace = Workspaces.get(g.current_user, workspace_id)
+    task_order = TaskOrders.get(task_order_id)
+    return render_template(
+        "workspaces/task_orders/show.html", workspace=workspace, task_order=task_order
+    )

--- a/templates/navigation/workspace_navigation.html
+++ b/templates/navigation/workspace_navigation.html
@@ -40,6 +40,13 @@
       ) }}
     {% endif %}
 
+    {{ SidenavItem(
+      ("navigation.workspace_navigation.task_orders" | translate),
+      href=url_for("workspaces.workspace_task_orders", workspace_id=workspace.id),
+      active=request.url_rule.rule.startswith('/workspaces/<workspace_id>/task_order'),
+      subnav=None
+    ) }}
+
     {% if user_can(permissions.EDIT_WORKSPACE_INFORMATION) %}
       {{ SidenavItem(
         ("navigation.workspace_navigation.workspace_settings" | translate),

--- a/templates/workspaces/task_orders/index.html
+++ b/templates/workspaces/task_orders/index.html
@@ -1,0 +1,30 @@
+{% from "components/empty_state.html" import EmptyState %}
+
+{% extends "workspaces/base.html" %}
+
+{% block workspace_content %}
+
+{% if not workspace.task_orders %}
+
+  {{ EmptyState(
+    'This workspace doesn’t have any task orders yet.',
+    action_label='Add a New Task Order',
+    action_href=url_for('task_orders.new', screen=1, workspace_id=workspace.id),
+    icon='cloud',
+  ) }}
+
+{% else %}
+
+  <ul>
+    {% for task_order in workspace.task_orders %}
+      <li class='block-list__item'>
+        <a href='{{ url_for("workspaces.view_task_order", workspace_id=workspace.id, task_order_id=task_order.id)}}'>
+          <span>{{ task_order.start_date }} - {{ task_order.end_date }}</span>
+        </a>
+      </li>
+    {% endfor %}
+  </ul>
+
+{% endif %}
+
+{% endblock %}

--- a/templates/workspaces/task_orders/show.html
+++ b/templates/workspaces/task_orders/show.html
@@ -1,0 +1,7 @@
+{% extends "workspaces/base.html" %}
+
+{% block workspace_content %}
+
+You're looking at TO {{ task_order.id }}
+
+{% endblock %}

--- a/translations.yaml
+++ b/translations.yaml
@@ -204,6 +204,7 @@ navigation:
     budget_report: Budget Report
     members: Members
     projects: Projects
+    task_orders: Task Orders
     workspace_settings: Workspace Settings
 requests:
   _new:


### PR DESCRIPTION
This PR adds a very simplified version of the task order listing and viewing page. These pages don't really cover any requirements of the final pages, but I wanted to lay the groundwork for the routes/templates as early as possible to prevent conflicts in multiple branches as the work moves on.

Listing of task orders for a workspace shows each task order with the start/end date:

![image](https://user-images.githubusercontent.com/40774582/50909857-af946300-13fa-11e9-8d11-539110bfa161.png)

Clicking the link takes one to a placeholder page:

![image](https://user-images.githubusercontent.com/40774582/50909925-c9ce4100-13fa-11e9-8595-b42f3d437068.png)
