### PR TITLE
add missing crl sync config option to k8s clusters

### DIFF
--- a/deploy/kubernetes/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-envvars-configmap.yml
@@ -9,3 +9,4 @@ data:
   FLASK_ENV: dev
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini
+  CRL_STORAGE_PROVIDER: CLOUDFILES

--- a/deploy/kubernetes/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/atst-worker-envvars-configmap.yml
@@ -7,3 +7,4 @@ metadata:
 data:
   TZ: UTC
   DISABLE_CRL_CHECK: "True"
+  CRL_STORAGE_PROVIDER: CLOUDFILES

--- a/deploy/kubernetes/test/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/test/atst-envvars-configmap.yml
@@ -10,3 +10,4 @@ data:
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini
   RQ_QUEUES: atat-test
+  CRL_STORAGE_PROVIDER: CLOUDFILES

--- a/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/test/atst-worker-envvars-configmap.yml
@@ -7,3 +7,4 @@ metadata:
 data:
   TZ: UTC
   DISABLE_CRL_CHECK: "True"
+  CRL_STORAGE_PROVIDER: CLOUDFILES

--- a/deploy/kubernetes/uat/atst-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-envvars-configmap.yml
@@ -10,3 +10,4 @@ data:
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi-config.ini
   RQ_QUEUES: atat-uat
+  CRL_STORAGE_PROVIDER: CLOUDFILES

--- a/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
+++ b/deploy/kubernetes/uat/atst-worker-envvars-configmap.yml
@@ -7,3 +7,4 @@ metadata:
 data:
   TZ: UTC
   DISABLE_CRL_CHECK: "True"
+  CRL_STORAGE_PROVIDER: CLOUDFILES


### PR DESCRIPTION
We were missing a config option that specifies that our storage location for the CRL cache is Rackspace (CLOUDFILES) instead of local storage. This change has already been applied. I verified it's working by running `script/sync-crls` on the uat and test clusters.