### PR TITLE
Portfolio name validation

### DIFF
--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -31,7 +31,14 @@ class AppInfoForm(CacheableForm):
     portfolio_name = StringField(
         translate("forms.task_order.portfolio_name_label"),
         description=translate("forms.task_order.portfolio_name_description"),
-        validators=[Required()],
+        validators=[
+            Required(),
+            Length(
+                min=4,
+                max=100,
+                message=translate("forms.portfolio.name_length_validation_message"),
+            ),
+        ],
     )
     scope = TextAreaField(
         translate("forms.task_order.scope_label"),

--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -122,6 +122,6 @@ export default {
     match: /^.{4,100}$/,
     unmask: [],
     validationError:
-      'Portfolio and request names must be at least 4 and not more than 100 characters',
+      'Portfolio names must be at least 4 and not more than 100 characters',
   },
 }

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -13,7 +13,7 @@
 
 <!-- App Info Section -->
 <h3 class="task-order-form__heading subheading">{{ "task_orders.new.app_info.basic_info_title"| translate }}</h3>
-{{ TextInput(form.portfolio_name, placeholder="The name of your office or organization") }}
+{{ TextInput(form.portfolio_name, placeholder="The name of your office or organization", validation="portfolioName") }}
 {{ TextInput(form.scope, paragraph=True) }}
 <p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
 <div class="subheading--black">

--- a/translations.yaml
+++ b/translations.yaml
@@ -254,7 +254,7 @@ forms:
     is_required: This field is required.
   portfolio:
     name_label: Portfolio Name
-    name_length_validation_message: Portfolio names must be at least 4 and not more than 50 characters
+    name_length_validation_message: Portfolio names must be at least 4 and not more than 100 characters
 fragments:
   edit_application_form:
     existing_application_title: 'Edit {application_name} application'


### PR DESCRIPTION
## Description
Fixed a bug so now when creating a new portfolio via the task order builder, there are requirements on the name of the portfolio. Now the validations on portfolio name are consistent in the TO form and edit portfolio form. 

## Pivotal
[https://www.pivotaltracker.com/story/show/163748431](https://www.pivotaltracker.com/story/show/163748431)

## Screenshots
<img width="869" alt="screen shot 2019-02-06 at 10 51 47 am" src="https://user-images.githubusercontent.com/43828539/52353796-3c800b80-29fd-11e9-9205-a166515f0fe3.png">
