### PR TITLE
Only include active Task Orders in portfolio budget

### DIFF
--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -106,12 +106,15 @@ class TaskOrder(Base, mixins.TimestampsMixin):
 
     @property
     def is_submitted(self):
-
         return (
             self.number is not None
             and self.start_date is not None
             and self.end_date is not None
         )
+
+    @property
+    def is_active(self):
+        return self.status == Status.ACTIVE
 
     @property
     def status(self):

--- a/templates/portfolios/header.html
+++ b/templates/portfolios/header.html
@@ -20,7 +20,7 @@
         {{ Icon('info') }}
       </button>
       <span class='portfolio-header__budget--dollars'>
-        {{ portfolio.task_orders | sum(attribute='budget') | dollars }}
+        {{ portfolio.task_orders | selectattr('is_active') | sum(attribute='budget') | dollars }}
       </span>
     </div>
   </div>


### PR DESCRIPTION
The budget shown on the portfolio header nav should only include active task orders, not pending or expired task orders.