### PR TITLE
Remove #app-root height 100%

### DIFF
--- a/styles/components/_global_layout.scss
+++ b/styles/components/_global_layout.scss
@@ -1,4 +1,4 @@
-html, body, #app-root {
+html, body {
   height: 100%;
 }
 


### PR DESCRIPTION
The `#app-root { height: 100%; }` breaks display for long pages.

## Before

<img width="1440" alt="screen shot 2019-02-20 at 14 39 12" src="https://user-images.githubusercontent.com/45772525/53119397-636e2f80-351d-11e9-91c7-0d3960801b4e.png">

## After

<img width="1440" alt="screen shot 2019-02-20 at 14 40 31" src="https://user-images.githubusercontent.com/45772525/53119436-800a6780-351d-11e9-800b-58cb94b3fe9d.png">
