### PR TITLE
Fix issue with caret sticking on scrollable table

### DIFF
--- a/styles/elements/_tables.scss
+++ b/styles/elements/_tables.scss
@@ -32,9 +32,20 @@
         display: table-cell;
       }
     }
+  }
 
-    .sorting-direction {
-      position: absolute;
+  thead {
+    tr th {
+      .sorting-direction {
+        position: inherit;
+        margin-right: -16px;
+        width: 16px;
+        .icon {
+          height: 14px;
+          width: 16px;
+          margin: 0;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Caret was sticking with `position: absolute;`. This fixes that.

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163534185)

![caret-scroll gif sb-26174db3-cgirfs](https://user-images.githubusercontent.com/45772525/52585814-d08a1280-2e03-11e9-9aaf-6218f3f0bdd9.gif)
