### PR TITLE
Display app users

### DIFF
--- a/atst/models/application.py
+++ b/atst/models/application.py
@@ -5,6 +5,13 @@ from atst.models import Base
 from atst.models.types import Id
 from atst.models import mixins
 
+from atst.models.application_role import (
+    ApplicationRole,
+    Status as ApplicationRoleStatuses,
+)
+
+from atst.database import db
+
 
 class Application(
     Base, mixins.TimestampsMixin, mixins.AuditableMixin, mixins.DeletableMixin
@@ -27,6 +34,15 @@ class Application(
     @property
     def users(self):
         return set(role.user for role in self.roles)
+
+    @property
+    def members(self):
+        return (
+            db.session.query(ApplicationRole)
+            .filter(ApplicationRole.application_id == self.id)
+            .filter(ApplicationRole.status != ApplicationRoleStatuses.DISABLED)
+            .all()
+        )
 
     @property
     def num_users(self):

--- a/atst/models/application_role.py
+++ b/atst/models/application_role.py
@@ -4,6 +4,7 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import relationship
 from sqlalchemy.event import listen
 
+from atst.utils import first_or_none
 from atst.models import Base, mixins
 from atst.models.mixins.auditable import record_permission_sets_updates
 from .types import Id
@@ -58,6 +59,11 @@ class ApplicationRole(
     @property
     def history(self):
         return self.get_changes()
+
+    def has_permission_set(self, perm_set_name):
+        return first_or_none(
+            lambda prms: prms.name == perm_set_name, self.permission_sets
+        )
 
 
 Index(

--- a/atst/routes/portfolios/applications.py
+++ b/atst/routes/portfolios/applications.py
@@ -9,6 +9,7 @@ from flask import (
 
 from . import portfolios_bp
 from atst.domain.environment_roles import EnvironmentRoles
+from atst.domain.environments import Environments
 from atst.domain.exceptions import UnauthorizedError
 from atst.domain.applications import Applications
 from atst.domain.portfolios import Portfolios
@@ -16,6 +17,8 @@ from atst.forms.application import NewApplicationForm, ApplicationForm
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.models.permissions import Permissions
 from atst.utils.flash import formatted_flash as flash
+from atst.domain.permission_sets import PermissionSets
+from atst.utils.localization import translate
 
 
 @portfolios_bp.route("/portfolios/<portfolio_id>/applications")
@@ -138,4 +141,45 @@ def delete_application(portfolio_id, application_id):
 
     return redirect(
         url_for("portfolios.portfolio_applications", portfolio_id=portfolio_id)
+    )
+
+
+def permission_str(member, edit_perm_set):
+    if member.has_permission_set(edit_perm_set):
+        return translate("portfolios.members.permissions.edit_access")
+    else:
+        return translate("portfolios.members.permissions.view_only")
+
+
+@portfolios_bp.route("/portfolios/<portfolio_id>/applications/<application_id>/team")
+@user_can(Permissions.VIEW_APPLICATION, message="view portfolio applications")
+def application_team(portfolio_id, application_id):
+    application = Applications.get(application_id)
+    portfolio = Portfolios.get(g.current_user, portfolio_id)
+
+    environment_users = {}
+    for member in application.members:
+        user_id = member.user.id
+        environment_users[user_id] = {
+            "permissions": {
+                "delete_access": permission_str(
+                    member, PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
+                ),
+                "environment_management": permission_str(
+                    member, PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
+                ),
+                "team_management": permission_str(
+                    member, PermissionSets.EDIT_APPLICATION_TEAM
+                ),
+            },
+            "environments": Environments.for_user(
+                user=member.user, application=application
+            ),
+        }
+
+    return render_template(
+        "portfolios/applications/team.html",
+        application=application,
+        portfolio=portfolio,
+        environment_users=environment_users,
     )

--- a/atst/routes/portfolios/applications.py
+++ b/atst/routes/portfolios/applications.py
@@ -154,7 +154,6 @@ def permission_str(member, edit_perm_set):
 @portfolios_bp.route("/portfolios/<portfolio_id>/applications/<application_id>/team")
 @user_can(Permissions.VIEW_APPLICATION, message="view portfolio applications")
 def application_team(portfolio_id, application_id):
-    portfolio = Portfolios.get(g.current_user, portfolio_id)
     application = Applications.get(
         resource_id=application_id, portfolio_id=portfolio_id
     )
@@ -182,6 +181,5 @@ def application_team(portfolio_id, application_id):
     return render_template(
         "portfolios/applications/team.html",
         application=application,
-        portfolio=portfolio,
         environment_users=environment_users,
     )

--- a/atst/routes/portfolios/applications.py
+++ b/atst/routes/portfolios/applications.py
@@ -154,8 +154,10 @@ def permission_str(member, edit_perm_set):
 @portfolios_bp.route("/portfolios/<portfolio_id>/applications/<application_id>/team")
 @user_can(Permissions.VIEW_APPLICATION, message="view portfolio applications")
 def application_team(portfolio_id, application_id):
-    application = Applications.get(application_id)
     portfolio = Portfolios.get(g.current_user, portfolio_id)
+    application = Applications.get(
+        resource_id=application_id, portfolio_id=portfolio_id
+    )
 
     environment_users = {}
     for member in application.members:

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -129,16 +129,18 @@
       display: flex;
 
       & > span {
-        width: 75%;
+        flex-grow: 3;
+        display: flex;
+        flex-basis: 0;
         &.icon-link {
-          width: 25%;
+          flex-grow: 1;
         }
       }
     }
 
     span {
-      display: flex;
-      width: 25%;
+      flex-grow: 1;
+      flex-basis: 0;
     }
   }
 }

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -117,3 +117,28 @@
     }
   }
 }
