### PR TITLE
Removing KO from language

### DIFF
--- a/translations.yaml
+++ b/translations.yaml
@@ -91,7 +91,7 @@ forms:
     to_number: Task order number
     loa: Line of accounting (LOA) &#35;1
     custom_clauses_label: Task order custom clauses (optional)
-    custom_clauses_description: This will put a pause on the CSP access once the KO signs until the CCPO reviews that language to make sure it is legal.
+    custom_clauses_description: This will put a pause on the CSP access once the contracting officer signs until the CCPO reviews that language to make sure it is legal.
   edit_member:
     portfolio_role_label: Portfolio Role
   edit_user:
@@ -274,7 +274,7 @@ forms:
     oversight_phone_label: Phone Number
     oversight_dod_id_label: DoD ID
     oversight_am_cor_label: I am the Contracting Officer Representative (COR) for this task order
-    ko_invite_label: Invite KO to Task Order Builder
+    ko_invite_label: Invite contracting officer to Task Order Builder
     cor_invite_label: Invite COR to Task Order Builder
     so_invite_label: Invite Security Officer to Task Order Builder
     skip_invite_description: |
@@ -304,7 +304,7 @@ forms:
     name_label: Portfolio name
     name_length_validation_message: Portfolio names can be between 4-100 characters
   officers:
-    contracting_officer_invite: Invite KO to Task Order Builder
+    contracting_officer_invite: Invite contracting officer to Task Order Builder
     contracting_officer_representative_invite: Invite COR to Task Order Builder
     security_officer_invite: Invite Security Officer to Task Order Builder
 fragments:
@@ -317,13 +317,13 @@ fragments:
   pending_ccpo_acceptance_alert:
     learn_more_link_text: Learn more about the JEDI cloud task order and the financial verification process.
     paragraph_1: The CCPO will review and respond to your request in 3 business days. You’ll be notified via email or phone. Please note if your request is for over $1M of JEDI cloud resources it will require a manual review by the CCPO.
-    paragraph_2: 'While your request is being reviewed, your next step is to create a task order (TO) associated with the JEDI cloud. Please contact a Contracting Officer (KO), Contracting Officer Representative (COR), or a Financial Manager to help with this step.'
+    paragraph_2: 'While your request is being reviewed, your next step is to create a task order (TO) associated with the JEDI cloud. Please contact a Contracting Officer, Contracting Officer Representative (COR), or a Financial Manager to help with this step.'
   pending_ccpo_approval_modal:
     paragraph_1: The CCPO will review and respond to your Financial Verification submission in 3 business days. You will be notified via email or phone.
     paragraph_2: Once the financial verification is approved you will be invited to create your JEDI Portfolio and set-up your applications. Click here for more details.
   pending_financial_verification:
     learn_more_link_text: Learn more about the JEDI cloud task order and the financial verification process.
-    paragraph_1: 'The next step is to create a task order associated with JEDI cloud.  Please contact a Contracting Officer (KO), Contracting Officer Representative (COR), or a Financial Manager to help with this step.'
+    paragraph_1: 'The next step is to create a task order associated with JEDI cloud.  Please contact a Contracting Officer, Contracting Officer Representative (COR), or a Financial Manager to help with this step.'
     paragraph_2: 'Once the task order has been created, you will be asked to provide details about the task order in the Financial Verification step.'
   ko_review_message:
     title: Steps
@@ -399,7 +399,7 @@ requests:
     revision_instructions_or_notes_label: Revision instructions or notes
     save_notes: Save Notes
   financial_verification:
-    contracting_officer_information_title: Contracting Officer (KO) Information
+    contracting_officer_information_title: Contracting Officer Information
     contracting_officer_representative_information_title: Contracting Officer Representative (COR) Information
     draft_saved: Draft saved
     enter_task_order_manually_link_text: Enter Task Order information manually
@@ -519,8 +519,8 @@ task_orders:
       total: 'Total task order value:'
     oversight:
       section_title: Oversight
-      ko_info_title: Contracting officer (KO) information
-      ko_info_paragraph: Your KO will need to approve funding for this task order by logging into the JEDI cloud portal, submitting the task order documents within their official system of record, and then finally providing a digital signature. It might be helpful to work with your program's Financial Manager to get your TO documents moving.
+      ko_info_title: Contracting officer information
+      ko_info_paragraph: Your contracting officer will need to approve funding for this task order by logging into the JEDI cloud portal, submitting the task order documents within their official system of record, and then finally providing a digital signature. It might be helpful to work with your program's Financial Manager to get your TO documents moving.
       skip_ko_label: "Skip for now (We'll remind you to enter one later)"
       dod_id_tooltip: "The DoD ID is needed to verify the identity of the indicated officer or representative."
       cor_info_title: Contracting officer representative (COR) information
@@ -546,7 +546,7 @@ task_orders:
       clin_4: 'CLIN #4: Classified Cloud'
       classified_inactive: (Available Soon)
       oversight: Oversight
-      ko: Contracting Officer (KO)
+      ko: Contracting Officer
       cor: Contracting Officer Representative (COR)
       so: Security Officer
       dod_id: 'DoD ID:'
@@ -560,9 +560,9 @@ task_orders:
     resend_btn: Resend
     resend_confirmation_message: Are you sure you'd like to resend this invitation?
     contracting_officer:
-      title: Contracting officer (KO) information
-      description: You'll need a signature from your KO. You might want to work with your program Financial Manager to get your TO documents moving in the right direction.
-      add_button_text: Add / Invite KO
+      title: Contracting officer information
+      description: You'll need a signature from your contracting officer. You might want to work with your program Financial Manager to get your TO documents moving in the right direction.
+      add_button_text: Add / Invite contracting officer
       invite_button_text: Invite KO
       edit_title: Edit KO
     contracting_officer_representative:


### PR DESCRIPTION
## Description

Getting rid of any mentions of "KO" in AT-AT as it was recently disclosed that not all organizations in the DoD use that abbreviation for contracting officer.