### PR TITLE
Update Point of Contact

### DIFF
--- a/atst/domain/portfolio_roles.py
+++ b/atst/domain/portfolio_roles.py
@@ -122,6 +122,28 @@ class PortfolioRoles(object):
         return PermissionSets.get_many(perms_set_names)
 
     @classmethod
+    def make_ppoc(cls, portfolio_role):
+        portfolio = portfolio_role.portfolio
+        original_owner_role = PortfolioRoles.get(
+            portfolio_id=portfolio.id, user_id=portfolio.owner.id
+        )
+        PortfolioRoles.revoke_ppoc_permissions(portfolio_role=original_owner_role)
+        PortfolioRoles.add(
+            user=portfolio_role.user,
+            portfolio_id=portfolio.id,
+            permission_sets=PortfolioRoles.PORTFOLIO_PERMISSION_SETS,
+        )
+
+    @classmethod
+    def revoke_ppoc_permissions(cls, portfolio_role):
+        permission_sets = [
+            permission_set.name
+            for permission_set in portfolio_role.permission_sets
+            if permission_set.name != PermissionSets.PORTFOLIO_POC
+        ]
+        PortfolioRoles.update(portfolio_role=portfolio_role, set_names=permission_sets)
+
+    @classmethod
     def disable(cls, portfolio_role):
         portfolio_role.status = PortfolioRoleStatus.DISABLED
 

--- a/atst/forms/portfolio_member.py
+++ b/atst/forms/portfolio_member.py
@@ -80,3 +80,11 @@ class NewForm(PermissionsForm):
         translate("forms.new_member.dod_id_label"),
         validators=[Required(), Length(min=10), IsNumber()],
     )
+
+
+class AssignPPOCForm(PermissionsForm):
+    user_id = SelectField(
+        label=translate("forms.assign_ppoc.dod_id"),
+        validators=[Required()],
+        choices=[("", "- Select -")],
+    )

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -2,6 +2,11 @@ from flask import flash, render_template_string
 from atst.utils.localization import translate
 
 MESSAGES = {
+    "primary_point_of_contact_changed": {
+        "title_template": "Primary Point of Contact Changed",
+        "message_template": "You have successfully added {{ ppoc_name }} as Point of Contact. You are no longer the PoC.",
+        "category": "success",
+    },
     "invitation_resent": {
         "title_template": "Invitation resent",
         "message_template": "The {{ officer_type }}  has been resent instructions to join this portfolio.",

--- a/templates/components/multi_step_modal_form.html
+++ b/templates/components/multi_step_modal_form.html
@@ -25,13 +25,16 @@
   </div>
 {% endmacro %}
 
-{% macro MultiStepModalForm(name, form, form_action, steps, button_text="", dismissable=False) -%}
+{% macro MultiStepModalForm(name, form, form_action, steps, button_icon="", button_text="", link_classes="icon-link modal-link", dismissable=False) -%}
   {% set step_count = steps|length %}
   <multi-step-modal-form inline-template :steps={{ step_count }}>
     <div>
-      <a class='icon-link modal-link' v-on:click="openModal('{{ name }}')">
+      <a class='{{ link_classes }}' v-on:click="openModal('{{ name }}')">
         {{ button_text }}
-        {{ Icon('plus-circle-solid') }}
+
+        {% if button_icon != "" %}
+          {{ Icon(button_icon) }}
+        {% endif %}
       </a>
         {% call Modal(name=name, dismissable=dismissable, classes="wide") %}
           <form id="{{ name }}" action="{{ form_action }}" method="POST" v-on:submit="handleSubmit">

--- a/templates/fragments/admin/add_new_portfolio_member.html
+++ b/templates/fragments/admin/add_new_portfolio_member.html
@@ -80,5 +80,6 @@
     member_form,
     url_for("portfolios.create_member", portfolio_id=portfolio.id),
     [step_one, step_two],
-    button_text="portfolios.admin.add_new_member" | translate)
-  }}
+    button_text=("portfolios.admin.add_new_member" | translate),
+    button_icon="plus-circle-solid",
+  ) }}

