### PR TITLE
User can only update apps or revoke invites related to their portfolios

### DIFF
--- a/atst/domain/authz/decorator.py
+++ b/atst/domain/authz/decorator.py
@@ -13,22 +13,22 @@ from atst.domain.exceptions import UnauthorizedError
 def check_access(permission, message, exception, *args, **kwargs):
     access_args = {"message": message}
 
-    if "portfolio_id" in kwargs:
-        access_args["portfolio"] = Portfolios.get(
-            g.current_user, kwargs["portfolio_id"]
-        )
-
     if "application_id" in kwargs:
         application = Applications.get(kwargs["application_id"])
         access_args["portfolio"] = application.portfolio
 
-    if "task_order_id" in kwargs:
+    elif "task_order_id" in kwargs:
         task_order = TaskOrders.get(kwargs["task_order_id"])
         access_args["portfolio"] = task_order.portfolio
 
-    if "token" in kwargs:
+    elif "token" in kwargs:
         invite = Invitations._get(kwargs["token"])
         access_args["portfolio"] = invite.portfolio_role.portfolio
+
+    elif "portfolio_id" in kwargs:
+        access_args["portfolio"] = Portfolios.get(
+            g.current_user, kwargs["portfolio_id"]
+        )
 
     if exception is not None and exception(g.current_user, **access_args, **kwargs):
         return True

--- a/atst/domain/authz/decorator.py
+++ b/atst/domain/authz/decorator.py
@@ -5,6 +5,7 @@ from flask import g, current_app as app, request
 from . import user_can_access
 from atst.domain.portfolios import Portfolios
 from atst.domain.task_orders import TaskOrders
+from atst.domain.applications import Applications
 from atst.domain.exceptions import UnauthorizedError
 
 
@@ -15,6 +16,10 @@ def check_access(permission, message, exception, *args, **kwargs):
         access_args["portfolio"] = Portfolios.get(
             g.current_user, kwargs["portfolio_id"]
         )
+
+    if "application_id" in kwargs:
+        application = Applications.get(kwargs["application_id"])
+        access_args["portfolio"] = application.portfolio
 
     if "task_order_id" in kwargs:
         task_order = TaskOrders.get(kwargs["task_order_id"])

--- a/atst/domain/authz/decorator.py
+++ b/atst/domain/authz/decorator.py
@@ -6,6 +6,7 @@ from . import user_can_access
 from atst.domain.portfolios import Portfolios
 from atst.domain.task_orders import TaskOrders
 from atst.domain.applications import Applications
+from atst.domain.invitations import Invitations
 from atst.domain.exceptions import UnauthorizedError
 
 
@@ -24,6 +25,10 @@ def check_access(permission, message, exception, *args, **kwargs):
     if "task_order_id" in kwargs:
         task_order = TaskOrders.get(kwargs["task_order_id"])
         access_args["portfolio"] = task_order.portfolio