+
+#portfolio-members {
+  .accordion-table {
+    .accordion-table__head {
+      font-size: $small-font-size;
+      padding-left: $gap*3;
+    }
+
+    .accordion-table__item-content, .accordion-table__head {
+      display: flex;
+
+      & > span {
+        width: 75%;
+        &.icon-link {
+          width: 25%;
+        }
+      }
+    }
+
+    span {
+      display: flex;
+      width: 25%;
+    }
+  }
+}

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -118,7 +118,7 @@
   }
 }
 
-#portfolio-members {
+#application-members {
   .accordion-table {
     .accordion-table__head {
       font-size: $small-font-size;

--- a/templates/components/toggle_list.html
+++ b/templates/components/toggle_list.html
@@ -12,7 +12,9 @@
   <li is="toggler" class="accordion-table__item">
     <template slot-scope="props">
       <div class="accordion-table__item-content">
-        <span v-on:click="props.toggle">{{ item_name }}</span>
+        <span v-on:click="props.toggle">
+          {{ item_name }}
+        </span>
 
         <template v-if="props.isVisible">
           {{

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -49,7 +49,9 @@
                     <div class='separator'></div>
                   {% endif %}
                   {% if user_can(permissions.VIEW_PORTFOLIO_USERS) %}
-                    <a class='icon-link'>
+                  <a
+                    href="{{ url_for('portfolios.application_team', portfolio_id=portfolio.id, application_id=application.id) }}"
+                    class='icon-link'>
                       <span>{{ "portfolios.applications.team_text" | translate }}</span>
                       <span class='counter'>{{ application.num_users }}</span>
                     </a>

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -1,0 +1,104 @@
+{% extends "portfolios/applications/base.html" %}
+
+{% from "components/empty_state.html" import EmptyState %}
+{% from "components/icon.html" import Icon %}
+{% from "components/toggle_list.html" import ToggleList %}
+
+{% set secondary_breadcrumb = 'portfolios.applications.team_settings.title' | translate({ "application_name": application.name }) %}
+
+{% block application_content %}
+  {% if not application.members %}
+    {% set user_can_invite = user_can(permissions.CREATE_APPLICATION_MEMBER) %}
+
+    {{ EmptyState(
+      ("portfolios.applications.team_settings.blank_slate.title" | translate),
+      action_label=("portfolios.applications.team_settings.blank_slate.action_label" | translate),
+      action_href='#' if user_can_invite else None,
+      sub_message=None if user_can_invite else ("portfolios.team_settings.blank_slate.sub_message" | translate),
+      icon='avatar'
+    ) }}
+
+  {% else %}
+    <div class='subheading'>
+      {{ 'portfolios.applications.team_settings.subheading' | translate }}
+    </div>
+
+    <section class="member-list" id="portfolio-members">
+      <div class='responsive-table-wrapper panel'>
+        {% if g.matchesPath("portfolio-members") %}
+          {% include "fragments/flash.html" %}
+        {% endif %}
+        <form>
+          <header>
+            <div class="responsive-table-wrapper__header">
+              <div class="responsive-table-wrapper__title">
+                <div class="h3">
+                  {{ "portfolios.applications.team_settings.section.title" | translate({ "application_name": application.name }) }}
+                </div>
+              </div>
+              <a class='icon-link'>
+                {{ Icon('info') }}
+                {{ "portfolios.admin.settings_info" | translate }}
+              </a>
+            </div>
+          </header>
+
+          <div class="accordion-table accordion-table-list">
+            <div class="accordion-table__head">
+              <span>
+                <span>
+                  {{ "portfolios.applications.team_settings.user" | translate }}
+                </span>
+                <span>
+                  {{ "portfolios.applications.team_settings.section.table.delete_access" | translate }}
+                </span>
+                <span>
+                  {{ "portfolios.applications.team_settings.section.table.environment_management" | translate }}
+                </span>
+                <span>
+                  {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
+                </span>
+              </span>
+            </div>
+            <ul class="accordion-table__items">
+              {% for member in application.members %}
+                {% set user = member.user %}
+                {% set user_info = environment_users[user.id] %}
+                {% set user_permissions = user_info["permissions"] %}
+
+                {% set user_row %}
+                  <span>{{ user.full_name }}</span>
+                  <span>{{ user_permissions["delete_access"] }}</span>
+                  <span>{{ user_permissions["environment_management"] }}</span>
+                  <span>{{ user_permissions["team_management"] }}</span>
+                {% endset %}
+
+                {% call ToggleList(
+                    item_name=user_row,
+                    item_type=("portfolios.applications.team_settings.environments" | translate),
+                    length=(user_info["environments"] | length)
+                  )
+                %}
+                  <ul>
+                    {% for environment in user_info["environments"] %}
+                      <li class="accordion-table__item__expanded">
+                        <div class="accordion-table__item-content">
+                          {{ environment.name }}
+                        </div>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% endcall %}
+              {% endfor %}
+            </ul>
+          </div>
+
+          <div class="members-table-footer">
+            <div class="action-group save">
+            </div>
+          </div>
+        </form>
+      </div>
+    </section>
+  {% endif %}
+{% endblock %}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -59,6 +59,7 @@
                   {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
                 </span>
               </span>
+              <span class="icon-link" />
             </div>
             <ul class="accordion-table__items">
               {% for member in application.members %}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -23,9 +23,9 @@
       {{ 'portfolios.applications.team_settings.subheading' | translate }}
     </div>
 
-    <section class="member-list" id="portfolio-members">
+    <section class="member-list" id="application-members">
       <div class='responsive-table-wrapper panel'>
-        {% if g.matchesPath("portfolio-members") %}
+        {% if g.matchesPath("application-members") %}
           {% include "fragments/flash.html" %}
         {% endif %}
         <form>

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -347,4 +347,40 @@ def test_edit_application_scope(client, user_session):
             application_id=port1.applications[0].id,
         )
     )
+
+    assert response.status_code == 404
+
+
+def test_application_team_with_permissions(client, user_session):
+    portfolio = PortfolioFactory.create()
+    application = ApplicationFactory.create(portfolio=portfolio)
+
+    user_session(portfolio.owner)
+
+    response = client.get(
+        url_for(
+            "portfolios.application_team",
+            portfolio_id=portfolio.id,
+            application_id=application.id,
+        )
+    )
+
+    assert response.status_code == 200
+
+
+def test_application_team_without_permissions(client, user_session):
+    random_user = UserFactory.create()
+    portfolio = PortfolioFactory.create()
+    application = ApplicationFactory.create(portfolio=portfolio)
+
+    user_session(random_user)
+
+    response = client.get(
+        url_for(
+            "portfolios.application_team",
+            portfolio_id=portfolio.id,
+            application_id=application.id,
+        )
+    )
+
     assert response.status_code == 404

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -351,7 +351,7 @@ def test_edit_application_scope(client, user_session):
     assert response.status_code == 404
 
 
-def test_application_team_with_permissions(client, user_session):
+def test_application_team(client, user_session):
     portfolio = PortfolioFactory.create()
     application = ApplicationFactory.create(portfolio=portfolio)
 
@@ -366,21 +366,3 @@ def test_application_team_with_permissions(client, user_session):
     )
 
     assert response.status_code == 200
-
-
-def test_application_team_without_permissions(client, user_session):
-    random_user = UserFactory.create()
-    portfolio = PortfolioFactory.create()
-    application = ApplicationFactory.create(portfolio=portfolio)
-
-    user_session(random_user)
-
-    response = client.get(
-        url_for(
-            "portfolios.application_team",
-            portfolio_id=portfolio.id,
-            application_id=application.id,
-        )
-    )
-
-    assert response.status_code == 404

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -12,6 +12,7 @@ from atst.models.portfolio_role import Status as PortfolioRoleStatus
 
 from tests.factories import (
     AttachmentFactory,
+    ApplicationFactory,
     ApplicationRoleFactory,
     InvitationFactory,
     PortfolioFactory,
@@ -815,3 +816,21 @@ def test_task_orders_update_access(post_url_assert_status):
     post_url_assert_status(owner, url, 302)
     post_url_assert_status(ccpo, url, 302)
     post_url_assert_status(rando, url, 404)
+
+
+def test_portfolio_application_team_access(get_url_assert_status):
+    ccpo = UserFactory.create_ccpo()
+    rando = UserFactory.create()
+
+    portfolio = PortfolioFactory.create()
+    application = ApplicationFactory.create(portfolio=portfolio)
+
+    url = url_for(
+        "portfolios.application_team",
+        portfolio_id=portfolio.id,
+        application_id=application.id,
+    )
+
+    get_url_assert_status(ccpo, url, 200)
+    get_url_assert_status(portfolio.owner, url, 200)
+    get_url_assert_status(rando, url, 404)

--- a/translations.yaml
+++ b/translations.yaml
@@ -601,6 +601,24 @@ portfolios:
     environments_description: Each environment created within an application is logically separated from one another for easier management and security.
     update_button_text: Save
     create_button_text: Create
+    team_settings:
+      title: '{application_name} Team Settings'
+      subheading: Team Settings
+      user: User
+      environments: Environments
+      blank_slate:
+        action_label: Invite a new team member
+        sub_message: Please contact your JEDI Cloud portfolio administrator to invite new members.
+        title: There are currently no team members for this application.
+      section:
+        title: '{application_name} Team'
+        members_count: 'Members ({members_count})'
+        table:
+          delete_access: Delete Access
+          environment_management: Environment Management
+          environments: Environments
+          name: Name
+          team_management: Team Management
     team_management:
       title: '{application_name} Team Management'
       subheading: Team Management


### PR DESCRIPTION
## Ticket information

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165059837)

```cucumber
Scenario: 
Given I am logged into AT-AT as a user with "view only" access to an application (set at the portfolio level),
When I click on Team Settings,
Then I see the Team Settings table per the design,
And the count of users is up at the top as "Members,"
And each user is listed that has been added to the app,
And the "Environment Access" contains the number of environments to which that user has access of any kind,
And their Environment & Team Mgmt & delete access permissions are displayed,
And Delete is a yes/no rather than the "view/edit" in the design,
And I can click the carat/plus sign to expand the list of environments per the design,
But there are no dropdowns to change permissions,
And there are no buttons to edit or add or save anything.
```

## Screenshots

### Table open 

![Screen Shot 2019-04-17 at 09 38 47](https://user-images.githubusercontent.com/45772525/56292289-e7473100-60f4-11e9-86da-a71753f6780a.png)

### Table closed

![Screen Shot 2019-04-17 at 09 38 35](https://user-images.githubusercontent.com/45772525/56292290-e7473100-60f4-11e9-9f6a-89420f805e90.png)
