### PR TITLE
Checkbox is inline for select box validation checkmark

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -90,6 +90,10 @@
     display: flex;
     align-items: center;
 
+    &-inline {
+      display: inline-block;
+    }
+
     .icon-tooltip {
       padding: 0 $gap/2;
       cursor: default;

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -13,7 +13,7 @@
 
       <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
-          <div class="usa-input__title">
+          <div class="usa-input__title{% if not field.description %}-inline{% endif %}">
             {{ field.label | striptags}}
             {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
           </div>


### PR DESCRIPTION
Fix the validation checkmark being pushed onto the second line on the `Department of Defense Component`

---

## Before

<img width="779" alt="screen shot 2019-01-17 at 16 20 58" src="https://user-images.githubusercontent.com/45772525/51349636-ea8a3c80-1a73-11e9-94b0-4673f94edd7f.png">

---

## After

<img width="777" alt="screen shot 2019-01-17 at 16 18 29" src="https://user-images.githubusercontent.com/45772525/51349572-c595c980-1a73-11e9-9627-5e508e74bf86.png">
