### PR TITLE
Save as draft without draft button

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -16,6 +16,7 @@ class TaskOrderError(Exception):
 class TaskOrders(object):
     SECTIONS = {
         "app_info": [
+            "portfolio_name",
             "scope",
             "defense_component",
             "app_migration",

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -93,7 +93,7 @@ class TaskOrders(object):
 
     @classmethod
     def section_completion_status(cls, task_order, section):
-        if section in TaskOrders.SECTIONS:
+        if section in TaskOrders.mission_owner_sections():
             passed = []
             failed = []
 
@@ -124,7 +124,7 @@ class TaskOrders(object):
         return True
 
     @classmethod
-    def sections(cls):
+    def mission_owner_sections(cls):
         section_list = TaskOrders.SECTIONS
         if not app.config.get("CLASSIFIED"):
             section_list["funding"] = TaskOrders.UNCLASSIFIED_FUNDING

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -99,12 +99,10 @@ class TaskOrders(object):
             failed = []
 
             for attr in TaskOrders.SECTIONS[section]:
-                if not app.config.get("CLASSIFIED") and attr in ["clin_02", "clin_04"]:
-                    pass
-                elif not getattr(task_order, attr):
-                    failed.append(attr)
-                else:
+                if getattr(task_order, attr):
                     passed.append(attr)
+                else:
+                    failed.append(attr)
 
             if not failed:
                 return "complete"

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -109,8 +109,8 @@ class TaskOrders(object):
                 return "complete"
             elif passed and failed:
                 return "draft"
-            else:
-                return "incomplete"
+
+        return "incomplete"
 
     @classmethod
     def all_sections_complete(cls, task_order):

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -51,6 +51,7 @@ class AppInfoForm(CacheableForm):
         translate("forms.task_order.native_apps.label"),
         description=translate("forms.task_order.native_apps.description"),
         choices=[("yes", "Yes"), ("no", "No"), ("not_sure", "Not Sure")],
+        default="",
         validators=[Optional()],
     )
     complexity = SelectMultipleField(

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -10,7 +10,7 @@ from wtforms.fields import (
 )
 from wtforms.fields.html5 import DateField, TelField
 from wtforms.widgets import ListWidget, CheckboxInput
-from wtforms.validators import Length, InputRequired
+from wtforms.validators import Length, Required, InputRequired, Optional
 from flask_wtf.file import FileAllowed
 
 from atst.forms.validators import IsNumber, PhoneNumber, RequiredIf
@@ -31,6 +31,7 @@ class AppInfoForm(CacheableForm):
     portfolio_name = StringField(
         translate("forms.task_order.portfolio_name_label"),
         description=translate("forms.task_order.portfolio_name_description"),
+        validators=[Required()],
     )
     scope = TextAreaField(
         translate("forms.task_order.scope_label"),
@@ -100,25 +101,37 @@ class FundingForm(CacheableForm):
     clin_01 = DecimalField(
         translate("forms.task_order.clin_01_label"),
         validators=[
-            InputRequired(message=(translate("forms.task_order.clin_validation_error")))
+            Optional(),
+            InputRequired(
+                message=(translate("forms.task_order.clin_validation_error"))
+            ),
         ],
     )
     clin_02 = DecimalField(
         translate("forms.task_order.clin_02_label"),
         validators=[
-            InputRequired(message=(translate("forms.task_order.clin_validation_error")))
+            Optional(),
+            InputRequired(
+                message=(translate("forms.task_order.clin_validation_error"))
+            ),
         ],
     )
     clin_03 = DecimalField(
         translate("forms.task_order.clin_03_label"),
         validators=[
-            InputRequired(message=(translate("forms.task_order.clin_validation_error")))
+            Optional(),
+            InputRequired(
+                message=(translate("forms.task_order.clin_validation_error"))
+            ),
         ],
     )
     clin_04 = DecimalField(
         translate("forms.task_order.clin_04_label"),
         validators=[
-            InputRequired(message=(translate("forms.task_order.clin_validation_error")))
+            Optional(),
+            InputRequired(
+                message=(translate("forms.task_order.clin_validation_error"))
+            ),
         ],
     )
 
@@ -141,7 +154,8 @@ class OversightForm(CacheableForm):
     ko_last_name = StringField(translate("forms.task_order.oversight_last_name_label"))
     ko_email = StringField(translate("forms.task_order.oversight_email_label"))
     ko_phone_number = TelField(
-        translate("forms.task_order.oversight_phone_label"), validators=[PhoneNumber()]
+        translate("forms.task_order.oversight_phone_label"),
+        validators=[Optional(), PhoneNumber()],
     )
     ko_dod_id = StringField(
         translate("forms.task_order.oversight_dod_id_label"),
@@ -162,6 +176,7 @@ class OversightForm(CacheableForm):
         translate("forms.task_order.oversight_phone_label"),
         validators=[
             RequiredIf(lambda form: not form._fields.get("am_cor").data),
+            Optional(),
             PhoneNumber(),
         ],
     )
@@ -183,7 +198,8 @@ class OversightForm(CacheableForm):
     so_last_name = StringField(translate("forms.task_order.oversight_last_name_label"))
     so_email = StringField(translate("forms.task_order.oversight_email_label"))
     so_phone_number = TelField(
-        translate("forms.task_order.oversight_phone_label"), validators=[PhoneNumber()]
+        translate("forms.task_order.oversight_phone_label"),
+        validators=[Optional(), PhoneNumber()],
     )
     so_dod_id = StringField(
         translate("forms.task_order.oversight_dod_id_label"),

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -103,40 +103,16 @@ class FundingForm(CacheableForm):
         render_kw={"accept": ".pdf,.png,application/pdf,image/png"},
     )
     clin_01 = DecimalField(
-        translate("forms.task_order.clin_01_label"),
-        validators=[
-            Optional(),
-            InputRequired(
-                message=(translate("forms.task_order.clin_validation_error"))
-            ),
-        ],
+        translate("forms.task_order.clin_01_label"), validators=[Optional()]
     )
     clin_02 = DecimalField(
-        translate("forms.task_order.clin_02_label"),
-        validators=[
-            Optional(),
-            InputRequired(
-                message=(translate("forms.task_order.clin_validation_error"))
-            ),
-        ],
+        translate("forms.task_order.clin_02_label"), validators=[Optional()]
     )
     clin_03 = DecimalField(
-        translate("forms.task_order.clin_03_label"),
-        validators=[
-            Optional(),
-            InputRequired(
-                message=(translate("forms.task_order.clin_validation_error"))
-            ),
-        ],
+        translate("forms.task_order.clin_03_label"), validators=[Optional()]
     )
     clin_04 = DecimalField(
-        translate("forms.task_order.clin_04_label"),
-        validators=[
-            Optional(),
-            InputRequired(
-                message=(translate("forms.task_order.clin_validation_error"))
-            ),
-        ],
+        translate("forms.task_order.clin_04_label"), validators=[Optional()]
     )
 
 

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -45,11 +45,13 @@ class AppInfoForm(CacheableForm):
         description=translate("forms.task_order.app_migration.description"),
         choices=APP_MIGRATION,
         default="",
+        validators=[Optional()],
     )
     native_apps = RadioField(
         translate("forms.task_order.native_apps.label"),
         description=translate("forms.task_order.native_apps.description"),
         choices=[("yes", "Yes"), ("no", "No"), ("not_sure", "Not Sure")],
+        validators=[Optional()],
     )
     complexity = SelectMultipleField(
         translate("forms.task_order.complexity.label"),
@@ -74,6 +76,7 @@ class AppInfoForm(CacheableForm):
         description=translate("forms.task_order.team_experience.description"),
         choices=TEAM_EXPERIENCE,
         default="",
+        validators=[Optional()],
     )
 
 

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -10,7 +10,7 @@ from wtforms.fields import (
 )
 from wtforms.fields.html5 import DateField, TelField
 from wtforms.widgets import ListWidget, CheckboxInput
-from wtforms.validators import Length, Required, InputRequired, Optional
+from wtforms.validators import Length, Required, Optional
 from flask_wtf.file import FileAllowed
 
 from atst.forms.validators import IsNumber, PhoneNumber, RequiredIf

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -103,8 +103,9 @@ class ShowTaskOrderWorkflow:
 
         if self.task_order:
             for section in screen_info:
-                if TaskOrders.is_section_complete(self.task_order, section["section"]):
-                    section["complete"] = True
+                section["completion"] = TaskOrders.section_completion_status(
+                    self.task_order, section["section"]
+                )
 
         return screen_info
 

--- a/styles/components/_progress_menu.scss
+++ b/styles/components/_progress_menu.scss
@@ -107,6 +107,13 @@
       padding: 1px 2px;
     }
 
+    &--draft:before {
+      background: $color-gold;
+      border: none;
+      font-size: $h6-font-size;
+      mask-image: url('#{$asset-path}/icons/alert.svg');
+    }
+
     &--incomplete:before {
       border: 2px solid $color-gray-light;
     }

--- a/templates/task_orders/_new.html
+++ b/templates/task_orders/_new.html
@@ -40,7 +40,6 @@
 
       <div class='action-group'>
         <input type='submit' class='usa-button usa-button-primary' value='Save & Continue' />
-        <input class='usa-button usa-button-secondary' value='Save Draft' />
       </div>
 
     {% endblock %}

--- a/templates/task_orders/new/menu.html
+++ b/templates/task_orders/new/menu.html
@@ -1,15 +1,7 @@
 <div class="progress-menu progress-menu--four">
   <ul>
     {% for s in screens %}
-      {% if s.complete %}
-        {% set step_indicator = 'complete' %}
-      {% elif loop.index == current %}
-        {% set step_indicator = 'active' %}
-      {% else %}
-        {% set step_indicator = 'incomplete' %}
-      {% endif %}
-
-      <li class="progress-menu__item progress-menu__item--{{ step_indicator }}">
+      <li class="progress-menu__item progress-menu__item--{{ s.completion }}">
         <a
           {% set class='' %}
           {% if task_order_id %}

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -67,13 +67,21 @@
 <h3 class="subheading">{{ "task_orders.new.review.reporting"| translate }} {{ TOEditLink(screen=1, anchor="reporting") }}</h3>
 
 <div class="row">
-  {% if task_order.app_migration %}
-    {{ ReviewField(("forms.task_order.app_migration.label" | translate), ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate), filter="removeHtml") }}
-  {% endif %}
+  {{
+    ReviewField(("forms.task_order.app_migration.label" | translate),
+      (
+        ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate) if task_order.app_migration else RequiredLabel()
+      ),
+      filter="removeHtml"
+    )
+  }}
 
