### PR TITLE
KO Review styling

### DIFF
--- a/styles/components/_forms.scss
+++ b/styles/components/_forms.scss
@@ -77,6 +77,7 @@
 .form__sub-fields {
   @include alert;
   @include alert-level('default');
+  margin-top: $gap * 2;
   display: block;
 
   .usa-input {

--- a/styles/elements/_panels.scss
+++ b/styles/elements/_panels.scss
@@ -68,6 +68,10 @@
     }
   }
 
+  .panel__body {
+    margin-right: $gap * 2;
+  }
+
   .panel__heading {
     padding: $gap * 2;
 

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -281,9 +281,6 @@
     }
   }
 
-  .usa-input__title {
-    color: $color-gray;
-  }
 
   .subheading, .description {
     color: $color-gray;

--- a/templates/components/review_field.html
+++ b/templates/components/review_field.html
@@ -1,5 +1,5 @@
 {% macro ReviewField(heading, field, filter=None) %}
-  <div class="col col--grow">
+  <div class="col col--grow panel__body">
     <h4 class='task-order-form__heading'>{{ heading }}</h4>
     {% if field %}
       <p>{{ field | findFilter(filter) }}</p>

--- a/templates/fragments/task_order_review/reporting.html
+++ b/templates/fragments/task_order_review/reporting.html
@@ -21,21 +21,25 @@
   }}
 </div>
 
-<h4 class='task-order-form__heading'>{{ "task_orders.new.review.complexity"| translate }}</h4>
-{% if task_order.complexity %}
-  <ul class="checklist">
-  {% for item in task_order.complexity %}
-    <li>
-      {{ Icon('ok', classes='icon--gray icon--medium') }}{{ "forms.task_order.complexity.{}".format(item) | translate }}{% if item == 'other' %}: {{ task_order.complexity_other }}{% endif %}
-    </li>
-  {% endfor %}
-  </ul>
-{% else %}
-  <p>{{ RequiredLabel() }}</p>
-{% endif %}
+<div class="row">
+  <div class="col col--grow panel__body">
+    <h4 class='task-order-form__heading'>{{ "task_orders.new.review.complexity"| translate }}</h4>
+    {% if task_order.complexity %}
+      <ul class="checklist">
+      {% for item in task_order.complexity %}
+        <li>
+          {{ Icon('ok', classes='icon--gray icon--medium') }}{{ "forms.task_order.complexity.{}".format(item) | translate }}{% if item == 'other' %}: {{ task_order.complexity_other }}{% endif %}
+        </li>
+      {% endfor %}
+      </ul>
+    {% else %}
+      <p>{{ RequiredLabel() }}</p>
+    {% endif %}
+  </div>
+</div>
 
 <div class="row">
-  <div class="col col--grow">
+  <div class="col col--grow panel__body">
     <h4 class='task-order-form__heading'>{{ "task_orders.new.review.team"| translate }}</h4>
     {% if task_order.dev_team %}
       <ul class="checklist">

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -66,7 +66,7 @@
         <div class="h2">{{ "task_orders.ko_review.task_order_information"| translate }}</div>
 
         <div class="form__sub-fields">
-          {{ UploadInput(form.pdf) }}
+          {{ UploadInput(form.pdf, show_label=True) }}
           {{ TextInput(form.number) }}
           {{ TextInput(form.loa) }}
           {{ TextInput(form.custom_clauses, paragraph=True) }}

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -67,8 +67,8 @@
 
         <div class="form__sub-fields">
           {{ UploadInput(form.pdf, show_label=True) }}
-          {{ TextInput(form.number) }}
-          {{ TextInput(form.loa) }}
+          {{ TextInput(form.number, placeholder='1234567890') }}
+          {{ TextInput(form.loa, placeholder='1234567890') }}
           {{ TextInput(form.custom_clauses, paragraph=True) }}
         </div>
 

--- a/translations.yaml
+++ b/translations.yaml
@@ -62,7 +62,7 @@ forms:
     pdf_label: Upload a copy of your Task Order document
     pdf_description: Upload a PDF of the Task Order that you entered in your system of record for your organization.
     to_number: Task Order Number
-    loa: Line of Accounting (LOA) #1
+    loa: Line of Accounting (LOA) &#35;1
     custom_clauses_label: Task Order Custom Clauses (optional)
     custom_clauses_description: This will put a pause on the CSP access once the KO signs until the CCPO reviews that language to make sure it is legal.
   edit_member:


### PR DESCRIPTION
## Description
There were some design discrepancies with the KO Review page that are addressed here:
* input titles are black
* show input label on pdf uploader
* show `#1` on LOA label
* add spacing above blue input boxes for dates and for KO input
* prevent text in left columns from melding into right columns

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163368662

## Screenshots
<img width="1532" alt="screen shot 2019-02-13 at 12 59 26 pm" src="https://user-images.githubusercontent.com/42577527/52732884-479fe200-2f8f-11e9-8b4e-0d5d7ad68ce1.png">
<img width="1532" alt="screen shot 2019-02-13 at 12 59 31 pm" src="https://user-images.githubusercontent.com/42577527/52732886-48387880-2f8f-11e9-9bba-e6e8f347a953.png">
<img width="1532" alt="screen shot 2019-02-13 at 12 59 42 pm" src="https://user-images.githubusercontent.com/42577527/52732887-48387880-2f8f-11e9-9bc9-ccd619464b55.png">