+
+    if "token" in kwargs:
+        invite = Invitations._get(kwargs["token"])
+        access_args["portfolio"] = invite.portfolio_role.portfolio
 
     if exception is not None and exception(g.current_user, **access_args, **kwargs):
         return True

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -196,8 +196,10 @@ def test_user_can_only_access_apps_in_their_portfolio(client, user_session):
 
     # user can't view application members
     response = client.get(
-        "/portfolios/{}/applications/{}/members".format(
-            portfolio.id, other_application.id
+        url_for(
+            "portfolios.application_members",
+            portfolio_id=portfolio.id,
+            application_id=other_application.id,
         )
     )
     assert response.status_code == 404

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -157,6 +157,47 @@ def test_user_without_permission_cannot_update_application(client, user_session)
     assert application.description == "Cool stuff happening here!"
 
 
+def test_user_can_only_access_apps_in_their_portfolio(client, user_session):
+    portfolio = PortfolioFactory.create()
+    other_portfolio = PortfolioFactory.create(
+        applications=[
+            {
+                "name": "Awesome Application",
+                "description": "More cool stuff happening here!",
+                "environments": [{"name": "dev"}],
+            }
+        ]
+    )
+    other_application = other_portfolio.applications[0]
+    user_session(portfolio.owner)
+
+    # user can't view application edit form
+    response = client.get(
+        "/portfolios/{}/applications/{}/edit".format(portfolio.id, other_application.id)
+    )
+    assert response.status_code == 404
+
+    # user can't post update application form
+    response = client.post(
+        url_for(
+            "portfolios.update_application",
+            portfolio_id=portfolio.id,
+            application_id=other_application.id,
+        ),
+        data={"name": "New Name", "description": "A new description."},
+        follow_redirects=True,
+    )
+    assert response.status_code == 404
+
+    # user can't view application members
+    response = client.get(
+        "/portfolios/{}/applications/{}/members".format(
+            portfolio.id, other_application.id
+        )
+    )
+    assert response.status_code == 404
+
+
 def create_environment(user):
     portfolio = PortfolioFactory.create()
     portfolio_role = PortfolioRoleFactory.create(portfolio=portfolio, user=user)

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -173,11 +173,16 @@ def test_user_can_only_access_apps_in_their_portfolio(client, user_session):
 
     # user can't view application edit form
     response = client.get(
-        "/portfolios/{}/applications/{}/edit".format(portfolio.id, other_application.id)
+        url_for(
+            "portfolios.edit_application",
+            portfolio_id=portfolio.id,
+            application_id=other_application.id,
+        )
     )
     assert response.status_code == 404
 
     # user can't post update application form
+    time_updated = other_application.time_updated
     response = client.post(
         url_for(
             "portfolios.update_application",
@@ -185,9 +190,9 @@ def test_user_can_only_access_apps_in_their_portfolio(client, user_session):
             application_id=other_application.id,
         ),
         data={"name": "New Name", "description": "A new description."},
-        follow_redirects=True,
     )
     assert response.status_code == 404
+    assert time_updated == other_application.time_updated
 
     # user can't view application members
     response = client.get(

--- a/tests/routes/portfolios/test_invitations.py
+++ b/tests/routes/portfolios/test_invitations.py
@@ -173,12 +173,12 @@ def test_user_can_only_revoke_invites_in_their_portfolio(client, user_session):
     portfolio = PortfolioFactory.create()
     other_portfolio = PortfolioFactory.create()
     user = UserFactory.create()
-    ws_role = PortfolioRoleFactory.create(
+    portfolio_role = PortfolioRoleFactory.create(
         user=user, portfolio=other_portfolio, status=PortfolioRoleStatus.PENDING
     )
     invite = InvitationFactory.create(
         user_id=user.id,
-        portfolio_role=ws_role,
+        portfolio_role=portfolio_role,
         status=InvitationStatus.REJECTED_EXPIRED,
         expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
     )
@@ -199,12 +199,12 @@ def test_user_can_only_resend_invites_in_their_portfolio(client, user_session, q
     portfolio = PortfolioFactory.create()
     other_portfolio = PortfolioFactory.create()
     user = UserFactory.create()
-    ws_role = PortfolioRoleFactory.create(
+    portfolio_role = PortfolioRoleFactory.create(
         user=user, portfolio=other_portfolio, status=PortfolioRoleStatus.PENDING
     )
     invite = InvitationFactory.create(
         user_id=user.id,
-        portfolio_role=ws_role,
+        portfolio_role=portfolio_role,
         status=InvitationStatus.REJECTED_EXPIRED,
         expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
     )

--- a/tests/routes/portfolios/test_invitations.py
+++ b/tests/routes/portfolios/test_invitations.py
@@ -169,6 +169,58 @@ def test_revoke_invitation(client, user_session):
     assert invite.is_revoked
 
 
+def test_user_can_only_revoke_invites_in_their_portfolio(client, user_session):
+    portfolio = PortfolioFactory.create()
+    other_portfolio = PortfolioFactory.create()
+    user = UserFactory.create()
+    ws_role = PortfolioRoleFactory.create(
+        user=user, portfolio=other_portfolio, status=PortfolioRoleStatus.PENDING
+    )
+    invite = InvitationFactory.create(
+        user_id=user.id,
+        portfolio_role=ws_role,
+        status=InvitationStatus.REJECTED_EXPIRED,
+        expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+    )
+    user_session(portfolio.owner)
+    response = client.post(
+        url_for(
+            "portfolios.revoke_invitation",
+            portfolio_id=portfolio.id,
+            token=invite.token,
+        )
+    )
+
+    assert response.status_code == 404
+    assert not invite.is_revoked
+
+
+def test_user_can_only_resend_invites_in_their_portfolio(client, user_session, queue):
+    portfolio = PortfolioFactory.create()
+    other_portfolio = PortfolioFactory.create()
+    user = UserFactory.create()
+    ws_role = PortfolioRoleFactory.create(
+        user=user, portfolio=other_portfolio, status=PortfolioRoleStatus.PENDING
+    )
+    invite = InvitationFactory.create(
+        user_id=user.id,
+        portfolio_role=ws_role,
+        status=InvitationStatus.REJECTED_EXPIRED,
+        expiration_time=datetime.datetime.now() - datetime.timedelta(seconds=1),
+    )
+    user_session(portfolio.owner)
+    response = client.post(
+        url_for(
+            "portfolios.resend_invitation",
+            portfolio_id=portfolio.id,
+            token=invite.token,
+        )
+    )
+
+    assert response.status_code == 404
+    assert len(queue.get_queue()) == 0
+
+
 def test_resend_invitation_sends_email(client, user_session, queue):
     user = UserFactory.create()
     portfolio = PortfolioFactory.create()


### PR DESCRIPTION
## Description
This fixes a bug were a user could access the Application edit page and the members page for an app that they were not associated with. Replicate the bug by visiting:
`/portfolios/<portfolio-id-associated-with-current-user>/applications/<unassociated-app-id>/edit`
Users could also revoke invites that were unassociated with them

This fixes the issue by adding to the decorator introduced in #720.

## Pivotal
[https://www.pivotaltracker.com/story/show/164836692](https://www.pivotaltracker.com/story/show/164836692)