### PR TITLE
Moving scope examples with rest of scope description

### DIFF
--- a/templates/task_orders/new/app_info.html
+++ b/templates/task_orders/new/app_info.html
@@ -23,7 +23,6 @@
 {% endif %}
 
 {{ TextInput(form.scope, paragraph=True) }}
-<p><i>{{ "task_orders.new.app_info.sample_scope" | translate | safe }}</i></p>
 
 <div class="subheading--black">
     {% if portfolio %}

--- a/translations.yaml
+++ b/translations.yaml
@@ -184,7 +184,7 @@ forms:
     portfolio_name_label: Organization Portfolio Name
     portfolio_name_description: The name of your office or organization. You can add multiple applications to your portfolio. Your task orders are used to pay for these applications and their environments.
     scope_label: Cloud Project Scope
-    scope_description: Your team's plan for using the cloud, such as migrating an existing application or creating a prototype.
+    scope_description: Your team's plan for using the cloud, such as migrating an existing application or creating a prototype. <p>Not sure how to describe your scope? <a href="#">Read some examples</a> to get some inspiration.</p>
     defense_component_label: Department of Defense Component
     app_migration:
       label: App Migration


### PR DESCRIPTION
## Description

Moved the scope example text on the what you're making of TO flow to be with the rest of its friends. Currently it looks like it belongs more to the DoD component dropdown.

## Screenshot
<img width="795" alt="Screen Shot 2019-04-02 at 10 57 27 AM" src="https://user-images.githubusercontent.com/45826956/55412823-1dea4c80-5536-11e9-8194-8785120b3c8c.png">
