### PR TITLE
Only show Non-PPOC Portfolio Members in Update PPOC Dropdown

### DIFF
--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -75,7 +75,7 @@ def render_admin_page(portfolio, form=None):
 
     assign_ppoc_form = member_forms.AssignPPOCForm()
     assign_ppoc_form.user_id.choices += [
-        (user.id, user.full_name) for user in portfolio.users
+        (user.id, user.full_name) for user in portfolio.users if user != portfolio.owner
     ]
 
     return render_template(


### PR DESCRIPTION
## Description
The dropdown for selecting a new PPOC will now only include portfolio members who are not the PPOC.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165214947

## Screenshots
![Screen Shot 2019-04-17 at 11 47 21 AM](https://user-images.githubusercontent.com/42577527/56301913-c8ea3100-6106-11e9-904a-de54a72be1d0.png)

