### PR TITLE
Invite Officer From Manage Invitations Page

### DIFF
--- a/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
+++ b/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
@@ -17,11 +17,13 @@ depends_on = None
 
 
 def upgrade():
+    op.alter_column('task_orders', 'cor_invite', type_=sa.Boolean(), server_default=False)
     op.alter_column('task_orders', 'ko_invite', type_=sa.Boolean(), server_default=False)
     op.alter_column('task_orders', 'so_invite', type_=sa.Boolean(), server_default=False)
-    op.alter_column('task_orders', 'cor_invite', type_=sa.Boolean(), server_default=False)
+    op.alter_column('task_orders', 'unlimited_level_of_warrant', type_=sa.Boolean(), server_default=False)
 
 def downgrade():
+    op.alter_column('task_orders', 'cor_invite', server_default=sa.Boolean())
     op.alter_column('task_orders', 'ko_invite', server_default=sa.Boolean())
     op.alter_column('task_orders', 'so_invite', server_default=sa.Boolean())
-    op.alter_column('task_orders', 'cor_invite', server_default=sa.Boolean())
+    op.alter_column('task_orders', 'unlimited_level_of_warrant', server_default=sa.Boolean())

--- a/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
+++ b/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
@@ -23,7 +23,7 @@ def upgrade():
     op.alter_column('task_orders', 'unlimited_level_of_warrant', type_=sa.Boolean(), server_default=False)
 
 def downgrade():
-    op.alter_column('task_orders', 'cor_invite', server_default=sa.Boolean())
-    op.alter_column('task_orders', 'ko_invite', server_default=sa.Boolean())
-    op.alter_column('task_orders', 'so_invite', server_default=sa.Boolean())
-    op.alter_column('task_orders', 'unlimited_level_of_warrant', server_default=sa.Boolean())
+    op.alter_column('task_orders', 'cor_invite', type_=sa.Boolean(), server_default=None)
+    op.alter_column('task_orders', 'ko_invite', type_=sa.Boolean(), server_default=None)
+    op.alter_column('task_orders', 'so_invite', type_=sa.Boolean(), server_default=None)
+    op.alter_column('task_orders', 'unlimited_level_of_warrant', type_=sa.Boolean(), server_default=None)

