### PR TITLE
Fix string formatting on review page

### DIFF
--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -72,7 +72,8 @@
       ("forms.task_order.app_migration.label" | translate),
       (
         ("forms.task_order.app_migration.{}".format(task_order.app_migration) | translate) if task_order.app_migration
-      )
+      ),
+      filter='safe'
     )
   }}
 


### PR DESCRIPTION
The "app migration" field has some `<strong>` formatting in it that was not being rendered correctly on the review page. Previously:

![image](https://user-images.githubusercontent.com/40774582/52229616-5bf32900-2883-11e9-9075-d33054283540.png)

Now:

![image](https://user-images.githubusercontent.com/40774582/52229637-63b2cd80-2883-11e9-9ef2-2a37b7b94682.png)
