### PR TITLE
DOD ID Toggle Fixes

### DIFF
--- a/js/components/forms/oversight.js
+++ b/js/components/forms/oversight.js
@@ -2,15 +2,37 @@ import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
 import checkboxinput from '../checkbox_input'
 
+const dodid = {
+  name: 'dodid',
+
+  mixins: [FormMixin],
+
+  components: {
+    textinput,
+  },
+
+  props: {
+    initialKoInvite: Boolean,
+    initialSoInvite: Boolean,
+  },
+
+  data: function() {
+    return {
+      ko_invite: this.initialKoInvite,
+      so_invite: this.initialSoInvite,
+    }
+  },
+}
+
 const cordata = {
   name: 'cordata',
+
+  mixins: [FormMixin],
 
   components: {
     textinput,
     checkboxinput,
   },
-
-  mixins: [FormMixin],
 
   props: {
     initialCorInvite: Boolean,
@@ -32,6 +54,7 @@ export default {
     textinput,
     checkboxinput,
     cordata,
+    dodid,
   },
 
   props: {

--- a/js/components/forms/oversight.js
+++ b/js/components/forms/oversight.js
@@ -2,6 +2,27 @@ import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
 import checkboxinput from '../checkbox_input'
 
+const cordata = {
+  name: 'cordata',
+
+  components: {
+    textinput,
+    checkboxinput,
+  },
+
+  mixins: [FormMixin],
+
+  props: {
+    initialCorInvite: Boolean,
+  },
+
+  data: function() {
+    return {
+      cor_invite: this.initialCorInvite,
+    }
+  },
+}
+
 export default {
   name: 'oversight',
 
@@ -10,6 +31,7 @@ export default {
   components: {
     textinput,
     checkboxinput,
+    cordata,
   },
 
   props: {

--- a/js/components/forms/oversight.js
+++ b/js/components/forms/oversight.js
@@ -12,14 +12,12 @@ const dodid = {
   },
 
   props: {
-    initialKoInvite: Boolean,
-    initialSoInvite: Boolean,
+    initialInvite: Boolean,
   },
 
   data: function() {
     return {
-      ko_invite: this.initialKoInvite,
-      so_invite: this.initialSoInvite,
+      invite: this.initialInvite,
     }
   },
 }

--- a/templates/task_orders/new/oversight.html
+++ b/templates/task_orders/new/oversight.html
@@ -17,9 +17,11 @@
     <div class='usa-input'>
         {{ UserInfo(form.ko_first_name, form.ko_last_name, form.ko_email, form.ko_phone_number) }}
         {{ CheckboxInput(form.ko_invite) }}
-        <template v-if="ko_invite">
-            {{ TextInput(form.ko_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
-        </template>
+        <keep-alive>
+            <dodid v-bind:initial-ko-invite="ko_invite" inline-template v-if="ko_invite">
+                {{ TextInput(form.ko_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
+            </dodid>
+        </keep-alive>
 
         <hr />
 
@@ -45,9 +47,11 @@
         <p>{{ "task_orders.new.oversight.so_info_paragraph" | translate }}</p>
         {{ UserInfo(form.so_first_name, form.so_last_name, form.so_email, form.so_phone_number) }}
         {{ CheckboxInput(form.so_invite) }}
-        <template v-if="so_invite">
-            {{ TextInput(form.so_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
-        </template>
+        <keep-alive>
+            <dodid v-bind:initial-so-invite="so_invite" inline-template v-if="so_invite">
+                {{ TextInput(form.so_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
+            </dodid>
+        </keep-alive>
     </div>
 </oversight>
 

--- a/templates/task_orders/new/oversight.html
+++ b/templates/task_orders/new/oversight.html
@@ -18,7 +18,7 @@
         {{ UserInfo(form.ko_first_name, form.ko_last_name, form.ko_email, form.ko_phone_number) }}
         {{ CheckboxInput(form.ko_invite) }}
         <keep-alive>
-            <dodid v-bind:initial-ko-invite="ko_invite" inline-template v-if="ko_invite">
+            <dodid v-bind:initial-invite="invite" inline-template v-if="ko_invite">
                 {{ TextInput(form.ko_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
             </dodid>
         </keep-alive>
@@ -48,7 +48,7 @@
         {{ UserInfo(form.so_first_name, form.so_last_name, form.so_email, form.so_phone_number) }}
         {{ CheckboxInput(form.so_invite) }}
         <keep-alive>
-            <dodid v-bind:initial-so-invite="so_invite" inline-template v-if="so_invite">
+            <dodid v-bind:initial-invite="invite" inline-template v-if="so_invite">
                 {{ TextInput(form.so_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
             </dodid>
         </keep-alive>

--- a/templates/task_orders/new/oversight.html
+++ b/templates/task_orders/new/oversight.html
@@ -26,13 +26,18 @@
         <h3 class="subheading">{{ "task_orders.new.oversight.cor_info_title" | translate }}</h3>
         <p>{{ "task_orders.new.oversight.cor_info_paragraph" | translate }}</p>
         {{ CheckboxInput(form.am_cor, classes="normal") }}
-        <template v-if="!am_cor">
-            {{ UserInfo(form.cor_first_name, form.cor_last_name, form.cor_email, form.cor_phone_number) }}
-            {{ CheckboxInput(form.cor_invite) }}
-            <template v-if="cor_invite">
-                {{ TextInput(form.cor_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
-            </template>
-        </template>
+
+        <keep-alive>
+            <cordata v-bind:initial-cor-invite="cor_invite" inline-template v-if="!am_cor">
+                <div>
+                {{ UserInfo(form.cor_first_name, form.cor_last_name, form.cor_email, form.cor_phone_number) }}
+                {{ CheckboxInput(form.cor_invite) }}
+                <template v-if="cor_invite">
+                    {{ TextInput(form.cor_dod_id, placeholder="1234567890", tooltip="Why", tooltip_title='Why', validation='dodId', classes="task-order__invite-officer")}}
+                </template>
+                </div>
+            </cordata>
+        </keep-alive>
 
         <hr />
 


### PR DESCRIPTION
## Description
This PR allows the user to toggle checkboxes on the Oversight screen without losing text that they had inputted. It also fixes a bug where if `Invite COR` was clicked, then `Am COR` was toggled, the text input field for the COR DOD ID would appear, but the checkbox for `Invite COR` was unchecked.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163436529
https://www.pivotaltracker.com/story/show/163067040