### PR TITLE
View Primary Point of Contact (non-PoC)

### DIFF
--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -34,6 +34,7 @@ def portfolio_admin(portfolio_id):
         "portfolios/admin.html",
         form=form,
         portfolio=portfolio,
+        current_user=g.current_user,
         audit_events=audit_events,
     )
 

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -34,7 +34,6 @@ def portfolio_admin(portfolio_id):
         "portfolios/admin.html",
         form=form,
         portfolio=portfolio,
-        current_user=g.current_user,
         audit_events=audit_events,
     )
 

--- a/templates/fragments/primary_point_of_contact.html
+++ b/templates/fragments/primary_point_of_contact.html
@@ -1,7 +1,7 @@
 <div class="panel">
   <div class="panel__content">
-    <h2>Primary Point of Contact</h2>
-    <p>The PoC has the ability to edit all aspects of a portfolio.</p>
+    <h2>{{ "fragments.ppoc.title" | translate }}</h2>
+    <p>{{ "fragments.ppoc.subtitle" | translate }}</p>
 
     <p>
       <strong>
@@ -14,10 +14,12 @@
       {{ portfolio.owner.phone_number | usPhone }}
     </p>
 
-    <div class="flex-reverse-row">
-      <a class="usa-button-primary">
-        Update Primary PoC
-      </a>
-    </div>
+    {% if portfolio.owner == current_user %}
+      <div class="flex-reverse-row">
+        <a class="usa-button-primary">
+          {{ "fragments.ppoc.update_btn" | translate }}
+        </a>
+      </div>
+    {% endif %}
   </div>
 </div>

--- a/templates/fragments/primary_point_of_contact.html
+++ b/templates/fragments/primary_point_of_contact.html
@@ -14,7 +14,7 @@
       {{ portfolio.owner.phone_number | usPhone }}
     </p>
 
-    {% if portfolio.owner == current_user %}
+    {% if user_can(permissions.EDIT_PORTFOLIO_POC) %}
       <div class="flex-reverse-row">
         <a class="usa-button-primary">
           {{ "fragments.ppoc.update_btn" | translate }}

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -66,7 +66,9 @@ def test_portfolio_admin_screen_when_ppoc(client, user_session):
 def test_portfolio_admin_screen_when_not_ppoc(client, user_session):
     portfolio = PortfolioFactory.create()
     user = UserFactory.create()
-    permission_sets = PermissionSets.get_all()
+    permission_sets = PermissionSets.get_many(
+        [PermissionSets.EDIT_PORTFOLIO_ADMIN, PermissionSets.VIEW_PORTFOLIO_ADMIN]
+    )
     PortfolioRoleFactory.create(
         portfolio=portfolio, user=user, permission_sets=permission_sets
     )

--- a/translations.yaml
+++ b/translations.yaml
@@ -304,6 +304,10 @@ fragments:
     bullet_3: Add both the Task Order (TO) and Line(s) of Accounting (LOA) numbers
   portfolio_admin:
     none: Not Selected
+  ppoc:
+    title: Primary Point of Contact
+    subtitle: The PoC has the ability to edit all aspects of a portfolio.
+    update_btn: Update Primary PoC
 login:
   ccpo_logo_alt_text: Cloud Computing Program Office Logo
   certificate_selection:


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164746444)

```cucumber
Given I am NOT the Primary Point of Contact for a portfolio,
When I view the admin page for a portfolio,
    Then I see a section "Primary Point of contact,"
    And it has the fields listed in notes,
    And there is NO “Update Primary PoC” button.
```