### PR TITLE
Require First TO Screen to be filled out

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -108,22 +108,13 @@ class ShowTaskOrderWorkflow:
 
         return screen_info
 
-    def completed(self):
-        screen_info = deepcopy(TASK_ORDER_SECTIONS)
-
+    @property
+    def is_complete(self):
         if self.task_order:
-            for section in screen_info:
-                if (
-                    not TaskOrders.is_section_complete(
-                        self.task_order, section["section"]
-                    )
-                    and section["section"] != "review"
-                ):
-                    return False
+            if TaskOrders.all_sections_complete(self.task_order):
+                return True
         else:
             return False
-
-        return True
 
 
 class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
@@ -271,7 +262,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
         portfolio_id=portfolio_id,
         screens=workflow.display_screens,
         form=workflow.form,
-        complete=workflow.completed(),
+        complete=workflow.is_complete,
     )
 
 

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -108,6 +108,23 @@ class ShowTaskOrderWorkflow:
 
         return screen_info
 
+    def completed(self):
+        screen_info = deepcopy(TASK_ORDER_SECTIONS)
+
+        if self.task_order:
+            for section in screen_info:
+                if (
+                    not TaskOrders.is_section_complete(
+                        self.task_order, section["section"]
+                    )
+                    and section["section"] != "review"
+                ):
+                    return False
+        else:
+            return False
+
+        return True
+
 
 class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
     def __init__(
@@ -254,6 +271,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
         portfolio_id=portfolio_id,
         screens=workflow.display_screens,
         form=workflow.form,
+        complete=workflow.completed(),
     )
 
 

--- a/styles/components/_progress_menu.scss
+++ b/styles/components/_progress_menu.scss
@@ -50,6 +50,12 @@
 
     a.active {
       color: $color-blue;
+      cursor: default;
+    }
+
+    a.disabled{
+      color: $color-gray-light;
+      cursor: default;
     }
 
 

--- a/templates/task_orders/new/menu.html
+++ b/templates/task_orders/new/menu.html
@@ -10,8 +10,17 @@
       {% endif %}
 
       <li class="progress-menu__item progress-menu__item--{{ step_indicator }}">
-        <a href="{{ url_for('task_orders.new', screen=loop.index, task_order_id=task_order_id) }}"
-          {% if g.matchesPath(url_for('task_orders.new', screen=loop.index)) %}class="active"{% endif %}
+        <a
+          {% set class='' %}
+          {% if task_order_id %}
+            href="{{ url_for('task_orders.new', screen=loop.index, task_order_id=task_order_id) }}"
+          {% else %}
+            {% set class="disabled"%}
+          {% endif %}
+          {% if g.matchesPath(url_for('task_orders.new', screen=loop.index)) %}
+            {% set class="active" %}
+          {% endif %}
+          class={{class}}
         >
           {{ s['title'] }}
         </a>

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -194,7 +194,8 @@
 
 {% block next %}
   <div class='action-group'>
-    <input type='submit' class='usa-button usa-button-primary' value='Done' />
+    <input type='submit' class='usa-button usa-button-primary' value='Done'
+    {% if not complete %}disabled{% endif %}/>
   </div>
 {% endblock %}
 

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -76,6 +76,49 @@ def test_create_new_task_order(client, user_session):
     )
     assert url_for("task_orders.new", screen=4) in response.headers["Location"]
 
