### PR TITLE
Fix for IE "Continue" button color in DoD notice

### DIFF
--- a/styles/components/_dod_login_notice.scss
+++ b/styles/components/_dod_login_notice.scss
@@ -19,6 +19,7 @@
       -webkit-transition: none;
       -o-transition: color 0 ease-in;
       transition: none;
+      color: $color-white;
     }
   }
 }


### PR DESCRIPTION
Fix IE/Firefox "Continue" button in DoD modal

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/164911276)