### PR TITLE
Fix hover state of disabled link on IE

### DIFF
--- a/styles/elements/_icon_link.scss
+++ b/styles/elements/_icon_link.scss
@@ -67,8 +67,13 @@
 
   &.icon-link--disabled {
     opacity: 0.3;
-    pointer-events: none;
     text-decoration: none;
+    pointer-events: none;
+
+    &:hover {
+      cursor: default;
+      background: $color-white;
+    }
   }
 
   &.icon-link--left {

--- a/styles/elements/_icon_link.scss
+++ b/styles/elements/_icon_link.scss
@@ -72,7 +72,7 @@
 
     &:hover {
       cursor: default;
-      background: $color-white;
+      background: inherit;
     }
   }
 


### PR DESCRIPTION
The `DD 254` link on the task order page was displaying a very faint background on hover when using IE. This PR fixes that.

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163759711)