### PR TITLE
Add "Congrats" message after completing TO form

### DIFF
--- a/atst/routes/task_orders/invite.py
+++ b/atst/routes/task_orders/invite.py
@@ -8,7 +8,12 @@ from atst.utils.flash import formatted_flash as flash
 @task_orders_bp.route("/task_orders/invite/<task_order_id>", methods=["POST"])
 def invite(task_order_id):
     task_order = TaskOrders.get(g.current_user, task_order_id)
-    flash("task_order_submitted", task_order=task_order)
+    portfolio = task_order.portfolio
+    flash("task_order_congrats", portfolio=portfolio)
     return redirect(
-        url_for("portfolios.portfolio_members", portfolio_id=task_order.portfolio.id)
+        url_for(
+            "portfolios.view_task_order",
+            portfolio_id=task_order.portfolio_id,
+            task_order_id=task_order.id,
+        )
     )

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -108,6 +108,26 @@ MESSAGES = {
         """,
         "category": "success",
     },
+    "task_order_congrats": {
+        "title_template": "Congrats!",
+        "message_template": """
+        You've created a new JEDI portfolio and jump started your first task order!
+        """,
+        "actions": """
+            {% from "components/icon.html" import Icon %}
+            <div class='alert__actions'>
+              <a href='{{ url_for("portfolios.show_portfolio", portfolio_id=portfolio.id) }}' class='icon-link'>
+                {{ Icon('shield') }}
+                <span>Go to my Portfolio Home Page</span>
+              </a>
+              <a href='#next-steps' class='icon-link'>
+                {{ Icon('arrow-down') }}
+                <span>Review Next Steps Below</span>
+              </a>
+            </div>
+        """,
+        "category": "success",
+    },
 }
 
 

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -115,4 +115,7 @@ def formatted_flash(message_name, **message_args):
     config = MESSAGES[message_name]
     title = render_template_string(config["title_template"], **message_args)
     message = render_template_string(config["message_template"], **message_args)
-    flash({"title": title, "message": message}, config["category"])
+    actions = None
+    if "actions" in config:
+        actions = render_template_string(config["actions"], **message_args)
+    flash({"title": title, "message": message, "actions": actions}, config["category"])

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -59,6 +59,10 @@
 
 .task-order-summary {
 
+  .alert .alert__actions {
+    margin-top: 2 * $gap;
+  }
+
   .panel {
     width: 100%;
   }

--- a/templates/fragments/flash.html
+++ b/templates/fragments/flash.html
@@ -7,7 +7,7 @@
 {% with messages = get_flashed_messages(with_categories=true, category_filter=category_filter) %}
   {% if messages %}
     {% for category, message_config in messages %}
-      {{ Alert(message_config["title"], message=message_config.get("message"), level=category) }}
+      {{ Alert(message_config["title"], message=message_config.get("message"), actions=message_config.get("actions"), level=category) }}
     {% endfor %}
   {% endif %}
 {% endwith %}

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -59,7 +59,10 @@
   </div>
 {% endmacro %}
 
+
 <div class="task-order-summary">
+  {% include "fragments/flash.html" %}
+
   <div class="panel task-order-heading row">
     <div class="panel__content task-order-heading__name row">
       <h2>New Task Order</h2>
@@ -83,7 +86,7 @@
   </div>
 
   <div class="task-order-details">
-    <div class="task-order-next-steps">
+    <div id="next-steps" class="task-order-next-steps">
       <div class="panel">
         <h3 class="panel__content">What's next?</h3>
         {{ Step(

--- a/tests/routes/task_orders/test_invite.py
+++ b/tests/routes/task_orders/test_invite.py
@@ -1,11 +1,17 @@
 import pytest
 from flask import url_for
 
-from tests.factories import TaskOrderFactory
+from tests.factories import PortfolioFactory, TaskOrderFactory
 
 
-def test_invite(client):
-    to = TaskOrderFactory.create()
+def test_invite(client, user_session):
+    portfolio = PortfolioFactory.create()
+    user_session(portfolio.owner)
+    to = TaskOrderFactory.create(portfolio=portfolio)
     response = client.post(
         url_for("task_orders.invite", task_order_id=to.id), follow_redirects=False
     )
+    redirect = url_for(
+        "portfolios.view_task_order", portfolio_id=to.portfolio_id, task_order_id=to.id
+    )
+    assert redirect in response.headers["Location"]


### PR DESCRIPTION
After submitting the task order form (clicking "Send Invitations" on the review form), display a "Congrats" message on the top of the page:

![image](https://user-images.githubusercontent.com/40774582/51323761-0f13f380-1a37-11e9-9775-97589bd9861a.png)

In order to have the correct links on the bottom of the alert, I've added an `actions` option to the flashed messages configuration that, similar to the title and message, will render a template string and pass it on to the `Alert` template.

The arrow icon doesn't match whats in the design, but I've used the `arrow-down` icon here and I'm not sure it's worth adding an extra icon just for this. 