### PR TITLE
Better updating of multiple officers

### DIFF
--- a/atst/forms/fields.py
+++ b/atst/forms/fields.py
@@ -1,4 +1,4 @@
-from wtforms.fields import Field, StringField, SelectField as SelectField_
+from wtforms.fields import Field, FormField, StringField, SelectField as SelectField_
 from wtforms.widgets import TextArea
 
 
@@ -39,3 +39,14 @@ class NumberStringField(StringField):
             self.data = str(value)
         else:
             self.data = value
+
+
+class FormFieldWrapper(FormField):
+    def has_changes(self):
+        if not self.object_data:
+            return False
+
+        for (attr, field) in self._fields.items():
+            if attr in self.object_data and self.object_data[attr] != field.data:
+                return True
+        return False

--- a/atst/forms/officers.py
+++ b/atst/forms/officers.py
@@ -1,11 +1,12 @@
 from flask_wtf import FlaskForm
-from wtforms.fields import FormField, StringField
+from wtforms.fields import StringField
 from wtforms.fields.html5 import TelField
 from wtforms.validators import Length, Optional
 
 from atst.forms.validators import IsNumber, PhoneNumber
 
 from .forms import CacheableForm
+from .fields import FormFieldWrapper
 
 
 class OfficerForm(FlaskForm):
@@ -18,9 +19,9 @@ class OfficerForm(FlaskForm):
 
 class EditTaskOrderOfficersForm(CacheableForm):
 
-    contracting_officer = FormField(OfficerForm)
-    contracting_officer_representative = FormField(OfficerForm)
-    security_officer = FormField(OfficerForm)
+    contracting_officer = FormFieldWrapper(OfficerForm)
+    contracting_officer_representative = FormFieldWrapper(OfficerForm)
+    security_officer = FormFieldWrapper(OfficerForm)
 
     OFFICER_PREFIXES = {
         "contracting_officer": "ko",

--- a/js/components/forms/__tests__/edit_officer_form.test.js
+++ b/js/components/forms/__tests__/edit_officer_form.test.js
@@ -22,6 +22,13 @@ describe('EditOfficerForm', () => {
     expect(wrapper.vm.$data.editing).toEqual(true)
   })
 
+  it('does start in editing mode when the form has changes', () => {
+    const wrapper = shallowMount(EditOfficerForm, {
+      propsData: { hasChanges: true },
+    })
+    expect(wrapper.vm.$data.editing).toEqual(true)
+  })
+
   it('starts editing when edit method called', () => {
     const wrapper = shallowMount(EditOfficerForm)
     wrapper.vm.edit({ preventDefault: () => null })

--- a/js/components/forms/edit_officer_form.js
+++ b/js/components/forms/edit_officer_form.js
@@ -13,6 +13,10 @@ export default {
   },
 
   props: {
+    hasChanges: {
+      type: Boolean,
+      default: () => false,
+    },
     hasErrors: {
       type: Boolean,
       default: () => false,
@@ -21,7 +25,7 @@ export default {
 
   data: function() {
     return {
-      editing: this.hasErrors,
+      editing: this.hasErrors || this.hasChanges,
     }
   },
 

--- a/templates/portfolios/task_orders/invitations.html
+++ b/templates/portfolios/task_orders/invitations.html
@@ -56,7 +56,7 @@
     <h2 class="officer__title">{{ ("task_orders.invitations." + officer_type + ".title") | translate }}</h2>
     <p class="officer__description">{{ ("task_orders.invitations." + officer_type + ".description") | translate }}</p>
 
-    <edit-officer-form v-bind:has-errors='{{ ((form.errors|length) > 0)|tojson }}' inline-template>
+    <edit-officer-form v-bind:has-errors='{{ ((form.errors|length) > 0)|tojson }}' v-bind:has-changes='{{ form.has_changes() | tojson }}' inline-template>
       <div>
 
       {% set prefix = { "contracting_officer": "ko", "contracting_officer_representative": "cor", "security_officer": "so" }[officer_type] %}

--- a/tests/forms/test_fields.py
+++ b/tests/forms/test_fields.py
@@ -1,9 +1,10 @@
 import pytest
 from wtforms import Form
+from wtforms.fields import StringField
 import pendulum
 from werkzeug.datastructures import ImmutableMultiDict
 
-from atst.forms.fields import NewlineListField
+from atst.forms.fields import NewlineListField, FormFieldWrapper
 
 
 class NewlineListForm(Form):
@@ -38,3 +39,37 @@ def test_newline_list_value(input_, expected):
 
     assert form.validate()
     assert form.newline_list._value() == expected
+
+
+class PersonForm(Form):
+    first_name = StringField("first_name")
+
+
+class FormWithFormField(Form):
+    person = FormFieldWrapper(PersonForm)
+
+
+class TestFormFieldWrapper:
+    class Foo:
+        person = {"first_name": "Luke"}
+
+    obj = Foo()
+
+    def test_form_data_does_not_match_object_data(self):
+        form_data = ImmutableMultiDict({"person-first_name": "Han"})
+        form = FormWithFormField(form_data, obj=self.obj)
+        assert form.person.has_changes()
+
+    def test_when_no_form_data(self):
+        form = FormWithFormField(None, obj=self.obj)
+        assert not form.person.has_changes()
+
+    def test_when_no_obj_data(self):
+        form_data = ImmutableMultiDict({"person-first_name": "Han"})
+        form = FormWithFormField(form_data)
+        assert not form.person.has_changes()
+
+    def test_when_form_data_matches_obj_dta(self):
+        form_data = ImmutableMultiDict({"person-first_name": "Luke"})
+        form = FormWithFormField(form_data, obj=self.obj)
+        assert not form.person.has_changes()


### PR DESCRIPTION
Previously, when updating the Task Order officers' information and an error occurred (most easily reproduced with submitting an invalid phone number), only forms with errors would be expanded, causing changes to any other officer to be discarded. Now, forms will expand if there are errors or changes.

For example: 

1. click to update the KO info
1. change any KO field
1. click to update the COR info
1. change any COR field
1. enter an invalid phone number
1. submit the changes

Previously, only the COR form would be expanded and show the error, discarding your KO change. Now, the KO and COR forms will be expanded, with the KO form showing the change and the COR form showing the error.