### PR TITLE
Fix meter when budget is 0

### DIFF
--- a/templates/portfolios/reports/index.html
+++ b/templates/portfolios/reports/index.html
@@ -33,7 +33,7 @@
         <hr></hr>
 
         <div>
-          <meter value='{{ spent }}' min='0' max='{{ budget }}' title='{{ spent | dollars }} Total spend to date'>
+          <meter value='{{ spent }}' min='0' {% if budget %}max='{{ budget }}' {% endif %}title='{{ spent | dollars }} Total spend to date'>
             <div class='meter__fallback' style='width:{{ (spent / budget) * 100 if budget else 0 }}%;'></div>
           </meter>
 


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163990717)

On Firefox when the budget is set to 0 it was showing as 100% of the budget spent, which is different to IE and Chrome.

This fix removes the `max` value if its 0 and makes the display behavior consistent in IE, Chrome, and Firefox.

## Firefox Before

<img width="1282" alt="screen shot 2019-02-18 at 14 52 02" src="https://user-images.githubusercontent.com/45772525/52973659-c5e3f600-338c-11e9-817e-a108936c8a54.png">

## Firefox After

<img width="1281" alt="screen shot 2019-02-18 at 14 51 31" src="https://user-images.githubusercontent.com/45772525/52973635-b4025300-338c-11e9-8380-86fdcaacca11.png">

## IE

<img width="1422" alt="screen shot 2019-02-18 at 14 50 49" src="https://user-images.githubusercontent.com/45772525/52973615-9fbe5600-338c-11e9-9bc5-5efd369bd259.png">


## Chrome

<img width="1438" alt="screen shot 2019-02-18 at 14 49 37" src="https://user-images.githubusercontent.com/45772525/52973561-7271a800-338c-11e9-9dc4-4d598c17e1ff.png">

