### PR TITLE
Fix shifting inputs

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -155,6 +155,11 @@
       padding: 0 0 $gap 0;
       @include h4;
 
+      .icon {
+        margin-top: 0;
+        margin-bottom: 0;
+      }
+
       label {
         font-weight: $font-bold;
       }


### PR DESCRIPTION
On radio and select inputs, the the validation icon was causing the content to shift around after a choice was selected. The margin on the icon for those components was adjusted to fix the dancing content.

Some tiny gifs that illustrate the behavior. Before:

![jiggle](https://user-images.githubusercontent.com/40774582/52234397-91057880-288f-11e9-9dbc-2bb8324a82ed.gif)

After:

![fixed](https://user-images.githubusercontent.com/40774582/52234410-99f64a00-288f-11e9-98c1-177e0fddf056.gif)
