### PR TITLE
Fix typo

### DIFF
--- a/translations.yaml
+++ b/translations.yaml
@@ -77,7 +77,7 @@ forms:
     date_latest_training_description: |
       To complete the training, you can find it in
       <a class="icon-link" href="https://iatraining.disa.mil/eta/disa_cac2018/launchPage.htm" target="_blank">
-        Information Assurance Cyber Awareness Challange
+        Information Assurance Cyber Awareness Challenge
       </a> website.
     date_latest_training_label: Latest Information Assurance (IA) Training Completion Date
     designation_description: What is your designation within the DoD?


### PR DESCRIPTION
## Description
Fix typo on the user profile page in the description for 'Latest Information Assurance (IA) Training Completion Date'.

## Pivotal
[https://www.pivotaltracker.com/story/show/164473166](https://www.pivotaltracker.com/story/show/164473166)

## Screenshot
<img width="769" alt="Screen Shot 2019-03-14 at 1 15 40 PM" src="https://user-images.githubusercontent.com/43828539/54377347-4f6ca800-465b-11e9-8163-a188fba10b9a.png">
