### PR TITLE
Update redirect to point to portfolios index

### DIFF
--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -55,7 +55,7 @@ def home():
     num_portfolios = len(user.portfolio_roles)
 
     if num_portfolios == 0:
-        return redirect(url_for("requests.requests_index"))
+        return redirect(url_for("portfolios.portfolios"))
     elif num_portfolios == 1:
         portfolio_role = user.portfolio_roles[0]
         portfolio_id = portfolio_role.portfolio.id


### PR DESCRIPTION
## Description
Fixes the redirect for new users so they are redirected to `/portfolios`
This PR only covers the redirect when a new user logs in, updating the new user landing page is covered in this card: [https://www.pivotaltracker.com/story/show/163272393](https://www.pivotaltracker.com/story/show/163272393)

## Pivotal
[https://www.pivotaltracker.com/story/show/163771404](https://www.pivotaltracker.com/story/show/163771404)