-  {% if task_order.native_apps %}
-    {{ ReviewField(("forms.task_order.native_apps.label" | translate), ("forms.task_order.native_apps.{}".format(task_order.native_apps))| translate) }}
-  {% endif %}
+  {{
+    ReviewField(("forms.task_order.native_apps.label" | translate),
+    (
+      ("forms.task_order.native_apps.{}".format(task_order.native_apps))| translate) if task_order.native_apps else RequiredLabel()
+    )
+  }}
 </div>
 
 <h4 class='task-order-form__heading'>{{ "task_orders.new.review.complexity"| translate }}</h4>
@@ -109,9 +117,13 @@
     {% endif %}
   </div>
 
-  {% if task_order.team_experience %}
-    {{ ReviewField(("forms.task_order.team_experience.label" |translate), ("forms.task_order.team_experience.{}".format(task_order.team_experience)) | translate) }}
-  {% endif %}
+  {{
+    ReviewField(("forms.task_order.team_experience.label" |translate),
+    (
+
+      ("forms.task_order.team_experience.{}".format(task_order.team_experience)) | translate) if task_order.team_experience else RequiredLabel()
+    )
+  }}
 </div>
 
 <hr>

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -67,8 +67,13 @@
 <h3 class="subheading">{{ "task_orders.new.review.reporting"| translate }} {{ TOEditLink(screen=1, anchor="reporting") }}</h3>
 
 <div class="row">