--- a/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
+++ b/alembic/versions/6512aa8d4641_default_boolean_fields_to_false.py
@@ -1,0 +1,27 @@
+"""Default Boolean fields to False
+
+Revision ID: 6512aa8d4641
+Revises: ec1ba2363191
+Create Date: 2019-02-27 13:22:03.863516
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '6512aa8d4641'
+down_revision = 'ec1ba2363191'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column('task_orders', 'ko_invite', type_=sa.Boolean(), server_default=False)
+    op.alter_column('task_orders', 'so_invite', type_=sa.Boolean(), server_default=False)
+    op.alter_column('task_orders', 'cor_invite', type_=sa.Boolean(), server_default=False)
+
+def downgrade():
+    op.alter_column('task_orders', 'ko_invite', server_default=sa.Boolean())
+    op.alter_column('task_orders', 'so_invite', server_default=sa.Boolean())
+    op.alter_column('task_orders', 'cor_invite', server_default=sa.Boolean())

--- a/atst/forms/officers.py
+++ b/atst/forms/officers.py
@@ -35,6 +35,7 @@ class EditTaskOrderOfficersForm(CacheableForm):
         "email",
         "phone_number",
         "dod_id",
+        "invite",
     ]
 
     def process(self, formdata=None, obj=None, data=None, **kwargs):

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -74,19 +74,19 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     ko_email = Column(String)  # Email
     ko_phone_number = Column(String)  # Phone Number
     ko_dod_id = Column(String)  # DOD ID
-    ko_invite = Column(Boolean)
+    ko_invite = Column(Boolean, default=False)
     cor_first_name = Column(String)  # First Name
     cor_last_name = Column(String)  # Last Name
     cor_email = Column(String)  # Email
     cor_phone_number = Column(String)  # Phone Number
     cor_dod_id = Column(String)  # DOD ID
-    cor_invite = Column(Boolean)
+    cor_invite = Column(Boolean, default=False)
     so_first_name = Column(String)  # First Name
     so_last_name = Column(String)  # Last Name
     so_email = Column(String)  # Email
     so_phone_number = Column(String)  # Phone Number
     so_dod_id = Column(String)  # DOD ID
-    so_invite = Column(Boolean)
+    so_invite = Column(Boolean, default=False)
     pdf_attachment_id = Column(ForeignKey("attachments.id"))
     _pdf = relationship("Attachment", foreign_keys=[pdf_attachment_id])
     number = Column(String, unique=True)  # Task Order Number
@@ -95,7 +95,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     signer_dod_id = Column(String)
     signed_at = Column(DateTime)
     level_of_warrant = Column(Numeric(scale=2))
-    unlimited_level_of_warrant = Column(Boolean)
+    unlimited_level_of_warrant = Column(Boolean, default=False)
 
     @hybrid_property
     def csp_estimate(self):

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -12,6 +12,7 @@ from atst.forms.officers import EditTaskOrderOfficersForm
 from atst.models.task_order import Status as TaskOrderStatus
 from atst.forms.ko_review import KOReviewForm
 from atst.forms.dd_254 import DD254Form
+from atst.services.invitation import update_officer_invitations
 
 
 @portfolios_bp.route("/portfolios/<portfolio_id>/task_orders")
@@ -157,6 +158,7 @@ def edit_task_order_invitations(portfolio_id, task_order_id):
         form.populate_obj(task_order)
         db.session.add(task_order)
         db.session.commit()
+        update_officer_invitations(g.current_user, task_order)
 
         return redirect(
             url_for(

--- a/atst/routes/task_orders/invite.py
+++ b/atst/routes/task_orders/invite.py
@@ -3,49 +3,7 @@ from flask import redirect, url_for, g
 from . import task_orders_bp
 from atst.domain.task_orders import TaskOrders
 from atst.utils.flash import formatted_flash as flash
-from atst.domain.portfolio_roles import PortfolioRoles
-from atst.services.invitation import Invitation as InvitationService
-
-
-OFFICER_INVITATIONS = [
-    {
-        "field": "ko_invite",
-        "role": "contracting_officer",
-        "subject": "Review a task order",
-        "template": "emails/invitation.txt",
-    },
-    {
-        "field": "cor_invite",
-        "role": "contracting_officer_representative",
-        "subject": "Help with a task order",
-        "template": "emails/invitation.txt",
-    },
-    {
-        "field": "so_invite",
-        "role": "security_officer",
-        "subject": "Review security for a task order",
-        "template": "emails/invitation.txt",
-    },
-]
-
-
-def update_officer_invitations(user, task_order):
-    for officer_type in OFFICER_INVITATIONS:
-        field = officer_type["field"]
-        if getattr(task_order, field) and not getattr(task_order, officer_type["role"]):
-            officer_data = task_order.officer_dictionary(officer_type["role"])
-            officer = TaskOrders.add_officer(
-                user, task_order, officer_type["role"], officer_data
-            )
-            pf_officer_member = PortfolioRoles.get(task_order.portfolio.id, officer.id)
-            invite_service = InvitationService(
-                user,
-                pf_officer_member,
-                officer_data["email"],
-                subject=officer_type["subject"],
-                email_template=officer_type["template"],
-            )
-            invite_service.invite()
+from atst.services.invitation import update_officer_invitations
 
 
 @task_orders_bp.route("/task_orders/invite/<task_order_id>", methods=["POST"])

--- a/atst/services/invitation.py
+++ b/atst/services/invitation.py
@@ -2,6 +2,48 @@ from flask import render_template
 
 from atst.domain.invitations import Invitations
 from atst.queue import queue
+from atst.domain.task_orders import TaskOrders
+from atst.domain.portfolio_roles import PortfolioRoles
+
+OFFICER_INVITATIONS = [
+    {
+        "field": "ko_invite",
+        "role": "contracting_officer",
+        "subject": "Review a task order",
+        "template": "emails/invitation.txt",
+    },
+    {
+        "field": "cor_invite",
+        "role": "contracting_officer_representative",
+        "subject": "Help with a task order",
+        "template": "emails/invitation.txt",
+    },
+    {
+        "field": "so_invite",
+        "role": "security_officer",
+        "subject": "Review security for a task order",
+        "template": "emails/invitation.txt",
+    },
+]
+
+
+def update_officer_invitations(user, task_order):
+    for officer_type in OFFICER_INVITATIONS:
+        field = officer_type["field"]
+        if getattr(task_order, field) and not getattr(task_order, officer_type["role"]):
+            officer_data = task_order.officer_dictionary(officer_type["role"])
+            officer = TaskOrders.add_officer(
+                user, task_order, officer_type["role"], officer_data
+            )
+            pf_officer_member = PortfolioRoles.get(task_order.portfolio.id, officer.id)
+            invite_service = Invitation(
+                user,
+                pf_officer_member,
+                officer_data["email"],
+                subject=officer_type["subject"],
+                email_template=officer_type["template"],
+            )
+            invite_service.invite()
 
 
 class Invitation:


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164176343)

## Acceptance Criteria

```
Scenario: An MO invites a KO, SO, or COR from the "manage invitations" page
Given that I have an existing TO and have completed the TO form
Given that I did not invite one of the officers yet (KO, SO, COR)
When I edit the officer's information, click "update", and save
Then that officer should be invited
```