### PR TITLE
DOD ID isn't required on oversight page

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -38,17 +38,14 @@ class TaskOrders(object):
             "ko_last_name",
             "ko_email",
             "ko_phone_number",
-            "ko_dod_id",
             "cor_first_name",
             "cor_last_name",
             "cor_email",
             "cor_phone_number",
-            "cor_dod_id",
             "so_first_name",
             "so_last_name",
             "so_email",
             "so_phone_number",
-            "so_dod_id",
         ],
     }
 


### PR DESCRIPTION
We shouldn't require the DOD ID on the oversight form for the section to be complete