### PR TITLE
record portfolio_role permission_set changes with bulk_replace event

### DIFF
--- a/atst/models/mixins/auditable.py
+++ b/atst/models/mixins/auditable.py
@@ -11,14 +11,15 @@ ACTION_DELETE = "delete"
 
 class AuditableMixin(object):
     @staticmethod
-    def create_audit_event(connection, resource, action):
+    def create_audit_event(connection, resource, action, changed_state=None):
         user_id = getattr_path(g, "current_user.id")
         portfolio_id = resource.portfolio_id
         resource_type = resource.resource_type
         display_name = resource.displayname
         event_details = resource.event_details
 
-        changed_state = resource.history if action == ACTION_UPDATE else None
+        if changed_state is None:
+            changed_state = resource.history if action == ACTION_UPDATE else None
 
         audit_event = AuditEvent(
             user_id=user_id,

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -36,6 +36,7 @@ PORTFOLIO_USERS = [
         "email": "knight@mil.gov",
         "portfolio_role": "developer",
         "dod_id": "0000000001",
+        "permission_sets": PortfolioRoles.DEFAULT_PORTFOLIO_PERMISSION_SETS,
     },
     {
         "first_name": "Mario",
@@ -43,6 +44,7 @@ PORTFOLIO_USERS = [
         "email": "hudson@mil.gov",
         "portfolio_role": "billing_auditor",
         "dod_id": "0000000002",
+        "permission_sets": PortfolioRoles.DEFAULT_PORTFOLIO_PERMISSION_SETS,
     },
     {
         "first_name": "Louise",
@@ -50,6 +52,7 @@ PORTFOLIO_USERS = [
         "email": "greer@mil.gov",
         "portfolio_role": "admin",
         "dod_id": "0000000003",
+        "permission_sets": PortfolioRoles.DEFAULT_PORTFOLIO_PERMISSION_SETS,
     },
 ]
 


### PR DESCRIPTION
This fixes the problem outlined in this PT card: https://www.pivotaltracker.com/story/show/164648971

We were not recording permission set changes for the portfolio role in the audit log because changes to the join table did not trigger the `after_insert` or `after_update` events we use to track all other changes that appear in the audit log. Instead, I've added a separate event listener for [`bulk_replace` ORM events](https://docs.sqlalchemy.org/en/latest/orm/events.html#sqlalchemy.orm.events.AttributeEvents.bulk_replace) on the `permission_set` attribute. I've set the decorator to provide the [`raw` instance state](https://docs.sqlalchemy.org/en/latest/orm/events.html#sqlalchemy.orm.events.AttributeEvents.params.raw) so that we can get the previous permission set and build a correct `change_set` for the audit event.

The drawback to this method is that it doesn't correspond to a database write the way the other event types we use do. After a lot of research, I couldn't find an appropriate event tied directly to a database write that would let us track permission sets changes. It would only be in very unusual circumstances that this hook creates an incorrect audit event, though (the actual perm sets update is rolled back but the audit event insertion succeeds).