### PR TITLE
Fix positioning of info icon

### DIFF
--- a/styles/elements/_icon_link.scss
+++ b/styles/elements/_icon_link.scss
@@ -26,8 +26,18 @@
 
   .icon {
     @include icon-color($color-primary);
-    @include icon-size(12);
+    @include icon-size(16);
     margin-right: $gap;
+
+    &--help {
+      position: relative;
+      bottom: -3px;
+    }
+
+    &--info {
+      position: relative;
+      bottom: 3px;
+    }
   }
 }
 


### PR DESCRIPTION
## Description
The icon on the Portfolio Members table for the link to settings info was too small and positioned too low.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/164742052

## Screenshots
### Before:
![Screen Shot 2019-03-21 at 4 19 08 PM](https://user-images.githubusercontent.com/42577527/54782488-6a0fc580-4bf5-11e9-80de-46a4fb23f83e.png)
### After:
![Screen Shot 2019-03-21 at 4 19 21 PM](https://user-images.githubusercontent.com/42577527/54782510-7431c400-4bf5-11e9-9f1c-8935f938a388.png)
