### PR TITLE
Fix py36=true deprecation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 88
-py36 = true
+target-version = ['py36']
 include = '\.pyi?$'
 exclude = '''
 /(


### PR DESCRIPTION
We had a warning when running `script/format`. Changing the toml config fixes the warning.

```
--py36 is deprecated and will be removed in a future version. Use --target-version py36 instead.
```

[This is also how black have configured their project](https://github.com/ambv/black/blob/master/pyproject.toml)

