### PR TITLE
Use 'border-left-color' prop

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -272,7 +272,7 @@
   .task-order__invite-officer {
     padding: 1.5rem;
     background-color: $color-aqua-lightest;
-    border-color: $color-blue;
+    border-left-color: $color-blue;
     border-left-style: solid;
     border-left-width: $gap / 2;
 


### PR DESCRIPTION
## Description
Quick fix for the styling on the DoD ID box that was not working properly on atat.code.
I defined the styling more explicitly so it should not fall back to the initial styling. 

## Screenshots
<img width="523" alt="screen shot 2019-01-28 at 5 19 33 pm" src="https://user-images.githubusercontent.com/43828539/51870206-eb975580-2320-11e9-9e6b-91f725370ef8.png">
