### PR TITLE
Add v-cloak to Portfolio edit page

### DIFF
--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -15,6 +15,7 @@
   noMaxWidth=False) -%}
 
   <textinput
+    v-cloak
     name='{{ field.name }}'
     validation='{{ validation }}'
     {% if paragraph %}paragraph='true'{% endif %}

--- a/templates/portfolios/edit.html
+++ b/templates/portfolios/edit.html
@@ -7,7 +7,7 @@
 
 {% include "fragments/flash.html" %}
 
-<form v-cloak method="POST" action="{{ url_for('portfolios.edit_portfolio', portfolio_id=portfolio.id) }}" autocomplete="false">
+<form method="POST" action="{{ url_for('portfolios.edit_portfolio', portfolio_id=portfolio.id) }}" autocomplete="false">
   {{ form.csrf_token }}
 
   <div class="panel">

--- a/templates/portfolios/edit.html
+++ b/templates/portfolios/edit.html
@@ -7,7 +7,7 @@
 
 {% include "fragments/flash.html" %}
 
-<form method="POST" action="{{ url_for('portfolios.edit_portfolio', portfolio_id=portfolio.id) }}" autocomplete="false">
+<form v-cloak method="POST" action="{{ url_for('portfolios.edit_portfolio', portfolio_id=portfolio.id) }}" autocomplete="false">
   {{ form.csrf_token }}
 
   <div class="panel">


### PR DESCRIPTION
## Description
A `!` was briefly showing instead of  `✓` on the name and description of a Portfolio in the Portfolio's edit page.  This PR adds a v-cloak to the portfolio edit form to prevent that render glitch.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/161959592