### PR TITLE
Fix inconsistency in tooltip styling

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -65,6 +65,10 @@
 
   margin: 2 * $gap;
 
+  .col--grow {
+    overflow: inherit;
+  }
+
   .portfolio-header__name {
     @include h1;
   }

--- a/styles/elements/_tooltip.scss
+++ b/styles/elements/_tooltip.scss
@@ -8,8 +8,6 @@
     background-color: $color-aqua-lightest;
     padding: $gap * 3;
     border-left: ($gap / 2) solid $color-blue;
-    position: relative;
-    z-index: 2;
   }
 
   .tooltip-arrow {

--- a/templates/portfolios/header.html
+++ b/templates/portfolios/header.html
@@ -1,4 +1,5 @@
 {% from "components/icon.html" import Icon %}
+{% from "components/tooltip.html" import Tooltip %}
 
 {% macro Link(icon, text, url, active=False) %}
   <a class='icon-link {{ "active icon-link--disabled" if active }}' href='{{ url }}'>
@@ -17,9 +18,12 @@
     <div class='portfolio-header__budget row'>
       <div class='column-left'>
         <span>Available budget</span>
-        <button type="button" tabindex="0" class="icon-tooltip" v-tooltip.right="{content: 'The available budget shown includes the available budget of all active task orders', container: false}">
-          {{ Icon('info') }}
-        </button>
+        {{
+          Tooltip(
+            ('portfolios.task_orders.available_budget_help_description' | translate),
+            title=''
+          )
+        }}
       </div>
       <div class='portfolio-header__budget--amount'>
         <span class='portfolio-header__budget--dollars'>

--- a/translations.yaml
+++ b/translations.yaml
@@ -510,6 +510,8 @@ task_orders:
     review_title: Task Order Builder
     task_order_information: Task Order Information
 portfolios:
+  task_orders:
+    available_budget_help_description: The available budget shown includes the available budget of all active task orders
   index:
     empty:
       title: You have no apps yet


### PR DESCRIPTION
The previous fix was not consistent in styling elsewhere. To fix this I reverted the previous commit and made a change to use the `Tooltip` component.

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163793647)

## Before

![screen shot 2019-02-18 at 10 44 44 am_big](https://user-images.githubusercontent.com/45772525/52965606-38e07300-3373-11e9-80aa-745132ee1c8e.png)

## After

![localhost_8000_portfolios_58c4b6e2-8f9b-42a8-88aa-cdb9531da4ba_applications](https://user-images.githubusercontent.com/45772525/52965581-249c7600-3373-11e9-8c15-25b25ad59f30.png)
