### PR TITLE
Use list-different option for js prettier

### DIFF
--- a/script/format
+++ b/script/format
@@ -4,9 +4,9 @@ FILES_TO_FORMAT="atst/ tests/ app.py script/"
 
 if [ "$1" == "check" ]; then
   pipenv run black --check ${FILES_TO_FORMAT}
-  yarn run prettier --check "js/**/*.js" --config ./prettier.config.json
+  yarn run prettier --list-different "js/**/*.js" --config ./prettier.config.json
 else
   pipenv run black ${FILES_TO_FORMAT}
-  yarn run prettier --write "js/**/*.js" --config ./prettier.config.json
+  yarn run prettier --list-different --write "js/**/*.js" --config ./prettier.config.json
   sass-convert ./styles --in-place --recursive --from scss --to scss --quiet
 fi


### PR DESCRIPTION
When running the `script/format` command, we get every JS file show up in the log output.

This change only lists files that have changed or will change when running the `check` version of the command.