+def test_create_new_task_order_on_funding_screen(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+
+    task_order_data = TaskOrderFactory.dictionary()
+    app_info_data = slice_data_for_section(task_order_data, "app_info")
+    portfolio_name = "Mos Eisley"
+    app_info_data["portfolio_name"] = portfolio_name
+
+    response = client.post(
+        url_for("task_orders.update", screen=2),
+        data=app_info_data,
+        follow_redirects=False,
+    )
+    assert url_for("task_orders.new", screen=3) in response.headers["Location"]
+
+    created_task_order_id = response.headers["Location"].split("/")[-1]
+    created_task_order = TaskOrders.get(creator, created_task_order_id)
+    assert created_task_order.portfolio is not None
+    assert created_task_order.portfolio.name == portfolio_name
+
+def test_create_new_task_order_on_oversight_screen(client, user_session):
+    creator = UserFactory.create()
+    user_session(creator)
+
+    task_order_data = TaskOrderFactory.dictionary()
+    app_info_data = slice_data_for_section(task_order_data, "app_info")
+    portfolio_name = "Mos Eisley"
+    app_info_data["portfolio_name"] = portfolio_name
+
+    response = client.post(
+        url_for("task_orders.update", screen=3),
+        data=app_info_data,
+        follow_redirects=False,
+    )
+    import ipdb; ipdb.set_trace()
+    assert url_for("task_orders.new", screen=4) in response.headers["Location"]
+
+    created_task_order_id = response.headers["Location"].split("/")[-1]
+    created_task_order = TaskOrders.get(creator, created_task_order_id)
+    assert created_task_order.portfolio is not None
+    assert created_task_order.portfolio.name == portfolio_name
+
 
 def test_create_new_task_order_for_portfolio(client, user_session):
     portfolio = PortfolioFactory.create()

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -76,49 +76,6 @@ def test_create_new_task_order(client, user_session):
     )
     assert url_for("task_orders.new", screen=4) in response.headers["Location"]
 
-def test_create_new_task_order_on_funding_screen(client, user_session):
-    creator = UserFactory.create()
-    user_session(creator)
-
-    task_order_data = TaskOrderFactory.dictionary()
-    app_info_data = slice_data_for_section(task_order_data, "app_info")
-    portfolio_name = "Mos Eisley"
-    app_info_data["portfolio_name"] = portfolio_name
-
-    response = client.post(
-        url_for("task_orders.update", screen=2),
-        data=app_info_data,
-        follow_redirects=False,
-    )
-    assert url_for("task_orders.new", screen=3) in response.headers["Location"]
-
-    created_task_order_id = response.headers["Location"].split("/")[-1]
-    created_task_order = TaskOrders.get(creator, created_task_order_id)
-    assert created_task_order.portfolio is not None
-    assert created_task_order.portfolio.name == portfolio_name
-
-def test_create_new_task_order_on_oversight_screen(client, user_session):
-    creator = UserFactory.create()
-    user_session(creator)
-
-    task_order_data = TaskOrderFactory.dictionary()
-    app_info_data = slice_data_for_section(task_order_data, "app_info")
-    portfolio_name = "Mos Eisley"
-    app_info_data["portfolio_name"] = portfolio_name
-
-    response = client.post(
-        url_for("task_orders.update", screen=3),
-        data=app_info_data,
-        follow_redirects=False,
-    )
-    import ipdb; ipdb.set_trace()
-    assert url_for("task_orders.new", screen=4) in response.headers["Location"]
-
-    created_task_order_id = response.headers["Location"].split("/")[-1]
-    created_task_order = TaskOrders.get(creator, created_task_order_id)
-    assert created_task_order.portfolio is not None
-    assert created_task_order.portfolio.name == portfolio_name
-
 
 def test_create_new_task_order_for_portfolio(client, user_session):
     portfolio = PortfolioFactory.create()


### PR DESCRIPTION
## Description
We were running into some bugs when trying to begin a task order form without first providing a Portfolio Name. Since the Portfolio Name is given in the first screen, we now require that screen to be submitted before being able to navigate ahead to other pages. 

- The other pages are grayed out in the top navigation until screen one is complete.
- The user is able to navigate to Funding, Oversight, or Review once screen one is complete.
- The `Done` button at the bottom of the Review screen is disabled until all screens are completed.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163300624
https://www.pivotaltracker.com/story/show/163268456

## Screenshots
![screen shot 2019-01-22 at 11 19 49 am](https://user-images.githubusercontent.com/42577527/51549355-4409b700-1e38-11e9-8038-b3b32de2032b.png)
![screen shot 2019-01-22 at 11 19 35 am](https://user-images.githubusercontent.com/42577527/51549354-4409b700-1e38-11e9-8a4e-f666e1d2fb0f.png)
![screen shot 2019-01-22 at 11 20 31 am](https://user-images.githubusercontent.com/42577527/51549361-45d37a80-1e38-11e9-92ff-fd76b6d8fb4f.png)
