### PR TITLE
Fix empty state alignment

### DIFF
--- a/templates/portfolios/blank_slate.html
+++ b/templates/portfolios/blank_slate.html
@@ -3,9 +3,6 @@
 {% from "components/empty_state.html" import EmptyState %}
 {% from "components/tooltip.html" import Tooltip %}
 
-{% block global_sidenav %}
-{% endblock %}
-
 {% block content %}
   {{
     EmptyState(


### PR DESCRIPTION
I had merged this yesterday and it was looking good. I think maybe a change in a template somewhere else has thrown off the alignment now? I removed the line that hides the sidebar to fix this for the demo.

## After

<img width="1439" alt="screen shot 2019-02-13 at 09 59 28" src="https://user-images.githubusercontent.com/45772525/52720781-4adaa400-2f76-11e9-97ca-9ff051cc452b.png">

## Before

<img width="1440" alt="screen shot 2019-02-13 at 09 59 52" src="https://user-images.githubusercontent.com/45772525/52720795-4f9f5800-2f76-11e9-8475-f9462e4cfd5e.png">
