### PR TITLE
Fix portfolio header on small screens

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -42,6 +42,11 @@
 }
 
 .portfolio-header {
+  flex-direction: column;
+  @include media($small-screen) {
+    flex-direction: row;
+  }
+
   margin: 2 * $gap 0;
 
   .portfolio-header__name {
@@ -64,6 +69,7 @@
   }
 
   .links {
+    justify-content: center;
     font-size: $small-font-size;
 
     .icon-link {


### PR DESCRIPTION
Previously, on small screens, the nav links in the portfolio header would obscure the portfolio name:

![image](https://user-images.githubusercontent.com/40774582/52535348-46ff1580-2d1b-11e9-965c-abc5ae826ea9.png)

This PR changes the flex direction so that the buttons are below portfolio name/budget on small screens (and unchanged on larger screens):

![image](https://user-images.githubusercontent.com/40774582/52535343-3353af00-2d1b-11e9-9e4d-300e79c5a197.png)

![image](https://user-images.githubusercontent.com/40774582/52535359-6a29c500-2d1b-11e9-838e-66a939cde6e1.png)
