### PR TITLE
ensure KO can view task order page

### DIFF
--- a/atst/domain/roles.py
+++ b/atst/domain/roles.py
@@ -153,7 +153,11 @@ PORTFOLIO_ROLES = [
         "name": "officer",
         "description": "Officer involved with setting up a Task Order",
         "display_name": "Task Order Officer",
-        "permissions": [],
+        "permissions": [
+            Permissions.VIEW_PORTFOLIO,
+            Permissions.VIEW_USAGE_REPORT,
+            Permissions.VIEW_USAGE_DOLLARS,
+        ],
     },
 ]
 


### PR DESCRIPTION
This fixes a bug where the KO could not view anything related to their task order. KOs have been given view permissions for the relevant portfolio and its usage info.