### PR TITLE
Emit event from root when modal closes

### DIFF
--- a/js/mixins/modal.js
+++ b/js/mixins/modal.js
@@ -4,7 +4,7 @@ export default {
   methods: {
     closeModal: function(name) {
       this.activeModal = null
-      this.$emit('modalOpen', false)
+      this.$root.$emit('modalOpen', { isOpen: false, name: name })
       if (this.allyHandler) this.allyHandler.disengage()
     },
 


### PR DESCRIPTION
## Description
Closing a modal was freezing the site. Updating the event when a modal closes to emit from the root component fixed the issue. 

## Pivotal
[https://www.pivotaltracker.com/story/show/165214427](https://www.pivotaltracker.com/story/show/165214427)