### PR TITLE
CLIN Input field bugfixes

### DIFF
--- a/atst/filters.py
+++ b/atst/filters.py
@@ -16,14 +16,6 @@ def dollars(value):
         numberValue = float(value)
     except ValueError:
         numberValue = 0
-    return "${:,.0f}".format(numberValue)
-
-
-def dollarsWithCents(value):
-    try:
-        numberValue = float(value)
-    except ValueError:
-        numberValue = 0
     return "${:,.2f}".format(numberValue)
 
 
@@ -107,7 +99,6 @@ def normalizeOrder(title):
 def register_filters(app):
     app.jinja_env.filters["iconSvg"] = iconSvg
     app.jinja_env.filters["dollars"] = dollars
-    app.jinja_env.filters["dollarsWithCents"] = dollarsWithCents
     app.jinja_env.filters["usPhone"] = usPhone
     app.jinja_env.filters["readableInteger"] = readableInteger
     app.jinja_env.filters["getOptionLabel"] = getOptionLabel

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -1,5 +1,6 @@
 import MaskedInput, { conformToMask } from 'vue-text-mask'
 import inputValidations from '../lib/input_validations'
+import { formatDollars } from '../lib/dollars'
 
 export default {
   name: 'textinput',
@@ -78,6 +79,9 @@ export default {
     onChange: function(e) {
       // Only invalidate the field when it blurs
       this._checkIfValid({ value: e.target.value, invalidate: true })
+      if (this.validation === 'dollars') {
+        this.value = formatDollars(this._rawValue(e.target.value))
+      }
     },
 
     //

--- a/js/lib/dollars.js
+++ b/js/lib/dollars.js
@@ -4,6 +4,11 @@ export const formatDollars = (value, cents = true) => {
       style: 'currency',
       currency: 'USD',
     })
+  } else if (typeof value === 'string') {
+    return parseFloat(value).toLocaleString('us-US', {
+      style: 'currency',
+      currency: 'USD',
+    })
   }
   return ''
 }

--- a/js/lib/dollars.js
+++ b/js/lib/dollars.js
@@ -1,8 +1,9 @@
 export const formatDollars = (value, cents = true) => {
   if (typeof value === 'number') {
-    return cents
-      ? `$${value.toFixed(2).replace(/\d(?=(\d{3})+\.)/g, '$&,')}`
-      : `$${value.toFixed(0).replace(/\d(?=(\d{3})+(?!\d))/g, '$&,')}`
+    return value.toLocaleString('us-US', {
+      style: 'currency',
+      currency: 'USD',
+    })
   }
   return ''
 }

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -132,7 +132,7 @@
           <td><h4>{{ "task_orders.new.review.to_value"| translate }}</h4></td>
           <td class="table-cell--align-right">
             {% if task_order.budget %}
-              {{ task_order.budget | dollarsWithCents }}
+              {{ task_order.budget | dollars }}
             {% endif %}
           </td>
         </tr>
@@ -140,7 +140,7 @@
           <td><h4 class='task-order-form__heading funding-summary__td'>{{ "task_orders.new.review.clin_1"| translate }}</h4></td>
           <td class="table-cell--align-right">
             {% if task_order.clin_01 %}
-              {{ task_order.clin_01 | dollarsWithCents }}
+              {{ task_order.clin_01 | dollars }}
             {% else %}
               {{ RequiredLabel() }}
             {% endif %}
@@ -155,7 +155,7 @@
           </h4></td>
           <td class="table-cell--align-right">
             {% if task_order.clin_02 and config.CLASSIFIED %}
-              {{ task_order.clin_02 | dollarsWithCents or RequiredLabel() }}
+              {{ task_order.clin_02 | dollars or RequiredLabel() }}
             {% endif %}
           </td>
         </tr>
@@ -163,7 +163,7 @@
           <td><h4 class='task-order-form__heading funding-summary__td'>{{ "task_orders.new.review.clin_3"| translate }}</h4></td>
           <td class="table-cell--align-right">
             {% if task_order.clin_03 %}
-              {{ task_order.clin_03 | dollarsWithCents or RequiredLabel() }}
+              {{ task_order.clin_03 | dollars or RequiredLabel() }}
             {% else %}
               {{ RequiredLabel() }}
             {% endif %}
@@ -178,7 +178,7 @@
           </h4></td>
           <td class="table-cell--align-right">
             {% if task_order.clin_04 and config.CLASSIFIED %}
-              {{ task_order.clin_04 | dollarsWithCents or RequiredLabel() }}
+              {{ task_order.clin_04 | dollars or RequiredLabel() }}
             {% endif %}
           </td>
         <tr>

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -7,11 +7,11 @@ from atst.models import AuditEvent
 @pytest.mark.parametrize(
     "input,expected",
     [
-        ("0", "$0"),
-        ("123.00", "$123"),
-        ("1234567", "$1,234,567"),
-        ("-1234", "$-1,234"),
-        ("one", "$0"),
+        ("0", "$0.00"),
+        ("123.00", "$123.00"),
+        ("1234567", "$1,234,567.00"),
+        ("-1234", "$-1,234.00"),
+        ("one", "$0.00"),
     ],
 )
 def test_dollar_fomatter(input, expected):


### PR DESCRIPTION
## Description
This PR fixes a couple of issues brought up by QA. 
1) Adds cents to all dollar amounts across the app
2) Adds cents to the CLIN input fields if the user does not add them, ie: if a user inputs "$25.5" or "$10", when the focus moves away from the input the trailing zero(s) will be added.

## Pivotal
[https://www.pivotaltracker.com/story/show/163465960](https://www.pivotaltracker.com/story/show/163465960)

## Screenshots 
<img width="1228" alt="screen shot 2019-02-01 at 1 20 30 pm" src="https://user-images.githubusercontent.com/43828539/52141634-5350e780-2624-11e9-8676-362ddd10ff4e.png">
<img width="966" alt="screen shot 2019-02-01 at 1 21 09 pm" src="https://user-images.githubusercontent.com/43828539/52141637-55b34180-2624-11e9-8226-0fb3e5c9b3ef.png">