### PR TITLE
Manage invitations should be inactive until user has completed TO flow

### DIFF
--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -5,6 +5,7 @@ from flask import g, redirect, render_template, url_for, request as http_request
 from . import portfolios_bp
 from atst.database import db
 from atst.domain.task_orders import TaskOrders
+from atst.domain.exceptions import NotFoundError
 from atst.domain.portfolios import Portfolios
 from atst.domain.authz import Authorization
 from atst.forms.officers import EditTaskOrderOfficersForm
@@ -122,13 +123,7 @@ def task_order_invitations(portfolio_id, task_order_id):
             form=form,
         )
     else:
-        return redirect(
-            url_for(
-                "portfolios.view_task_order",
-                task_order_id=task_order.id,
-                portfolio_id=portfolio.id,
-            )
-        )
+        raise NotFoundError("task_order")
 
 
 @portfolios_bp.route(

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -113,12 +113,22 @@ def task_order_invitations(portfolio_id, task_order_id):
     portfolio = Portfolios.get(g.current_user, portfolio_id)
     task_order = TaskOrders.get(g.current_user, task_order_id)
     form = EditTaskOrderOfficersForm(obj=task_order)
-    return render_template(
-        "portfolios/task_orders/invitations.html",
-        portfolio=portfolio,
-        task_order=task_order,
-        form=form,
-    )
+
+    if TaskOrders.all_sections_complete(task_order):
+        return render_template(
+            "portfolios/task_orders/invitations.html",
+            portfolio=portfolio,
+            task_order=task_order,
+            form=form,
+        )
+    else:
+        return redirect(
+            url_for(
+                "portfolios.view_task_order",
+                task_order_id=task_order.id,
+                portfolio_id=portfolio.id,
+            )
+        )
 
 
 @portfolios_bp.route(

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -203,10 +203,12 @@
         <div class="panel__content">
           <div class="task-order-invitations__heading row">
             <h3>Invitations</h3>
-            <a href="{{ url_for('portfolios.task_order_invitations', portfolio_id=portfolio.id, task_order_id=task_order.id) }}" class="icon-link">
-              <span>manage</span>
-              {{ Icon("edit") }}
-            </a>
+            {% if all_sections_complete %}
+              <a href="{{ url_for('portfolios.task_order_invitations', portfolio_id=portfolio.id, task_order_id=task_order.id) }}" class="icon-link">
+                <span>{{ "common.manage" | translate }}</span>
+                {{ Icon("edit") }}
+              </a>
+            {% endif %}
           </div>
           {{ InvitationStatus('Contracting Officer', task_order.contracting_officer, officer_info=task_order.officer_dictionary('contracting_officer')) }}
           {{ InvitationStatus('Contracting Officer Representative', task_order.contracting_officer_representative, officer_info=task_order.officer_dictionary('contracting_officer_representative')) }}

--- a/tests/routes/portfolios/test_task_orders.py
+++ b/tests/routes/portfolios/test_task_orders.py
@@ -227,14 +227,7 @@ def test_cant_view_task_order_invitations_when_not_complete(client, user_session
             task_order_id=task_order.id,
         )
     )
-    assert (
-        url_for(
-            "portfolios.view_task_order",
-            task_order_id=task_order.id,
-            portfolio_id=portfolio.id,
-        )
-        in response.location
-    )
+    assert response.status_code == 404
 
 
 def test_ko_can_view_ko_review_page(client, user_session):

--- a/tests/routes/portfolios/test_task_orders.py
+++ b/tests/routes/portfolios/test_task_orders.py
@@ -5,6 +5,7 @@ from datetime import timedelta, date
 from atst.domain.roles import Roles
 from atst.domain.task_orders import TaskOrders
 from atst.models.portfolio_role import Status as PortfolioStatus
+from atst.utils.localization import translate
 
 from tests.factories import (
     PortfolioFactory,
@@ -178,6 +179,7 @@ def test_ko_can_view_task_order(client, user_session):
     )
     task_order = TaskOrderFactory.create(portfolio=portfolio, contracting_officer=ko)
     user_session(ko)
+
     response = client.get(
         url_for(
             "portfolios.view_task_order",
@@ -186,9 +188,21 @@ def test_ko_can_view_task_order(client, user_session):
         )
     )
     assert response.status_code == 200
+    assert translate("common.manage") in response.data.decode()
+
+    TaskOrders.update(ko, task_order, clin_01=None)
+    response = client.get(
+        url_for(
+            "portfolios.view_task_order",
+            portfolio_id=portfolio.id,
+            task_order_id=task_order.id,
+        )
+    )
+    assert response.status_code == 200
+    assert translate("common.manage") not in response.data.decode()
 
 
-def test_can_view_task_order_invitations(client, user_session):
+def test_can_view_task_order_invitations_when_complete(client, user_session):
     portfolio = PortfolioFactory.create()
     user_session(portfolio.owner)
     task_order = TaskOrderFactory.create(portfolio=portfolio)
@@ -200,6 +214,27 @@ def test_can_view_task_order_invitations(client, user_session):
         )
     )
     assert response.status_code == 200
+
+
+def test_cant_view_task_order_invitations_when_not_complete(client, user_session):
+    portfolio = PortfolioFactory.create()
+    user_session(portfolio.owner)
+    task_order = TaskOrderFactory.create(portfolio=portfolio, clin_01=None)
+    response = client.get(
+        url_for(
+            "portfolios.task_order_invitations",
+            portfolio_id=portfolio.id,
+            task_order_id=task_order.id,
+        )
+    )
+    assert (
+        url_for(
+            "portfolios.view_task_order",
+            task_order_id=task_order.id,
+            portfolio_id=portfolio.id,
+        )
+        in response.location
+    )
 
 
 def test_ko_can_view_ko_review_page(client, user_session):

--- a/translations.yaml
+++ b/translations.yaml
@@ -20,6 +20,7 @@ base_public:
   title_tag: JEDI Cloud
 common:
   back: Back
+  manage: manage
   save_and_continue: Save & Continue
   sign: Sign
 components:


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163947440)

## Ticket info

### Steps to reproduce
Find an incomplete TO
Navigate to its TO Summary page (Portfolio > Funding > View)
### Expected
The Manage Invitations link should be inactive until the TO is completed and invitations are actually sent.

### Actual
Currently this link is always active