### PR TITLE
Disable crls in scripts

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -139,7 +139,7 @@ def map_config(config):
     }
 
 
-def make_config():
+def make_config(direct_config=None):
     BASE_CONFIG_FILENAME = os.path.join(os.path.dirname(__file__), "../config/base.ini")
     ENV_CONFIG_FILENAME = os.path.join(
         os.path.dirname(__file__), "../config/", "{}.ini".format(ENV.lower())
@@ -161,6 +161,10 @@ def make_config():
         env_override = os.getenv(confsetting.upper())
         if env_override:
             config.set("default", confsetting, env_override)
+
+    # override if a dictionary of options has been given
+    if direct_config:
+        config.read_dict({"default": direct_config})
 
     # Assemble DATABASE_URI value
     database_uri = (

--- a/atst/app.py
+++ b/atst/app.py
@@ -48,10 +48,7 @@ def make_app(config):
     app.config.update({"SESSION_REDIS": app.redis})
 
     make_flask_callbacks(app)
-    # TODO: deprecate the REQUIRE_CRLs setting in favor of the
-    # DISABLE_CRL_CHECK; both have the effect of never loading CRLs
-    if app.config.get("REQUIRE_CRLS"):
-        make_crl_validator(app)
+    make_crl_validator(app)
     register_filters(app)
     make_eda_client(app)
     make_csp_provider(app)
@@ -132,7 +129,6 @@ def map_config(config):
         "PERMANENT_SESSION_LIFETIME": config.getint(
             "default", "PERMANENT_SESSION_LIFETIME"
         ),
-        "REQUIRE_CRLS": config.getboolean("default", "REQUIRE_CRLS"),
         "RQ_REDIS_URL": config["default"]["REDIS_URI"],
         "RQ_QUEUES": [config["default"]["RQ_QUEUES"]],
         "DISABLE_CRL_CHECK": config.getboolean("default", "DISABLE_CRL_CHECK"),

--- a/config/base.ini
+++ b/config/base.ini
@@ -17,7 +17,6 @@ PGPORT = 5432
 PGUSER = postgres
 PORT=8000
 REDIS_URI = redis://localhost:6379
-REQUIRE_CRLS = true
 RQ_QUEUES = atat_%(ENVIRONMENT)s
 SECRET = change_me_into_something_secret
 SECRET_KEY = change_me_into_something_secret

--- a/deploy/kubernetes/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-worker-envvars-configmap.yml
@@ -5,4 +5,4 @@ metadata:
   name: atst-worker-envvars
   namespace: atat
 data:
-  REQUIRE_CRLS: "False"
+  DISABLE_CRL_CHECK: "True"

--- a/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
@@ -5,4 +5,4 @@ metadata:
   name: atst-worker-envvars
   namespace: atat-test
 data:
-  REQUIRE_CRLS: "False"
+  DISABLE_CRL_CHECK: "True"

--- a/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
@@ -5,4 +5,4 @@ metadata:
   name: atst-worker-envvars
   namespace: atat-uat
 data:
-  REQUIRE_CRLS: "False"
+  DISABLE_CRL_CHECK: "True"

--- a/script/example_fetch_from_eda.py
+++ b/script/example_fetch_from_eda.py
@@ -9,7 +9,7 @@ from atst.app import make_config, make_app
 from atst.eda_client import EDAClient
 
 
-config = make_config()
+config = make_config({"DISABLE_CRL_CHECK": True})
 
 client = EDAClient(
     base_url=config.get("EDA_HOST"),

--- a/script/ingest_pe_numbers.py
+++ b/script/ingest_pe_numbers.py
@@ -19,7 +19,7 @@ def get_pe_numbers(url):
 
 
 if __name__ == "__main__":
-    config = make_config()
+    config = make_config({"DISABLE_CRL_CHECK": True})
     url = config["PE_NUMBER_CSV_URL"]
     print("Fetching PE numbers from {}".format(url))
     pe_numbers = get_pe_numbers(url)

--- a/script/remove_sample_data.py
+++ b/script/remove_sample_data.py
@@ -153,7 +153,7 @@ def remove_sample_data(all_users=False):
 
 
 if __name__ == "__main__":
-    config = make_config()
+    config = make_config({"DISABLE_CRL_CHECK": True})
     app = make_app(config)
     with app.app_context():
         remove_sample_data()

--- a/script/seed_roles.py
+++ b/script/seed_roles.py
@@ -31,7 +31,7 @@ def seed_roles():
 
 
 if __name__ == "__main__":
-    config = make_config()
+    config = make_config({"DISABLE_CRL_CHECK": True})
     app = make_app(config)
     with app.app_context():
         seed_roles()

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -163,7 +163,7 @@ def seed_db():
 
 
 if __name__ == "__main__":
-    config = make_config()
+    config = make_config({"DISABLE_CRL_CHECK": True})
     app = make_app(config)
     with app.app_context():
         seed_db()


### PR DESCRIPTION
This should fix a problem we're seeing in the nightly build. I've introduced two changes:

1. We can now pass a dictionary directly to `make_config`. Because we often have to initialize an application context for the scripts (like `script/remove_sample_data.py`, which broke last night) they should be able to modify settings in a way relevant to the scripts need. In this case, they don't need an application instance with CRLs loaded, so I've disabled it for all of them.
2. I deprecated the `REQUIRE_CRLS` setting in favor of `DISABLE_CRL_CHECK`. In both cases, the application won't load CRLs. If this looks okay, I'll apply the updated k8s config.