### PR TITLE
Only show active members for PPOC Update Dropdown

### DIFF
--- a/atst/routes/portfolios/admin.py
+++ b/atst/routes/portfolios/admin.py
@@ -70,9 +70,11 @@ def render_admin_page(portfolio, form=None):
     )
 
     assign_ppoc_form = member_forms.AssignPPOCForm()
-    assign_ppoc_form.user_id.choices += [
-        (user.id, user.full_name) for user in portfolio.users if user != portfolio.owner
-    ]
+    for pf_role in portfolio.roles:
+        if pf_role.user != portfolio.owner and pf_role.is_active:
+            assign_ppoc_form.user_id.choices += [
+                (pf_role.user.id, pf_role.user.full_name)
+            ]
 
     return render_template(
         "portfolios/admin.html",


### PR DESCRIPTION
## Description
The dropdown for changing the PPOC was populating with all members, even if pending or disabled. This PR changes the dropdown to only populate with active portfolio members.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165451605

## Screenshots
<img width="1421" alt="Screen Shot 2019-04-22 at 11 00 44 AM" src="https://user-images.githubusercontent.com/42577527/56508523-88b5f480-64f2-11e9-97c0-d6c67a8d432d.png">
