### PR TITLE
specify timezone in an environment variable for app containers

### DIFF
--- a/deploy/kubernetes/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-envvars-configmap.yml
@@ -5,6 +5,7 @@ metadata:
   name: atst-envvars
   namespace: atat
 data:
+  TZ: UTC
   FLASK_ENV: dev
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini

--- a/deploy/kubernetes/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-worker-envvars-configmap.yml
@@ -5,4 +5,5 @@ metadata:
   name: atst-worker-envvars
   namespace: atat
 data:
+  TZ: UTC
   DISABLE_CRL_CHECK: "True"

--- a/deploy/kubernetes/test/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/test/atst-envvars-configmap.yml
@@ -5,6 +5,7 @@ metadata:
   name: atst-envvars
   namespace: atat-test
 data:
+  TZ: UTC
   FLASK_ENV: dev
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini

--- a/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
@@ -5,4 +5,5 @@ metadata:
   name: atst-worker-envvars
   namespace: atat-test
 data:
+  TZ: UTC
   DISABLE_CRL_CHECK: "True"

--- a/deploy/kubernetes/uat/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-envvars-configmap.yml
@@ -5,6 +5,7 @@ metadata:
   name: atst-envvars
   namespace: atat-uat
 data:
+  TZ: UTC
   FLASK_ENV: dev
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini

--- a/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
@@ -5,4 +5,5 @@ metadata:
   name: atst-worker-envvars
   namespace: atat-uat
 data:
+  TZ: UTC
   DISABLE_CRL_CHECK: "True"


### PR DESCRIPTION
We were getting errors in our running application containers because `pendulum`, our python datetime lib, could not find any timezone configuration. I'm not sure why that's the case; possibly a change in the alpine base container or a change in the way `pendulum` itself detects tz config. (I'll investigate more tomorrow. I don't know why we wouldn't have seen the problem during the CI build.) 

`pendulum` respects the `TZ` environment variable, so I'm just setting that in our config maps. This change is already applied and working. It's probably good to specify this, anyway.