### PR TITLE
Remove Portfolio User

### DIFF
--- a/atst/domain/authz/__init__.py
+++ b/atst/domain/authz/__init__.py
@@ -1,7 +1,6 @@
 from atst.utils import first_or_none
 from atst.models.permissions import Permissions
 from atst.domain.exceptions import UnauthorizedError
-from atst.domain.portfolio_roles import PortfolioRoles
 from atst.models.portfolio_role import Status as PortfolioRoleStatus
 
 

--- a/atst/domain/authz/__init__.py
+++ b/atst/domain/authz/__init__.py
@@ -1,6 +1,8 @@
 from atst.utils import first_or_none
 from atst.models.permissions import Permissions
 from atst.domain.exceptions import UnauthorizedError
+from atst.domain.portfolio_roles import PortfolioRoles
+from atst.models.portfolio_role import Status as PortfolioRoleStatus
 
 
 class Authorization(object):
@@ -9,7 +11,7 @@ class Authorization(object):
         port_role = first_or_none(
             lambda pr: pr.portfolio == portfolio, user.portfolio_roles
         )
-        if port_role:
+        if port_role and port_role.status is not PortfolioRoleStatus.DISABLED:
             return permission in port_role.permissions
         else:
             return False

--- a/atst/domain/portfolio_roles.py
+++ b/atst/domain/portfolio_roles.py
@@ -122,6 +122,15 @@ class PortfolioRoles(object):
         return PermissionSets.get_many(perms_set_names)
 
     @classmethod
+    def disable(cls, portfolio_role):
+        portfolio_role.status = PortfolioRoleStatus.DISABLED
+
+        db.session.add(portfolio_role)
+        db.session.commit()
+
+        return portfolio_role
+
+    @classmethod
     def update(cls, portfolio_role, set_names):
         new_permission_sets = PortfolioRoles._permission_sets_for_names(set_names)
         portfolio_role.permission_sets = new_permission_sets

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -177,18 +177,16 @@ def portfolio_reports(portfolio_id):
 
 
 @portfolios_bp.route(
-    "/portfolios/<portfolio_id>/members/<member_id>/delete", methods=["POST"]
+    "/portfolios/<portfolio_id>/members/<user_id>/delete", methods=["POST"]
 )
 @user_can(Permissions.EDIT_PORTFOLIO_USERS, message="update portfolio members")
-def remove_member(portfolio_id, member_id):
-    if member_id == str(g.current_user.id):
+def remove_member(portfolio_id, user_id):
+    if str(g.current_user.id) == user_id:
         raise UnauthorizedError(
-            user=g.current_user, action="you cant remove yourself from the portfolio"
+            g.current_user, "you cant remove yourself from the portfolio"
         )
 
-    portfolio = Portfolios.get(g.current_user, portfolio_id)
-    portfolio_role = PortfolioRoles.get(portfolio_id=portfolio_id, user_id=member_id)
-
+    portfolio_role = PortfolioRoles.get(portfolio_id=portfolio_id, user_id=user_id)
     PortfolioRoles.disable(portfolio_role=portfolio_role)
 
     flash("portfolio_member_removed", member_name=portfolio_role.user.full_name)
