### PR TITLE
Portfolio admin users table

### DIFF
--- a/atst/models/portfolio_role.py
+++ b/atst/models/portfolio_role.py
@@ -7,6 +7,7 @@ from atst.models import Base, mixins
 from .types import Id
 
 from atst.database import db
+from atst.utils import first_or_none
 from atst.models.environment_role import EnvironmentRole
 from atst.models.application import Application
 from atst.models.environment import Environment
@@ -110,6 +111,11 @@ class PortfolioRole(Base, mixins.TimestampsMixin, mixins.AuditableMixin):
                 return MEMBER_STATUSES["pending"]
         else:
             return MEMBER_STATUSES["unknown"]
+
+    def has_permission_set(self, perm_set_name):
+        return first_or_none(
+            lambda prms: prms.name == perm_set_name, self.permission_sets
+        )
 
     @property
     def has_dod_id_error(self):

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -35,6 +35,7 @@ def portfolio_admin(portfolio_id):
         form=form,
         portfolio=portfolio,
         audit_events=audit_events,
+        user=g.current_user,
     )
 
 

--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -168,13 +168,50 @@
   .member-list {
     .panel {
       @include shadow-panel;
+      padding-bottom: 0;
+    }
+
+    .member-list-header {
+      margin: 2 * $gap 5 * $gap;
+      padding: inherit;
+      overflow: auto;
+
+      .left {
+        float: left;
+        padding-bottom: 0.8rem;
+      }
+
+      .icon-link {
+        float: right;
+        margin-top: 0.8rem;
+      }
+
+      .icon {
+
+      }
+    }
+
+    .subheading {
+      font-size: 1.4rem;
+      color: $color-gray;
     }
 
     table {
       box-shadow: 0 6px 18px 0 rgba(144,164,183,0.3);
+
       thead {
         th:first-child {
           padding-left: 3 * $gap;
+        }
+
+        tr:first-child {
+          padding: 0 2 * $gap 0 5 * $gap;
+        }
+
+        td {
+          font-weight: bold;
+          font-size: 1.4rem;
+          border-top: 0;
         }
       }
 
@@ -186,8 +223,29 @@
         color: $color-gray;
       }
 
-      td {
-        border-bottom: 1px solid $color-gray-lightest;
+      td:first-child {
+        padding: 2 * $gap 2 * $gap 2 * $gap 5 * $gap;
+      }
+
+      tbody {
+        td {
+          border-bottom: 1px solid $color-gray-lightest;
+          font-size: 1.6rem;
+          border-top: 0;
+          padding: 3 * $gap 2 * $gap;
+        }
+
+        .green {
+          color: $color-green;
+        }
+
+        .name {
+          font-weight: bold;
+
+          .you {
+            font-size: 1.2rem;
+          }
+        }
       }
 
       .add-member-link {

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -35,17 +35,17 @@
       </thead>
 
       <tbody>
-        {% for member in portfolio.members %}
+        {% for member_data in members_data %}
         <tr>
-            <td class='name'>{{ member.user_name }}
-              {% if member.user == user %}
+            <td class='name'>{{ member_data.member.user_name }}
+              {% if member_data.member.user == user %}
                 <span class='you'>(<span class='green'>you</span>)</span>
               {% endif %}
             </td>
-            {% set heading_perms = ['edit_application', 'view_portfolio_funding', 'view_portfolio_reports', 'edit_portfolio_name'] %}
+            {% set heading_perms = [member_data.app_mgmt, member_data.funding, member_data.reporting, member_data.portfolio_mgmt] %}
 
-            {% for perm in heading_perms %}
-              {% if perm in member.permissions %}
+            {% for has_perm in heading_perms %}
+              {% if has_perm %}
                 <td class='green'>Edit Access</td>
               {% else %}
                 <td>View Only</td>

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -1,8 +1,19 @@
+{% from "components/icon.html" import Icon %}
+
 <section class="member-list">
   <div class='responsive-table-wrapper panel'>
-    <div class='title'>{{ "portfolios.admin.portfolio_members_title" | translate }}</div>
-    <div class='subheading'>{{ "portfolios.admin.portfolio_members_subheading" | translate }}</div>
-    <a class='icon-link'>{{ "portfolios.admin.settings_info" | translate }}</a>
+    <div class='member-list-header'>
+      <div class='left'>
+        <div class='h3'>{{ "portfolios.admin.portfolio_members_title" | translate }}</div>
+        <div class='subheading'>
+          {{ "portfolios.admin.portfolio_members_subheading" | translate }}
+        </div>
+      </div>
+      <a class='icon-link'>
+        <span class='icon'>{{ Icon('info') }}</span>
+        {{ "portfolios.admin.settings_info" | translate }}
+      </a>
+    </div>
 
   {% if not portfolio.members %}
 
@@ -14,47 +25,33 @@
 
       <thead>
         <tr>
-            <td class='members-table-cell'>{{ "portfolios.members.permissions.name" | translate }}</td>
-            <td class='members-table-cell'>{{ "portfolios.members.permissions.app_mgmt" | translate }}</td>
-            <td class='members-table-cell'>{{ "portfolios.members.permissions.funding" | translate }}</td>
-            <td class='members-table-cell'>{{ "portfolios.members.permissions.reporting" | translate }}</td>
-            <td class='members-table-cell'>{{ "portfolios.members.permissions.portfolio_mgmt" | translate }}</td>
-            <td class='members-table-cell'></td>
+            <td>{{ "portfolios.members.permissions.name" | translate }}</td>
+            <td>{{ "portfolios.members.permissions.app_mgmt" | translate }}</td>
+            <td>{{ "portfolios.members.permissions.funding" | translate }}</td>
+            <td>{{ "portfolios.members.permissions.reporting" | translate }}</td>
+            <td>{{ "portfolios.members.permissions.portfolio_mgmt" | translate }}</td>
+            <td></td>
         </tr>
       </thead>
 
       <tbody>
         {% for member in portfolio.members %}
         <tr>
-            <td>{{ member.user_name }}
+            <td class='name'>{{ member.user_name }}
               {% if member.user == user %}
-                (you)
+                <span class='you'>(<a>you</a>)</span>
               {% endif %}
             </td>
+            {% set heading_perms = ['edit_application', 'view_portfolio_funding', 'view_portfolio_reports', 'edit_portfolio_name'] %}
 
-            {% if 'edit_application' in member.permissions %}
-              <td>Edit Access</td>
-            {% else %}
-              <td>View Only</td>
-            {% endif %}
+            {% for perm in heading_perms %}
+              {% if perm in member.permissions %}
+                <td><a>Edit Access</a></td>
+              {% else %}
+                <td>View Only</td>
+              {% endif %}
+            {% endfor %}
 
-            {% if 'view_portfolio_funding' in member.permissions %}
-              <td>Edit Access</td>
-            {% else %}
-              <td>View Only</td>
-            {% endif %}
-
-            {% if 'view_portfolio_reports' in member.permissions %}
-              <td>Edit Access</td>
-            {% else %}
-              <td>View Only</td>
-            {% endif %}
-
-            {% if 'edit_portfolio_name' in member.permissions %}
-              <td>Edit Access</td>
-            {% else %}
-              <td>View Only</td>
-            {% endif %}
         </tr>
         {% endfor %}
       </tbody>

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -1,0 +1,63 @@
+<section class="member-list">
+  <div class='responsive-table-wrapper panel'>
+    <div class='title'>{{ "portfolios.admin.portfolio_members_title" | translate }}</div>
+    <div class='subheading'>{{ "portfolios.admin.portfolio_members_subheading" | translate }}</div>
+    <a class='icon-link'>{{ "portfolios.admin.settings_info" | translate }}</a>
+
+  {% if not portfolio.members %}
+
+    <p>There are currently no members in this Portfolio.</p>
+
+  {% else %}
+
+    <table>
+
+      <thead>
+        <tr>
+            <td class='members-table-cell'>{{ "portfolios.members.permissions.name" | translate }}</td>
+            <td class='members-table-cell'>{{ "portfolios.members.permissions.app_mgmt" | translate }}</td>
+            <td class='members-table-cell'>{{ "portfolios.members.permissions.funding" | translate }}</td>
+            <td class='members-table-cell'>{{ "portfolios.members.permissions.reporting" | translate }}</td>
+            <td class='members-table-cell'>{{ "portfolios.members.permissions.portfolio_mgmt" | translate }}</td>
+            <td class='members-table-cell'></td>
+        </tr>
+      </thead>
+
+      <tbody>
+        {% for member in portfolio.members %}
+        <tr>
+            <td>{{ member.user_name }}</td>
+
+            {% if 'edit_application' in member.permissions %}
+              <td>Edit Access</td>
+            {% else %}
+              <td>View Only</td>
+            {% endif %}
+
+            {% if 'view_portfolio_funding' in member.permissions %}
+              <td>Edit Access</td>
+            {% else %}
+              <td>View Only</td>
+            {% endif %}
+
+            {% if 'view_portfolio_reports' in member.permissions %}
+              <td>Edit Access</td>
+            {% else %}
+              <td>View Only</td>
+            {% endif %}
+
+            {% if 'edit_portfolio_name' in member.permissions %}
+              <td>Edit Access</td>
+            {% else %}
+              <td>View Only</td>
+            {% endif %}
+        </tr>
+        {% endfor %}
+      </tbody>
+
+    </table>
+  </div>
+
+{% endif %}
+
+</section>

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -26,7 +26,11 @@
       <tbody>
         {% for member in portfolio.members %}
         <tr>
-            <td>{{ member.user_name }}</td>
+            <td>{{ member.user_name }}
+              {% if member.user == user %}
+                (you)
+              {% endif %}
+            </td>
 
             {% if 'edit_application' in member.permissions %}
               <td>Edit Access</td>

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -39,14 +39,14 @@
         <tr>
             <td class='name'>{{ member.user_name }}
               {% if member.user == user %}
-                <span class='you'>(<a>you</a>)</span>
+                <span class='you'>(<span class='green'>you</span>)</span>
               {% endif %}
             </td>
             {% set heading_perms = ['edit_application', 'view_portfolio_funding', 'view_portfolio_reports', 'edit_portfolio_name'] %}
 
             {% for perm in heading_perms %}
               {% if perm in member.permissions %}
-                <td><a>Edit Access</a></td>
+                <td class='green'>Edit Access</td>
               {% else %}
                 <td>View Only</td>
               {% endif %}

--- a/templates/fragments/audit_events_log.html
+++ b/templates/fragments/audit_events_log.html
@@ -1,5 +1,3 @@
-{% from "components/pagination.html" import Pagination %}
-
 <section class="block-list activity-log">
   <div class='subheading'>{{ "portfolios.admin.activity_log_title" | translate }}</div>
   <ul>

--- a/templates/portfolios/admin.html
+++ b/templates/portfolios/admin.html
@@ -41,6 +41,7 @@
 
     {% include "fragments/primary_point_of_contact.html" %}
 
+    {% include "fragments/admin/portfolio_members.html" %}
     {% include "fragments/audit_events_log.html" %}
 
     {{ Pagination(audit_events, 'portfolios.portfolio_admin', portfolio_id=portfolio.id) }}

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -48,7 +48,7 @@
                     <div class='separator'></div>
                   {% endif %}
                   {% if user_can(permissions.VIEW_PORTFOLIO_USERS) %}
-                    <a class='icon-link' href='{{ url_for("portfolios.application_members", portfolio_id=portfolio.id, application_id=application.id) }}'>
+                    <a class='icon-link'>
                       <span>{{ "portfolios.applications.team_text" | translate }}</span>
                       <span class='counter'>{{ application.num_users }}</span>
                     </a>

--- a/tests/models/test_portfolio_role.py
+++ b/tests/models/test_portfolio_role.py
@@ -307,3 +307,23 @@ def test_can_list_all_permissions():
     port_role = PortfolioRoleFactory.create(permission_sets=[role_one, role_two])
     expected_perms = role_one.permissions + role_two.permissions
     assert expected_perms == expected_perms
+
+
+def test_has_permission_set():
+    perm_sets = PermissionSets.get_many(
+        [PermissionSets.VIEW_PORTFOLIO_FUNDING, PermissionSets.VIEW_PORTFOLIO_REPORTS]
+    )
+    port_role = PortfolioRoleFactory.create(permission_sets=perm_sets)
+
+    assert port_role.has_permission_set(PermissionSets.VIEW_PORTFOLIO_REPORTS)
+
+
+def test_does_not_have_permission_set():
+    perm_sets = PermissionSets.get_many(
+        [PermissionSets.VIEW_PORTFOLIO_FUNDING, PermissionSets.VIEW_PORTFOLIO_REPORTS]
+    )
+    port_role = PortfolioRoleFactory.create(permission_sets=perm_sets)
+
+    assert not port_role.has_permission_set(
+        PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT
+    )

--- a/translations.yaml
+++ b/translations.yaml
@@ -563,9 +563,13 @@ portfolios:
       title: '{application_name} Team Management'
       subheading: Team Management
   admin:
+    portfolio_members_title: Portfolio Members
+    portfolio_members_subheading: These members have different levels of access to the portfolio.
+    settings_info: Learn more about these settings
     activity_log_title: Activity Log
   members:
     permissions:
+      name: Name
       app_mgmt: App Mgmt
       funding: Funding
       reporting: Reporting


### PR DESCRIPTION
## Description
Read only table of members in a portfolio. This does not include drop downs, archive user button, add user, or save button.

There is still some work to do on the icon for the `Learn more...` link, captured in this bug: https://www.pivotaltracker.com/story/show/164742052

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/164446620

## Screenshots
![Screen Shot 2019-03-19 at 10 58 13 AM](https://user-images.githubusercontent.com/42577527/54616412-f8d5e400-4a35-11e9-9ff1-9cbcb59eec4e.png)
