### PR TITLE
Fix checkbox

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -63,6 +63,21 @@ class ShowTaskOrderWorkflow:
         return self._task_order
 
     @property
+    def task_order_formdata(self):
+        task_order_dict = self.task_order.to_dictionary()
+        for field in task_order_dict:
+            if task_order_dict[field] is None:
+                task_order_dict[field] = ""
+
+        # don't save other text in DB unless "other" is checked
+        if 'other' not in task_order_dict['complexity']:
+            task_order_dict['complexity_other'] = ""
+        if 'other' not in task_order_dict['dev_team']:
+            task_order_dict['dev_team_other'] = ""
+
+        return task_order_dict
+
+    @property
     def form(self):
         form_type = (
             "unclassified_form"

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -126,9 +126,9 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
 
         # don't save other text in DB unless "other" is checked
         if "complexity" in to_data and "other" not in to_data["complexity"]:
-            to_data["complexity_other"] = ""
+            to_data["complexity_other"] = None
         if "dev_team" in to_data and "other" not in to_data["dev_team"]:
-            to_data["dev_team_other"] = ""
+            to_data["dev_team_other"] = None
 
         return to_data
 
@@ -139,8 +139,8 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
         if self.task_order:
             if "portfolio_name" in self.form.data:
                 new_name = self.form.data["portfolio_name"]
-                old_name = self.task_order.to_dictionary()["portfolio_name"]
-                if not new_name is old_name:
+                old_name = self.task_order.portfolio_name
+                if not new_name == old_name:
                     Portfolios.update(self.task_order.portfolio, {"name": new_name})
             TaskOrders.update(self.user, self.task_order, **self.task_order_form_data)
         else:

--- a/js/components/multi_checkbox_input.js
+++ b/js/components/multi_checkbox_input.js
@@ -30,7 +30,7 @@ export default {
       showValid: !showError && this.initialValue.length > 0,
       validationError: this.initialErrors.join(' '),
       otherChecked: this.initialValue.includes("other") ? true : this.otherChecked,
-      otherText: this.initialOtherValue,
+      otherText: this.initialValue.includes("other") ? this.initialOtherValue : '',
       selections: this.initialValue
     }
   },
@@ -46,7 +46,6 @@ export default {
     },
     otherToggle: function() {
       this.otherChecked = !this.otherChecked
-      this.otherText = ''
     },
   }
 }

--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -39,7 +39,7 @@
                 <label for='{{ field.name }}-{{ loop.index0 }}'>{{ choice[1] }}</label>
 
                 <div v-show="otherChecked">
-                  <input type='text' name='{{ other_input_field.name}}' id='{{ field.name }}-other'  v-bind:value="otherText" aria-expanded='false' />
+                  <input type='text' name='{{ other_input_field.name}}' id='{{ field.name }}-other'  v-model:value="otherText" aria-expanded='false' />
                 </div>
               {% endif %}
             </li>

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -165,13 +165,14 @@ def test_update_task_order_with_existing_task_order(task_order):
 def test_other_text_not_saved_if_other_not_checked(task_order):
     to_data = {
         **TaskOrderFactory.dictionary(),
-        "complexity": ["conus", "other"],
+        "complexity": ["conus"],
         "complexity_other": "quite complex",
     }
     workflow = UpdateTaskOrderWorkflow(
         task_order.creator, to_data, task_order_id=task_order.id
     )
     workflow.update()
+    assert not workflow.task_order.complexity_other
 
 
 def test_invite_officers_to_task_order(task_order, queue):

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -162,6 +162,18 @@ def test_update_task_order_with_existing_task_order(task_order):
     assert workflow.task_order.start_date.strftime("%m/%d/%Y") == to_data["start_date"]
 
 
+def test_other_text_not_saved_if_other_not_checked(task_order):
+    to_data = {
+        **TaskOrderFactory.dictionary(),
+        "complexity": ["conus", "other"],
+        "complexity_other": "quite complex",
+    }
+    workflow = UpdateTaskOrderWorkflow(
+        task_order.creator, to_data, task_order_id=task_order.id
+    )
+    workflow.update()
+
+
 def test_invite_officers_to_task_order(task_order, queue):
     to_data = {
         **TaskOrderFactory.dictionary(),


### PR DESCRIPTION
## Description
This ticket had been kicked back due to a bug and some functionality concerns. 

- If a user clicked `other`, enters text, then clicks another box, the text was erasing. That is now fixed.
- Whenever a user unclicked `other`, the corresponding text would delete. Now the text persists until the user submits the page. 

In addition to those issues, this PR addresses a problem that was happening when a user had completed the first page of the TO form, and then tried to go back and change one of the fields. There was a set Attribute server error occurring in that case. Now, the data being sent for update is in a form that will allow for the user to make changes on information that was already saved to the DB.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/162667897