### PR TITLE
Use NoAccessError instead of NotFoundError

### DIFF
--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -111,6 +111,10 @@ class Invitations(object):
     @classmethod
     def lookup_by_portfolio_and_user(cls, portfolio, user):
         portfolio_role = PortfolioRoles.get(portfolio.id, user.id)
+
+        if portfolio_role.latest_invitation is None:
+            raise NotFoundError("invitation")
+
         return portfolio_role.latest_invitation
 
     @classmethod

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -126,8 +126,11 @@ def resend_invite(portfolio_id, task_order_id, form=None):
 
     invitation = Invitations.lookup_by_portfolio_and_user(portfolio, officer)
 
-    if not invitation or (invitation.status is not InvitationStatus.PENDING):
+    if not invitation:
         raise NotFoundError("invitation")
+
+    if invitation.status is not InvitationStatus.PENDING:
+        raise NoAccessError("invitation")
 
     Invitations.revoke(token=invitation.token)
 
@@ -210,7 +213,7 @@ def task_order_invitations(portfolio_id, task_order_id):
             form=form,
         )
     else:
-        raise NotFoundError("task_order")
+        raise NoAccessError("task_order")
 
 
 @portfolios_bp.route(

--- a/atst/routes/portfolios/task_orders.py
+++ b/atst/routes/portfolios/task_orders.py
@@ -126,9 +126,6 @@ def resend_invite(portfolio_id, task_order_id, form=None):
 
     invitation = Invitations.lookup_by_portfolio_and_user(portfolio, officer)
 
-    if not invitation:
-        raise NotFoundError("invitation")
-
     if invitation.status is not InvitationStatus.PENDING:
         raise NoAccessError("invitation")
 


### PR DESCRIPTION
## Description
`NotFoundError` was being used in places where a resource was found, but because of the state of the resource the user is not able to access it. This PR updates those cases to use `NoAccessError` instead.
I did a project-wide search to look at every instance that `NotFoundError` was used, but I would appreciate a second set of eyes to make sure I didn't miss any!

## Pivotal
[https://www.pivotaltracker.com/story/show/164444503](https://www.pivotaltracker.com/story/show/164444503)