### PR TITLE
Set min width for panel container to fix IE bug

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -1,6 +1,7 @@
 .portfolio-panel-container {
   @include media($large-screen) {
     @include grid-row;
+    min-height: 500px;
   }
 
   margin-left: 2 * $gap;


### PR DESCRIPTION
This PR fixes an issue where the sidebar bottom was displayed when only one application was part of the portfolio.