### PR TITLE
Fix margin that was causing alignment issue

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -49,6 +49,10 @@
         top: 2.5rem;
         margin-left: -23rem;
       }
+
+      .usa-button {
+        margin: 0.5em;
+      }
     }
 
     p {


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163869712)

Margin was causing alignment to be off. This PR fixes the margin around the "Let's do cloud!" button.\

## Before

<img width="479" alt="screen shot 2019-02-13 at 10 49 26" src="https://user-images.githubusercontent.com/45772525/52724307-1ae2cf00-2f7d-11e9-8eb1-b49f78aa58bd.png">

## After

<img width="433" alt="screen shot 2019-02-13 at 10 49 10" src="https://user-images.githubusercontent.com/45772525/52724329-21714680-2f7d-11e9-997e-26793f37531d.png">
