### PR TITLE
Fix side scroll issue on Firefox

### DIFF
--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -278,6 +278,8 @@
 }
 
 .portfolio-funding {
+  padding: 2 * $gap;
+
   .panel {
     @include shadow-panel;
   }


### PR DESCRIPTION
## Description
The list of TOs for a portfolio was side scrolling in Firefox. Adding padding to the div that contained all of the content fixed the issue. 

## Pivotal
[https://www.pivotaltracker.com/story/show/163794683](https://www.pivotaltracker.com/story/show/163794683)