### PR TITLE
Test fixes

### DIFF
--- a/tests/domain/test_workspace_roles.py
+++ b/tests/domain/test_workspace_roles.py
@@ -55,5 +55,11 @@ def test_workspace_role_permissions():
         status=WorkspaceRoleStatus.PENDING,
     )
 
-    assert WorkspaceRoles.workspace_role_permissions(workspace_one, new_user)
-    assert not WorkspaceRoles.workspace_role_permissions(workspace_two, new_user)
+    default_perms = set(new_user.atat_role.permissions)
+    assert len(
+        WorkspaceRoles.workspace_role_permissions(workspace_one, new_user)
+    ) > len(default_perms)
+    assert (
+        WorkspaceRoles.workspace_role_permissions(workspace_two, new_user)
+        == default_perms
+    )

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -18,7 +18,7 @@ from atst.models.task_order import TaskOrder
 from atst.models.user import User
 from atst.models.role import Role
 from atst.models.workspace import Workspace
-from atst.domain.roles import Roles
+from atst.domain.roles import Roles, WORKSPACE_ROLES
 from atst.models.workspace_role import WorkspaceRole, Status as WorkspaceRoleStatus
 from atst.models.environment_role import EnvironmentRole
 from atst.models.invitation import Invitation, Status as InvitationStatus
@@ -50,20 +50,15 @@ def random_future_date(year_min=1, year_max=5):
     )
 
 
+def random_workspace_role():
+    choice = random.choice(WORKSPACE_ROLES)
+    return Roles.get(choice["name"])
+
+
 class Base(factory.alchemy.SQLAlchemyModelFactory):
     @classmethod
     def dictionary(cls, **attrs):
         return factory.build(dict, FACTORY_CLASS=cls, **attrs)
-
-
-class RoleFactory(Base):
-    class Meta:
-        model = Role
-
-    name = factory.Faker("name")
-    display_name = "Role display name"
-    description = "This is a test role."
-    permissions = []
 
 
 class UserFactory(Base):
@@ -74,7 +69,7 @@ class UserFactory(Base):
     email = factory.Faker("email")
     first_name = factory.Faker("first_name")
     last_name = factory.Faker("last_name")
-    atat_role = factory.SubFactory(RoleFactory)
+    atat_role = factory.LazyFunction(lambda: Roles.get("default"))
     dod_id = factory.LazyFunction(random_dod_id)
     phone_number = factory.LazyFunction(
         lambda: "".join(random.choices(string.digits, k=10))
@@ -340,7 +335,7 @@ class WorkspaceRoleFactory(Base):
         model = WorkspaceRole
 
     workspace = factory.SubFactory(WorkspaceFactory)
-    role = factory.SubFactory(RoleFactory)
+    role = factory.LazyFunction(random_workspace_role)
     user = factory.SubFactory(UserFactory)
     status = WorkspaceRoleStatus.PENDING
 

--- a/tests/mocks.py
+++ b/tests/mocks.py
@@ -1,8 +1,6 @@
 from tests.factories import RequestFactory, UserFactory
 
 
-MOCK_USER = UserFactory.build()
-MOCK_REQUEST = RequestFactory.build(creator=MOCK_USER)
 DOD_SDN_INFO = {"first_name": "ART", "last_name": "GARFUNKEL", "dod_id": "5892460358"}
 DOD_SDN = f"CN={DOD_SDN_INFO['last_name']}.{DOD_SDN_INFO['first_name']}.G.{DOD_SDN_INFO['dod_id']},OU=OTHER,OU=PKI,OU=DoD,O=U.S. Government,C=US"
 

--- a/tests/routes/requests/requests_form/test_submit.py
+++ b/tests/routes/requests/requests_form/test_submit.py
@@ -1,5 +1,4 @@
 import pytest
-from tests.mocks import MOCK_USER
 from tests.factories import RequestFactory
 from atst.models.request_status_event import RequestStatus
 

--- a/tests/routes/task_orders/test_index.py
+++ b/tests/routes/task_orders/test_index.py
@@ -9,7 +9,9 @@ from tests.factories import TaskOrderFactory, WorkspaceFactory, UserFactory
 
 
 def xml_translated(val):
-    return re.sub("'", "&#39;", str(val))
+    val = re.sub("'", "&#39;", str(val))
+    val = re.sub(" & ", " &amp; ", str(val))
+    return val
 
 
 def test_download_summary(client, user_session):


### PR DESCRIPTION
This makes two small changes to our tests:

- We should use real ATAT and workspace roles for users in tests. `Faker` doesn't return unique data within a test run reliably and so sometimes we see test flickers. More importantly, we should be deliberate about what kind of user is involved when testing something.
- I fixed a string comparison issue in the TO download. (This test would also flicker because some Defense Components have ampersands that show up as `&amp;` in XML.)