--- a/templates/fragments/admin/change_ppoc.html
+++ b/templates/fragments/admin/change_ppoc.html
@@ -1,0 +1,82 @@
+{% from "components/icon.html" import Icon %}
+{% from "components/selector.html" import Selector %}
+{% from "components/text_input.html" import TextInput %}
+{% from "components/multi_step_modal_form.html" import MultiStepModalForm %}
+{% from "components/alert.html" import Alert %}
+{% from "components/options_input.html" import OptionsInput %}
+
+{% set step_one %}
+  <div class="modal__form--header">
+    <h1>{{ "fragments.ppoc.update_ppoc_title" | translate }}</h1>
+  </div>
+
+  {{
+    Alert(
+      level="warning",
+      title=("fragments.ppoc.alert.title" | translate),
+      message=("fragments.ppoc.alert.message" | translate),
+    )
+  }}
+
+  <div class='form-row'>
+    <div class='form-col form-col--half'>
+      {{
+        OptionsInput(
+          assign_ppoc_form.user_id
+        )
+      }}
+    </div>
+    <div class='form-col form-col--half'>
+    </div>
+  </div>
+  <div class='action-group'>
+    <input
+        type='button'
+        v-on:click="next()"
+        v-bind:disabled="invalid"
+        class='action-group__action usa-button'
+        value='{{ "fragments.ppoc.assign_user_button_text" | translate }}'>
+    <a class='action-group__action icon-link icon-link--default' v-on:click="closeModal('change-ppoc-form')">
+      {{ "common.cancel" | translate }}
+    </a>
+  </div>
+{% endset %}
+
+{% set step_two %}
+  <div class="modal__form--padded">
+    <div class="modal__form--header">
+      <h1>{{ "fragments.ppoc.update_ppoc_confirmation_title" | translate }}</h1>
+    </div>
+
+    {{
+      Alert(
+        level="info",
+        title=("fragments.ppoc.confirm_alert.title" | translate),
+      )
+    }}
+
+    <div class='action-group'>
+      <input
+        type="submit"
+        class='action-group__action usa-button'
+        form="change-ppoc-form"
+        value='{{ "common.confirm" | translate }}'>
+      <a class='action-group__action icon-link icon-link--default' v-on:click="closeModal('change-ppoc-form')">
+        {{ "common.cancel" | translate }}
+      </a>
+    </div>
+  </div>
+{% endset %}
+
+<div class="flex-reverse-row">
+  {{
+    MultiStepModalForm(
+      'change-ppoc-form',
+      assign_ppoc_form,
+      form_action=url_for("portfolios.update_ppoc", portfolio_id=portfolio.id),
+      steps=[step_one, step_two],
+      button_text=("fragments.ppoc.update_btn" | translate),
+      link_classes="usa-button-primary"
+    )
+  }}
+</div>

--- a/templates/fragments/primary_point_of_contact.html
+++ b/templates/fragments/primary_point_of_contact.html
@@ -1,5 +1,9 @@
-<div class="panel">
+<section id="primary-point-of-contact" class="panel">
   <div class="panel__content">
+    {% if g.matchesPath("primary-point-of-contact") %}
+      {% include "fragments/flash.html" %}
+    {% endif %}
+
     <h2>{{ "fragments.ppoc.title" | translate }}</h2>
     <p>{{ "fragments.ppoc.subtitle" | translate }}</p>
 
@@ -15,11 +19,7 @@
     </p>
 
     {% if user_can(permissions.EDIT_PORTFOLIO_POC) %}
-      <div class="flex-reverse-row">
-        <a class="usa-button-primary">
-          {{ "fragments.ppoc.update_btn" | translate }}
-        </a>
-      </div>
+      {% include "fragments/admin/change_ppoc.html" %}
     {% endif %}
   </div>
-</div>
+</section>

--- a/tests/routes/portfolios/test_portfolios_index.py
+++ b/tests/routes/portfolios/test_portfolios_index.py
@@ -1,9 +1,12 @@
-from flask import url_for
+import pytest
 
+from flask import url_for
 from atst.domain.permission_sets import PermissionSets
+from atst.domain.portfolios import Portfolios
 from atst.models.permissions import Permissions
 from atst.domain.portfolio_roles import PortfolioRoles
 from atst.models.portfolio_role import Status as PortfolioRoleStatus
+from atst.domain.exceptions import UnauthorizedError
 
 from tests.factories import (
     random_future_date,
@@ -26,6 +29,114 @@ def test_update_portfolio_name(client, user_session):
     )
     assert response.status_code == 200
     assert portfolio.name == "a cool new name"
