### PR TITLE
Allow CCPO to create TO on anyone's portfolio

### DIFF
--- a/atst/domain/authz.py
+++ b/atst/domain/authz.py
@@ -6,7 +6,9 @@ from atst.domain.exceptions import UnauthorizedError
 class Authorization(object):
     @classmethod
     def has_portfolio_permission(cls, user, portfolio, permission):
-        return permission in PortfolioRoles.portfolio_role_permissions(portfolio, user)
+        return permission in PortfolioRoles.portfolio_role_permissions(
+            portfolio, user
+        ) or Authorization.is_ccpo(user)
 
     @classmethod
     def has_atat_permission(cls, user, permission):

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -300,6 +300,10 @@ def test_get_for_update_information():
     ccpo = UserFactory.from_atat_role("ccpo")
     assert Portfolios.get_for_update_information(ccpo, portfolio.id)
 
+    developer = UserFactory.from_atat_role("developer")
+    with pytest.raises(UnauthorizedError):
+        Portfolios.get_for_update_information(developer, portfolio.id)
+
 
 def test_can_create_portfolios_with_matching_names():
     portfolio_name = "Great Portfolio"

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -298,8 +298,7 @@ def test_get_for_update_information():
     assert portfolio == admin_ws
 
     ccpo = UserFactory.from_atat_role("ccpo")
-    with pytest.raises(UnauthorizedError):
-        Portfolios.get_for_update_information(ccpo, portfolio.id)
+    assert Portfolios.get_for_update_information(ccpo, portfolio.id)
 
 
 def test_can_create_portfolios_with_matching_names():


### PR DESCRIPTION
## Description
A CCPO user is now able to create a new Task Order from any other user's Portfolio > Funding page. There was a bug in permissions that is now fixed.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163268456