### PR TITLE
Add validation for textInput on blur

### DIFF
--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -84,6 +84,10 @@ export default {
       }
     },
 
+    onBlur: function(e) {
+      this._checkIfValid({ value: e.target.value, invalidate: true })
+    },
+
     //
     _checkIfValid: function({ value, invalidate = false }) {
       // Validate the value

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -64,6 +64,7 @@
 
         <masked-input
           v-on:input='onInput'
+          v-on:blur='onBlur'
           v-on:change='onChange'
           v-bind:value='value'
           v-bind:mask='mask'


### PR DESCRIPTION
## Description
This fixes a bug where the input field was sometimes not validating on blur. I added in an event listener to all non-hidden textInput fields so now they validate when expected. 

Steps to reproduce the bug: 
1. type in a valid input into the Portfolio Name field, move focus from the input (also an issue for email and phone number inputs)
2. go back to the input and then delete until there are 3 characters, move focus from the input
3. go back to the input and add in one character so you get the green check, then delete one character (should be back to 3 characters)
4. move focus from the input
Expected - Error message
Actual - No error message

## Pivotal
[https://www.pivotaltracker.com/story/show/163748431](https://www.pivotaltracker.com/story/show/163748431)