### PR TITLE
Prevent page from shifting downward when validation error shows

### DIFF
--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -88,6 +88,9 @@
       <template v-if='showError'>
         <span class='usa-input__message' v-html='validationError'></span>
       </template>
+      <template v-else>
+        <span class='usa-input__message'></span>
+      </template>
 
     </div>
   </textinput>


### PR DESCRIPTION
## Description
When entering an invalid Organization Portfolio Name, a validation error renders. This error message was shifting everything on the page that was lower than the error message down by the height of the error message. 
This PR adds an empty placeholder span when the Name is valid, which prevents this shifting.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163832394

## Screenshots
![screen shot 2019-02-14 at 8 58 47 am](https://user-images.githubusercontent.com/42577527/52791619-5f32a580-3037-11e9-90d2-8967f5c07c05.png)
![screen shot 2019-02-14 at 8 58 53 am](https://user-images.githubusercontent.com/42577527/52791621-5f32a580-3037-11e9-8804-f8ab157a5acf.png)
