### PR TITLE
configure json logging for nginx in k8s cluster

### DIFF
--- a/deploy/kubernetes/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/atst-nginx-configmap.yml
@@ -8,6 +8,7 @@ data:
   nginx-config: |-
     server {
         server_name www.atat.code.mil atat.code.mil;
+        access_log /var/log/nginx/access.log json;
         listen 8442;
         listen [::]:8442 ipv6only=on;
         if ($http_x_forwarded_proto != 'https') {
@@ -25,15 +26,18 @@ data:
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
         location @appbasicauth {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
             auth_basic "Developer Access";
             auth_basic_user_file /etc/nginx/.htpasswd;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
     server {
+        access_log /var/log/nginx/access.log json;
         server_name auth.atat.code.mil;
         listen 8443 ssl;
         listen [::]:8443 ssl ipv6only=on;
@@ -75,5 +79,21 @@ data:
             uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
+  nginx-json-log-config: |-
+    log_format json escape=json
+      '{'
+        '"timestamp":"$time_iso8601",'
+        '"msec":"$msec",'
+        '"request_id":"$request_id",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for"'
+      '}';

--- a/deploy/kubernetes/atst.yml
+++ b/deploy/kubernetes/atst.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:4d50a80e
           resources:
             requests:
                memory: "2500Mi"
@@ -63,6 +63,9 @@ spec:
             - name: nginx-config
               mountPath: "/etc/nginx/conf.d/atst.conf"
               subPath: atst.conf
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d/00json_log.conf"
+              subPath: 00json_log.conf
             - name: nginx-dhparam
               mountPath: "/etc/ssl/dhparam.pem"
               subPath: dhparam.pem
@@ -104,6 +107,8 @@ spec:
             items:
             - key: nginx-config
               path: atst.conf
+            - key: nginx-json-log-config
+              path: 00json_log.conf
         - name: nginx-dhparam
           secret:
             secretName: dhparam-4096
@@ -153,7 +158,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:4d50a80e
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:

--- a/deploy/kubernetes/test/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/test/atst-nginx-configmap.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   nginx-config: |-
     server {
+        access_log /var/log/nginx/access.log json;
         server_name test.atat.code.mil;
         listen 8442;
         listen [::]:8442 ipv6only=on;
@@ -25,15 +26,18 @@ data:
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
         location @appbasicauth {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
             auth_basic "Developer Access";
             auth_basic_user_file /etc/nginx/.htpasswd;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
     server {
+        access_log /var/log/nginx/access.log json;
         server_name auth-test.atat.code.mil;
         listen 8443 ssl;
         listen [::]:8443 ssl ipv6only=on;
@@ -75,5 +79,21 @@ data:
             uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
+  nginx-json-log-config: |-
+    log_format json escape=json
+      '{'
+        '"timestamp":"$time_iso8601",'
+        '"msec":"$msec",'
+        '"request_id":"$request_id",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for"'
+      '}';

--- a/deploy/kubernetes/test/test.yml
+++ b/deploy/kubernetes/test/test.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:47ce80b4
           resources:
             requests:
                memory: "2500Mi"
@@ -60,6 +60,9 @@ spec:
             - name: nginx-config
               mountPath: "/etc/nginx/conf.d/atst.conf"
               subPath: atst.conf
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d/00json_log.conf"
+              subPath: 00json_log.conf
             - name: nginx-dhparam
               mountPath: "/etc/ssl/dhparam.pem"
               subPath: dhparam.pem
@@ -101,6 +104,8 @@ spec:
             items:
             - key: nginx-config
               path: atst.conf
+            - key: nginx-json-log-config
+              path: 00json_log.conf
         - name: nginx-dhparam
           secret:
             secretName: dhparam-4096
@@ -150,7 +155,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:47ce80b4
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:

--- a/deploy/kubernetes/uat/atst-nginx-configmap.yml
+++ b/deploy/kubernetes/uat/atst-nginx-configmap.yml
@@ -7,6 +7,7 @@ metadata:
 data:
   nginx-config: |-
     server {
+        access_log /var/log/nginx/access.log json;
         server_name uat.atat.code.mil;
         listen 8442;
         listen [::]:8442 ipv6only=on;
@@ -25,15 +26,18 @@ data:
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
         location @appbasicauth {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
             auth_basic "Developer Access";
             auth_basic_user_file /etc/nginx/.htpasswd;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
     server {
+        access_log /var/log/nginx/access.log json;
         server_name auth-uat.atat.code.mil;
         listen 8443 ssl;
         listen [::]:8443 ssl ipv6only=on;
@@ -75,5 +79,21 @@ data:
             uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
             uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+            uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }
+  nginx-json-log-config: |-
+    log_format json escape=json
+      '{'
+        '"timestamp":"$time_iso8601",'
+        '"msec":"$msec",'
+        '"request_id":"$request_id",'
+        '"remote_addr":"$remote_addr",'
+        '"remote_user":"$remote_user",'
+        '"request":"$request",'
+        '"status":$status,'
+        '"body_bytes_sent":$body_bytes_sent,'
+        '"referer":"$http_referer",'
+        '"user_agent":"$http_user_agent",'
+        '"http_x_forwarded_for":"$http_x_forwarded_for"'
+      '}';

--- a/deploy/kubernetes/uat/uat.yml
+++ b/deploy/kubernetes/uat/uat.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:03ee3438
           resources:
             requests:
                memory: "2500Mi"
@@ -63,6 +63,9 @@ spec:
             - name: nginx-config
               mountPath: "/etc/nginx/conf.d/atst.conf"
               subPath: atst.conf
+            - name: nginx-config
+              mountPath: "/etc/nginx/conf.d/00json_log.conf"
+              subPath: 00json_log.conf
             - name: nginx-dhparam
               mountPath: "/etc/ssl/dhparam.pem"
               subPath: dhparam.pem
@@ -104,6 +107,8 @@ spec:
             items:
             - key: nginx-config
               path: atst.conf
+            - key: nginx-json-log-config
+              path: 00json_log.conf
         - name: nginx-dhparam
           secret:
             secretName: dhparam-4096
@@ -153,7 +158,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: registry.atat.codes:443/atst-prod:50f0843c
+          image: registry.atat.codes:443/atst-prod:03ee3438
           args: ["/bin/bash", "-c", "/opt/atat/atst/script/rq_worker"]
           resources:
             requests:


### PR DESCRIPTION
This adds a JSON log format for our NGINX web servers in the kubernetes pods. 

The new log format includes most of the information that was available in the default NGINX logs, with some changes:
- it removes the `time_local` field
- it adds a [`request_id`](https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_id) field
- it adds a `timestamp` field which uses the [ISO 8601 timestamp from NGINX](https://nginx.org/en/docs/http/ngx_http_log_module.html#var_time_iso8601)
- it adds an `msec` field, which corresponds to the NGINX [`$msec`](https://nginx.org/en/docs/http/ngx_http_log_module.html#var_msec) variable (a UNIX epoch timestamp with milliseconds); this is just for additional info if someone wants millisecond data which isn't available on the other timestamp

We're also passing the `request_id` to the UWSGI environment so that it will be available to the Flask app when we adjust those logs on a subsequent PR.

These changes are already applied. If you tail web server logs for any environment, you'll get JSON entries: `kubectl -n atat logs [pod-name] -f --tail=5`