### PR TITLE
Fix invites bug that used a method without all the needed arguments

### DIFF
--- a/atst/routes/task_orders/invite.py
+++ b/atst/routes/task_orders/invite.py
@@ -1,4 +1,4 @@
-from flask import redirect, url_for
+from flask import redirect, url_for, g
 
 from . import task_orders_bp
 from atst.domain.task_orders import TaskOrders
@@ -8,7 +8,7 @@ from atst.utils.flash import formatted_flash as flash
 # TODO: add a real implementation for this
 @task_orders_bp.route("/task_orders/invite/<task_order_id>", methods=["POST"])
 def invite(task_order_id):
-    task_order = TaskOrders.get(task_order_id)
+    task_order = TaskOrders.get(g.current_user, task_order_id)
     flash("task_order_submitted", task_order=task_order)
     return redirect(
         url_for("workspaces.workspace_members", workspace_id=task_order.workspace.id)


### PR DESCRIPTION
## Description
Invites were unable to retrieve the task order because the current user wasn't passed to the `get` method.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163151289