### PR TITLE
Fix browse button in Firefox

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -285,6 +285,10 @@
   &.usa-input--success {
     @include input-state('success');
   }
+
+  [type='file'] {
+    height: auto
+  }
 }
 
 select {


### PR DESCRIPTION
## Description
Previously there was a default height on all inputs, which was causing the bottom of the browse button to be cut off. I changed the height of the file inputs to auto so they will no longer be cut off.

## Pivotal
[https://www.pivotaltracker.com/story/show/163129607](https://www.pivotaltracker.com/story/show/163129607)

## Screenshots
<img width="687" alt="screen shot 2019-01-17 at 2 01 32 pm" src="https://user-images.githubusercontent.com/43828539/51341938-8447ee80-1a60-11e9-9d26-c296893b6d5f.png">
