### PR TITLE
Portfolio Name and Defense Component read only

### DIFF
--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -27,25 +27,10 @@ from .data import (
 from atst.utils.localization import translate
 
 
-class AppInfoForm(BaseForm):
-    portfolio_name = StringField(
-        translate("forms.task_order.portfolio_name_label"),
-        description=translate("forms.task_order.portfolio_name_description"),
-        validators=[
-            Required(),
-            Length(
-                min=4,
-                max=100,
-                message=translate("forms.portfolio.name_length_validation_message"),
-            ),
-        ],
-    )
+class AppInfoWithExistingPortfolioForm(BaseForm):
     scope = TextAreaField(
         translate("forms.task_order.scope_label"),
         description=translate("forms.task_order.scope_description"),
-    )
-    defense_component = SelectField(
-        translate("forms.task_order.defense_component_label"), choices=SERVICE_BRANCHES
     )
     app_migration = RadioField(
         translate("forms.task_order.app_migration.label"),
@@ -85,6 +70,24 @@ class AppInfoForm(BaseForm):
         choices=TEAM_EXPERIENCE,
         default="",
         validators=[Optional()],
+    )
+
+
+class AppInfoForm(AppInfoWithExistingPortfolioForm):
+    portfolio_name = StringField(
+        translate("forms.task_order.portfolio_name_label"),
+        description=translate("forms.task_order.portfolio_name_description"),
+        validators=[
+            Required(),
+            Length(
+                min=4,
+                max=100,
+                message=translate("forms.portfolio.name_length_validation_message"),
+            ),
+        ],
+    )
+    defense_component = SelectField(
+        translate("forms.task_order.defense_component_label"), choices=SERVICE_BRANCHES
     )
 
 

--- a/atst/models/portfolio.py
+++ b/atst/models/portfolio.py
@@ -37,6 +37,10 @@ class Portfolio(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
         return len(self.members)
 
     @property
+    def num_task_orders(self):
+        return len(self.task_orders)
+
+    @property
     def members(self):
         return (
             db.session.query(PortfolioRole)

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -97,6 +97,11 @@ class ShowTaskOrderWorkflow:
         else:
             self._form = self._section[form_type]()
 
+        if self.pf_attributes_read_only() and self.screen == 1:
+            self._form = task_order_form.AppInfoWithExistingPortfolioForm(
+                obj=self.task_order
+            )
+
         return self._form
 
     @form.setter
@@ -238,16 +243,12 @@ def new(screen, task_order_id=None, portfolio_id=None):
         "complete": workflow.is_complete,
     }
 
-    if workflow.pf_attributes_read_only():
-        template_args["portfolio"] = workflow.portfolio
-        if screen == 1:
-            workflow.form = task_order_form.AppInfoWithExistingPortfolioForm(
-                obj=workflow.task_order
-            )
-
     if task_order_id and screen is 4:
         if not TaskOrders.all_sections_complete(workflow.task_order):
             flash("task_order_draft")
+
+    if workflow.pf_attributes_read_only():
+        template_args["portfolio"] = workflow.portfolio
 
     url_args = {"screen": screen}
     if task_order_id:

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -120,14 +120,14 @@ class ShowTaskOrderWorkflow:
         else:
             return False
 
-    def can_edit_pf_attributes(self, portfolio_id=None):
+    def pf_attributes_read_only(self, portfolio_id=None):
         if self.task_order:
             if self.task_order.portfolio.num_task_orders > 1:
-                return False
+                return True
         elif portfolio_id:
             if self.get_portfolio(portfolio_id).num_task_orders > 0:
-                return False
-        return True
+                return True
+        return False
 
     def get_portfolio(self, portfolio_id=None):
         if self.task_order:
@@ -155,7 +155,7 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
 
     @property
     def form(self):
-        if not self.can_edit_pf_attributes(self.portfolio_id) and self.screen == 1:
+        if self.pf_attributes_read_only(self.portfolio_id) and self.screen == 1:
             return task_order_form.AppInfoWithExistingPortfolioForm(self.form_data)
         return self._form
 
@@ -235,7 +235,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
         "complete": workflow.is_complete,
     }
 
-    if not workflow.can_edit_pf_attributes(portfolio_id):
+    if workflow.pf_attributes_read_only(portfolio_id):
         template_args["portfolio"] = workflow.get_portfolio(portfolio_id=portfolio_id)
         if screen == 1:
             workflow.form = task_order_form.AppInfoWithExistingPortfolioForm(

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -63,6 +63,12 @@ class ShowTaskOrderWorkflow:
         return self._task_order
 
     @property
+    def portfolio(self):
+        if self.task_order:
+            return self.task_order.portfolio
+        return Portfolios.get(self.user, self.portfolio_id)
+
+    @property
     def form(self):
         form_type = (
             "unclassified_form"
@@ -128,11 +134,6 @@ class ShowTaskOrderWorkflow:
         elif self.portfolio_id:
             return True
         return False
-
-    def get_portfolio(self):
-        if self.task_order:
-            return self.task_order.portfolio
-        return Portfolios.get(self.user, self.portfolio_id)
 
 
 class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
@@ -238,7 +239,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
     }
 
     if workflow.pf_attributes_read_only():
-        template_args["portfolio"] = workflow.get_portfolio()
+        template_args["portfolio"] = workflow.portfolio
         if screen == 1:
             workflow.form = task_order_form.AppInfoWithExistingPortfolioForm(
                 obj=workflow.task_order

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -126,8 +126,7 @@ class ShowTaskOrderWorkflow:
             if self.task_order.portfolio.num_task_orders > 1:
                 return True
         elif self.portfolio_id:
-            if self.get_portfolio().num_task_orders > 0:
-                return True
+            return True
         return False
 
     def get_portfolio(self):

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -246,8 +246,7 @@ def new(screen, task_order_id=None, portfolio_id=None):
             )
 
     if task_order_id and screen is 4:
-        task_order = TaskOrders.get(g.current_user, task_order_id)
-        if not TaskOrders.all_sections_complete(task_order):
+        if not TaskOrders.all_sections_complete(workflow.task_order):
             flash("task_order_draft")
 
     url_args = {"screen": screen}

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -237,6 +237,11 @@ def new(screen, task_order_id=None, portfolio_id=None):
                 task_order_id=task_order_id,
             )
             url_args["next"] = template_args["next"]
+    elif http_request.args.get("new_to_on_portfolio"):
+        portfolio = Portfolios.get(g.current_user, portfolio_id)
+        template_args["portfolio_name"] = portfolio.name
+        template_args["defense_component"] = portfolio.defense_component
+        template_args["new_to_on_portfolio"] = True
 
     template_args["action_url"] = url_for("task_orders.update", **url_args)
 

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -92,6 +92,10 @@ class ShowTaskOrderWorkflow:
 
         return self._form
 
+    @form.setter
+    def form(self, value):
+        self._form = value
+
     @property
     def template(self):
         return self._section["template"]
@@ -137,6 +141,8 @@ class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
 
     @property
     def form(self):
+        if self.screen == 1 and self.portfolio_id:
+            return task_order_form.AppInfoWithExistingPortfolioForm()
         return self._form
 
     @property
@@ -222,6 +228,8 @@ def new(screen, task_order_id=None, portfolio_id=None):
 
     if portfolio_id:
         template_args["portfolio"] = Portfolios.get(g.current_user, portfolio_id)
+        if screen == 1:
+            workflow.form = task_order_form.AppInfoWithExistingPortfolioForm()
 
     url_args = {"screen": screen}
     if task_order_id:

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -120,6 +120,23 @@ class ShowTaskOrderWorkflow:
         else:
             return False
 
+    def can_edit_pf_attributes(self, portfolio_id=None):
+        if self.task_order:
+            if (
+                self.task_order.portfolio.num_task_orders > 1
+                or not portfolio_id is None
+            ):
+                return False
+        elif portfolio_id:
+            if self.get_portfolio(portfolio_id).num_task_orders > 0:
+                return False
+        return True
+
+    def get_portfolio(self, portfolio_id=None):
+        if self.task_order:
+            return self.task_order.portfolio
+        return Portfolios.get(self.user, portfolio_id)
+
 
 class UpdateTaskOrderWorkflow(ShowTaskOrderWorkflow):
     def __init__(
@@ -220,6 +237,9 @@ def new(screen, task_order_id=None, portfolio_id=None):
         "form": workflow.form,
         "complete": workflow.is_complete,
     }
+
+    if not workflow.can_edit_pf_attributes(portfolio_id):
+        template_args["portfolio"] = workflow.get_portfolio(portfolio_id=portfolio_id)
 
     if task_order_id and screen is 4:
         task_order = TaskOrders.get(g.current_user, task_order_id)

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -93,7 +93,7 @@
 <div class="portfolio-funding">
 
   <div class='portfolio-funding__header row'>
-    <a href="{{ url_for("task_orders.new", screen=1, portfolio_id=portfolio.id, new_to_on_portfolio=True) }}" class="usa-button">Start a New Task Order</a>
+    <a href="{{ url_for("task_orders.new", screen=1, portfolio_id=portfolio.id) }}" class="usa-button">Start a New Task Order</a>
   </div>
 
   {% for task_order in pending_task_orders %}

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -93,7 +93,7 @@
 <div class="portfolio-funding">
 
   <div class='portfolio-funding__header row'>
-    <a href="{{ url_for("task_orders.new", screen=1, portfolio_id=portfolio.id) }}" class="usa-button">Start a New Task Order</a>
+    <a href="{{ url_for("task_orders.new", screen=1, portfolio_id=portfolio.id, new_to_on_portfolio=True) }}" class="usa-button">Start a New Task Order</a>
   </div>
 
   {% for task_order in pending_task_orders %}

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -20,9 +20,9 @@
     {{ ReviewField(heading="forms.portfolio.name_label" | translate, field=portfolio.name) }}
 {% else %}
     {{ TextInput(form.portfolio_name, placeholder="The name of your office or organization", validation="portfolioName") }}
-    {{ TextInput(form.scope, paragraph=True) }}
-    <p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
 {% endif %}
+{{ TextInput(form.scope, paragraph=True) }}
+<p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
 
 <div class="subheading--black">
     {% if portfolio %}

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -16,8 +16,8 @@
 <!-- App Info Section -->
 <h3 class="task-order-form__heading subheading">{{ "task_orders.new.app_info.basic_info_title"| translate }}</h3>
 
-{% if new_to_on_portfolio %}
-    {{ ReviewField(heading="forms.portfolio.name_label" | translate, field=portfolio_name) }}
+{% if portfolio %}
+    {{ ReviewField(heading="forms.portfolio.name_label" | translate, field=portfolio.name) }}
 {% else %}
     {{ TextInput(form.portfolio_name, placeholder="The name of your office or organization", validation="portfolioName") }}
     {{ TextInput(form.scope, paragraph=True) }}
@@ -25,8 +25,8 @@
 {% endif %}
 
 <div class="subheading--black">
-    {% if new_to_on_portfolio %}
-        {{ ReviewField(heading="forms.task_order.defense_component_label" | translate, field=defense_component) }}
+    {% if portfolio %}
+        {{ ReviewField(heading="forms.task_order.defense_component_label" | translate, field=portfolio.defense_component) }}
     {% else %}
         {{ OptionsInput(form.defense_component) }}
     {% endif %}

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -4,6 +4,7 @@
 {% from "components/options_input.html" import OptionsInput %}
 {% from "components/date_input.html" import DateInput %}
 {% from "components/multi_checkbox_input.html" import MultiCheckboxInput %}
+{% from "components/review_field.html" import ReviewField %}
 
 {% block heading %}
   {{ "task_orders.new.app_info.section_title"| translate }}
@@ -14,11 +15,17 @@
 
 <!-- App Info Section -->
 <h3 class="task-order-form__heading subheading">{{ "task_orders.new.app_info.basic_info_title"| translate }}</h3>
-{{ TextInput(form.portfolio_name, placeholder="The name of your office or organization", validation="portfolioName") }}
-{{ TextInput(form.scope, paragraph=True) }}
-<p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
+
+{% if new_to_on_portfolio %}
+    {{ ReviewField(heading="forms.portfolio.name_label" | translate, field=portfolio_name) }}
+{% else %}
+    {{ TextInput(form.portfolio_name, placeholder="The name of your office or organization", validation="portfolioName") }}
+    {{ TextInput(form.scope, paragraph=True) }}
+    <p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
+{% endif %}
+
 <div class="subheading--black">
-  {{ OptionsInput(form.defense_component) }}
+    {{ ReviewField(heading="forms.task_order.defense_component_label" | translate, field=defense_component) if new_to_on_portfolio else OptionsInput(form.defense_component) }}
 </div>
 
 <hr>

--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -25,7 +25,11 @@
 {% endif %}
 
 <div class="subheading--black">
-    {{ ReviewField(heading="forms.task_order.defense_component_label" | translate, field=defense_component) if new_to_on_portfolio else OptionsInput(form.defense_component) }}
+    {% if new_to_on_portfolio %}
+        {{ ReviewField(heading="forms.task_order.defense_component_label" | translate, field=defense_component) }}
+    {% else %}
+        {{ OptionsInput(form.defense_component) }}
+    {% endif %}
 </div>
 
 <hr>

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -48,10 +48,13 @@ def test_new_to_can_edit_pf_attributes_screen_1():
     assert workflow.can_edit_pf_attributes(portfolio.id)
 
 
-def test_new_to_can_edit_pf_attributes_on_return_to_screen_1():
+def test_new_pf_can_edit_pf_attributes_on_back_navigation():
     portfolio = PortfolioFactory.create()
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
-    assert workflow.can_edit_pf_attributes()
+    pf_task_order = TaskOrderFactory(portfolio=portfolio)
+    pf_workflow = ShowTaskOrderWorkflow(
+        user=pf_task_order.creator, task_order_id=pf_task_order.id
+    )
+    assert pf_workflow.can_edit_pf_attributes()
 
 
 def test_to_on_pf_cannot_edit_pf_attributes():
@@ -60,10 +63,7 @@ def test_to_on_pf_cannot_edit_pf_attributes():
 
     workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
     assert portfolio.num_task_orders == 1
-    # case: TO is created from am existing portfolio
     assert not workflow.can_edit_pf_attributes(portfolio.id)
-    # case: Portfolio is being created and user navigates back to app_info screen
-    assert workflow.can_edit_pf_attributes()
 
     second_task_order = TaskOrderFactory(portfolio=portfolio)
     workflow = ShowTaskOrderWorkflow(
@@ -71,6 +71,7 @@ def test_to_on_pf_cannot_edit_pf_attributes():
     )
     assert portfolio.num_task_orders > 1
     assert not workflow.can_edit_pf_attributes()
+
 
 def test_get_portfolio_when_task_order_exists():
     portfolio = PortfolioFactory.create()

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -65,7 +65,7 @@ def serialize_dates(data):
 def test_new_to_can_edit_pf_attributes_screen_1():
     portfolio = PortfolioFactory.create()
     workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
-    assert not workflow.pf_attributes_read_only()
+    assert not workflow.pf_attributes_read_only
 
 
 def test_new_pf_can_edit_pf_attributes_on_back_navigation():
@@ -74,7 +74,7 @@ def test_new_pf_can_edit_pf_attributes_on_back_navigation():
     pf_workflow = ShowTaskOrderWorkflow(
         user=pf_task_order.creator, task_order_id=pf_task_order.id
     )
-    assert not pf_workflow.pf_attributes_read_only()
+    assert not pf_workflow.pf_attributes_read_only
 
 
 def test_to_on_pf_cannot_edit_pf_attributes():
@@ -83,14 +83,14 @@ def test_to_on_pf_cannot_edit_pf_attributes():
 
     workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
     assert portfolio.num_task_orders == 1
-    assert workflow.pf_attributes_read_only()
+    assert workflow.pf_attributes_read_only
 
     second_task_order = TaskOrderFactory(portfolio=portfolio)
     second_workflow = ShowTaskOrderWorkflow(
         user=portfolio.owner, task_order_id=second_task_order.id
     )
     assert portfolio.num_task_orders > 1
-    assert second_workflow.pf_attributes_read_only()
+    assert second_workflow.pf_attributes_read_only
 
 
 # TODO: this test will need to be more complicated when we add validation to

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -44,7 +44,7 @@ def serialize_dates(data):
 
 def test_new_to_can_edit_pf_attributes_screen_1():
     portfolio = PortfolioFactory.create()
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
     assert not workflow.pf_attributes_read_only()
 
 

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -44,8 +44,8 @@ def serialize_dates(data):
 
 def test_new_to_can_edit_pf_attributes_screen_1():
     portfolio = PortfolioFactory.create()
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
-    assert not workflow.pf_attributes_read_only(portfolio.id)
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
+    assert not workflow.pf_attributes_read_only()
 
 
 def test_new_pf_can_edit_pf_attributes_on_back_navigation():
@@ -61,9 +61,9 @@ def test_to_on_pf_cannot_edit_pf_attributes():
     portfolio = PortfolioFactory.create()
     pf_task_order = TaskOrderFactory(portfolio=portfolio)
 
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
     assert portfolio.num_task_orders == 1
-    assert workflow.pf_attributes_read_only(portfolio.id)
+    assert workflow.pf_attributes_read_only()
 
     second_task_order = TaskOrderFactory(portfolio=portfolio)
     second_workflow = ShowTaskOrderWorkflow(
@@ -87,8 +87,8 @@ def test_get_portfolio_when_task_order_exists():
 def test_get_portfolio_with_portfolio_id():
     user = UserFactory.create()
     portfolio = PortfolioFactory.create(owner=user)
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
-    assert portfolio == workflow.get_portfolio(portfolio_id=portfolio.id)
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
+    assert portfolio == workflow.get_portfolio()
 
 
 # TODO: this test will need to be more complicated when we add validation to

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -42,6 +42,54 @@ def serialize_dates(data):
     return data
 
 
+def test_new_to_can_edit_pf_attributes_screen_1():
+    portfolio = PortfolioFactory.create()
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
+    assert workflow.can_edit_pf_attributes(portfolio.id)
+
+
+def test_new_to_can_edit_pf_attributes_on_return_to_screen_1():
+    portfolio = PortfolioFactory.create()
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
+    assert workflow.can_edit_pf_attributes()
+
+
+def test_to_on_pf_cannot_edit_pf_attributes():
+    portfolio = PortfolioFactory.create()
+    pf_task_order = TaskOrderFactory(portfolio=portfolio)
+
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
+    assert portfolio.num_task_orders == 1
+    # case: TO is created from am existing portfolio
+    assert not workflow.can_edit_pf_attributes(portfolio.id)
+    # case: Portfolio is being created and user navigates back to app_info screen
+    assert workflow.can_edit_pf_attributes()
+
+    second_task_order = TaskOrderFactory(portfolio=portfolio)
+    workflow = ShowTaskOrderWorkflow(
+        user=second_task_order.creator, task_order_id=second_task_order.id
+    )
+    assert portfolio.num_task_orders > 1
+    assert not workflow.can_edit_pf_attributes()
+
+def test_get_portfolio_when_task_order_exists():
+    portfolio = PortfolioFactory.create()
+    task_order = TaskOrderFactory(portfolio=portfolio)
+    assert portfolio.num_task_orders > 0
+
+    workflow = ShowTaskOrderWorkflow(
+        user=task_order.creator, task_order_id=task_order.id
+    )
+    assert portfolio == workflow.get_portfolio()
+
+
+def test_get_portfolio_with_portfolio_id():
+    user = UserFactory.create()
+    portfolio = PortfolioFactory.create(owner=user)
+    workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
+    assert portfolio == workflow.get_portfolio(portfolio_id=portfolio.id)
+
+
 # TODO: this test will need to be more complicated when we add validation to
 # the forms
 def test_create_new_task_order(client, user_session, pdf_upload):

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -91,10 +91,8 @@ def test_create_new_task_order_for_portfolio(client, user_session):
 
     task_order_data = TaskOrderFactory.dictionary()
     app_info_data = slice_data_for_section(task_order_data, "app_info")
-    portfolio_name = "This is ignored for now"
-    app_info_data["portfolio_name"] = portfolio_name
-    defense_component = "Defense Health Agency"  # this is also ignored
-    app_info_data["defense_component"] = defense_component
+    app_info_data["portfolio_name"] = portfolio.name
+    app_info_data["defense_component"] = portfolio.defense_component
 
     response = client.post(
         url_for("task_orders.update", screen=1, portfolio_id=portfolio.id),
@@ -105,6 +103,8 @@ def test_create_new_task_order_for_portfolio(client, user_session):
 
     created_task_order_id = response.headers["Location"].split("/")[-1]
     created_task_order = TaskOrders.get(creator, created_task_order_id)
+    assert created_task_order.portfolio_name == portfolio.name
+    assert created_task_order.defense_component == portfolio.defense_component
     assert created_task_order.portfolio == portfolio
 
 

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -45,7 +45,7 @@ def serialize_dates(data):
 def test_new_to_can_edit_pf_attributes_screen_1():
     portfolio = PortfolioFactory.create()
     workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
-    assert workflow.can_edit_pf_attributes(portfolio.id)
+    assert not workflow.pf_attributes_read_only(portfolio.id)
 
 
 def test_new_pf_can_edit_pf_attributes_on_back_navigation():
@@ -54,7 +54,7 @@ def test_new_pf_can_edit_pf_attributes_on_back_navigation():
     pf_workflow = ShowTaskOrderWorkflow(
         user=pf_task_order.creator, task_order_id=pf_task_order.id
     )
-    assert pf_workflow.can_edit_pf_attributes()
+    assert not pf_workflow.pf_attributes_read_only()
 
 
 def test_to_on_pf_cannot_edit_pf_attributes():
@@ -63,14 +63,14 @@ def test_to_on_pf_cannot_edit_pf_attributes():
 
     workflow = ShowTaskOrderWorkflow(user=portfolio.owner)
     assert portfolio.num_task_orders == 1
-    assert not workflow.can_edit_pf_attributes(portfolio.id)
+    assert workflow.pf_attributes_read_only(portfolio.id)
 
     second_task_order = TaskOrderFactory(portfolio=portfolio)
-    workflow = ShowTaskOrderWorkflow(
-        user=second_task_order.creator, task_order_id=second_task_order.id
+    second_workflow = ShowTaskOrderWorkflow(
+        user=portfolio.owner, task_order_id=second_task_order.id
     )
     assert portfolio.num_task_orders > 1
-    assert not workflow.can_edit_pf_attributes()
+    assert second_workflow.pf_attributes_read_only()
 
 
 def test_get_portfolio_when_task_order_exists():

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -66,7 +66,6 @@ def test_create_new_task_order(client, user_session, pdf_upload):
     created_task_order = TaskOrders.get(creator, created_task_order_id)
     assert created_task_order.portfolio is not None
     assert created_task_order.portfolio.name == portfolio_name
-    assert created_task_order.portfolio is not None
     assert created_task_order.portfolio.defense_component == defense_component
 
     funding_data = slice_data_for_section(task_order_data, "funding")

--- a/tests/routes/task_orders/test_new_task_order.py
+++ b/tests/routes/task_orders/test_new_task_order.py
@@ -9,6 +9,26 @@ from atst.utils.localization import translate
 from tests.factories import UserFactory, TaskOrderFactory, PortfolioFactory
 
 
+class TestShowTaskOrderWorkflow:
+    def test_portfolio_when_task_order_exists(self):
+        portfolio = PortfolioFactory.create()
+        task_order = TaskOrderFactory(portfolio=portfolio)
+        assert portfolio.num_task_orders > 0
+
+        workflow = ShowTaskOrderWorkflow(
+            user=task_order.creator, task_order_id=task_order.id
+        )
+        assert portfolio == workflow.portfolio
+
+    def test_portfolio_with_portfolio_id(self):
+        user = UserFactory.create()
+        portfolio = PortfolioFactory.create(owner=user)
+        workflow = ShowTaskOrderWorkflow(
+            user=portfolio.owner, portfolio_id=portfolio.id
+        )
+        assert portfolio == workflow.portfolio
+
+
 def test_new_task_order(client, user_session):
     creator = UserFactory.create()
     user_session()
@@ -71,24 +91,6 @@ def test_to_on_pf_cannot_edit_pf_attributes():
     )
     assert portfolio.num_task_orders > 1
     assert second_workflow.pf_attributes_read_only()
-
-
-def test_get_portfolio_when_task_order_exists():
-    portfolio = PortfolioFactory.create()
-    task_order = TaskOrderFactory(portfolio=portfolio)
-    assert portfolio.num_task_orders > 0
-
-    workflow = ShowTaskOrderWorkflow(
-        user=task_order.creator, task_order_id=task_order.id
-    )
-    assert portfolio == workflow.get_portfolio()
-
-
-def test_get_portfolio_with_portfolio_id():
-    user = UserFactory.create()
-    portfolio = PortfolioFactory.create(owner=user)
-    workflow = ShowTaskOrderWorkflow(user=portfolio.owner, portfolio_id=portfolio.id)
-    assert portfolio == workflow.get_portfolio()
 
 
 # TODO: this test will need to be more complicated when we add validation to


### PR DESCRIPTION
## Description
When a new TO is started from an existing portfolio, the portfolio name and defense component are inherited from the portfolio and are read only on the form.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/163953148

## Screenshots
![screen shot 2019-02-28 at 11 19 36 am](https://user-images.githubusercontent.com/42577527/53580996-c168cb80-3b4a-11e9-8610-896539f30b43.png)
