### PR TITLE
manually set list/SelectMultipleField data for task order AppInfoForm

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -62,14 +62,6 @@ class ShowTaskOrderWorkflow:
         return self._task_order
 
     @property
-    def task_order_formdata(self):
-        task_order_dict = self.task_order.to_dictionary()
-        for field in task_order_dict:
-            if task_order_dict[field] is None:
-                task_order_dict[field] = ""
-        return task_order_dict
-
-    @property
     def form(self):
         form_type = (
             "unclassified_form"
@@ -80,7 +72,11 @@ class ShowTaskOrderWorkflow:
         if self._form:
             pass
         elif self.task_order:
-            self._form = self._section[form_type](formdata=self.task_order_formdata)
+            self._form = self._section[form_type](obj=self.task_order)
+            # manually set SelectMultipleFields
+            if self._section["section"] == "app_info":
+                self._form.complexity.data = self.task_order.complexity
+                self._form.dev_team.data = self.task_order.dev_team
         else:
             self._form = self._section[form_type]()
 

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -100,14 +100,12 @@ def test_show_task_order():
     assert another_workflow.task_order == task_order
 
 
-def test_show_task_order_formdata():
-    task_order = TaskOrderFactory.create()
+def test_show_task_order_form_list_data():
+    complexity = ["oconus", "tactical_edge"]
+    task_order = TaskOrderFactory.create(complexity=complexity)
     workflow = ShowTaskOrderWorkflow(task_order_id=task_order.id)
 
-    assert workflow.task_order.to_dictionary()["user_id"] is None
-    assert workflow.task_order_formdata["user_id"] is ""
-    for field in workflow.task_order_formdata:
-        assert not field is None
+    assert workflow.form.complexity.data == complexity
 
 
 def test_show_task_order_form():
@@ -220,3 +218,16 @@ def test_update_does_not_resend_invitation():
     for i in range(2):
         workflow.update()
     assert len(contracting_officer.invitations) == 1
+
+
+def test_review_task_order_form(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+
+    task_order = TaskOrderFactory.create(creator=creator)
+
+    for idx, section in enumerate(TaskOrders.SECTIONS):
+        response = client.get(
+            url_for("task_orders.new", screen=idx + 1, task_order_id=task_order.id)
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
This fixes a bug on master where you can't click back to the "funding" section of the TO form because it's expecting string data for the date fields.

WTForms expects you to pass end-user data when you initialize a form with the `formdata` kwarg, which is not what we're doing in this case. Instead, I'm using the `obj` kwarg and giving it the task order entity directly (this is equivalent to giving the `data` kwarg a dictionary of the task order data, but fewer steps). https://wtforms.readthedocs.io/en/stable/forms.html#wtforms.form.Form.__init__ 

The root of the problem is that the form can't seem to load list types for `SelectMultipleField` from the `data` or `obj` kwargs. I've decided to manually set the form data for those, rather than jump through other hoops. I've also added a test to confirm that we can load every page of the TO form for a completed TO.