@@ -196,7 +194,7 @@ def remove_member(portfolio_id, member_id):
     return redirect(
         url_for(
             "portfolios.portfolio_admin",
-            portfolio_id=portfolio.id,
+            portfolio_id=portfolio_id,
             _anchor="portfolio-members",
             fragment="portfolio-members",
         )

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -2,8 +2,6 @@ from datetime import date, timedelta
 
 from flask import render_template, request as http_request, g, redirect, url_for
 
-from atst.utils.flash import formatted_flash as flash
-
 from . import portfolios_bp
 from atst.domain.reports import Reports
 from atst.domain.portfolios import Portfolios

--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -16,6 +16,7 @@ from atst.models.permissions import Permissions
 from atst.domain.permission_sets import PermissionSets
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.utils.flash import formatted_flash as flash
+from atst.domain.exceptions import UnauthorizedError
 
 
 @portfolios_bp.route("/portfolios")
@@ -184,7 +185,7 @@ def portfolio_reports(portfolio_id):
 def remove_member(portfolio_id, member_id):
     if member_id == str(g.current_user.id):
         raise UnauthorizedError(
-            user=user, message="you cant remove yourself from the portfolio"
+            user=g.current_user, action="you cant remove yourself from the portfolio"
         )
 
     portfolio = Portfolios.get(g.current_user, portfolio_id)

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -138,6 +138,11 @@ MESSAGES = {
         """,
         "category": "error",
     },
+    "portfolio_member_removed": {
+        "title_template": "Portfolio Member Removed",
+        "message_template": "You have successfully removed {{ member_name }} from the portfolio.",
+        "category": "success",
+    },
 }
 
 

--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -291,6 +291,10 @@
       height: 4rem;
     }
 
+    .usa-button-danger {
+      background: $color-red;
+    }
+
     .members-table-footer {
       float: right;
       padding: 3 * $gap;

--- a/templates/fragments/admin/members_edit.html
+++ b/templates/fragments/admin/members_edit.html
@@ -1,8 +1,8 @@
 {% from "components/confirmation_button.html" import ConfirmationButton %}
 
-{% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, user.id) %}
-
 {% for subform in member_perms_form.members_permissions %}
+  {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, subform.user_id.data) %}
+
   <tr>
     <td class='name'>{{ subform.member.data }}
       {% if subform.member.data == user.full_name %}

--- a/templates/fragments/admin/members_edit.html
+++ b/templates/fragments/admin/members_edit.html
@@ -1,3 +1,7 @@
+{% from "components/confirmation_button.html" import ConfirmationButton %}
+
+{% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, user.id) %}
+
 {% for subform in member_perms_form.members_permissions %}
   <tr>
     <td class='name'>{{ subform.member.data }}
@@ -14,7 +18,10 @@
     <td>{{ OptionsInput(subform.perms_reporting, label=False) }}</td>
     <td>{{ OptionsInput(subform.perms_portfolio_mgmt, label=False) }}</td>
 
-    <td><button type="button" class='{{ archive_button_class }}'>{{ "portfolios.members.archive_button" | translate }}</button>
+    <td>
+      <a v-on:click="openModal('{{ modal_id }}')" class='usa-button {{ archive_button_class }}'>
+        {{ "portfolios.members.archive_button" | translate }}
+      </a>
     </td>
     {{ subform.user_id() }}
   </tr>

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -1,6 +1,9 @@
 {% from "components/icon.html" import Icon %}
 {% from "components/options_input.html" import OptionsInput %}
 
+{% from "components/modal.html" import Modal %}
+{% from "components/alert.html" import Alert %}
+
 <section class="member-list" id="portfolio-members">
   <div class='responsive-table-wrapper panel'>
     {% if g.matchesPath("portfolio-members") %}
@@ -51,6 +54,34 @@
     {% endif %}
 
     </form>
+
+    {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
+      {% for member in portfolio.members %}
+        {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, user.id) %}
+        {% call Modal(name=modal_id, dismissable=False) %}
+          <h1>Are you sure you want to archive this user?</h1>
+
+          {{
+            Alert(
+              title="Warning! You  are about to  archive a user from the portfolio  admin.",
+              message="User will be removed from the portfolio, but their log history will be retained.",
+              level="warning"
+            )
+          }}
+
+          <div class="action-group">
+            <form method="POST" action="{{ url_for('portfolios.remove_member', portfolio_id=portfolio.id, member_id=member.user_id)  }}">
+              {{ member_perms_form.csrf_token }}
+              <button class="usa-button usa-button-danger">
+                {{ "portfolios.members.archive_button" | translate }}
+              </button>
+            </form>
+            <a v-on:click="closeModal('d')">Cancel</a>
+          </div>
+        {% endcall %}
+      {% endfor %}
+    {% endif %}
+
     <div class="members-table-footer">
       <div class="action-group">
         {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -76,7 +76,7 @@
                 {{ "portfolios.members.archive_button" | translate }}
               </button>
             </form>
-            <a v-on:click="closeModal('{{ modal_id }}')">Cancel</a>
+            <a v-on:click="closeModal('{{ modal_id }}')" class="action-group__action icon-link icon-link--default">Cancel</a>
           </div>
         {% endcall %}
       {% endfor %}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -70,7 +70,7 @@
           }}
 
           <div class="action-group">
-            <form method="POST" action="{{ url_for('portfolios.remove_member', portfolio_id=portfolio.id, member_id=member.user_id)  }}">
+            <form method="POST" action="{{ url_for('portfolios.remove_member', portfolio_id=portfolio.id, user_id=member.user_id)  }}">
               {{ member_perms_form.csrf_token }}
               <button class="usa-button usa-button-danger">
                 {{ "portfolios.members.archive_button" | translate }}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -76,7 +76,7 @@
                 {{ "portfolios.members.archive_button" | translate }}
               </button>
             </form>
-            <a v-on:click="closeModal('d')">Cancel</a>
+            <a v-on:click="closeModal('{{ modal_id }}')">Cancel</a>
           </div>
         {% endcall %}
       {% endfor %}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -57,7 +57,7 @@
 
     {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
       {% for member in portfolio.members %}
-        {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, user.id) %}
+        {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, member.user_id) %}
         {% call Modal(name=modal_id, dismissable=False) %}
           <h1>Are you sure you want to archive this user?</h1>
 

--- a/tests/domain/test_authz.py
+++ b/tests/domain/test_authz.py
@@ -11,6 +11,7 @@ from atst.domain.authz.decorator import user_can_access_decorator
 from atst.domain.permission_sets import PermissionSets
 from atst.domain.exceptions import UnauthorizedError
 from atst.models.permissions import Permissions
+from atst.domain.portfolio_roles import PortfolioRoles
 
 from tests.utils import FakeLogger
 
@@ -96,6 +97,14 @@ def test_user_can_access():
     assert user_can_access(
         edit_admin, Permissions.EDIT_PORTFOLIO_NAME, portfolio=portfolio
     )
+    with pytest.raises(UnauthorizedError):
+        user_can_access(
+            view_admin, Permissions.EDIT_PORTFOLIO_NAME, portfolio=portfolio
+        )
+
+    # check when portfolio_role is disabled
+    view_admin_pr = PortfolioRoles.get(portfolio_id=portfolio.id, user_id=view_admin.id)
+    PortfolioRoles.disable(portfolio_role=view_admin_pr)
     with pytest.raises(UnauthorizedError):
         user_can_access(
             view_admin, Permissions.EDIT_PORTFOLIO_NAME, portfolio=portfolio

--- a/tests/domain/test_authz.py
+++ b/tests/domain/test_authz.py
@@ -76,7 +76,7 @@ def test_user_can_access():
 
     portfolio = PortfolioFactory.create(owner=edit_admin)
     # factory gives view perms by default
-    PortfolioRoleFactory.create(user=view_admin, portfolio=portfolio)
+    view_admin_pr = PortfolioRoleFactory.create(user=view_admin, portfolio=portfolio)
 
     # check a site-wide permission
     assert user_can_access(ccpo, Permissions.VIEW_AUDIT_LOG)
@@ -103,7 +103,6 @@ def test_user_can_access():
         )
 
     # check when portfolio_role is disabled
-    view_admin_pr = PortfolioRoles.get(portfolio_id=portfolio.id, user_id=view_admin.id)
     PortfolioRoles.disable(portfolio_role=view_admin_pr)
     with pytest.raises(UnauthorizedError):
         user_can_access(

--- a/tests/domain/test_portfolio_roles.py
+++ b/tests/domain/test_portfolio_roles.py
@@ -29,3 +29,11 @@ def test_add_portfolio_role_with_permission_sets():
     ]
     actual_names = [prms.name for prms in port_role.permission_sets]
     assert expected_names == expected_names
+
+
+def test_disable_portfolio_role():
+    portfolio_role = PortfolioRoleFactory.create(status=PortfolioRoleStatus.ACTIVE)
+    assert portfolio_role.status == PortfolioRoleStatus.ACTIVE
+
+    PortfolioRoles.disable(portfolio_role=portfolio_role)
+    assert portfolio_role.status == PortfolioRoleStatus.DISABLED

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -92,9 +92,7 @@ def test_remove_portfolio_member(client, user_session):
     user_session(portfolio.owner)
 
     response = client.post(
-        url_for(
-            "portfolios.remove_member", portfolio_id=portfolio.id, member_id=user.id
-        ),
+        url_for("portfolios.remove_member", portfolio_id=portfolio.id, user_id=user.id),
         follow_redirects=False,
     )
 
@@ -121,7 +119,7 @@ def test_remove_portfolio_member_self(client, user_session):
         url_for(
             "portfolios.remove_member",
             portfolio_id=portfolio.id,
-            member_id=portfolio.owner.id,
+            user_id=portfolio.owner.id,
         ),
         follow_redirects=False,
     )

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -2,7 +2,8 @@ from flask import url_for
 
 from atst.domain.permission_sets import PermissionSets
 from atst.models.permissions import Permissions
-from atst.domain.portfolio_roles import PortfolioRoles, Status as PortfolioRoleStatus
+from atst.domain.portfolio_roles import PortfolioRoles
+from atst.models.portfolio_role import Status as PortfolioRoleStatus
 
 from tests.factories import (
     random_future_date,

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -126,7 +126,7 @@ def test_remove_portfolio_member_self(client, user_session):
         follow_redirects=False,
     )
 
-    assert response.status_code == 500
+    assert response.status_code == 404
     assert (
         PortfolioRoles.get(portfolio_id=portfolio.id, user_id=portfolio.owner.id).status
         == PortfolioRoleStatus.ACTIVE

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -2,8 +2,7 @@ from flask import url_for
 
 from atst.domain.permission_sets import PermissionSets
 from atst.models.permissions import Permissions
-from atst.domain.portfolio_roles import PortfolioRoles
-from atst.models.portfolio_role import Status as PortfolioRoleStatus
+from atst.domain.portfolio_roles import PortfolioRoles, Status as PortfolioRoleStatus
 
 from tests.factories import (
     random_future_date,


### PR DESCRIPTION
### Questions

Do we have a standard way of displaying a flash message in different form sections?

### Pivotal Tracker

* https://www.pivotaltracker.com/story/show/164446534

### Acceptance Criteria

```gherkin
Scenario: 
Given I am viewing the portfolio admin page as a user with Edit privileges for Portfolio Admin,
When I click "remove user" next to a user's row on the table,
Then I see a confirmation dialog per the design,
Then if I click 'Archive user" I am returned to the portfolio admin page at an anchor above the table,
And I see a success banner reading "You have successfully removed [User Name] from the portfolio,"
And the user has No Access to the portfolio.
```
