### PR TITLE
Check if form is complete before showing the TO Review page

### DIFF
--- a/atst/domain/exceptions.py
+++ b/atst/domain/exceptions.py
@@ -34,3 +34,12 @@ class UnauthenticatedError(Exception):
 
 class UploadError(Exception):
     pass
+
+
+class NoAccessError(Exception):
+    def __init__(self, resource_name):
+        self.resource_name = resource_name
+
+    @property
+    def message(self):
+        return "Route for {} cannot be accessed".format(self.resource_name)

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -27,6 +27,7 @@ def make_error_pages(app):
     @app.errorhandler(exceptions.NotFoundError)
     @app.errorhandler(exceptions.UnauthorizedError)
     @app.errorhandler(PortfolioError)
+    @app.errorhandler(exceptions.NoAccessError)
     # pylint: disable=unused-variable
     def not_found(e):
         return handle_error(e)

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -5,7 +5,7 @@ from flask import g, redirect, render_template, url_for, request as http_request
 from . import portfolios_bp
 from atst.database import db
 from atst.domain.task_orders import TaskOrders, DD254s
-from atst.domain.exceptions import NotFoundError
+from atst.domain.exceptions import NotFoundError, NoAccessError
 from atst.domain.portfolios import Portfolios
 from atst.domain.authz import Authorization
 from atst.forms.officers import EditTaskOrderOfficersForm
@@ -93,7 +93,7 @@ def ko_review(portfolio_id, task_order_id):
             form=KOReviewForm(obj=task_order),
         )
     else:
-        raise NotFoundError("task_order")
+        raise NoAccessError("task_order")
 
 
 @portfolios_bp.route(

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -85,12 +85,15 @@ def ko_review(portfolio_id, task_order_id):
 
     Authorization.check_is_ko_or_cor(g.current_user, task_order)
 
-    return render_template(
-        "/portfolios/task_orders/review.html",
-        portfolio=portfolio,
-        task_order=task_order,
-        form=KOReviewForm(obj=task_order),
-    )
+    if TaskOrders.all_sections_complete(task_order):
+        return render_template(
+            "/portfolios/task_orders/review.html",
+            portfolio=portfolio,
+            task_order=task_order,
+            form=KOReviewForm(obj=task_order),
+        )
+    else:
+        raise NotFoundError("task_order")
 
 
 @portfolios_bp.route(

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -32,7 +32,7 @@
         </div>
       </div>
       <div class="task-order-next-steps__action col">
-        {% if not task_order.is_active and button_text and button_url %}
+        {% if not task_order.is_active and complete and button_text and button_url %}
           <a
             href="{{ button_url }}"
             class="usa-button usa-button-primary">

--- a/templates/portfolios/task_orders/show.html
+++ b/templates/portfolios/task_orders/show.html
@@ -6,6 +6,10 @@
 
 {% block portfolio_content %}
 
+{% set show_dd_254_button = is_so and to_form_complete %}
+{% set show_to_info_button = (is_cor or is_ko) and to_form_complete %}
+{% set show_sign_to_button = is_ko and dd_254_complete and not is_to_signed %}
+
 {% macro officer_name(officer) -%}
   {%- if not officer -%}
     Not specified
@@ -32,7 +36,7 @@
         </div>
       </div>
       <div class="task-order-next-steps__action col">
-        {% if not task_order.is_active and complete and button_text and button_url %}
+        {% if not task_order.is_active and button_text and button_url %}
           <a
             href="{{ button_url }}"
             class="usa-button usa-button-primary">
@@ -136,8 +140,8 @@
         }}
         {{
           Step(
-            button_text=is_so and ("common.edit" | translate),
-            button_url=is_so and url_for("portfolios.so_review", portfolio_id=portfolio.id, task_order_id=task_order.id),
+            button_text=show_dd_254_button and ("common.edit" | translate),
+            button_url=show_dd_254_button and url_for("portfolios.so_review", portfolio_id=portfolio.id, task_order_id=task_order.id),
             complete=dd_254_complete,
             description="task_orders.view.steps.security" | translate({
               "security_officer": officer_name(task_order.security_officer)
@@ -149,12 +153,12 @@
             "contracting_officer": officer_name(task_order.contracting_officer),
             "contracting_officer_representative": officer_name(task_order.contracting_officer_representative)
           }) | safe,
-          button_url=url_for(
+          button_url=show_to_info_button and url_for(
             "portfolios.ko_review",
             portfolio_id=portfolio.id,
             task_order_id=task_order.id,
           ),
-          button_text=(is_cor or is_ko) and ("common.edit" | translate),
+          button_text=show_to_info_button and ("common.edit" | translate),
           complete=False) %}
           <div class='alert alert--warning'>
             <div class='alert__content'>
@@ -166,8 +170,8 @@
         {% endcall %}
         {{
           Step(
-            button_text=is_ko and not is_to_signed and ("common.sign" | translate),
-            button_url=is_ko and url_for(
+            button_text=show_sign_to_button and ("common.sign" | translate),
+            button_url=show_sign_to_button and url_for(
               "portfolios.ko_review",
               portfolio_id=portfolio.id,
               task_order_id=task_order.id,

--- a/tests/routes/portfolios/test_task_orders.py
+++ b/tests/routes/portfolios/test_task_orders.py
@@ -308,6 +308,22 @@ def test_ko_can_view_ko_review_page(client, user_session):
     assert response.status_code == 404
 
 
+def test_cor_cant_view_review_until_to_completed(client, user_session):
+    portfolio = PortfolioFactory.create()
+    user_session(portfolio.owner)
+    task_order = TaskOrderFactory.create(
+        portfolio=portfolio, clin_01=None, cor_dod_id=portfolio.owner.dod_id
+    )
+    response = client.get(
+        url_for(
+            "portfolios.ko_review",
+            portfolio_id=portfolio.id,
+            task_order_id=task_order.id,
+        )
+    )
+    assert response.status_code == 404
+
+
 def test_mo_redirected_to_build_page(client, user_session):
     portfolio = PortfolioFactory.create()
     user_session(portfolio.owner)


### PR DESCRIPTION
## Description
Add in a check to make sure that the TO is completed before the COR can view or fill out the TO Review form.

There was an existing function `all_sections_complete()` that was implemented for similar checks that I also used for this check. However, I noticed that this checks to make sure that all form fields on the first three pages have been filled out and does not consider whether or not the MO has submitted the form by clicking 'Done' on the 4th page. I noticed that when the MO is also the COR and has completed the form, but has not clicked 'Done', the COR/MO would be able to view and fill out the TO Review form. 

For this PR, I made the assumption that the current implementation of `all_sections_complete()` is correctly determining when a TO is complete, and that it is ok that the COR/MO can view the form before 'Done' is clicked. If this assumption was not correct, let me know and I will fix it!

## Pivotal
[https://www.pivotaltracker.com/story/show/164282346](https://www.pivotaltracker.com/story/show/164282346)