### PR TITLE
portfolio user can view application settings page

### DIFF
--- a/atst/routes/portfolios/applications.py
+++ b/atst/routes/portfolios/applications.py
@@ -67,7 +67,7 @@ def get_environments_obj_for_app(application):
 
 
 @portfolios_bp.route("/portfolios/<portfolio_id>/applications/<application_id>/edit")
-@user_can(Permissions.EDIT_APPLICATION, message="view application edit form")
+@user_can(Permissions.VIEW_APPLICATION, message="view application edit form")
 def edit_application(portfolio_id, application_id):
     application = Applications.get(application_id, portfolio_id=portfolio_id)
     form = ApplicationForm(name=application.name, description=application.description)

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -42,7 +42,7 @@
                 <h3 class='icon-link accordion__title' v-on:click="props.toggle">{{ application.name }}</h3>
                 <span class='accordion__description'>{{ application.description }}</span>
                 <div class='accordion__actions'>
-                  {% if user_can(permissions.EDIT_APPLICATION) %}
+                  {% if user_can(permissions.VIEW_APPLICATION) %}
                     <a class='icon-link' href='{{ url_for("portfolios.edit_application", portfolio_id=portfolio.id, application_id=application.id) }}'>
                       <span>{{ "portfolios.applications.app_settings_text" | translate }}</span>
                     </a>

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -243,7 +243,7 @@ def test_portfolios_delete_application_access(post_url_assert_status, monkeypatc
 
 # portfolios.edit_application
 def test_portfolios_edit_application_access(get_url_assert_status):
-    ccpo = user_with(PermissionSets.EDIT_PORTFOLIO_APPLICATION_MANAGEMENT)
+    ccpo = user_with(PermissionSets.VIEW_PORTFOLIO_APPLICATION_MANAGEMENT)
     owner = user_with()
     rando = user_with()
     portfolio = PortfolioFactory.create(


### PR DESCRIPTION
Portfolio users with view-only perms should be able to see the link and page for application settings for an app within the portfolio.