### PR TITLE
Fix colors on breadcrumb links in nav

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -17,7 +17,7 @@
   font-size: $h5-font-size;
 
   .icon-link {
-    color: $color-gray-medium;
+    color: $color-blue;
     font-weight: normal;
   }
 
@@ -26,16 +26,26 @@
   }
 
   .icon {
-    @include icon-color($color-gray-medium);
+    @include icon-color($color-blue);
+  }
+
+  .portfolio-breadcrumbs__home {
+    &.icon-link--disabled {
+      color: $color-gray-medium;
+      opacity: 1;
+      .icon {
+        @include icon-color($color-gray-medium);
+      }
+    }
   }
 
   .portfolio-breadcrumbs__crumb {
     .icon {
-      @include icon-color($color-blue);
+      @include icon-color($color-gray-medium);
     }
 
     .icon-link {
-      color: $color-blue;
+      color: $color-gray-medium;
       pointer-events: none;
     }
   }

--- a/templates/portfolios/breadcrumbs.html
+++ b/templates/portfolios/breadcrumbs.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 <div class="row portfolio-breadcrumbs">
-  <a class="icon-link portfolio-breadcrumbs__home" href="{{ url_for("portfolios.portfolio_applications", portfolio_id=portfolio.id) }}">
+  <a class="icon-link portfolio-breadcrumbs__home {{ 'icon-link--disabled' if not secondary_breadcrumb }}" href="{{ url_for("portfolios.portfolio_applications", portfolio_id=portfolio.id) }}">
     {{ Icon("home") }}
     <span>
       {{ portfolio.name }} Portfolio


### PR DESCRIPTION
Previously, the colors in the breadcrumb nav were inverted. When a breadcrumb is clickable, it should be blue. If it's not clickable (if it's the last or only breadcrumb), it should be gray.

![image](https://user-images.githubusercontent.com/40774582/52635877-1b099e80-2e99-11e9-9bcf-6b7969c7623a.png)

![image](https://user-images.githubusercontent.com/40774582/52635942-42606b80-2e99-11e9-8975-261fe1a68c06.png)

![image](https://user-images.githubusercontent.com/40774582/52635958-4a201000-2e99-11e9-9920-aa008ce044f8.png)
