### PR TITLE
KO redirect

### DIFF
--- a/atst/routes/portfolios/invitations.py
+++ b/atst/routes/portfolios/invitations.py
@@ -28,7 +28,11 @@ def accept_invitation(token):
     for task_order in invite.portfolio.task_orders:
         if g.current_user == task_order.contracting_officer:
             return redirect(
-                url_for("task_orders.new", screen=4, task_order_id=task_order.id)
+                url_for(
+                    "portfolios.view_task_order",
+                    portfolio_id=task_order.portfolio_id,
+                    task_order_id=task_order.id,
+                )
             )
         elif g.current_user == task_order.contracting_officer_representative:
             return redirect(

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -120,8 +120,19 @@
       width: 100%;
     }
 
+    .task-order-next-steps__panel-head {
+      border-bottom: 1px solid black;
+      padding: ($gap * 4) ($gap * 2);
+      margin: 0;
+    }
+
     .task-order-next-steps__step {
+      border-bottom: 1px dotted $color-gray;
+      padding: ($gap * 4) ($gap * 2);
+      margin: 0;
+
       .task-order-next-steps__icon {
+        width: 8%;
         padding: $gap $gap 0 0;
         justify-content: center;
         .complete {
@@ -133,8 +144,17 @@
       }
 
       .task-order-next-steps__text {
+        width: 60%;
         @include ie-only {
           width: 100%
+        }
+      }
+
+      .task-order-next-steps__action {
+        padding: $gap 0 0 $gap;
+        width: 32%;
+        a.usa-button {
+          width: 100%;
         }
       }
 

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -4,25 +4,22 @@
 
 {% block portfolio_content %}
 
-{% macro Step(title="", description="", link_text=None, link_url=None, complete=True) %}
+{% macro Step(title="", description="", link_text=None, complete=True) %}
   <div class="task-order-next-steps__step panel__content row">
     <div class="task-order-next-steps__icon col">
       <span>{{ Icon("ok", classes="complete" if complete else "incomplete") }}</span>
     </div>
-    <div class="task-order-next-steps__text">
+    <div class="task-order-next-steps__text col">
       <div class="task-order-next-steps__heading row">
         <h4>{{ title }}</h4>
-        {% if link_url %}
-          <a href="{{ link_url }}" class="icon-link">
-            {{ Icon("edit") }}
-            <span>{{ link_text }}</span>
-          </a>
-        {% endif %}
       </div>
       <div class="task-order-next-steps__description">
         {{ description }}
       </div>
     </div>
+    {% if caller %}
+      {{ caller() }}
+    {% endif %}
   </div>
 {% endmacro %}
 
@@ -88,13 +85,20 @@
   <div class="task-order-details">
     <div id="next-steps" class="task-order-next-steps">
       <div class="panel">
-        <h3 class="panel__content">What's next?</h3>
-        {{ Step(
+        <h3 class="task-order-next-steps__panel-head panel__content">What's next?</h3>
+        {% call Step(
           title="Submit draft Task Order",
           description="Complete initial task order request form.",
           link_text="edit",
-          link_url=url_for("task_orders.new", screen=1, task_order_id=task_order.id),
-          complete=True) }}
+          complete=True) %}
+          <div class="task-order-next-steps__action col">
+            <a
+              href="{{ url_for("task_orders.new", screen=1, task_order_id=task_order.id) }}"
+              class="usa-button usa-button-primary">
+                Edit
+            </a>
+          </div>
+        {% endcall %}
         {{ Step(
           title="Complete a Security Requirements Document",
           description="The IA Security Official you specified received an email invitation to complete and sign a DD-254: Security Requirements document that's been customized for the JEDI program here.",

--- a/tests/routes/portfolios/test_invitations.py
+++ b/tests/routes/portfolios/test_invitations.py
@@ -210,7 +210,7 @@ def test_existing_member_invite_resent_to_email_submitted_in_form(
     assert send_mail_job.args[0] == ["example@example.com"]
 
 
-def test_task_order_officer_accepts_invite(monkeypatch, client, user_session):
+def test_contracting_officer_accepts_invite(monkeypatch, client, user_session):
     portfolio = PortfolioFactory.create()
     task_order = TaskOrderFactory.create(portfolio=portfolio)
     user_info = UserFactory.dictionary()
@@ -246,6 +246,9 @@ def test_task_order_officer_accepts_invite(monkeypatch, client, user_session):
     # user is redirected to the task order review page
     assert response.status_code == 302
     to_review_url = url_for(
-        "task_orders.new", screen=4, task_order_id=task_order.id, _external=True
+        "portfolios.view_task_order",
+        portfolio_id=task_order.portfolio_id,
+        task_order_id=task_order.id,
+        _external=True,
     )
     assert response.headers["Location"] == to_review_url


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/163368819

When a KO follows an invitation link from an email, they are taken to the TO view page. Here, they see an edit button for the Task Order next to the first step.

**notes**
- The edit button currently links to the regular TO form because we haven't implemented the KO review page (https://www.pivotaltracker.com/story/show/163368662)
- I've updated some of the styles to reflect changes to the TO view page that seem settled. I haven't updated content or the step icons.
- It's not clear yet what access control for elements on the TO view page looks like yet, so anyone who can view the TO page can see the edit button for now.

![screenshot_2019-01-23 jedi cloud](https://user-images.githubusercontent.com/38955503/51619958-674b6980-1eff-11e9-8f0c-02a12b3b79a5.png)

lol the footer