### PR TITLE
remove extra application template partial

### DIFF
--- a/templates/portfolios/applications/edit.html
+++ b/templates/portfolios/applications/edit.html
@@ -15,7 +15,6 @@
     <div class="panel">
       <div class="panel__content">
 
-        {% include "fragments/applications/edit_application_form.html" %}
         {{ form.csrf_token }}
         <p>
           {{ "fragments.edit_application_form.explain" | translate }}


### PR DESCRIPTION
Ugh, I messed up the rebase for #754 . There's an extra partial inclusion that causes the name and descrip fields for the application to render twice.