### PR TITLE
Use a custom JSON encoder

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -26,6 +26,7 @@ from atst.models.permissions import Permissions
 from atst.eda_client import MockEDAClient
 from atst.utils import mailer
 from atst.utils.form_cache import FormCache
+from atst.utils.json import CustomJSONEncoder
 from atst.queue import queue
 
 
@@ -41,6 +42,7 @@ def make_app(config):
         template_folder=parent_dir.child("templates").absolute(),
         static_folder=parent_dir.child("static").absolute(),
     )
+    app.json_encoder = CustomJSONEncoder
     make_redis(app, config)
     csrf = CSRFProtect()
 

--- a/atst/filters.py
+++ b/atst/filters.py
@@ -49,19 +49,6 @@ def getOptionLabel(value, options):
         return
 
 
-def mixedContentToJson(value):
-    """
-    This coerces the file upload in form data to its filename
-    so that the data can be JSON serialized.
-    """
-    if isinstance(value, dict):
-        for k, v in value.items():
-            if hasattr(v, "filename"):
-                value[k] = v.filename
-
-    return app.jinja_env.filters["tojson"](value)
-
-
 def findFilter(value, filter_name, filter_args=[]):
     if not filter_name:
         return value
@@ -124,7 +111,6 @@ def register_filters(app):
     app.jinja_env.filters["usPhone"] = usPhone
     app.jinja_env.filters["readableInteger"] = readableInteger
     app.jinja_env.filters["getOptionLabel"] = getOptionLabel
-    app.jinja_env.filters["mixedContentToJson"] = mixedContentToJson
     app.jinja_env.filters["findFilter"] = findFilter
     app.jinja_env.filters["renderList"] = renderList
     app.jinja_env.filters["formattedDate"] = formattedDate

--- a/atst/utils/json.py
+++ b/atst/utils/json.py
@@ -1,0 +1,9 @@
+from flask.json import JSONEncoder
+from atst.models.attachment import Attachment
+
+
+class CustomJSONEncoder(JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, Attachment):
+            return obj.filename
+        return JSONEncoder.default(self, obj)

--- a/templates/requests/financial_verification.html
+++ b/templates/requests/financial_verification.html
@@ -21,7 +21,7 @@
   {{ Alert(("requests.financial_verification.pending_financial_verification" | translate), fragment="fragments/pending_financial_verification.html") }}
 {% endif %}
 
-<financial inline-template v-bind:initial-data='{{ f.data|mixedContentToJson }}'>
+<financial inline-template v-bind:initial-data='{{ f.data|tojson }}'>
 <div class="col">
   {% if extended %}
     {{ Alert(("requests.financial_verification.manually_enter_task_information_label" | translate),

--- a/templates/task_orders/new/funding.html
+++ b/templates/task_orders/new/funding.html
@@ -14,7 +14,7 @@
 
 <funding
   inline-template
-  v-bind:initial-data='{{ form.data|mixedContentToJson }}'
+  v-bind:initial-data='{{ form.data|tojson }}'
   v-bind:upload-errors='{{ form.csp_estimate.errors | list }}'
   >
   <div>

--- a/tests/utils/test_json.py
+++ b/tests/utils/test_json.py
@@ -1,0 +1,15 @@
+import json
+from atst.utils.json import CustomJSONEncoder
+
+from tests.factories import AttachmentFactory
+
+
+encoder = CustomJSONEncoder()
+
+
+def test_custom_encoder_serializes_attachments():
+    filename = "jar_jar_is_secretly_a_sith_lord.pdf"
+    attachment = AttachmentFactory.create(filename=filename)
+    encoded = encoder.encode({"file": attachment})
+    expected = json.dumps({"file": filename})
+    assert encoded == expected


### PR DESCRIPTION
This PR adds a custom JSON encoder for the flask app. Previously, we were using a special filter, `mixedContentToJson`, to serialize file objects (`Attachment` instances) in a specific way. Now, we can use the `tojson` filter everywhere and the custom JSON encoder can be updated as necessary in the future.