### PR TITLE
WIP: Use crl archive

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,11 @@ jobs:
             - ./node_modules
           key: node-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
       - run:
+          name: "Add jq for JSON parsing"
+          command: apk update && apk add jq
+      - run:
           name: "Download and unpack CRLs"
-          command: ./script/sync-crls
+          command: ./script/install_crls
       - run:
           name: "Generate build info"
           command: ./script/generate_build_info.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,18 +83,9 @@ jobs:
           paths:
             - ./node_modules
           key: node-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - restore_cache:
-          name: "Load Cache: CRLs"
-          keys:
-            - disa-crls-v2
       - run:
-          name: "Update CRLs"
+          name: "Download and unpack CRLs"
           command: ./script/sync-crls
-      - save_cache:
-          name: "Save Cache: CRLs"
-          paths:
-            - ./crl
-          key: disa-crls-v2-{{ .Branch }}-{{ epoch}}
       - run:
           name: "Generate build info"
           command: ./script/generate_build_info.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,9 @@ jobs:
           name: "Load Cache: Node Modules"
           keys:
             - node-v1-{{ .Branch }}-{{ checksum "yarn.lock" }}
-      - run: ./script/setup
+      - run:
+          name: "Run App Setup script"
+          command: ./script/setup
       - save_cache:
           name: "Save Cache: Pipenv Refrences"
           paths:

--- a/script/install_crls
+++ b/script/install_crls
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# script/install_crls: Fetches and unpacks an archive of all relevant DoD CRL
+#                      files from cloud storage
+
+source "$(dirname "${0}")"/../script/include/global_header.inc.sh
+
+# Get Rackspace API token
+RACKSPACE_TOKEN=$(curl -H 'Content-type: application/json' -XPOST ${RACKSPACE_AUTH_URL} -d "{\"auth\":{\"RAX-KSKEY:apiKeyCredentials\":{\"username\":\"${RACKSPACE_USERNAME}\",\"apiKey\":\"${RACKSPACE_PASSWORD}\"}}}" | jq -r '.access.token.id')
+export RACKSPACE_TOKEN
+
+# Fetch DoD CRL archive
+curl -H 'Content-type: application/json' -H "X-Auth-Token: ${RACKSPACE_TOKEN}" -XGET ${RACKSPACE_STORAGE_URL}/MossoCloudFS_1095493/crls/dod_crls.tar.bz -o ./crl/crls.tar.bz
+
+# Unpack CRL archive
+tar -xjvf ./crl/crls.tar.bz -C ./crl

--- a/script/install_crls
+++ b/script/install_crls
@@ -9,6 +9,9 @@ source "$(dirname "${0}")"/../script/include/global_header.inc.sh
 RACKSPACE_TOKEN=$(curl -H 'Content-type: application/json' -XPOST ${RACKSPACE_AUTH_URL} -d "{\"auth\":{\"RAX-KSKEY:apiKeyCredentials\":{\"username\":\"${RACKSPACE_USERNAME}\",\"apiKey\":\"${RACKSPACE_PASSWORD}\"}}}" | jq -r '.access.token.id')
 export RACKSPACE_TOKEN
 
+# Ensure the ./crl director exists
+mkdir -p ./crl
+
 # Fetch DoD CRL archive
 curl -H 'Content-type: application/json' -H "X-Auth-Token: ${RACKSPACE_TOKEN}" -XGET ${RACKSPACE_STORAGE_URL}/MossoCloudFS_1095493/crls/dod_crls.tar.bz -o ./crl/crls.tar.bz
 


### PR DESCRIPTION
This PR switches the build over to using the Rackspace Cloud Files hosted CRL archive maintained by the crlupdater process.