### PR TITLE
Fix issue with selecting component with vue chrome extension

### DIFF
--- a/js/components/date_selector.js
+++ b/js/components/date_selector.js
@@ -1,4 +1,3 @@
-import Vue from 'vue'
 import { getDaysInMonth } from 'date-fns'
 
 var paddedNumber = function(number) {
@@ -9,7 +8,9 @@ var paddedNumber = function(number) {
   }
 }
 
-export default Vue.component('date-selector', {
+export default {
+  name: 'date-selector',
+
   props: ['initialday', 'initialmonth', 'initialyear', 'mindate', 'maxdate'],
 
   data() {
@@ -123,4 +124,4 @@ export default Vue.component('date-selector', {
   render(createElement) {
     return createElement('p', 'Please implement inline-template')
   },
-})
+}

--- a/templates/components/date_picker.html
+++ b/templates/components/date_picker.html
@@ -13,6 +13,7 @@
   initialmonth="{{ field.data.month }}"
   initialday="{{ field.data.day }}"
   initialyear="{{ field.data.year }}"
+  key="{{ field.name }}"
   inline-template>
 
     <fieldset class="usa-input date-picker" v-bind:class="{ 'usa-input--success': isDateValid }">


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164082456)

## Steps to reproduce

1. Go to a page that uses the DateSelector component (ie KO Review)
2. Inspect the Vue components on the page
3. Click on DateSelector

## Expected

Only date selector is highlighted

## Actual

Also highlights other components