### PR TITLE
Break KO signing  into two steps

### DIFF
--- a/atst/domain/authz.py
+++ b/atst/domain/authz.py
@@ -37,6 +37,27 @@ class Authorization(object):
         return user.atat_role.name == "ccpo"
 
     @classmethod
+    def is_ko(cls, user, task_order):
+        return user == task_order.contracting_officer
+
+    @classmethod
+    def is_cor(cls, user, task_order):
+        return user == task_order.contracting_officer_representative
+
+    @classmethod
+    def is_so(cls, user, task_order):
+        return user == task_order.security_officer
+
+    @classmethod
+    def check_is_ko_or_cor(cls, user, task_order):
+        if Authorization.is_ko(user, task_order) or Authorization.is_cor(
+            user, task_order
+        ):
+            return True
+        else:
+            raise UnauthorizedError(user, "not KO or COR")
+
+    @classmethod
     def check_is_ko(cls, user, task_order):
         if task_order.contracting_officer != user:
             message = "review task order {}".format(task_order.id)

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -15,6 +15,8 @@ class TaskOrderError(Exception):
 
 
 class TaskOrders(object):
+    INFORMATION_RECORDED_ATTRIBUTES = ["end_date", "loa", "number", "start_date"]
+
     SECTIONS = {
         "app_info": [
             "portfolio_name",
@@ -119,6 +121,10 @@ class TaskOrders(object):
                 return False
 
         return True
+
+    @classmethod
+    def is_signed_by_ko(cls, task_order):
+        return task_order.signer_dod_id is not None
 
     @classmethod
     def mission_owner_sections(cls):

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -15,8 +15,6 @@ class TaskOrderError(Exception):
 
 
 class TaskOrders(object):
-    INFORMATION_RECORDED_ATTRIBUTES = ["end_date", "loa", "number", "start_date"]
-
     SECTIONS = {
         "app_info": [
             "portfolio_name",

--- a/atst/routes/task_orders/signing.py
+++ b/atst/routes/task_orders/signing.py
@@ -14,7 +14,7 @@ def find_unsigned_ko_to(task_order_id):
     task_order = TaskOrders.get(g.current_user, task_order_id)
     Authorization.check_is_ko(g.current_user, task_order)
 
-    if task_order.signer_dod_id is not None:
+    if TaskOrders.is_signed_by_ko(task_order):
         raise NotFoundError("task_order")
 
     return task_order

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -124,27 +124,37 @@
     <div id="next-steps" class="task-order-next-steps">
       <div class="panel">
         <h3 class="task-order-next-steps__panel-head panel__content">{{ "task_orders.view.whats_next" | translate }}</h3>
-        {% call Step(
-          description="task_orders.view.steps.draft" | translate({
-            "contact": officer_name(task_order.creator)
-          })| safe,
-          button_url=url_for("task_orders.new", screen=1, task_order_id=task_order.id),
-          button_text='Edit',
-          complete=to_form_complete) %}
-        {% endcall %}
-        {% set is_so = user == task_order.security_officer %}
-        {{ Step(
-          description="task_orders.view.steps.security" | translate({
-            "security_officer": officer_name(task_order.security_officer)
-          }) | safe,
-          button_url=is_so and url_for("portfolios.so_review", portfolio_id=portfolio.id, task_order_id=task_order.id),
-          button_text=is_so and 'Edit',
-          complete=dd_254_complete) }}
+        {{
+          Step(
+            button_text='Edit',
+            button_url=url_for("task_orders.new", screen=1, task_order_id=task_order.id),
+            complete=to_form_complete,
+            description="task_orders.view.steps.draft" | translate({
+              "contact": officer_name(task_order.creator)
+            })| safe,
+          )
+        }}
+        {{
+          Step(
+            button_text=is_so and ("common.edit" | translate),
+            button_url=is_so and url_for("portfolios.so_review", portfolio_id=portfolio.id, task_order_id=task_order.id),
+            complete=dd_254_complete,
+            description="task_orders.view.steps.security" | translate({
+              "security_officer": officer_name(task_order.security_officer)
+            }) | safe,
+          )
+        }}
         {% call Step(
           description="task_orders.view.steps.record" | translate({
             "contracting_officer": officer_name(task_order.contracting_officer),
             "contracting_officer_representative": officer_name(task_order.contracting_officer_representative)
           }) | safe,
+          button_url=url_for(
+            "portfolios.ko_review",
+            portfolio_id=portfolio.id,
+            task_order_id=task_order.id,
+          ),
+          button_text=(is_cor or is_ko) and ("common.edit" | translate),
           complete=False) %}
           <div class='alert alert--warning'>
             <div class='alert__content'>
@@ -154,14 +164,16 @@
             </div>
           </div>
         {% endcall %}
-        {% set is_ko = user == task_order.contracting_officer %}
-        {{ Step(
-          description="task_orders.view.steps.sign" | translate({
-            "contracting_officer": officer_name(task_order.contracting_officer)
-          }) | safe,
-          button_url=is_ko and url_for("portfolios.ko_review", portfolio_id=portfolio.id, task_order_id=task_order.id),
-          button_text=is_ko and 'Sign',
-          complete=False) }}
+        {{
+          Step(
+            button_text=is_ko and not is_to_signed and ("common.sign" | translate),
+            button_url=is_ko and url_for("task_orders.signature_requested", task_order_id=task_order.id),
+            complete=is_to_signed,
+            description="task_orders.view.steps.sign" | translate({
+              "contracting_officer": officer_name(task_order.contracting_officer)
+            }) | safe,
+          )
+        }}
       </div>
     </div>
     <div class="task-order-sidebar col">

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -167,7 +167,11 @@
         {{
           Step(
             button_text=is_ko and not is_to_signed and ("common.sign" | translate),
-            button_url=is_ko and url_for("task_orders.signature_requested", task_order_id=task_order.id),
+            button_url=is_ko and url_for(
+              "portfolios.ko_review",
+              portfolio_id=portfolio.id,
+              task_order_id=task_order.id,
+            ),
             complete=is_to_signed,
             description="task_orders.view.steps.sign" | translate({
               "contracting_officer": officer_name(task_order.contracting_officer)

--- a/tests/domain/test_authz.py
+++ b/tests/domain/test_authz.py
@@ -1,0 +1,42 @@
+import pytest
+
+from tests.factories import TaskOrderFactory, UserFactory
+from atst.domain.authz import Authorization
+from atst.domain.exceptions import UnauthorizedError
+
+
+@pytest.fixture
+def invalid_user():
+    return UserFactory.create()
+
+
+@pytest.fixture
+def task_order():
+    return TaskOrderFactory.create()
+
+
+def test_is_ko(task_order, invalid_user):
+    assert not Authorization.is_ko(invalid_user, task_order)
+    assert Authorization.is_ko(task_order.contracting_officer, task_order)
+
+
+def test_is_cor(task_order, invalid_user):
+    assert not Authorization.is_cor(invalid_user, task_order)
+    assert Authorization.is_cor(
+        task_order.contracting_officer_representative, task_order
+    )
+
+
+def test_is_so(task_order, invalid_user):
+    assert Authorization.is_so(task_order.security_officer, task_order)
+    assert not Authorization.is_so(invalid_user, task_order)
+
+
+def test_check_is_ko_or_cor(task_order, invalid_user):
+    assert Authorization.check_is_ko_or_cor(
+        task_order.contracting_officer_representative, task_order
+    )
+    assert Authorization.check_is_ko_or_cor(task_order.contracting_officer, task_order)
+
+    with pytest.raises(UnauthorizedError):
+        Authorization.check_is_ko_or_cor(invalid_user, task_order)

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -13,6 +13,17 @@ from tests.factories import (
 )
 
 
+def test_is_signed_by_ko():
+    user = UserFactory.create()
+    task_order = TaskOrderFactory.create(contracting_officer=user)
+
+    assert not TaskOrders.is_signed_by_ko(task_order)
+
+    TaskOrders.update(user, task_order, signer_dod_id=user.dod_id)
+
+    assert TaskOrders.is_signed_by_ko(task_order)
+
+
 def test_section_completion_status():
     dict_keys = [k for k in TaskOrders.SECTIONS.keys()]
     section = dict_keys[0]

--- a/translations.yaml
+++ b/translations.yaml
@@ -20,6 +20,7 @@ base_public:
   title_tag: JEDI Cloud
 common:
   back: Back
+  edit: Edit
   manage: manage
   save_and_continue: Save & Continue
   sign: Sign


### PR DESCRIPTION
## Ticket

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/163991825)

On the TO view page:

> Contracting Officer (Erica Eichner) or Contracting Officer Representative (You) records Task Order information

This should link to the first page of the KO/COR form and either the KO or COR should be able to to it. When successfully finished, it should redirect back to the TO view page.

> Contracting Officer (Erica Eichner) verifies funding to unlock cloud services.

This should also link to the first page of the KO/COR form and only be accessible to the KO. When the first page is done, it should redirect to the second page where the KO can sign. (This is how we have it now.)

The change lies in making the first page of the KO/COR form available to the COR.

---

## Questions

- [ ] Handle complete status for review page or wait until DD-254 is worked out?
