### PR TITLE
Fix layout for task order view page in IE

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -47,13 +47,8 @@
 
 .task-order-summary {
 
-
   .panel {
     width: 100%;
-
-    @include ie-only {
-      max-width: 100%;
-    }
   }
 
   .task-order-heading {
@@ -93,6 +88,10 @@
       padding-right: $gap;
     }
 
+    @include ie-only {
+      width: 100%;
+    }
+
     .task-order-next-steps__step {
       .task-order-next-steps__icon {
         padding: $gap $gap 0 0;
@@ -102,6 +101,12 @@
         }
         .incomplete {
           @include icon-color($color-gray-light);
+        }
+      }
+
+      .task-order-next-steps__text {
+        @include ie-only {
+          width: 100%
         }
       }
 

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -70,7 +70,7 @@
         <dt>Started</dt>
         <dd>
           <local-datetime
-            timestamp="{{ task_order.start_date }}"
+            timestamp="{{ task_order.time_created }}"
             format="M/D/YYYY">
             </local-datetime>
         </dd>

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -9,7 +9,7 @@
     <div class="task-order-next-steps__icon col">
       <span>{{ Icon("ok", classes="complete" if complete else "incomplete") }}</span>
     </div>
-    <div>
+    <div class="task-order-next-steps__text">
       <div class="task-order-next-steps__heading row">
         <h4>{{ title }}</h4>
         {% if link_url %}


### PR DESCRIPTION
This PR fixes the layout on the view task order page in IE10. The layout now matches the layout on Chrome & other browsers.