### PR TITLE
Sidebar full height on IE

### DIFF
--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -50,3 +50,4 @@
 @import 'sections/member_edit';
 @import 'sections/reports';
 @import 'sections/task_order';
+

--- a/styles/components/_global_layout.scss
+++ b/styles/components/_global_layout.scss
@@ -1,3 +1,7 @@
+html, body, #app-root {
+  height: 100%;
+}
+
 #app-root {
   background-color: $color-offwhite;
   display: flex;


### PR DESCRIPTION
Sidebar background does not extend to be 100% height. This PR fixes that issue.

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163867976)

## Screenshot with fix

![screen shot 2019-02-19 at 09 46 49](https://user-images.githubusercontent.com/45772525/53023642-9d5f0900-342b-11e9-9f8b-6c0f45f3b9e3.png)

## Screenshot with fix (background highlighted)

![screen shot 2019-02-19 at 09 48 25](https://user-images.githubusercontent.com/45772525/53023643-9df79f80-342b-11e9-9dfe-158dc754db38.png)

## Screenshot before fix (background highlighted)

![screen shot 2019-02-19 at 09 48 47](https://user-images.githubusercontent.com/45772525/53023644-9df79f80-342b-11e9-89a0-2499d3bc3afc.png)
