### PR TITLE
Handle submitting funding form without csp estimate

### DIFF
--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -88,7 +88,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
             )
         elif not new_csp_estimate and self._csp_estimate:
             self._csp_estimate = None
-        else:
+        elif new_csp_estimate:
             raise TypeError("Could not set csp_estimate with invalid type")
 
     @property

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -59,6 +59,13 @@ class TestCSPEstimate:
         with pytest.raises(TypeError):
             to.csp_estimate = "invalid"
 
+    def test_setting_estimate_with_empty_value(self):
+        to = TaskOrder()
+        assert to.csp_estimate is None
+
+        to.csp_estimate = ""
+        assert to.csp_estimate is None
+
     def test_removing_estimate(self):
         attachment = Attachment(filename="sample.pdf", object_name="sample")
         to = TaskOrder(csp_estimate=attachment)


### PR DESCRIPTION
When the CSP estimate is not provided, do not raise an error and also do not update the `csp_estimate` attribute on the model. Fixes [#163438611](https://www.pivotaltracker.com/n/projects/2160940/stories/163438611).