### PR TITLE
Better docker output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -174,7 +174,7 @@ jobs:
           command: |
             docker image ls
             docker login -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD} ${ATAT_DOCKER_REGISTRY_URL}
-            docker push ${IMAGE_NAME}
+            docker push ${IMAGE_NAME} | cat
             docker logout
 
   deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -175,6 +175,7 @@ jobs:
             docker image ls
             docker login -u ${REGISTRY_USERNAME} -p ${REGISTRY_PASSWORD} ${ATAT_DOCKER_REGISTRY_URL}
             docker push ${IMAGE_NAME} | cat
+            curl -s -H "Content-Type: application/json" --user ${REGISTRY_USERNAME}:${REGISTRY_PASSWORD} -XGET https://${ATAT_DOCKER_REGISTRY_URL}/v2/${PROD_IMAGE_NAME}/manifests/${GIT_SHA} || true
             docker logout
 
   deploy:


### PR DESCRIPTION
This makes a couple of tweaks to the image pushing process to provide more info in the CD logs:
- Pipe `docker push` output through cat so that it doesn't use console codes and actually shows up in the log
- Once the push is complete, pull the manifest for the new image from the private repository