### PR TITLE
Toggle accordion when click application name

### DIFF
--- a/styles/elements/_accordians.scss
+++ b/styles/elements/_accordians.scss
@@ -31,6 +31,12 @@
   @include block-list__title;
   color: $color-blue;
   @include h3;
+
+  &.icon-link {
+    margin: 0;
+    display: block;
+    padding: 0 $gap;
+  }
 }
 
 .accordian__description {

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -38,7 +38,7 @@
           <template slot-scope='props'>
             <header class='accordian__header row'>
               <div class='col col-grow'>
-                <h3 class='accordian__title'>{{ application.name }}</h3>
+                <h3 class='icon-link accordian__title' v-on:click="props.toggle">{{ application.name }}</h3>
                 <span class='accordian__description'>{{ application.description }}</span>
                 <div class='accordian__actions'>
                   {% if user_can(permissions.RENAME_APPLICATION_IN_PORTFOLIO) %}


### PR DESCRIPTION
This PR allows clicking the application name in the list of applications to toggle the accordion. Previously, the +/- button was the only clickable button, but the name needs to be clickable as well.