### PR TITLE
Trim extra whitespace on blur

### DIFF
--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -85,7 +85,8 @@ export default {
     },
 
     onBlur: function(e) {
-      this._checkIfValid({ value: e.target.value, invalidate: true })
+      this._checkIfValid({ value: e.target.value.trim(), invalidate: true })
+      this.value = e.target.value.trim()
     },
 
     //


### PR DESCRIPTION
## Description
Fixes a bug where users could type in 4 spaces and it would be a valid portfolio name. Updated the textInput component so it will trim beginning and trailing whitespace. 

## Pivotal
[https://www.pivotaltracker.com/story/show/163748431](https://www.pivotaltracker.com/story/show/163748431)