### PR TITLE
Fix padding issue on IE

### DIFF
--- a/templates/components/toggle_list.html
+++ b/templates/components/toggle_list.html
@@ -1,12 +1,12 @@
 {% macro ToggleButton(action, open_html, close_html, section_name) %}
-  <span v-on:click="toggleSection('{{ section_name }}')">
+  <div v-on:click="toggleSection('{{ section_name }}')">
     <div v-if="selectedSection === '{{ section_name }}'">
       {{ close_html }}
     </div>
     <div v-else>
       {{ open_html }}
     </div>
-  </span>
+  </div>
 {% endmacro %}
 
 {% macro ToggleSection(section_name) %}


### PR DESCRIPTION
Having the nested span applies padding twice on IE

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165067811)

## Before
![Screen Shot 2019-05-02 at 10 08 49](https://user-images.githubusercontent.com/45772525/57081353-8574f280-6cc2-11e9-89c3-6e97e8ba79a9.png)

## After
![Screen Shot 2019-05-02 at 10 09 00](https://user-images.githubusercontent.com/45772525/57081343-83129880-6cc2-11e9-9b71-3025c9634150.png)
