### PR TITLE
add uwsgi logfile plugin for additional loggers

### DIFF
--- a/script/alpine_setup
+++ b/script/alpine_setup
@@ -10,7 +10,7 @@ APP_USER="atst"
 APP_UID="8010"
 
 # Add additional packages required by app dependencies
-ADDITIONAL_PACKAGES="postgresql-libs python3 rsync uwsgi uwsgi-python3"
+ADDITIONAL_PACKAGES="postgresql-libs python3 rsync uwsgi uwsgi-python3 uwsgi-logfile"
 
 # add sync-crl cronjob for atst user
 echo "1 */6 * * * /opt/atat/atst/script/sync-crls tests/crl-tmp" >> /etc/crontabs/atst


### PR DESCRIPTION
This adds an additional uWSGI package to our build. I'm pretty sure it's how we get some of the basic uWSGI loggers like `file` and `stdio` (which I want!).