### PR TITLE
Edit environment save fail

### DIFF
--- a/atst/forms/application.py
+++ b/atst/forms/application.py
@@ -1,11 +1,12 @@
 from .forms import BaseForm
-from wtforms.fields import StringField, TextAreaField, FieldList
+from wtforms.fields import StringField, TextAreaField, FieldList, HiddenField
 from wtforms.validators import Required
 from atst.forms.validators import ListItemRequired, ListItemsUnique
 from atst.utils.localization import translate
 
 
 class EditEnvironmentForm(BaseForm):
+    id = HiddenField()
     name = StringField(
         label=translate("forms.environments.name_label"), validators=[Required()]
     )

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -13,13 +13,20 @@ from atst.models.permissions import Permissions
 from atst.utils.flash import formatted_flash as flash
 
 
-def get_environments_obj_for_app(application):
+def get_environments_obj_for_app(application, form=None):
     environments_obj = []
     for env in application.environments:
+        edit_form = None
+
+        if form == None or form.data["id"] != env.id:
+            edit_form = EditEnvironmentForm(obj=env)
+        else:
+            edit_form = form
+
         env_data = {
             "id": env.id,
             "name": env.name,
-            "edit_form": EditEnvironmentForm(obj=env),
+            "edit_form": edit_form,
             "members_form": EnvironmentRolesForm(data=data_for_env_members_form(env)),
             "members": sort_env_users_by_role(env),
         }
@@ -85,21 +92,35 @@ def update_environment(environment_id):
     environment = Environments.get(environment_id)
     application = environment.application
 
-    form = EditEnvironmentForm(formdata=http_request.form)
+    env_form = EditEnvironmentForm(obj=environment, formdata=http_request.form)
 
-    if form.validate():
-        Environments.update(environment=environment, name=form.name.data)
+    if env_form.validate():
+        Environments.update(environment=environment, name=env_form.name.data)
 
-    flash("application_environments_updated")
+        flash("application_environments_updated")
 
-    return redirect(
-        url_for(
-            "applications.settings",
-            application_id=application.id,
-            fragment="application-environments",
-            _anchor="application-environments",
+        return redirect(
+            url_for(
+                "applications.settings",
+                application_id=application.id,
+                fragment="application-environments",
+                _anchor="application-environments",
+            )
         )
-    )
+    else:
+        return (
+            render_template(
+                "portfolios/applications/settings.html",
+                application=application,
+                form=ApplicationForm(
+                    name=application.name, description=application.description
+                ),
+                environments_obj=get_environments_obj_for_app(
+                    application=application, form=env_form
+                ),
+            ),
+            400,
+        )
 
 
 @applications_bp.route("/applications/<application_id>/edit", methods=["POST"])

--- a/js/components/toggler.js
+++ b/js/components/toggler.js
@@ -6,13 +6,17 @@ export default {
 
   mixins: [FormMixin],
 
+  props: {
+    initialSelectedSection: String,
+  },
+
   components: {
     textinput,
   },
 
   data: function() {
     return {
-      selectedSection: null,
+      selectedSection: this.initialSelectedSection,
     }
   },
 

--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -45,11 +45,12 @@
 
     <ul class="accordion-table__items">
       {% for env in environments_obj %}
+        {% set edit_form = env['edit_form'] %}
         {% set member_count = env['members_form'].data['team_roles'] | length %}
         {% set members_by_role = env['members'] %}
         {% set unassigned = members_by_role['no_access'] %}
 
-        <toggler inline-template>
+        <toggler inline-template {% if edit_form.errors %}initial-selected-section="edit"{% endif %}>
           <li class="accordion-table__item">
             <div class="accordion-table__item-content">
               <span>
@@ -97,10 +98,9 @@
             {% call ToggleSection(section_name="edit") %}
               <ul>
                 <li class="accordion-table__item__expanded">
-                  {% set edit_form = env['edit_form'] %}
-                  <form action="{{ url_for('applications.update_environment', environment_id=env['id']) }}" method="post">
+                  <form action="{{ url_for('applications.update_environment', environment_id=env['id'], fragment='application-environments', _anchor='application-environments') }}" method="post">
                     {{ edit_form.csrf_token }}
-                    {{ TextInput(edit_form.name) }}
+                    {{ TextInput(edit_form.name, validation='requiredField') }}
                     {{
                       SaveButton(
                         text=("portfolios.applications.update_button_text" | translate)

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -27,7 +27,7 @@ from atst.forms.app_settings import EnvironmentRolesForm
 from tests.utils import captured_templates
 
 
-def test_updating_application_environments(client, user_session):
+def test_updating_application_environments_success(client, user_session):
     portfolio = PortfolioFactory.create()
     application = ApplicationFactory.create(portfolio=portfolio)
     environment = EnvironmentFactory.create(application=application)
@@ -50,6 +50,26 @@ def test_updating_application_environments(client, user_session):
         _anchor="application-environments",
     )
     assert environment.name == "new name a"
+
+
+def test_updating_application_environments_failure(client, user_session):
+    portfolio = PortfolioFactory.create()
+    application = ApplicationFactory.create(portfolio=portfolio)
+    environment = EnvironmentFactory.create(
+        application=application, name="original name"
+    )
+
+    user_session(portfolio.owner)
+
+    form_data = {"name": ""}
+
+    response = client.post(
+        url_for("applications.update_environment", environment_id=environment.id),
+        data=form_data,
+    )
+
+    assert response.status_code == 400
+    assert environment.name == "original name"
 
 
 def test_application_settings(client, user_session):


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165067811)

Clearing out the name for the "Edit environment name" form and then clicking submit would show incorrect and confusing errors. It would show "Error occurred" and also a "Success" banner. This PR shows the expected error and also opens the correct form dropdown where the errors are displayed for the missing environment name.

## After
![Screen Shot 2019-05-02 at 13 19 39](https://user-images.githubusercontent.com/45772525/57093871-fc1ee980-6cdc-11e9-8eb9-922d427c0554.png)

## Before
<img width="461" alt="Screen Shot 2019-05-01 at 1 30 18 PM_big" src="https://user-images.githubusercontent.com/45772525/57093878-0214ca80-6cdd-11e9-88b8-87762f215a05.png">
