### PR TITLE
Fix mock reporting

### DIFF
--- a/atst/domain/csp/reports.py
+++ b/atst/domain/csp/reports.py
@@ -183,7 +183,7 @@ class MockReportingProvider(ReportingInterface):
         "Beluga": {
             "cumulative": CUMULATIVE_BUDGET_BELUGA,
             "applications": [
-                MockApplication("NP02", ["Integ", "PreProd", "NP02_Prod"]),
+                MockApplication("NP02", ["Integ", "PreProd", "Prod"]),
                 MockApplication("FM", ["Integ", "Prod"]),
             ],
             "budget": 70000,

--- a/atst/domain/csp/reports.py
+++ b/atst/domain/csp/reports.py
@@ -296,10 +296,13 @@ class MockReportingProvider(ReportingInterface):
         else:
             budget_months = {}
 
-        this_year = pendulum.now().year
+        end = pendulum.now()
+        start = end.subtract(months=12)
+        period = pendulum.period(start, end)
+
         all_months = OrderedDict()
-        for m in range(1, 13):
-            month_str = "{month:02d}/{year}".format(month=m, year=this_year)
+        for t in period.range("months"):
+            month_str = "{month:02d}/{year}".format(month=t.month, year=t.year)
             all_months[month_str] = budget_months.get(month_str, None)
 
         return {"months": all_months}

--- a/tests/domain/test_reports.py
+++ b/tests/domain/test_reports.py
@@ -35,4 +35,4 @@ def test_cumulative_budget():
     portfolio = PortfolioFactory.create(request=request)
     months = Reports.cumulative_budget(portfolio)
 
-    assert len(months["months"]) == 12
+    assert len(months["months"]) >= 12


### PR DESCRIPTION
This fixes mock reporting for the Aardvark / Beluga portfolios (for those unaware: if you change the name of a portfolio to "Aardvark" or "Beluga", we'll return some mock data on the "Budget Report" page).

There was a typo in the data for Beluga and the module was relying on the year being 2018 (this will now return any mock data we have for the past year using `pendulum.period` instead).