### PR TITLE
handle empty strings when totalling clin value

### DIFF
--- a/js/components/forms/funding.js
+++ b/js/components/forms/funding.js
@@ -40,7 +40,7 @@ export default {
     totalBudget: function () {
       return [this.clin_01, this.clin_02, this.clin_03, this.clin_04].reduce(
         function(acc, curr) {
-          curr = curr === null ? 0 : parseInt(curr)
+          curr = !curr ? 0 : parseInt(curr)
           return acc + curr;
         }, 0
       )


### PR DESCRIPTION
Small JS fix for CLIN totals to address the issue noted here:

https://www.pivotaltracker.com/story/show/162772340/comments/198247235

