### PR TITLE
Edit Portfolio Members Access Levels

### DIFF
--- a/atst/forms/portfolio_member.py
+++ b/atst/forms/portfolio_member.py
@@ -1,6 +1,6 @@
-from wtforms.fields import StringField, FormField, FieldList
 from wtforms.fields.html5 import EmailField, TelField
 from wtforms.validators import Required, Email, Length, Optional
+from wtforms.fields import StringField, FormField, FieldList, HiddenField
 
 from atst.domain.permission_sets import PermissionSets
 from .forms import BaseForm
@@ -11,6 +11,7 @@ from atst.utils.localization import translate
 
 class PermissionsForm(BaseForm):
     member = StringField()
+    user_id = HiddenField()
     perms_app_mgmt = SelectField(
         None,
         choices=[

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -90,6 +90,20 @@ def portfolio_admin(portfolio_id):
     return render_admin_page(portfolio)
 
 
+def permission_set_has_changed(old_perm_set_names, new_perm_set_names):
+    has_changed = False
+    for perm_name in new_perm_set_names:
+        base = perm_name[4:]
+        if perm_name.split("_")[0] == "edit":
+            if perm_name not in old_perm_set_names:
+                has_changed = True
+        elif perm_name.split("_")[0] == "view":
+            edit_version = "edit" + base
+            if edit_version in old_perm_set_names:
+                has_changed = True
+    return has_changed
+
+
 @portfolios_bp.route("/portfolios/<portfolio_id>/admin", methods=["POST"])
 @user_can(Permissions.EDIT_PORTFOLIO_USERS, message="view portfolio admin page")
 def edit_portfolio_members(portfolio_id):

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -96,24 +96,25 @@ def edit_portfolio_members(portfolio_id):
     portfolio = Portfolios.get_for_update(portfolio_id)
     member_perms_form = member_forms.MembersPermissionsForm(http_request.form)
 
-    for subform in member_perms_form.members_permissions:
-        new_perm_set = subform.data["permission_sets"]
-        user_id = subform.user_id.data
-        portfolio_role = PortfolioRoles.get(portfolio.id, user_id)
-        PortfolioRoles.update(portfolio_role, new_perm_set)
+    if member_perms_form.validate():
+        for subform in member_perms_form.members_permissions:
+            new_perm_set = subform.data["permission_sets"]
+            user_id = subform.user_id.data
+            portfolio_role = PortfolioRoles.get(portfolio.id, user_id)
+            PortfolioRoles.update(portfolio_role, new_perm_set)
 
-    flash("update_portfolio_members", portfolio=portfolio)
+        flash("update_portfolio_members", portfolio=portfolio)
 
-    return redirect(
-        url_for(
-            "portfolios.portfolio_admin",
-            portfolio_id=portfolio.id,
-            fragment="portfolio-members",
-            _anchor="portfolio-members",
+        return redirect(
+            url_for(
+                "portfolios.portfolio_admin",
+                portfolio_id=portfolio.id,
+                fragment="portfolio-members",
+                _anchor="portfolio-members",
+            )
         )
-    )
-
-    return render_admin_page(portfolio)
+    else:
+        return render_admin_page(portfolio)
 
 
 @portfolios_bp.route("/portfolios/<portfolio_id>/edit", methods=["POST"])

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -2,6 +2,8 @@ from datetime import date, timedelta
 
 from flask import render_template, request as http_request, g, redirect, url_for
 
+from atst.utils.flash import formatted_flash as flash
+
 from . import portfolios_bp
 from atst.domain.reports import Reports
 from atst.domain.portfolios import Portfolios
@@ -92,7 +94,7 @@ def portfolio_admin(portfolio_id):
 @user_can(Permissions.EDIT_PORTFOLIO_USERS, message="view portfolio admin page")
 def edit_portfolio_members(portfolio_id):
     portfolio = Portfolios.get_for_update(portfolio_id)
-    member_perms_form = MembersPermissionsForm(http_request.form)
+    member_perms_form = member_forms.MembersPermissionsForm(http_request.form)
 
     for subform in member_perms_form.members_permissions:
         new_perm_set = subform.data["permission_sets"]
@@ -100,6 +102,17 @@ def edit_portfolio_members(portfolio_id):
         portfolio_role = PortfolioRoles.get(portfolio.id, user_id)
         if portfolio_role.permission_sets != new_perm_set:
             PortfolioRoles.update(portfolio_role, new_perm_set)
+
+    flash("update_portfolio_members", portfolio=portfolio)
+
+    return redirect(
+        url_for(
+            "portfolios.portfolio_admin",
+            portfolio_id=portfolio.id,
+            fragment="portfolio-members",
+            _anchor="portfolio-members",
+        )
+    )
 
     return render_admin_page(portfolio)
 

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -95,6 +95,7 @@ def portfolio_admin(portfolio_id):
 def edit_portfolio_members(portfolio_id):
     portfolio = Portfolios.get_for_update(portfolio_id)
     member_perms_form = member_forms.MembersPermissionsForm(http_request.form)
+    has_changed = False
 
     for subform in member_perms_form.members_permissions:
         new_perm_set = subform.data["permission_sets"]
@@ -102,8 +103,10 @@ def edit_portfolio_members(portfolio_id):
         portfolio_role = PortfolioRoles.get(portfolio.id, user_id)
         if portfolio_role.permission_sets != new_perm_set:
             PortfolioRoles.update(portfolio_role, new_perm_set)
+            has_changed = True
 
-    flash("update_portfolio_members", portfolio=portfolio)
+    if has_changed:
+        flash("update_portfolio_members", portfolio=portfolio)
 
     return redirect(
         url_for(
@@ -111,6 +114,7 @@ def edit_portfolio_members(portfolio_id):
             portfolio_id=portfolio.id,
             fragment="portfolio-members",
             _anchor="portfolio-members",
+            has_changed=has_changed,
         )
     )
 

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -34,6 +34,7 @@ def permission_str(member, edit_perm_set, view_perm_set):
 def serialize_member_form_data(member):
     return {
         "member": member.user.full_name,
+        "user_id": member.user_id,
         "perms_app_mgmt": permission_str(
             member,
             PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT,
@@ -83,6 +84,16 @@ def render_admin_page(portfolio, form=None):
 @user_can(Permissions.VIEW_PORTFOLIO_ADMIN, message="view portfolio admin page")
 def portfolio_admin(portfolio_id):
     portfolio = Portfolios.get_for_update(portfolio_id)
+    return render_admin_page(portfolio)
+
+
+@portfolios_bp.route("/portfolios/<portfolio_id>/admin", methods=["POST"])
+@user_can(Permissions.EDIT_PORTFOLIO_USERS, message="view portfolio admin page")
+def edit_portfolio_members(portfolio_id):
+    portfolio = Portfolios.get_for_update(portfolio_id)
+    member_perms_form = MembersPermissionsForm(
+        http_request.form
+    )
     return render_admin_page(portfolio)
 
 

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -21,6 +21,13 @@ MESSAGES = {
         """,
         "category": "success",
     },
+    "update_portfolio_members": {
+        "title_template": "Success!",
+        "message_template": """
+            <p>You have successfully updated access permissions for members of {{ portfolio.name }}.</p>
+        """,
+        "category": "success",
+    },
     "new_portfolio_member": {
         "title_template": "Success!",
         "message_template": """

--- a/templates/fragments/admin/members_edit.html
+++ b/templates/fragments/admin/members_edit.html
@@ -16,5 +16,6 @@
 
     <td><button type="button" class='{{ archive_button_class }}'>{{ "portfolios.members.archive_button" | translate }}</button>
     </td>
+    {{ subform.user_id() }}
   </tr>
 {% endfor %}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -3,7 +3,7 @@
 
 <section class="member-list" id="portfolio-members">
   <div class='responsive-table-wrapper panel'>
-    {% if g.matchesPath("portfolio-members") and has_changed %}
+    {% if g.matchesPath("portfolio-members") %}
       {% include "fragments/flash.html" %}
     {% endif %}
     <form method='POST' id="member-perms" action='{{ url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id) }}' autocomplete="off" enctype="multipart/form-data">

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -6,13 +6,14 @@
     {% if g.matchesPath("portfolio-members") %}
       {% include "fragments/flash.html" %}
     {% endif %}
-    <form method='POST' id="member-perms" autocomplete="off" enctype="multipart/form-data">
-      <div class='member-list-header'>
-        <div class='left'>
-          <div class='h3'>{{ "portfolios.admin.portfolio_members_title" | translate }}</div>
-          <div class='subheading'>
-            {{ "portfolios.admin.portfolio_members_subheading" | translate }}
-          </div>
+    <form method='POST' action='{{ url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id) }}' autocomplete="off">
+    {{ member_perms_form.csrf_token }}
+
+    <div class='member-list-header'>
+      <div class='left'>
+        <div class='h3'>{{ "portfolios.admin.portfolio_members_title" | translate }}</div>
+        <div class='subheading'>
+          {{ "portfolios.admin.portfolio_members_subheading" | translate }}
         </div>
         <a class='icon-link'>
           {{ Icon('info') }}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -3,7 +3,7 @@
 
 <section class="member-list" id="portfolio-members">
   <div class='responsive-table-wrapper panel'>
-    {% if g.matchesPath("portfolio-members") %}
+    {% if g.matchesPath("portfolio-members") and has_changed %}
       {% include "fragments/flash.html" %}
     {% endif %}
     <form method='POST' id="member-perms" action='{{ url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id) }}' autocomplete="off" enctype="multipart/form-data">

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -6,7 +6,7 @@
     {% if g.matchesPath("portfolio-members") %}
       {% include "fragments/flash.html" %}
     {% endif %}
-    <form method='POST' action='{{ url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id) }}' autocomplete="off">
+    <form method='POST' id="member-perms" action='{{ url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id) }}' autocomplete="off" enctype="multipart/form-data">
     {{ member_perms_form.csrf_token }}
 
     <div class='member-list-header'>
@@ -15,10 +15,11 @@
         <div class='subheading'>
           {{ "portfolios.admin.portfolio_members_subheading" | translate }}
         </div>
-        <a class='icon-link'>
-          {{ Icon('info') }}
-          {{ "portfolios.admin.settings_info" | translate }}
-        </a>
+      </div>
+      <a class='icon-link'>
+        {{ Icon('info') }}
+        {{ "portfolios.admin.settings_info" | translate }}
+      </a>
       </div>
 
     {% if not portfolio.members %}

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -26,3 +26,77 @@ def test_member_table_access(client, user_session):
     user_session(rando)
     view_resp = client.get(url)
     assert "<select" not in view_resp.data.decode()
+
+
+def test_update_member_permissions(client, user_session):
+    portfolio = PortfolioFactory.create()
+    rando = UserFactory.create()
+    rando_pf_role = PortfolioRoleFactory.create(
+        user=rando,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.get(PermissionSets.VIEW_PORTFOLIO_ADMIN)],
+    )
+
+    user = UserFactory.create()
+    PortfolioRoleFactory.create(
+        user=user,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.get(PermissionSets.EDIT_PORTFOLIO_ADMIN)],
+    )
+    user_session(user)
+
+    form_data = {
+        "members_permissions-0-user_id": rando.id,
+        "members_permissions-0-perms_app_mgmt": "edit_portfolio_application_management",
+        "members_permissions-0-perms_funding": "view_portfolio_funding",
+        "members_permissions-0-perms_reporting": "view_portfolio_reports",
+        "members_permissions-0-perms_portfolio_mgmt": "view_portfolio_admin",
+    }
+
+    response = client.post(
+        url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id),
+        data=form_data,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert rando_pf_role.has_permission_set(
+        PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT
+    )
+
+
+def test_no_update_member_permissions_without_edit_access(client, user_session):
+    portfolio = PortfolioFactory.create()
+    rando = UserFactory.create()
+    rando_pf_role = PortfolioRoleFactory.create(
+        user=rando,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.get(PermissionSets.VIEW_PORTFOLIO_ADMIN)],
+    )
+
+    user = UserFactory.create()
+    PortfolioRoleFactory.create(
+        user=user,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.get(PermissionSets.VIEW_PORTFOLIO_ADMIN)],
+    )
+    user_session(user)
+
+    form_data = {
+        "members_permissions-0-user_id": rando.id,
+        "members_permissions-0-perms_app_mgmt": "edit_portfolio_application_management",
+        "members_permissions-0-perms_funding": "view_portfolio_funding",
+        "members_permissions-0-perms_reporting": "view_portfolio_reports",
+        "members_permissions-0-perms_portfolio_mgmt": "view_portfolio_admin",
+    }
+
+    response = client.post(
+        url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id),
+        data=form_data,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 404
+    assert not rando_pf_role.has_permission_set(
+        PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT
+    )

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -102,3 +102,31 @@ def test_no_update_member_permissions_without_edit_access(client, user_session):
     assert not rando_pf_role.has_permission_set(
         PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT
     )
+
+
+def test_rerender_admin_page_if_member_perms_form_does_not_validate(
+    client, user_session
+):
+    portfolio = PortfolioFactory.create()
+    user = UserFactory.create()
+    PortfolioRoleFactory.create(
+        user=user,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.get(PermissionSets.EDIT_PORTFOLIO_ADMIN)],
+    )
+    user_session(user)
+    form_data = {
+        "members_permissions-0-user_id": user.id,
+        "members_permissions-0-perms_app_mgmt": "bad input",
+        "members_permissions-0-perms_funding": "view_portfolio_funding",
+        "members_permissions-0-perms_reporting": "view_portfolio_reports",
+        "members_permissions-0-perms_portfolio_mgmt": "view_portfolio_admin",
+    }
+
+    response = client.post(
+        url_for("portfolios.edit_portfolio_members", portfolio_id=portfolio.id),
+        data=form_data,
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Portfolio Administration" in response.data.decode()

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -1,6 +1,7 @@
 from flask import url_for
 
 from atst.domain.permission_sets import PermissionSets
+from atst.routes.portfolios.index import permission_set_has_changed
 
 from tests.factories import PortfolioFactory, PortfolioRoleFactory, UserFactory
 
@@ -26,6 +27,32 @@ def test_member_table_access(client, user_session):
     user_session(rando)
     view_resp = client.get(url)
     assert "<select" not in view_resp.data.decode()
+
+
+def test_permission_set_has_changed_with_changes():
+    old_set = [
+        "edit_portfolio_application_management",
+        "view_portfolio_application_management",
+    ]
+    new_set = ["view_portfolio_application_management"]
+    assert permission_set_has_changed(old_set, new_set)
+
+    old_set = ["view_funding"]
+    new_set = ["edit_funding"]
+    assert permission_set_has_changed(old_set, new_set)
+
+
+def test_permission_set_has_changed_without_changes():
+    old_set = [
+        "edit_portfolio_application_management",
+        "view_portfolio_application_management",
+    ]
+    new_set = ["edit_portfolio_application_management"]
+    assert not permission_set_has_changed(old_set, new_set)
+
+    old_set = ["view_funding"]
+    new_set = ["view_funding"]
+    assert not permission_set_has_changed(old_set, new_set)
 
 
 def test_update_member_permissions(client, user_session):

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -68,7 +68,9 @@ def test_update_member_permissions(client, user_session):
     PortfolioRoleFactory.create(
         user=user,
         portfolio=portfolio,
-        permission_sets=[PermissionSets.get(PermissionSets.EDIT_PORTFOLIO_ADMIN)],
+        permission_sets=PermissionSets.get_many(
+            [PermissionSets.EDIT_PORTFOLIO_ADMIN, PermissionSets.VIEW_PORTFOLIO_ADMIN]
+        ),
     )
     user_session(user)
 

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -1,7 +1,6 @@
 from flask import url_for
 
 from atst.domain.permission_sets import PermissionSets
-from atst.routes.portfolios.index import permission_set_has_changed
 
 from tests.factories import PortfolioFactory, PortfolioRoleFactory, UserFactory
 
@@ -27,32 +26,6 @@ def test_member_table_access(client, user_session):
     user_session(rando)
     view_resp = client.get(url)
     assert "<select" not in view_resp.data.decode()
-
-
-def test_permission_set_has_changed_with_changes():
-    old_set = [
-        "edit_portfolio_application_management",
-        "view_portfolio_application_management",
-    ]
-    new_set = ["view_portfolio_application_management"]
-    assert permission_set_has_changed(old_set, new_set)
-
-    old_set = ["view_funding"]
-    new_set = ["edit_funding"]
-    assert permission_set_has_changed(old_set, new_set)
-
-
-def test_permission_set_has_changed_without_changes():
-    old_set = [
-        "edit_portfolio_application_management",
-        "view_portfolio_application_management",
-    ]
-    new_set = ["edit_portfolio_application_management"]
-    assert not permission_set_has_changed(old_set, new_set)
-
-    old_set = ["view_funding"]
-    new_set = ["view_funding"]
-    assert not permission_set_has_changed(old_set, new_set)
 
 
 def test_update_member_permissions(client, user_session):


### PR DESCRIPTION
## Description
This PR adds functionality to the dropdowns for the portfolio members table. When a user with `Edit Access` clicks `Save`, the permissions for users are updated. 

After clicking `Save`, the user is brought back to the members table and will see a Success banner. The success banner will always flash, even if no changes were sent, since in a later story, we will disable the `Save` button altogether until changes have been made.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/164446780

## Screenshot
<img width="1136" alt="Screen Shot 2019-03-29 at 2 33 47 PM" src="https://user-images.githubusercontent.com/42577527/55254976-b7acb380-522f-11e9-93e1-da3e2e2d8cc5.png">
