### PR TITLE
Change overflow to auto

### DIFF
--- a/styles/components/_global_layout.scss
+++ b/styles/components/_global_layout.scss
@@ -23,7 +23,7 @@ html, body {
   .global-panel-container {
     margin: $gap;
     max-width: $site-max-width;
-    overflow-x: hidden;
+    overflow-x: auto;
     flex-grow: 1;
     -ms-flex-negative: 1;
 


### PR DESCRIPTION
## Description
Fixes bug where tool tips were overflowing their containing div in IE.

## Pivotal
[https://www.pivotaltracker.com/story/show/164113857](https://www.pivotaltracker.com/story/show/164113857)

## Screenshot
![screen shot 2019-03-06 at 4 15 50 pm](https://user-images.githubusercontent.com/43828539/53914229-22047680-402b-11e9-9f9d-a88dd53b36b2.png)
