### PR TITLE
Fix icon alert position

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -471,3 +471,8 @@
     }
   }
 }
+
+.to-expiration-alert .icon {
+    position: relative;
+    top: 3px;
+}


### PR DESCRIPTION
This PR fixed the alignment of the alert icon with the alert message in the funding screen.

*Before Fix:*
<img width="591" alt="screen shot 2019-02-13 at 14 59 12" src="https://user-images.githubusercontent.com/38014252/52796919-b68a4300-3042-11e9-9077-6787e1656125.png">

*After Fix:*
<img width="597" alt="screen shot 2019-02-13 at 14 59 04" src="https://user-images.githubusercontent.com/38014252/52796933-bd18ba80-3042-11e9-84c1-bc3e2c245401.png">


This PR fixes: https://www.pivotaltracker.com/n/projects/2160940/stories/163794280