### PR TITLE
PPoC in members table

### DIFF
--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -63,11 +63,20 @@ def serialize_member_form_data(member):
     }
 
 
+def get_members_data(portfolio):
+    members = [serialize_member_form_data(member) for member in portfolio.members]
+    for member in members:
+        if member["user_id"] == portfolio.owner.id:
+            ppoc = member
+            members.remove(member)
+    members.insert(0, ppoc)
+    return members
+
+
 def render_admin_page(portfolio, form=None):
     pagination_opts = Paginator.get_pagination_opts(http_request)
     audit_events = AuditLog.get_portfolio_events(portfolio, pagination_opts)
-    members_data = [serialize_member_form_data(member) for member in portfolio.members]
-
+    members_data = get_members_data(portfolio)
     portfolio_form = PortfolioForm(data={"name": portfolio.name})
     member_perms_form = member_forms.MembersPermissionsForm(
         data={"members_permissions": members_data}

--- a/styles/components/_portfolio_layout.scss
+++ b/styles/components/_portfolio_layout.scss
@@ -272,6 +272,7 @@
     .members-table-ppoc {
       select::-ms-expand {
         display: none;
+        color: $color-gray;
       }
 
       select {
@@ -288,11 +289,12 @@
         word-break: normal;
         padding-right: 3rem;
         padding-left: 1.2rem;
+        color: $color-gray;
       }
 
       select:hover {
         box-shadow: none;
-        color: $color-base;
+        color: $color-gray;
       }
     }
 

--- a/templates/fragments/admin/members_edit.html
+++ b/templates/fragments/admin/members_edit.html
@@ -3,17 +3,20 @@
 {% for subform in member_perms_form.members_permissions %}
   {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, subform.user_id.data) %}
   {% set ppoc = subform.user_id.data == portfolio.owner.id %}
+  {% set archive_button_class = 'button-danger-outline' %}
 
   <tr {% if ppoc %}class="members-table-ppoc"{% endif %}>
     <td class='name'>{{ subform.member.data }}
-      {% if subform.user_id.data == user.id %}
-        <span class='you'>(<span class='green'>you</span>)</span>
-        {% set archive_button_class = 'usa-button-disabled' %}
-      {% elif ppoc %}
-        {% set archive_button_class = 'usa-button-disabled' %}
-      {% else %}
-        {% set archive_button_class = 'button-danger-outline' %}
-      {% endif %}
+      <div>
+        {% if ppoc %}
+          {% set archive_button_class = 'usa-button-disabled' %}
+          <span class='you'>PPoC</span>
+        {% endif %}
+        {% if subform.user_id.data == user.id %}
+          {% set archive_button_class = 'usa-button-disabled' %}
+          <span class='you'>(<span class='green'>you</span>)</span>
+        {% endif %}
+      </div>
     </td>
 
     <td>{{ OptionsInput(subform.perms_app_mgmt, label=False, disabled=ppoc) }}</td>

--- a/templates/fragments/admin/members_view.html
+++ b/templates/fragments/admin/members_view.html
@@ -1,18 +1,24 @@
 {% for subform in member_perms_form.members_permissions %}
+  {% set ppoc = subform.user_id.data == portfolio.owner.id %}
+  {% set heading_perms = [subform.perms_app_mgmt, subform.perms_funding, subform.perms_reporting, subform.perms_portfolio_mgmt] %}
 
   <tr>
     <td class='name'>{{ subform.member.data }}
-      {% if subform.member.data == user.full_name %}
-        <span class='you'>(<span class='green'>you</span>)</span>
-      {% endif %}
+      <div>
+        {% if ppoc %}
+          <span class='you'>PPoC</span>
+        {% endif %}
+        {% if subform.user_id.data == user.id %}
+          <span class='you'>(<span class='green'>you</span>)</span>
+        {% endif %}
+      </div>
     </td>
-    {% set heading_perms = [subform.perms_app_mgmt, subform.perms_funding, subform.perms_reporting, subform.perms_portfolio_mgmt] %}
 
     {% for access in heading_perms %}
-      {% if dict(access.choices).get(access.data) == 'Edit Access'  %}
-        <td class='green'>Edit Access</td>
+      {% if dict(access.choices).get(access.data) == ('portfolios.members.permissions.edit_access' | translate)  %}
+        <td class='green'>{{ 'portfolios.members.permissions.edit_access' | translate }}</td>
       {% else %}
-        <td>View Only</td>
+        <td>{{ 'portfolios.members.permissions.view_only' | translate }}</td>
       {% endif %}
     {% endfor %}
 


### PR DESCRIPTION
## Description
Add the PPoC label under the PPoC and display them first in the members table. Added some minor design tweaks:
 - disabled fields for PPoC perms should be grey
- moved you and PPoC labels under the member's name
Also fixed issue in the view only version of the members table that had some text hard coded in the template which was causing the perms to not render correctly. 

## Pivotal
[https://www.pivotaltracker.com/story/show/165227381](https://www.pivotaltracker.com/story/show/165227381)

## Screenshots
<img width="1552" alt="Screen Shot 2019-04-17 at 11 36 58 AM" src="https://user-images.githubusercontent.com/43828539/56301162-401ec580-6105-11e9-810d-a7fca3c3a1ee.png">
<img width="1552" alt="Screen Shot 2019-04-17 at 11 37 13 AM" src="https://user-images.githubusercontent.com/43828539/56301174-4614a680-6105-11e9-96df-79766231127b.png">
