### PR TITLE
Fix issue with sorting arrow pushing out alignment of table

### DIFF
--- a/styles/elements/_tables.scss
+++ b/styles/elements/_tables.scss
@@ -32,6 +32,10 @@
         display: table-cell;
       }
     }
+
+    .sorting-direction {
+      position: absolute;
+    }
   }
 
   tbody {

--- a/templates/portfolios/members/index.html
+++ b/templates/portfolios/members/index.html
@@ -67,10 +67,10 @@
         <tr>
           <th v-for="col in getColumns()" @click="updateSort(col.displayName)" :width="col.width" :class="col.class" scope="col">
             !{ col.displayName }
-            <span v-if="col.displayName === sortInfo.columnName && sortInfo.isAscending">
+            <span class="sorting-direction" v-if="col.displayName === sortInfo.columnName && sortInfo.isAscending">
               {{ Icon("caret_down") }}
             </span>
-            <span v-if="col.displayName === sortInfo.columnName && !sortInfo.isAscending">
+            <span class="sorting-direction" v-if="col.displayName === sortInfo.columnName && !sortInfo.isAscending">
               {{ Icon("caret_up") }}
             </span>
           </th>

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -26,10 +26,10 @@
             <th v-for="col in getColumns()" @click="updateSort(col.displayName)" :width="col.width" :class="col.class" scope="col">
               !{ col.displayName }
               <template v-if="col.sortFunc">
-                <span v-if="col.displayName === sortInfo.columnName && sortInfo.isAscending">
+                <span class="sorting-direction" v-if="col.displayName === sortInfo.columnName && sortInfo.isAscending">
                   {{ Icon("caret_down") }}
                 </span>
-                <span v-if="col.displayName === sortInfo.columnName && !sortInfo.isAscending">
+                <span class="sorting-direction" v-if="col.displayName === sortInfo.columnName && !sortInfo.isAscending">
                   {{ Icon("caret_up") }}
                 </span>
               </template>

--- a/templates/requests/index.html
+++ b/templates/requests/index.html
@@ -115,10 +115,10 @@
           <tr>
             <th @click.prevent="updateSortValue(column.attr)" v-for="column in getColumns()"scope="col">
               !{ column.displayName }
-              <span v-if="column.attr === sort.columnName && sort.isAscending">
+              <span class="sorting-direction" v-if="column.attr === sort.columnName && sort.isAscending">
                 {{ Icon("caret_down") }}
               </span>
-              <span v-else-if="column.attr === sort.columnName && !sort.isAscending">
+              <span class="sorting-direction" v-else-if="column.attr === sort.columnName && !sort.isAscending">
                 {{ Icon("caret_up") }}
               </span>
             </th>


### PR DESCRIPTION
Fix for sorting caret pushing columns out of line when changing column being sorted and direction.

[Ticket](https://www.pivotaltracker.com/story/show/163158120)

## Before

![screen recording 2019-01-11 at 10 53 43 am](https://user-images.githubusercontent.com/45772525/51409043-ae67e200-1b2e-11e9-8b17-e1f92b14c21a.gif)

## After

![sorting-fix](https://user-images.githubusercontent.com/45772525/51409084-d1929180-1b2e-11e9-8089-3d50f85c716e.gif)
