### PR TITLE
Persist data in new TO for existing Portfolio

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -84,7 +84,12 @@ class ShowTaskOrderWorkflow:
         if self._form:
             pass
         elif self.task_order:
-            self._form = self._section[form_type](obj=self.task_order)
+            if self.pf_attributes_read_only and self.screen == 1:
+                self._form = task_order_form.AppInfoWithExistingPortfolioForm(
+                    obj=self.task_order
+                )
+            else:
+                self._form = self._section[form_type](obj=self.task_order)
             # manually set SelectMultipleFields
             if self._section["section"] == "app_info":
                 self._form.complexity.data = self.task_order.complexity
@@ -101,12 +106,6 @@ class ShowTaskOrderWorkflow:
 
         else:
             self._form = self._section[form_type]()
-
-        if self.pf_attributes_read_only and self.screen == 1:
-            self._form = task_order_form.AppInfoWithExistingPortfolioForm(
-                obj=self.task_order
-            )
-
         return self._form
 
     @property


### PR DESCRIPTION
## Description
When creating a new TO for an existing Portfolio, complexity and dev team on page 1 were not persisting when you revisited the page. This was because `._form` was being reassigned at the end of the form property of ShowTaskOrderWorkflow. Moving the check to see if the portfolio attributes fixed the  issue. 

## Pivotal
[https://www.pivotaltracker.com/story/show/164616128](https://www.pivotaltracker.com/story/show/164616128)