### PR TITLE
Clean up EditLink anchors

### DIFF
--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -51,7 +51,7 @@
 
           <div class="h2">
             {{ "task_orders.new.review.funding"| translate }}
-            {{ EditLink(url_for("task_orders.new", screen=2, task_order_id=task_order.id,  _anchor="reporting", ko_edit=True)) }}
+            {{ EditLink(url_for("task_orders.new", screen=2, task_order_id=task_order.id, ko_edit=True)) }}
           </div>
           {% include "fragments/task_order_review/funding.html" %}
 
@@ -63,7 +63,7 @@
 
           <div class="h2">
             {{ "task_orders.new.review.oversight"| translate }}
-            {{ EditLink(url_for("task_orders.new", screen=3, task_order_id=task_order.id,  _anchor="reporting", ko_edit=True)) }}
+            {{ EditLink(url_for("task_orders.new", screen=3, task_order_id=task_order.id, ko_edit=True)) }}
           </div>
           {% include "fragments/task_order_review/oversight.html" %}
           <hr>

--- a/templates/task_orders/new/review.html
+++ b/templates/task_orders/new/review.html
@@ -16,7 +16,7 @@
 {% include "fragments/task_order_review/app_info.html" %}
 <hr>
 
-<h3 class="subheading">{{ "task_orders.new.review.reporting"| translate }} {{ EditLink(url_for("task_orders.new", screen=1, task_order_id=task_order.id, anchor="reporting")) }}</h3>
+<h3 class="subheading">{{ "task_orders.new.review.reporting"| translate }} {{ EditLink(url_for("task_orders.new", screen=1, task_order_id=task_order.id, _anchor="reporting")) }}</h3>
 
 <div class="row">
   {{


### PR DESCRIPTION
## Description
When I was looking into restarting a card, I noticed that some of the edit links in the KO Review Form had unnecessary anchors and that the anchor for Reporting on the TO Review page was not working properly. 

## Pivotal
[https://www.pivotaltracker.com/story/show/164669163](https://www.pivotaltracker.com/story/show/164669163)