+
+
+def updating_ppoc_successfully(client, old_ppoc, new_ppoc, portfolio):
+    response = client.post(
+        url_for("portfolios.update_ppoc", portfolio_id=portfolio.id, _external=True),
+        data={"user_id": new_ppoc.id},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == url_for(
+        "portfolios.portfolio_admin",
+        portfolio_id=portfolio.id,
+        fragment="primary-point-of-contact",
+        _anchor="primary-point-of-contact",
+        _external=True,
+    )
+    assert portfolio.owner.id == new_ppoc.id
+    assert (
+        Permissions.EDIT_PORTFOLIO_POC
+        in PortfolioRoles.get(
+            portfolio_id=portfolio.id, user_id=new_ppoc.id
+        ).permissions
+    )
+    assert (
+        Permissions.EDIT_PORTFOLIO_POC
+        not in PortfolioRoles.get(portfolio.id, old_ppoc.id).permissions
+    )
+
+
+def test_update_ppoc_no_user_id_specified(client, user_session):
+    portfolio = PortfolioFactory.create()
+
+    user_session(portfolio.owner)
+
+    response = client.post(
+        url_for("portfolios.update_ppoc", portfolio_id=portfolio.id, _external=True),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 404
+
+
+def test_update_ppoc_to_member_not_on_portfolio(client, user_session):
+    portfolio = PortfolioFactory.create()
+    original_ppoc = portfolio.owner
+    non_portfolio_member = UserFactory.create()
+
+    user_session(original_ppoc)
+
+    response = client.post(
+        url_for("portfolios.update_ppoc", portfolio_id=portfolio.id, _external=True),
+        data={"user_id": non_portfolio_member.id},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 404
+    assert portfolio.owner.id == original_ppoc.id
+
+
+def test_update_ppoc_when_ppoc(client, user_session):
+    portfolio = PortfolioFactory.create()
+    original_ppoc = portfolio.owner
+    new_ppoc = UserFactory.create()
+    Portfolios.add_member(
+        member=new_ppoc,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.VIEW_PORTFOLIO],
+    )
+
+    user_session(original_ppoc)
+
+    updating_ppoc_successfully(
+        client=client, new_ppoc=new_ppoc, old_ppoc=original_ppoc, portfolio=portfolio
+    )
+
+
+def test_update_ppoc_when_cpo(client, user_session):
+    ccpo = UserFactory.create_ccpo()
+    portfolio = PortfolioFactory.create()
+    original_ppoc = portfolio.owner
+    new_ppoc = UserFactory.create()
+    Portfolios.add_member(
+        member=new_ppoc,
+        portfolio=portfolio,
+        permission_sets=[PermissionSets.VIEW_PORTFOLIO],
+    )
+
+    user_session(ccpo)
+
+    updating_ppoc_successfully(
+        client=client, new_ppoc=new_ppoc, old_ppoc=original_ppoc, portfolio=portfolio
+    )
+
+
+def test_update_ppoc_when_not_ppoc(client, user_session):
+    portfolio = PortfolioFactory.create()
+    new_owner = UserFactory.create()
+
+    user_session(new_owner)
+
+    response = client.post(
+        url_for("portfolios.update_ppoc", portfolio_id=portfolio.id, _external=True),
+        data={"dod_id": new_owner.dod_id},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 404
 
 
 def test_portfolio_index_with_existing_portfolios(client, user_session):

--- a/translations.yaml
+++ b/translations.yaml
@@ -28,6 +28,8 @@ flash:
   delete_member_success: You have successfully deleted {member_name} from the portfolio.
 common:
   back: Back
+  cancel: Cancel
+  confirm: Confirm
   edit: Edit
   manage: manage
   cancel: Cancel
@@ -61,6 +63,8 @@ footer:
   browser_support: JEDI Cloud supported on these web browsers
   jedi_help_link_text: Questions? Contact your CCPO representative
 forms:
+  assign_ppoc:
+    dod_id: "Select new primary point of contact:"
   ccpo_review:
     comment_description: Provide instructions or notes for additional information that is necessary to approve the request here. The requestor may then re-submit the updated request or initiate contact outside of AT-AT if further discussion is required. <strong>This message will be shared with the person making the JEDI request.</strong>.
     comment_label: Instructions or comments
@@ -319,6 +323,14 @@ fragments:
     title: Primary point of contact (PPoC)
     subtitle: The PPoC has the ability to edit all aspects of a portfolio and is the only one who can manage the PPoC role.
     update_btn: Update
+    assign_user_button_text: Assign User
+    update_ppoc_confirmation_title: Confirmation
+    update_ppoc_title: Update Primary Point of Contact.
+    confirm_alert:
+      title: Once you assign a new point of contact, you will no longer be able to request portfolio deactivation or manage the point of contact role.
+    alert:
+      title: Warning!
+      message: Selecting a new primary contact gives that member full access to the portfolio and removes your PoC rights. Please be sure you want to proceed.
 login:
   ccpo_logo_alt_text: Cloud Computing Program Office Logo
   certificate_selection:


### PR DESCRIPTION
### Ticket

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164447295)

### Acceptance Criteria

```gherkin
	Given I am the Primary Point of Contact for a portfolio,
	When I click the ‘Change Primary Point of Contact’ button,
	Then I see a modal with an info box per the design
	Then if I click Confirm I see a modal with the following:
	A warning with text per the design,
	A selection box reading “select primary point of contact,” populated with all portfolio users,
	But Pending users are grayed out and “(Pending)” is next to their name
	And if I select one and click Confirm,
	Then that user is set to be the Primary Point of Contact,
	And that user is given “Edit” access for all portfolio privileges,
	And I am set to NOT be the PoC,
	Then I am returned to the Portfolio Admin page,
	And I am sent to an anchor at the top of the Primary Point of Contact section,
	And I see a success banner reading “You have successfully added [new PoC name] as Point of Contact. You are no longer the PoC.” (see https://promptworks.invisionapp.com/share/CYQR5UKA5HM#/screens/349427846)
	And I can see the new PoC’s profile information in the PoC box.
```