### PR TITLE
Disable Next Button in Modal

### DIFF
--- a/js/components/checkbox_input.js
+++ b/js/components/checkbox_input.js
@@ -1,4 +1,4 @@
-import { emitFieldChange } from '../lib/emitters'
+import { emitEvent } from '../lib/emitters'
 
 export default {
   name: 'checkboxinput',
@@ -9,7 +9,10 @@ export default {
 
   methods: {
     onInput: function(e) {
-      emitFieldChange(this, { value: e.target.checked, name: this.name })
+      emitEvent('field-change', this, {
+        value: e.target.checked,
+        name: this.name,
+      })
     },
   },
 }

--- a/js/components/date_selector.js
+++ b/js/components/date_selector.js
@@ -1,6 +1,6 @@
 import Vue from 'vue'
 import { getDaysInMonth } from 'date-fns'
-import { emitFieldChange } from '../lib/emitters'
+import { emitEvent } from '../lib/emitters'
 
 var paddedNumber = function(number) {
   if ((number + '').length === 1) {
@@ -136,7 +136,7 @@ export default {
 
   methods: {
     _emitChange: function(name, value, valid) {
-      emitFieldChange(this, { value, name })
+      emitEvent('field-change', this, { value, name })
     },
   },
 

--- a/js/components/forms/multi_step_modal_form.js
+++ b/js/components/forms/multi_step_modal_form.js
@@ -27,7 +27,6 @@ export default {
       step: 0,
       fields: {},
       invalid: true,
-      parent_uid: '',
     }
   },
 
@@ -54,7 +53,7 @@ export default {
     handleValidChange: function(event) {
       const { name, valid, parent_uid } = event
       // check that this field is in the modal and not on some other form
-      if (parent_uid === this.parent_uid) {
+      if (parent_uid === this._uid) {
         this.fields[name] = valid
         this._checkIsValid()
       }
@@ -67,7 +66,6 @@ export default {
     handleFieldMount: function(event) {
       const { name, optional, parent_uid } = event
       this.fields[name] = optional
-      this.parent_uid = parent_uid
     },
     handleModalOpen: function(_bool) {
       this.step = 0

--- a/js/components/forms/multi_step_modal_form.js
+++ b/js/components/forms/multi_step_modal_form.js
@@ -27,6 +27,7 @@ export default {
       step: 0,
       fields: {},
       invalid: true,
+      parent_uid: '',
     }
   },
 
@@ -51,9 +52,12 @@ export default {
       }
     },
     handleValidChange: function(event) {
-      const { name, valid } = event
-      this.fields[name] = valid
-      this._checkIsValid()
+      const { name, valid, parent_uid } = event
+      // check that this field is in the modal and not on some other form
+      if (parent_uid === this.parent_uid) {
+        this.fields[name] = valid
+        this._checkIsValid()
+      }
     },
     _checkIsValid: function() {
       const valid = !Object.values(this.fields).some(field => field === false)
@@ -61,8 +65,9 @@ export default {
       return valid
     },
     handleFieldMount: function(event) {
-      const { name, optional } = event
+      const { name, optional, parent_uid } = event
       this.fields[name] = optional
+      this.parent_uid = parent_uid
     },
     handleModalOpen: function(_bool) {
       this.step = 0

--- a/js/components/forms/multi_step_modal_form.js
+++ b/js/components/forms/multi_step_modal_form.js
@@ -64,7 +64,7 @@ export default {
       return valid
     },
     handleFieldMount: function(event) {
-      const { name, optional, parent_uid } = event
+      const { name, optional } = event
       this.fields[name] = optional
     },
     handleModalOpen: function(_bool) {

--- a/js/components/multi_checkbox_input.js
+++ b/js/components/multi_checkbox_input.js
@@ -1,6 +1,6 @@
 import optionsinput from '../components/options_input'
 import textinput from '../components/text_input'
-import { emitFieldChange } from '../lib/emitters'
+import { emitEvent } from '../lib/emitters'
 
 export default {
   name: 'multicheckboxinput',
@@ -41,7 +41,10 @@ export default {
 
   methods: {
     onInput: function(e) {
-      emitFieldChange(this, { value: e.target.value, name: this.name })
+      emitEvent('field-change', this, {
+        value: e.target.value,
+        name: this.name,
+      })
       this.showError = false
       this.showValid = true
     },

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -1,4 +1,4 @@
-import { emitFieldChange } from '../lib/emitters'
+import { emitEvent } from '../lib/emitters'
 
 export default {
   name: 'optionsinput',
@@ -23,7 +23,10 @@ export default {
 
   methods: {
     onInput: function(e) {
-      emitFieldChange(this, { value: e.target.value, name: this.name })
+      emitEvent('field-change', this, {
+        value: e.target.value,
+        name: this.name,
+      })
       this.showError = false
       this.showValid = true
     },

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -27,7 +27,6 @@ export default {
     paragraph: String,
     noMaxWidth: String,
     optional: Boolean,
-    parent_uid: String,
   },
 
   data: function() {

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -1,7 +1,7 @@
 import MaskedInput, { conformToMask } from 'vue-text-mask'
 import inputValidations from '../lib/input_validations'
 import { formatDollars } from '../lib/dollars'
-import { emitFieldChange, emitFieldMount } from '../lib/emitters'
+import { emitEvent } from '../lib/emitters'
 
 export default {
   name: 'textinput',
@@ -68,7 +68,7 @@ export default {
   },
 
   created: function() {
-    emitFieldMount(this, {
+    emitEvent('field-mount', this, {
       optional: this.optional,
       name: this.name,
     })
@@ -126,7 +126,7 @@ export default {
       this.showValid = this.value != '' && valid
 
       // Emit a change event
-      emitFieldChange(this, {
+      emitEvent('field-change', this, {
         value: this._rawValue(value),
         valid,
         name: this.name,

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -1,7 +1,7 @@
 import MaskedInput, { conformToMask } from 'vue-text-mask'
 import inputValidations from '../lib/input_validations'
 import { formatDollars } from '../lib/dollars'
-import { emitFieldChange } from '../lib/emitters'
+import { emitFieldChange, emitFieldMount } from '../lib/emitters'
 
 export default {
   name: 'textinput',
@@ -27,6 +27,7 @@ export default {
     paragraph: String,
     noMaxWidth: String,
     optional: Boolean,
+    parent_uid: String,
   },
 
   data: function() {
@@ -67,9 +68,9 @@ export default {
   },
 
   created: function() {
-    this.$root.$emit('field-mount', {
-      name: this.name,
+    emitFieldMount(this, {
       optional: this.optional,
+      name: this.name,
     })
   },
 

--- a/js/lib/emitters.js
+++ b/js/lib/emitters.js
@@ -1,12 +1,5 @@
-export const emitFieldChange = (el, data) => {
-  el.$root.$emit('field-change', {
-    ...data,
-    parent_uid: el.$parent && el.$parent._uid,
-  })
-}
-
-export const emitFieldMount = (el, data) => {
-  el.$root.$emit('field-mount', {
+export const emitEvent = (event_type, el, data) => {
+  el.$root.$emit(event_type, {
     ...data,
     parent_uid: el.$parent && el.$parent._uid,
   })

--- a/js/lib/emitters.js
+++ b/js/lib/emitters.js
@@ -4,3 +4,10 @@ export const emitFieldChange = (el, data) => {
     parent_uid: el.$parent && el.$parent._uid,
   })
 }
+
+export const emitFieldMount = (el, data) => {
+  el.$root.$emit('field-mount', {
+    ...data,
+    parent_uid: el.$parent && el.$parent._uid,
+  })
+}

--- a/templates/fragments/admin/members_edit.html
+++ b/templates/fragments/admin/members_edit.html
@@ -1,4 +1,4 @@
-{% from "components/confirmation_button.html" import ConfirmationButton %}
+{% from "components/options_input.html" import OptionsInput %}
 
 {% for subform in member_perms_form.members_permissions %}
   {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, subform.user_id.data) %}

--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -1,7 +1,5 @@
 {% from "components/icon.html" import Icon %}
-{% from "components/options_input.html" import OptionsInput %}
 {% from 'components/save_button.html' import SaveButton %}
-
 {% from "components/modal.html" import Modal %}
 {% from "components/alert.html" import Alert %}
 

--- a/templates/portfolios/admin.html
+++ b/templates/portfolios/admin.html
@@ -1,9 +1,7 @@
 {% extends "portfolios/base.html" %}
 
 {% from "components/pagination.html" import Pagination %}
-{% from "components/icon.html" import Icon %}
 {% from "components/text_input.html" import TextInput %}
-{% from "components/multi_step_modal_form.html" import MultiStepModalForm %}
 {% from 'components/save_button.html' import SaveButton %}
 
 {% set secondary_breadcrumb = "navigation.portfolio_navigation.portfolio_admin" | translate %}


### PR DESCRIPTION
## Description
When the `add new member` multi-step modal opens, the `Next` button needs to be disabled until all of the required fields in that first step are complete. There was a bug in that the modal was tracking validity for all fields in all forms on the page instead of just the fields on the modal form.

This caused the `Next` button to be active if, for instance, a user changed a permission and then open the add member modal. In order to fix this, we need to check that the field in question is actually part of the modal. I needed to emit the field's parent uid when it mounted in order to verify that it belongs to the modal, so there is also a refactor of the js event emitter file.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165246981