### PR TITLE
Styling updates on TO Oversight Invite page

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -292,7 +292,7 @@
   .task-order-invitations__heading {
     margin-bottom: 0;
 
-    &.subheading .h2 {
+    &.subheading {
       color: $color-gray;
     }
   }
@@ -314,6 +314,10 @@
 
     h2 {
       color: $color-gray;
+    }
+
+    .officer__description {
+      margin-bottom: 2.5rem;
     }
 
     .officer__info {
@@ -344,6 +348,10 @@
           .icon {
             @include icon-color($color-red);
           }
+        }
+
+        .status-text {
+          vertical-align: top;
         }
       }
     }

--- a/templates/portfolios/task_orders/invitations.html
+++ b/templates/portfolios/task_orders/invitations.html
@@ -72,7 +72,7 @@
             <div class="officer__info--name">{{ first_name }} {{ last_name }}</div>
             <div class="officer__info--status invited">
               <span>{{ Icon("ok", classes="invited") }}</span>
-              <span>Invited</span>
+              <span class="status-text">Invited</span>
             </div>
           </div>
           <p class="officer__info--email">{{ email }}</p>
@@ -90,7 +90,7 @@
             <div class="officer__info--name">{{ first_name }} {{ last_name }}</div>
             <div class="officer__info--status uninvited">
               <span>{{ Icon("alert", classes="uninvited") }}</span>
-              Not Invited
+              <span class="status-text">Not Invited</span>
             </div>
           </div>
           <p class="officer__info--email">{{ email }}</p>

--- a/translations.yaml
+++ b/translations.yaml
@@ -443,7 +443,7 @@ task_orders:
     dod_id_label: DoD ID
     contracting_officer:
       title: Contracting Officer (KO) Information
-      description: You'll need a signature from your KO. You might want to work with your program Financial Manager to get your TO documents moved in the right direction.
+      description: You'll need a signature from your KO. You might want to work with your program Financial Manager to get your TO documents moving in the right direction.
       add_button_text: Add / Invite KO
       invite_button_text: Invite KO
     contracting_officer_representative:
@@ -453,7 +453,7 @@ task_orders:
       invite_button_text: Invite COR
     security_officer:
       title: IA Security Officer Information
-      description: Your Security Officer will need to answer some security configuration questions in order to generate a DD-254 document, then electronically sign.
+      description: Your Security Officer will need to answer some security configuration questions in order to generate a DD-254 document, then digitally sign.
       add_button_text: Add / Invite Security Officer
       invite_button_text: Invite Security Officer
 testing:


### PR DESCRIPTION
## Description
Some styling updates to the TO Oversight info page:
1) Update copy on the officer descriptions for KO and SO (“… to get your TO documents movING in the right direction” (instead of movED), and "digitally sign" instead of "electronically")
2) Change Oversight header to gray
3) Fix alignment of status text
4) Added more space below officer description text

## Pivotal
[https://www.pivotaltracker.com/story/show/163463465])https://www.pivotaltracker.com/story/show/163463465)

## Screenshots
![screen shot 2019-02-05 at 12 03 07 pm](https://user-images.githubusercontent.com/43828539/52290425-0d569500-293e-11e9-918a-d436a247dd06.png)
