### PR TITLE
fixed width for expanded sidenav

### DIFF
--- a/styles/components/_global_navigation.scss
+++ b/styles/components/_global_navigation.scss
@@ -2,29 +2,16 @@
   background-color: $color-white;
 
   .sidenav__link {
-    padding-right: $gap;
+    padding-right: $gap * 2;
 
     @include media($large-screen) {
       padding-right: $gap * 2;
     }
   }
 
-  .sidenav__link-label {
-    @include hide;
-
-    @include media($large-screen) {
-      @include unhide;
-      padding-left: $gap;
-    }
-  }
-
   &.global-navigation__context--portfolio {
     .sidenav__link {
       padding-right: $gap;
-    }
-
-    .sidenav__link-label {
-      @include hide;
     }
   }
 }

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -13,9 +13,9 @@
 
   .sidenav {
     @include media($large-screen) {
-      width: 25rem;
       margin: 0px;
     }
+    width: 25rem;
 
     box-shadow: 0 6px 18px 0 rgba(48,58,65,0.15);
 


### PR DESCRIPTION
This fixes the sidenav width at 25rems. This way it won't be compressed in narrow browser windows.

Before:

![screen shot 2019-02-13 at 10 43 58 am](https://user-images.githubusercontent.com/38955503/52723865-4b763900-2f7c-11e9-89c0-c5f758ebd540.png)

After:

![screen shot 2019-02-13 at 10 44 26 am](https://user-images.githubusercontent.com/38955503/52723908-5d57dc00-2f7c-11e9-9eb3-7bf9ee529081.png)

