### PR TITLE
Don't show outline on an anchor tag that doesn't have a href

### DIFF
--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -50,3 +50,7 @@
 @import 'sections/member_edit';
 @import 'sections/reports';
 @import 'sections/task_order';
+
+a:focus:not([href]) {
+  outline: none;
+}

--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -51,6 +51,10 @@
 @import 'sections/reports';
 @import 'sections/task_order';
 
-a:focus:not([href]) {
-  outline: none;
+//
+// IE likes to display an outline when focusing on an element. This
+// fix removes that unwanted outline on focus.
+//
+*:focus {
+  outline: 0;
 }


### PR DESCRIPTION
On IE don't show outline if we're clicking on an anchor tag that doesn't have a `href`.

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163759711)