### PR TITLE
Show COR as invited if am_cor is checked

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -264,7 +264,6 @@ def new(screen, task_order_id=None, portfolio_id=None):
         screens=workflow.display_screens,
         form=workflow.form,
         complete=workflow.is_complete,
-        user=g.current_user,
     )
 
 

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -158,6 +158,7 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
                 "cor_email": self.user.email,
                 "cor_phone_number": self.user.phone_number,
                 "cor_dod_id": self.user.dod_id,
+                "cor_id": self.user.id,
             }
             to_data = {**to_data, **cor_data}
 
@@ -263,6 +264,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
         screens=workflow.display_screens,
         form=workflow.form,
         complete=workflow.is_complete,
+        user=g.current_user,
     )
 
 

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -32,7 +32,7 @@
   </div>
 {% endmacro %}
 
-{% macro ReviewOfficerInfo(heading, first_name, last_name, email, phone_number, dod_id, invite, am_cor) %}
+{% macro ReviewOfficerInfo(heading, first_name, last_name, email, phone_number, dod_id, officer) %}
   <div class="col col--grow">
     <h4 class='task-order-form__heading'>{{ heading | translate }}</h4>
     {{ first_name }} {{ last_name }}<br>
@@ -44,7 +44,7 @@
     {% endif %}
     <br>
     {{ "task_orders.new.review.dod_id" | translate }} {{ dod_id}}<br>
-    {% if invite or am_cor %}
+    {% if officer %}
       {{ Icon('ok', classes='icon--green') }} <span class="task-order-invite-message sent">{{ "task_orders.new.review.invited"| translate }}</<span>
     {% else %}
       {{ Icon('alert', classes='icon--red') }} <span class="task-order-invite-message not-sent">{{ "task_orders.new.review.not_invited"| translate }}</span>
@@ -183,14 +183,11 @@
 <h3 class="subheading">{{ "task_orders.new.review.oversight"| translate }} {{ TOEditLink(screen=3) }}</h3>
 
 <div class="row">
-  {{ ReviewOfficerInfo("task_orders.new.review.ko", task_order.ko_first_name, task_order.ko_last_name, task_order.ko_email, task_order.ko_phone_number, task_order.ko_dod_id, task_order.ko_invite) }}
-  {% if task_order.cor_dod_id == user.dod_id%}
-    {% set am_cor = True%}
-  {% endif %}
-  {{ ReviewOfficerInfo("task_orders.new.review.cor", task_order.cor_first_name, task_order.cor_last_name, task_order.cor_email, task_order.cor_phone_number, task_order.cor_dod_id, task_order.cor_invite, am_cor) }}
+  {{ ReviewOfficerInfo("task_orders.new.review.ko", task_order.ko_first_name, task_order.ko_last_name, task_order.ko_email, task_order.ko_phone_number, task_order.ko_dod_id, task_order.contracting_officer) }}
+  {{ ReviewOfficerInfo("task_orders.new.review.cor", task_order.cor_first_name, task_order.cor_last_name, task_order.cor_email, task_order.cor_phone_number, task_order.cor_dod_id, task_order.contracting_officer_representative) }}
 </div>
 <div class="row">
-  {{ ReviewOfficerInfo("task_orders.new.review.so", task_order.so_first_name, task_order.so_last_name, task_order.so_email, task_order.so_phone_number, task_order.so_dod_id, task_order.so_invite) }}
+  {{ ReviewOfficerInfo("task_orders.new.review.so", task_order.so_first_name, task_order.so_last_name, task_order.so_email, task_order.so_phone_number, task_order.so_dod_id, task_order.security_officer) }}
 </div>
 
 {% endblock %}

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -32,7 +32,7 @@
   </div>
 {% endmacro %}
 
-{% macro ReviewOfficerInfo(heading, first_name, last_name, email, phone_number, dod_id, invite) %}
+{% macro ReviewOfficerInfo(heading, first_name, last_name, email, phone_number, dod_id, invite, am_cor) %}
   <div class="col col--grow">
     <h4 class='task-order-form__heading'>{{ heading | translate }}</h4>
     {{ first_name }} {{ last_name }}<br>
@@ -44,7 +44,7 @@
     {% endif %}
     <br>
     {{ "task_orders.new.review.dod_id" | translate }} {{ dod_id}}<br>
-    {% if invite %}
+    {% if invite or am_cor %}
       {{ Icon('ok', classes='icon--green') }} <span class="task-order-invite-message sent">{{ "task_orders.new.review.invited"| translate }}</<span>
     {% else %}
       {{ Icon('alert', classes='icon--red') }} <span class="task-order-invite-message not-sent">{{ "task_orders.new.review.not_invited"| translate }}</span>
@@ -184,7 +184,10 @@
 
 <div class="row">
   {{ ReviewOfficerInfo("task_orders.new.review.ko", task_order.ko_first_name, task_order.ko_last_name, task_order.ko_email, task_order.ko_phone_number, task_order.ko_dod_id, task_order.ko_invite) }}
-  {{ ReviewOfficerInfo("task_orders.new.review.cor", task_order.cor_first_name, task_order.cor_last_name, task_order.cor_email, task_order.cor_phone_number, task_order.cor_dod_id, task_order.cor_invite) }}
+  {% if task_order.cor_dod_id == user.dod_id%}
+    {% set am_cor = True%}
+  {% endif %}
+  {{ ReviewOfficerInfo("task_orders.new.review.cor", task_order.cor_first_name, task_order.cor_last_name, task_order.cor_email, task_order.cor_phone_number, task_order.cor_dod_id, task_order.cor_invite, am_cor) }}
 </div>
 <div class="row">
   {{ ReviewOfficerInfo("task_orders.new.review.so", task_order.so_first_name, task_order.so_last_name, task_order.so_email, task_order.so_phone_number, task_order.so_dod_id, task_order.so_invite) }}


### PR DESCRIPTION
## Description
After the TO has been completed and submitted, the user is brought to a "Next Steps" page. If the user had checked `am COR` on the Oversight screen, the COR shows as "invited."

COR also shows as "invited" at the bottom of the Review screen.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163067281

## Screenshots
![screen shot 2019-01-23 at 3 34 10 pm](https://user-images.githubusercontent.com/42577527/51635377-a213c880-1f24-11e9-979a-98a53b6380ed.png)
![screen shot 2019-01-23 at 3 34 19 pm](https://user-images.githubusercontent.com/42577527/51635378-a2ac5f00-1f24-11e9-9d06-db0c877cc515.png)
