### PR TITLE
Update Attachment Factory

### DIFF
--- a/tests/factories.py
+++ b/tests/factories.py
@@ -381,7 +381,7 @@ class AttachmentFactory(Base):
         model = Attachment
 
     filename = factory.Faker("domain_word")
-    object_name = factory.Faker("domain_word")
+    object_name = factory.LazyFunction(lambda *args: uuid4().hex)
 
 
 class TaskOrderFactory(Base):


### PR DESCRIPTION
## Description
Update the Attachment Factory to return a faked uuid. The factory that was previously used was not returning enough unique `object_name` values which causes the seeding the database to fail!