### PR TITLE
Fix TO Get Started Page in IE10

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -21,7 +21,7 @@
 
   .task-order-needs {
     .task-order-needs__list {
-      @include media($large-screen) {
+      @include media(960px) {
         @include grid-row;
       }
 

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -24,6 +24,18 @@
       @include media($large-screen) {
         @include grid-row;
       }
+
+      @include ie-only {
+        width: 100%;
+        max-width: 100%;
+
+        @include media($large-screen) {
+          .col {
+            max-width: 33%;
+          }
+        }
+      }
+
     }
   }
 


### PR DESCRIPTION
Fixes a rendering issue on IE10 on the TO get started page. When on a large screen, ensure the next steps don't take up more than 1/3 of the container width.