-  {{ ReviewField(("forms.task_order.app_migration.label" | translate), ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate), filter="removeHtml") }}
-  {{ ReviewField(("forms.task_order.native_apps.label" | translate), ("forms.task_order.native_apps.{}".format(task_order.native_apps))| translate) }}
+  {% if task_order.app_migration %}
+    {{ ReviewField(("forms.task_order.app_migration.label" | translate), ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate), filter="removeHtml") }}
+  {% endif %}
+
+  {% if task_order.native_apps %}
+    {{ ReviewField(("forms.task_order.native_apps.label" | translate), ("forms.task_order.native_apps.{}".format(task_order.native_apps))| translate) }}
+  {% endif %}
 </div>
 
 <h4 class='task-order-form__heading'>{{ "task_orders.new.review.complexity"| translate }}</h4>
@@ -104,7 +109,9 @@
     {% endif %}
   </div>
 
-  {{ ReviewField(("forms.task_order.team_experience.label" |translate), ("forms.task_order.team_experience.{}".format(task_order.team_experience)) | translate) }}
+  {% if task_order.team_experience %}
+    {{ ReviewField(("forms.task_order.team_experience.label" |translate), ("forms.task_order.team_experience.{}".format(task_order.team_experience)) | translate) }}
+  {% endif %}
 </div>
 
 <hr>

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -68,18 +68,20 @@
 
 <div class="row">
   {{
-    ReviewField(("forms.task_order.app_migration.label" | translate),
+    ReviewField(
+      ("forms.task_order.app_migration.label" | translate),
       (
-        ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate) if task_order.app_migration else RequiredLabel()
-      ),
-      filter="removeHtml"
+        ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate) if task_order.app_migration
+      )
     )
   }}
 
   {{
-    ReviewField(("forms.task_order.native_apps.label" | translate),
-    (
-      ("forms.task_order.native_apps.{}".format(task_order.native_apps))| translate) if task_order.native_apps else RequiredLabel()
+    ReviewField(
+      ("forms.task_order.native_apps.label" | translate),
+      (
+        ("forms.task_order.native_apps.{}".format(task_order.native_apps) | translate) if task_order.native_apps
+      )
     )
   }}
 </div>
@@ -118,10 +120,11 @@
   </div>
 
   {{
-    ReviewField(("forms.task_order.team_experience.label" |translate),
-    (
-
-      ("forms.task_order.team_experience.{}".format(task_order.team_experience)) | translate) if task_order.team_experience else RequiredLabel()
+    ReviewField(
+      ("forms.task_order.team_experience.label" |translate),
+      (
+        ("forms.task_order.team_experience.{}".format(task_order.team_experience) | translate) if task_order.team_experience
+      )
     )
   }}
 </div>

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -16,6 +16,7 @@ def test_section_completion_status():
     dict_keys = [k for k in TaskOrders.SECTIONS.keys()]
     section = dict_keys[0]
     attrs = TaskOrders.SECTIONS[section].copy()
+    attrs.remove("portfolio_name")
     task_order = TaskOrderFactory.create(**{k: None for k in attrs})
     leftover = attrs.pop()
 

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -12,17 +12,20 @@ from tests.factories import (
 )
 
 
-def test_is_section_complete():
+def test_section_completion_status():
     dict_keys = [k for k in TaskOrders.SECTIONS.keys()]
     section = dict_keys[0]
     attrs = TaskOrders.SECTIONS[section].copy()
     task_order = TaskOrderFactory.create(**{k: None for k in attrs})
     leftover = attrs.pop()
+
     for attr in attrs:
         setattr(task_order, attr, "str12345")
-    assert not TaskOrders.is_section_complete(task_order, section)
+
+    assert TaskOrders.section_completion_status(task_order, section) == "draft"
+
     setattr(task_order, leftover, "str12345")
-    assert TaskOrders.is_section_complete(task_order, section)
+    assert TaskOrders.section_completion_status(task_order, section) == "complete"
 
 
 def test_all_sections_complete():

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -170,9 +170,9 @@ def test_show_task_order_display_screen(task_order):
     screens = workflow.display_screens
     # every form section is complete
     for i in range(2):
-        assert screens[i]["complete"]
+        assert screens[i]["completion"] == "complete"
     # the review section is not
-    assert not screens[3].get("complete")
+    assert not screens[3]["completion"]
 
 
 def test_update_task_order_with_no_task_order():

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -172,7 +172,7 @@ def test_show_task_order_display_screen(task_order):
     for i in range(2):
         assert screens[i]["completion"] == "complete"
     # the review section is not
-    assert not screens[3]["completion"]
+    assert screens[3]["completion"] == "incomplete"
 
 
 def test_update_task_order_with_no_task_order():

--- a/translations.yaml
+++ b/translations.yaml
@@ -222,7 +222,6 @@ forms:
     clin_02_label: 'CLIN 02: Classified'
     clin_03_label: 'CLIN 03: Unclassified'
     clin_04_label: 'CLIN 04: Classified'
-    clin_validation_error: Please enter a dollar amount
     unclassified_clin_02_label: 'CLIN 02: Classified (available soon)'
     unclassified_clin_04_label: 'CLIN 04: Classified (available soon)'
     oversight_first_name_label: First Name


### PR DESCRIPTION
This PR replaces the old "Save as Draft" feature with the "Save as Draft" button - https://github.com/dod-ccpo/atst/pull/520

This implementation allows saving of the form without all the data required, but validation rules such as phone number/email/dod format are enforced when data is present. I have also renamed and reimplemented the `is_section_complete` to `section_completion_status` which now checks that all the required fields are present before marking that section as complete, draft, or incomplete.



* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/162772188)

---

<img width="1223" alt="screen shot 2019-01-29 at 14 04 17" src="https://user-images.githubusercontent.com/45772525/51933225-ccef9800-23ce-11e9-8a7f-a9125103a7c5.png">
