### PR TITLE
no op version of CRL cache for disabling crl check

### DIFF
--- a/config/base.ini
+++ b/config/base.ini
@@ -4,6 +4,7 @@ CA_CHAIN = ssl/server-certs/ca-chain.pem
 CLASSIFIED = false
 COOKIE_SECRET = some-secret-please-replace
 CRL_DIRECTORY = crl
+DISABLE_CRL_CHECK = false
 DEBUG = true
 ENVIRONMENT = dev
 PERMANENT_SESSION_LIFETIME = 600

--- a/tests/domain/authnid/test_crl.py
+++ b/tests/domain/authnid/test_crl.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from OpenSSL import crypto, SSL
 
-from atst.domain.authnid.crl import CRLCache, CRLRevocationException
+from atst.domain.authnid.crl import CRLCache, CRLRevocationException, NoOpCRLCache
 import atst.domain.authnid.crl.util as util
 
 from tests.mocks import FIXTURE_EMAIL_ADDRESS
@@ -161,3 +161,11 @@ def test_refresh_crls_with_error(tmpdir, monkeypatch):
     util.refresh_crls(tmpdir, tmpdir, logger)
 
     assert "Error downloading {}".format(fake_crl) in logger.messages[-1]
+
+
+def test_no_op_crl_cache_logs_common_name():
+    logger = FakeLogger()
+    cert = open("ssl/client-certs/atat.mil.crt", "rb").read()
+    cache = NoOpCRLCache(logger=logger)
+    assert cache.crl_check(cert)
+    assert "ART.GARFUNKEL.1234567890" in logger.messages[-1]


### PR DESCRIPTION
This gives us a version of the CRL Cache that will always return true when it checks a CRL. The app will use as its CRL cache/checker if `DISABLE_CRL_CHECK` is set to `True` in the app's config.