### PR TITLE
Show Members' Roles on Application Environments Table

### DIFF
--- a/atst/routes/portfolios/applications.py
+++ b/atst/routes/portfolios/applications.py
@@ -56,7 +56,12 @@ def get_environments_obj_for_app(application):
     environments_obj = {}
 
     for env in application.environments:
-        environments_obj[env.name] = [user.full_name for user in env.users]
+        environments_obj[env.name] = []
+        for user in env.users:
+            env_role = EnvironmentRoles.get(user.id, env.id)
+            environments_obj[env.name].append(
+                {"name": user.full_name, "role": env_role.displayname}
+            )
 
     return environments_obj
 

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -105,8 +105,15 @@
         }
 
         border-bottom: 1px dashed $color-white;
-        background-color: $color-gray-lightest;
       }
+
+      .accordion-table__item__expanded_first {
+        float: left;
+        font-weight: bold;
+      }
+
+      background-color: $color-gray-lightest;
+      padding: $gap $gap * 5 $gap * 4 $gap * 5;
     }
   }
 }

--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -18,6 +18,10 @@
   @include hide;
 }
 
+.right {
+  float: right;
+}
+
 @mixin unhide {
   clip: auto;
   clip-path: none;

--- a/templates/fragments/applications/environments.html
+++ b/templates/fragments/applications/environments.html
@@ -26,7 +26,8 @@
           <ul>
             {% for member in members_list %}
             <li class="accordion-table__item__expanded">
-              <div class="accordion-table__item-content">{{ member }}</div>
+              <div class="accordion-table__item__expanded_first">{{ member.name }}</div>
+              <div class="right">{{ member.role }}</div>
             </li>
             {% endfor %}
           </ul>

--- a/tests/routes/portfolios/test_applications.py
+++ b/tests/routes/portfolios/test_applications.py
@@ -119,9 +119,9 @@ def test_edit_application_environments_obj(app, client, user_session):
     user2 = UserFactory.create()
     env1 = application.environments[0]
     env2 = application.environments[1]
-    EnvironmentRoleFactory.create(environment=env1, user=user1)
-    EnvironmentRoleFactory.create(environment=env1, user=user2)
-    EnvironmentRoleFactory.create(environment=env2, user=user1)
+    env_role1 = EnvironmentRoleFactory.create(environment=env1, user=user1)
+    env_role2 = EnvironmentRoleFactory.create(environment=env1, user=user2)
+    env_role3 = EnvironmentRoleFactory.create(environment=env2, user=user1)
 
     user_session(portfolio.owner)
 
@@ -137,8 +137,11 @@ def test_edit_application_environments_obj(app, client, user_session):
         assert response.status_code == 200
         _, context = templates[0]
         assert context["environments_obj"] == {
-            env1.name: [user1.full_name, user2.full_name],
-            env2.name: [user1.full_name],
+            env1.name: [
+                {"name": user1.full_name, "role": env_role1.role},
+                {"name": user2.full_name, "role": env_role2.role},
+            ],
+            env2.name: [{"name": user1.full_name, "role": env_role3.role}],
         }
 
 


### PR DESCRIPTION
## Description
This PR displays each environment member's role in the accordion drop down for the Application Environments table. Some styling for the dropdown has also been addressed.

Once [Part 1](https://github.com/dod-ccpo/atst/pull/751) is merged, I'll rebase this.

## Pivotal Tracker
Part 2/2 for https://www.pivotaltracker.com/story/show/165067808

## Screenshots
![Screen Shot 2019-04-17 at 11 21 39 AM](https://user-images.githubusercontent.com/42577527/56299935-fe8d1b00-6102-11e9-9958-5c10a76b692b.png)

