### PR TITLE
Focus on checkbox/radio in fieldset passes through click event on IE

### DIFF
--- a/templates/components/checkbox_input.html
+++ b/templates/components/checkbox_input.html
@@ -6,7 +6,7 @@
   <checkboxinput name='{{ field.name }}' inline-template key='{{ field.name }}'>
     <div class='usa-input {{ classes }} {% if field.errors %}usa-input--error{% endif %}'>
 
-      <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
+      <fieldset data-ally-disabled="true" v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
           {{ field() }}
           <label for={{field.name}}>

--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -20,7 +20,7 @@
           <span v-show='showValid'>{{ Icon('ok',classes="icon-validation") }}</span>
       {% endset %}
 
-      <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
+      <fieldset data-ally-disabled="true" v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
           <div class="usa-input__title">
             {{ field.label | striptags}}

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -11,7 +11,7 @@
     <div
       v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">
 
-      <fieldset v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
+      <fieldset data-ally-disabled="true" v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
           <div class="usa-input__title{% if not field.description %}-inline{% endif %}">
             {{ field.label | striptags}}

--- a/templates/components/selector.html
+++ b/templates/components/selector.html
@@ -10,7 +10,7 @@
   {% if field.errors %}v-bind:initial-errors='{{ field.errors }}'{% endif %}
   inline-template>
 
-  <fieldset v-bind:class="['selector usa-input', { 'usa-input--error': initialErrors }]">
+  <fieldset data-ally-disabled="true" v-bind:class="['selector usa-input', { 'usa-input--error': initialErrors }]">
     <v-popover v-bind:container='false' ref='popover' v-on:show='onShow'>
       <legend>
         <div class="usa-input__title">{{ field.label | striptags }}</div>


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163990226)

## Steps to Reproduce

1. Start a new TO
2. Complete initial fields
3. Before the entire array of "App Migration" buttons is fully visible on screen, attempt to click the top one (migrating from on-premise data center)

## Actual Behavior/Result

Focus switches to the entire radio button array, but the button that the user thinks that they selected is not yet indicated as selected

## Expected Behavior/Result

The button that the user clicks should be marked as selected

Note: The same thing will occur with "Project Complexity" or "About Your Team" on the same form.

---

## Broken

![broken](https://user-images.githubusercontent.com/45772525/53195447-adb9e400-35e3-11e9-836b-c4f4dc3d07f1.gif)

## Fixed

![fixed](https://user-images.githubusercontent.com/45772525/53195465-b90d0f80-35e3-11e9-810b-ee698d079a2e.gif)
