### PR TITLE
Bug fix for $0 clin values

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -97,7 +97,7 @@ class TaskOrders(object):
             failed = []
 
             for attr in TaskOrders.SECTIONS[section]:
-                if getattr(task_order, attr):
+                if getattr(task_order, attr) is not None:
                     passed.append(attr)
                 else:
                     failed.append(attr)


### PR DESCRIPTION
## Description
This fixes a bug that showed the Funding page as incomplete if any of the CLIN fields had $0 values. 

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163771639