### PR TITLE
Set debug to false in test config

### DIFF
--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,4 +1,5 @@
 [default]
+DEBUG = false
 PGHOST = postgreshost
 PGDATABASE = atat_test
 REDIS_URI = redis://redishost:6379

--- a/config/test.ini
+++ b/config/test.ini
@@ -1,4 +1,5 @@
 [default]
+DEBUG = false
 ENVIRONMENT = test
 PGDATABASE = atat_test
 CRL_DIRECTORY = tests/fixtures/crl


### PR DESCRIPTION
This PR turns of sqlalchemy echo when running tests by setting `debug` to false in the test configuration. 

With the echoing on, the test output is a tad verbose. [Check out the "run tests" step of this CircleCI job](https://circleci.com/gh/dod-ccpo/atst/5258) -- the full output is 87328 lines and over 25MB!

The output with this change is back to what it was before: https://circleci.com/gh/dod-ccpo/atst/5288.