### PR TITLE
Remove duplicate label and description text

### DIFF
--- a/templates/fragments/edit_user_form.html
+++ b/templates/fragments/edit_user_form.html
@@ -27,11 +27,6 @@
 
 
       <div class="usa-input">
-        <label>
-          <div class="usa-input__title">{{ form.date_latest_training.label }}</div>
-        </label>
-
-        <span class="usa-form-hint">{{ "forms.date_hint" | translate }}</span>
         {{ DatePicker(form.date_latest_training, mindate=mindate, maxdate=maxdate) }}
       </div>
     </div>

--- a/translations.yaml
+++ b/translations.yaml
@@ -44,7 +44,6 @@ footer:
   browser_support: JEDI Cloud supported on these web browsers
   jedi_help_link_text: Questions? Contact your CCPO Representative
 forms:
-  date_hint: "For example: 11 28 1986"
   ccpo_review:
     comment_description: Provide instructions or notes for additional information that is necessary to approve the request here. The requestor may then re-submit the updated request or initiate contact outside of AT-AT if further discussion is required. <strong>This message will be shared with the person making the JEDI request.</strong>.
     comment_label: Instructions or comments


### PR DESCRIPTION
Remove duplicate label and hint text from the users setting page

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164012165)

## Before

![ia_big](https://user-images.githubusercontent.com/45772525/52958578-58bb6b00-3362-11e9-94fb-0bc8396d704e.png)

## After

<img width="753" alt="screen shot 2019-02-18 at 09 48 44" src="https://user-images.githubusercontent.com/45772525/52958604-6cff6800-3362-11e9-8c26-6ab78fc82fa7.png">
