### PR TITLE
Blank slate for no portfolios

### DIFF
--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -15,7 +15,11 @@ from atst.models.permissions import Permissions
 @portfolios_bp.route("/portfolios")
 def portfolios():
     portfolios = Portfolios.for_user(g.current_user)
-    return render_template("portfolios/index.html", page=5, portfolios=portfolios)
+
+    if portfolios:
+        return render_template("portfolios/index.html", page=5, portfolios=portfolios)
+    else:
+        return render_template("portfolios/blank_slate.html")
 
 
 @portfolios_bp.route("/portfolios/<portfolio_id>/edit")

--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -2,6 +2,10 @@
   white-space: nowrap;
 }
 
+.center {
+  text-align: center;
+}
+
 @mixin hide {
   border: 0;
   clip: rect(0 0 0 0);

--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -2,10 +2,6 @@
   white-space: nowrap;
 }
 
-.center {
-  text-align: center;
-}
-
 @mixin hide {
   border: 0;
   clip: rect(0 0 0 0);

--- a/templates/portfolios/blank_slate.html
+++ b/templates/portfolios/blank_slate.html
@@ -19,7 +19,6 @@
   <div class="center">
     {{
       Tooltip(
-        message=("portfolios.index.empty.help_message" | translate),
         title=("portfolios.index.empty.help_title" | translate),
       )
     }}

--- a/templates/portfolios/blank_slate.html
+++ b/templates/portfolios/blank_slate.html
@@ -15,13 +15,5 @@
       message=("portfolios.index.empty.title" | translate),
     )
   }}
-
-  <div class="center">
-    {{
-      Tooltip(
-        title=("portfolios.index.empty.help_title" | translate),
-      )
-    }}
-  </div>
 {% endblock %}
 

--- a/templates/portfolios/blank_slate.html
+++ b/templates/portfolios/blank_slate.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% from "components/empty_state.html" import EmptyState %}
+{% from "components/tooltip.html" import Tooltip %}
+
+{% block global_sidenav %}
+{% endblock %}
+
+{% block content %}
+  {{
+    EmptyState(
+      action_href=url_for("task_orders.new", screen=1),
+      action_label=("portfolios.index.empty.start_button" | translate),
+      icon="cloud",
+      message=("portfolios.index.empty.title" | translate),
+    )
+  }}
+
+  <div class="center">
+    {{
+      Tooltip(
+        message=("portfolios.index.empty.help_message" | translate),
+        title=("portfolios.index.empty.help_title" | translate),
+      )
+    }}
+  </div>
+{% endblock %}
+

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -1,6 +1,7 @@
 from flask import url_for
 
-from tests.factories import PortfolioFactory
+from tests.factories import PortfolioFactory, UserFactory
+from atst.utils.localization import translate
 
 
 def test_update_portfolio_name(client, user_session):
@@ -13,3 +14,29 @@ def test_update_portfolio_name(client, user_session):
     )
     assert response.status_code == 200
     assert portfolio.name == "a cool new name"
+
+
+def test_portfolio_index_with_existing_portfolios(client, user_session):
+    portfolio = PortfolioFactory.create()
+    user_session(portfolio.owner)
+
+    response = client.get(url_for("portfolios.portfolios"))
+
+    assert response.status_code == 200
+    assert portfolio.name.encode("utf8") in response.data
+    assert (
+        translate("portfolios.index.empty.start_button").encode("utf8")
+        not in response.data
+    )
+
+
+def test_portfolio_index_without_existing_portfolios(client, user_session):
+    user = UserFactory.create()
+    user_session(user)
+
+    response = client.get(url_for("portfolios.portfolios"))
+
+    assert response.status_code == 200
+    assert (
+        translate("portfolios.index.empty.start_button").encode("utf8") in response.data
+    )

--- a/translations.yaml
+++ b/translations.yaml
@@ -483,7 +483,6 @@ portfolios:
   index:
     empty:
       title: You have no apps yet
-      help_title: Should I do this?
       start_button: Start a New JEDI Portfolio
   applications:
     add_application_text: Add A New Application

--- a/translations.yaml
+++ b/translations.yaml
@@ -7,7 +7,6 @@
 
   # `{{ "login.title" | translate | safe }}`
 
-
 audit_log:
   events:
     default:
@@ -481,6 +480,12 @@ task_orders:
     submitted_by: Below is an overview of the projected portfolio submitted by {name}
     task_order_information: Task Order Information
 portfolios:
+  index:
+    empty:
+      title: You have no apps yet
+      help_title: Should I do this?
+      help_message: TODO
+      start_button: Start a New JEDI Portfolio
   applications:
     add_application_text: Add A New Application
     app_settings_text: App Settings

--- a/translations.yaml
+++ b/translations.yaml
@@ -484,7 +484,6 @@ portfolios:
     empty:
       title: You have no apps yet
       help_title: Should I do this?
-      help_message: TODO
       start_button: Start a New JEDI Portfolio
   applications:
     add_application_text: Add A New Application


### PR DESCRIPTION
New user landing page for when a user has no portfolios. We can ship it without the "sad icon" in the ticket, and the `TODO` text will be added in a follow up PR.

[Pivotal Tracker](https://www.pivotaltracker.com/story/show/163272393).

<img width="1350" alt="screen shot 2019-02-11 at 16 07 38" src="https://user-images.githubusercontent.com/45772525/52593535-316f1600-2e17-11e9-8797-0d9c184b168e.png">
