### PR TITLE
Fix NaN appearing in CLIN fields

### DIFF
--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -85,9 +85,6 @@ export default {
     },
 
     onBlur: function(e) {
-      if (this.validation === 'dollars' && this.value === '$NaN') {
-        this.value = this.initialValue
-      }
       this._checkIfValid({ value: e.target.value, invalidate: true })
     },
 

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -85,6 +85,9 @@ export default {
     },
 
     onBlur: function(e) {
+      if (this.validation === 'dollars' && this.value === '$NaN') {
+        this.value = this.initialValue
+      }
       this._checkIfValid({ value: e.target.value, invalidate: true })
     },
 

--- a/js/lib/dollars.js
+++ b/js/lib/dollars.js
@@ -5,6 +5,10 @@ export const formatDollars = (value, cents = true) => {
       currency: 'USD',
     })
   } else if (typeof value === 'string') {
+    if (value === '') {
+      return value
+    }
+
     return parseFloat(value).toLocaleString('us-US', {
       style: 'currency',
       currency: 'USD',


### PR DESCRIPTION
## Description
Fixes bug where NaN appeared in the CLIN fields when all characters were deleted. Now when the value is `$NaN` it resets to the initialValue.

## Pivotal
[https://www.pivotaltracker.com/story/show/163827535](https://www.pivotaltracker.com/story/show/163827535)