### PR TITLE
TO Officers Invite - IE bug in disabled DoD ID fields

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -385,4 +385,10 @@ select {
       box-shadow: none;
     }
   }
+
+  &.usa-input--success {
+    input[disabled] {
+      color: $color-gray-light;
+    }
+  }
 }


### PR DESCRIPTION
## Description
In IE, the text in the disabled DoD ID fields was still black. 
The default styling for disabled inputs was being overridden by the class `usa-input--success`. So I updated it so when an input is both disabled and has that class, the text will be grey. 

## Pivotal
[https://www.pivotaltracker.com/story/show/163463465](https://www.pivotaltracker.com/story/show/163463465)

## Screenshot
<img width="544" alt="screen shot 2019-02-20 at 7 12 56 pm" src="https://user-images.githubusercontent.com/43828539/53134064-91ff0100-3543-11e9-98a3-d155d35f920c.png">
