### PR TITLE
Show link to admin page if user has view admin permissions

### DIFF
--- a/templates/portfolios/header.html
+++ b/templates/portfolios/header.html
@@ -70,7 +70,7 @@
       url=url_for("portfolios.portfolio_funding", portfolio_id=portfolio.id),
       active=request.url_rule.endpoint == "portfolios.portfolio_funding",
     ) }}
-    {% if user_can(permissions.EDIT_PORTFOLIO_NAME) %}
+    {% if user_can(permissions.VIEW_PORTFOLIO_ADMIN) %}
       {{ Link(
         icon='cog',
         text='navigation.portfolio_navigation.breadcrumbs.admin' | translate,


### PR DESCRIPTION
## Description
The Admin link was not showing up in the panel header if the user only had view permissions. Now, they will see the link as long as they have `VIEW_PORTFOLIO_ADMIN` permissions.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165353102

## Screenshots
![Screen Shot 2019-04-17 at 10 47 21 AM](https://user-images.githubusercontent.com/42577527/56297495-6c831380-60fe-11e9-9da6-65da90b07ffe.png)
