### PR TITLE
Add check to see if KO can sign the TO and update tests

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -121,6 +121,14 @@ class TaskOrders(object):
         return True
 
     @classmethod
+    def can_ko_sign(cls, task_order):
+        return (
+            TaskOrders.all_sections_complete(task_order)
+            and DD254s.is_complete(task_order.dd_254)
+            and not TaskOrders.is_signed_by_ko(task_order)
+        )
+
+    @classmethod
     def is_signed_by_ko(cls, task_order):
         return task_order.signer_dod_id is not None
 

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -108,7 +108,9 @@ def submit_ko_review(portfolio_id, task_order_id, form=None):
 
     if form.validate():
         TaskOrders.update(user=g.current_user, task_order=task_order, **form.data)
-        if Authorization.is_ko(g.current_user, task_order):
+        if Authorization.is_ko(g.current_user, task_order) and TaskOrders.can_ko_sign(
+            task_order
+        ):
             return redirect(
                 url_for("task_orders.signature_requested", task_order_id=task_order_id)
             )

--- a/atst/routes/task_orders/signing.py
+++ b/atst/routes/task_orders/signing.py
@@ -4,7 +4,7 @@ import datetime
 
 from . import task_orders_bp
 from atst.domain.authz import Authorization
-from atst.domain.exceptions import NotFoundError
+from atst.domain.exceptions import NoAccessError
 from atst.domain.task_orders import TaskOrders
 from atst.forms.task_order import SignatureForm
 from atst.utils.flash import formatted_flash as flash
@@ -14,8 +14,8 @@ def find_unsigned_ko_to(task_order_id):
     task_order = TaskOrders.get(g.current_user, task_order_id)
     Authorization.check_is_ko(g.current_user, task_order)
 
-    if TaskOrders.is_signed_by_ko(task_order):
-        raise NotFoundError("task_order")
+    if not TaskOrders.can_ko_sign(task_order):
+        raise NoAccessError("task_order")
 
     return task_order
 

--- a/tests/routes/portfolios/test_task_orders.py
+++ b/tests/routes/portfolios/test_task_orders.py
@@ -412,6 +412,8 @@ def test_submit_completed_ko_review_page_as_ko(client, user_session, pdf_upload)
     )
 
     task_order = TaskOrderFactory.create(portfolio=portfolio, contracting_officer=ko)
+    dd_254 = DD254Factory.create()
+    TaskOrders.add_dd_254(task_order, dd_254.to_dictionary())
     user_session(ko)
     loa_list = ["123123123", "456456456", "789789789"]
 


### PR DESCRIPTION
## Description
Adds in a check to see if the TO is finished, the DD-254 is completed, and that the TO is not already signed before showing the KO the page to sign the TO. 
Also updated the error message that is given when a KO tries to access a TO when it cannot be signed to the new error introduced in [PR #691](https://www.github.com/dod-ccpo/atst/pull/691).

## Pivotal
[https://www.pivotaltracker.com/story/show/164282355](https://www.pivotaltracker.com/story/show/164282355)