### PR TITLE
Application Team Table Permissions

### DIFF
--- a/atst/domain/application_roles.py
+++ b/atst/domain/application_roles.py
@@ -1,6 +1,9 @@
+from sqlalchemy.orm.exc import NoResultFound
+
 from atst.database import db
 from atst.models import ApplicationRole, ApplicationRoleStatus
-from atst.domain.permission_sets import PermissionSets
+from .permission_sets import PermissionSets
+from .exceptions import NotFoundError
 
 
 class ApplicationRoles(object):
@@ -31,13 +34,16 @@ class ApplicationRoles(object):
 
     @classmethod
     def get(cls, user_id, application_id):
-        existing_app_role = (
-            db.session.query(ApplicationRole)
-            .filter_by(user_id=user_id, application_id=application_id)
-            .one_or_none()
-        )
+        try:
+            app_role = (
+                db.session.query(ApplicationRole)
+                .filter_by(user_id=user_id, application_id=application_id)
+                .one()
+            )
+        except NoResultFound:
+            raise NotFoundError("application_role")
 
-        return existing_app_role
+        return app_role
 
     @classmethod
     def update_permission_sets(cls, application_role, new_perm_sets_names):

--- a/atst/domain/application_roles.py
+++ b/atst/domain/application_roles.py
@@ -28,3 +28,24 @@ class ApplicationRoles(object):
 
         db.session.add(role)
         db.session.commit()
+
+    @classmethod
+    def get(cls, user_id, application_id):
+        existing_app_role = (
+            db.session.query(ApplicationRole)
+            .filter_by(user_id=user_id, application_id=application_id)
+            .one_or_none()
+        )
+
+        return existing_app_role
+
+    @classmethod
+    def update_permission_sets(cls, application_role, new_perm_sets_names):
+        application_role.permission_sets = ApplicationRoles._permission_sets_for_names(
+            new_perm_sets_names
+        )
+
+        db.session.add(application_role)
+        db.session.commit()
+
+        return application_role

--- a/atst/domain/environment_roles.py
+++ b/atst/domain/environment_roles.py
@@ -1,7 +1,7 @@
 from flask import current_app as app
 
 from atst.database import db
-from atst.models import EnvironmentRole
+from atst.models import EnvironmentRole, Application, Environment
 
 
 class EnvironmentRoles(object):
@@ -35,3 +35,15 @@ class EnvironmentRoles(object):
             return True
         else:
             return False
+
+    @classmethod
+    def get_for_application_and_user(cls, user_id, application_id):
+        return (
+            db.session.query(EnvironmentRole)
+            .join(Environment)
+            .join(Application, Environment.application_id == Application.id)
+            .filter(EnvironmentRole.user_id == user_id)
+            .filter(Application.id == application_id)
+            .filter(EnvironmentRole.environment_id == Environment.id)
+            .all()
+        )

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -12,27 +12,25 @@ class PermissionsForm(FlaskForm):
     perms_env_mgmt = SelectField(
         translate("portfolios.applications.members.new.manage_envs"),
         choices=[
-            (None, "View only"),
+            ("", "View only"),
             (PermissionSets.EDIT_APPLICATION_ENVIRONMENTS, "Edit access"),
         ],
-        filters=[BaseForm.remove_empty_string],
     )
     perms_team_mgmt = SelectField(
         translate("portfolios.applications.members.new.manage_team"),
         choices=[
-            (None, "View only"),
+            ("", "View only"),
             (PermissionSets.EDIT_APPLICATION_TEAM, "Edit access"),
         ],
-        filters=[BaseForm.remove_empty_string],
     )
     perms_del_env = SelectField(
-        choices=[(None, "No"), (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes")],
-        filters=[BaseForm.remove_empty_string],
+        choices=[("", "No"), (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes")]
     )
 
     @property
     def data(self):
         _data = super().data
+        _data.pop("csrf_token", None)
         permission_sets = []
         for field in _data:
             if _data[field] is not None:
@@ -46,6 +44,13 @@ class MemberForm(FlaskForm):
     user_name = StringField()
     environment_roles = FieldList(FormField(EnvironmentForm))
     permission_sets = FormField(PermissionsForm)
+
+    @property
+    def data(self):
+        _data = super().data
+        _data.pop("csrf_token", None)
+
+        return _data
 
 
 class TeamForm(BaseForm):

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -1,5 +1,6 @@
 from flask_wtf import FlaskForm
 from wtforms.fields import FormField, FieldList, HiddenField, StringField
+from wtforms.validators import Required
 
 from .application_member import EnvironmentForm
 from .forms import BaseForm
@@ -43,7 +44,7 @@ class PermissionsForm(FlaskForm):
 
 
 class MemberForm(FlaskForm):
-    user_id = HiddenField()
+    user_id = HiddenField(validators=[Required()])
     user_name = StringField()
     environment_roles = FieldList(FormField(EnvironmentForm))
     permission_sets = FormField(PermissionsForm)

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -1,0 +1,51 @@
+from flask_wtf import FlaskForm
+from wtforms.fields import FormField, FieldList, HiddenField
+
+from .application_member import EnvironmentForm
+from .forms import BaseForm
+from atst.forms.fields import SelectField
+from atst.domain.permission_sets import PermissionSets
+from atst.utils.localization import translate
+
+
+class PermissionsForm(FlaskForm):
+    perms_env_mgmt = SelectField(
+        translate("portfolios.applications.members.new.manage_envs"),
+        choices=[
+            (None, "View only"),
+            (PermissionSets.EDIT_APPLICATION_ENVIRONMENTS, "Edit access"),
+        ],
+        filters=[BaseForm.remove_empty_string],
+    )
+    perms_team_mgmt = SelectField(
+        translate("portfolios.applications.members.new.manage_team"),
+        choices=[
+            (None, "View only"),
+            (PermissionSets.EDIT_APPLICATION_TEAM, "Edit access"),
+        ],
+        filters=[BaseForm.remove_empty_string],
+    )
+    perms_del_env = SelectField(
+        choices=[(None, "No"), (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes")],
+        filters=[BaseForm.remove_empty_string],
+    )
+
+    @property
+    def data(self):
+        _data = super().data
+        permission_sets = []
+        for field in _data:
+            if _data[field] is not None:
+                permission_sets.append(_data[field])
+
+        return permission_sets
+
+
+class MemberForm(FlaskForm):
+    user_id = HiddenField()
+    environment_roles = FieldList(FormField(EnvironmentForm))
+    permission_sets = FormField(PermissionsForm)
+
+
+class TeamForm(BaseForm):
+    members = FieldList(FormField(MemberForm))

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -9,22 +9,25 @@ from atst.utils.localization import translate
 
 
 class PermissionsForm(FlaskForm):
-    perms_env_mgmt = SelectField(
-        translate("portfolios.applications.members.new.manage_envs"),
-        choices=[
-            ("", "View only"),
-            (PermissionSets.EDIT_APPLICATION_ENVIRONMENTS, "Edit access"),
-        ],
-    )
     perms_team_mgmt = SelectField(
         translate("portfolios.applications.members.new.manage_team"),
         choices=[
-            ("", "View only"),
+            (PermissionSets.VIEW_APPLICATION, "View only"),
             (PermissionSets.EDIT_APPLICATION_TEAM, "Edit access"),
         ],
     )
+    perms_env_mgmt = SelectField(
+        translate("portfolios.applications.members.new.manage_envs"),
+        choices=[
+            (PermissionSets.VIEW_APPLICATION, "View only"),
+            (PermissionSets.EDIT_APPLICATION_ENVIRONMENTS, "Edit access"),
+        ],
+    )
     perms_del_env = SelectField(
-        choices=[("", "No"), (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes")]
+        choices=[
+            ("View only", "No"),
+            (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes"),
+        ]
     )
 
     @property

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -26,7 +26,7 @@ class PermissionsForm(FlaskForm):
     )
     perms_del_env = SelectField(
         choices=[
-            ("View only", "No"),
+            (PermissionSets.VIEW_APPLICATION, "No"),
             (PermissionSets.DELETE_APPLICATION_ENVIRONMENTS, "Yes"),
         ]
     )
@@ -48,13 +48,6 @@ class MemberForm(FlaskForm):
     user_name = StringField()
     environment_roles = FieldList(FormField(EnvironmentForm))
     permission_sets = FormField(PermissionsForm)
-
-    @property
-    def data(self):
-        _data = super().data
-        _data.pop("csrf_token", None)
-
-        return _data
 
 
 class TeamForm(BaseForm):

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -1,5 +1,5 @@
 from flask_wtf import FlaskForm
-from wtforms.fields import FormField, FieldList, HiddenField
+from wtforms.fields import FormField, FieldList, HiddenField, StringField
 
 from .application_member import EnvironmentForm
 from .forms import BaseForm
@@ -43,6 +43,7 @@ class PermissionsForm(FlaskForm):
 
 class MemberForm(FlaskForm):
     user_id = HiddenField()
+    user_name = StringField()
     environment_roles = FieldList(FormField(EnvironmentForm))
     permission_sets = FormField(PermissionsForm)
 

--- a/atst/models/application.py
+++ b/atst/models/application.py
@@ -28,6 +28,7 @@ class Application(
         back_populates="application",
         primaryjoin="and_(Environment.application_id==Application.id, Environment.deleted==False)",
     )
+    # TODO: filter condition on this relationship?
     roles = relationship("ApplicationRole")
 
     @property

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -104,7 +104,6 @@ def update_team(application_id):
     form = TeamForm(http_request.form)
 
     if form.validate():
-        # TODO check that all users coming through are app members
         for member in form.members:
             app_role = ApplicationRoles.get(member.data["user_id"], application.id)
             new_perms = [

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -51,15 +51,15 @@ def team(application_id):
             ),
         }
         permission_sets = {
-            "perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
-            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
-            else "",
-            "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM
-            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_TEAM)
-            else "",
             "perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
             if member.has_permission_set(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
-            else "",
+            else translate("portfolios.members.permissions.view_only"),
+            "perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
+            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
+            else translate("portfolios.members.permissions.view_only"),
+            "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM
+            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_TEAM)
+            else translate("portfolios.members.permissions.view_only"),
         }
         roles = EnvironmentRoles.get_for_application_and_user(
             member.user.id, application.id
@@ -107,7 +107,9 @@ def update_team(application_id):
         # TODO check that all users coming through are app members
         for member in form.members:
             app_role = ApplicationRoles.get(member.data["user_id"], application.id)
-            new_perms = [perm for perm in member.data["permission_sets"] if perm != ""]
+            new_perms = [
+                perm for perm in member.data["permission_sets"] if perm != "View only"
+            ]
             ApplicationRoles.update_permission_sets(app_role, new_perms)
         flash("updated_application_members_permissions")
 

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -32,6 +32,7 @@ def team(application_id):
     team_data = []
     for member in application.members:
         user_id = member.user.id
+        # TODO: if no members, we get a server error
         user_name = member.user.full_name
         environment_users[user_id] = {
             "permissions": {

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -111,6 +111,7 @@ def update_team(application_id):
             app_role = ApplicationRoles.get(member.data["user_id"], application.id)
             new_perms = [perm for perm in member.data["permission_sets"] if perm != ""]
             ApplicationRoles.update_permission_sets(app_role, new_perms)
+        flash("updated_application_members_permissions")
 
     return redirect(
         url_for(

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -4,11 +4,11 @@ from flask import render_template, request as http_request, g, url_for, redirect
 from . import applications_bp
 from atst.domain.applications import Applications
 from atst.domain.application_roles import ApplicationRoles
+from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.domain.environments import Environments
 from atst.domain.environment_roles import EnvironmentRoles
-from atst.domain.authz.decorator import user_can_access_decorator as user_can
-from atst.domain.permission_sets import PermissionSets
 from atst.domain.exceptions import AlreadyExistsError
+from atst.domain.permission_sets import PermissionSets
 from atst.forms.application_member import NewForm as NewMemberForm
 from atst.forms.team import TeamForm
 from atst.models import Permissions
@@ -33,7 +33,6 @@ def team(application_id):
     team_data = []
     for member in application.members:
         user_id = member.user.id
-        # TODO: if no members, we get a server error
         user_name = member.user.full_name
         environment_users[user_id] = {
             "permissions": {
@@ -82,12 +81,11 @@ def team(application_id):
             }
         )
 
-        team_form = TeamForm(data={"members": team_data})
-
     env_roles = [
         {"environment_id": e.id, "environment_name": e.name}
         for e in application.environments
     ]
+    team_form = TeamForm(data={"members": team_data})
     new_member_form = NewMemberForm(data={"environment_roles": env_roles})
 
     return render_template(

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -36,14 +36,14 @@ def team(application_id):
         user_name = member.user.full_name
         environment_users[user_id] = {
             "permissions": {
-                "delete_access": permission_str(
-                    member, PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
+                "team_management": permission_str(
+                    member, PermissionSets.EDIT_APPLICATION_TEAM
                 ),
                 "environment_management": permission_str(
                     member, PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
                 ),
-                "team_management": permission_str(
-                    member, PermissionSets.EDIT_APPLICATION_TEAM
+                "delete_access": permission_str(
+                    member, PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
                 ),
             },
             "environments": Environments.for_user(
@@ -51,15 +51,15 @@ def team(application_id):
             ),
         }
         permission_sets = {
-            "perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
-            if member.has_permission_set(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
-            else translate("portfolios.members.permissions.view_only"),
-            "perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
-            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
-            else translate("portfolios.members.permissions.view_only"),
             "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM
             if member.has_permission_set(PermissionSets.EDIT_APPLICATION_TEAM)
-            else translate("portfolios.members.permissions.view_only"),
+            else "View only",
+            "perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS
+            if member.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
+            else "View only",
+            "perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
+            if member.has_permission_set(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
+            else "View only",
         }
         roles = EnvironmentRoles.get_for_application_and_user(
             member.user.id, application.id

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -168,6 +168,13 @@ MESSAGES = {
         """,
         "category": "success",
     },
+    "updated_application_members_permissions": {
+        "title_template": translate("flash.success"),
+        "message_template": """
+          <p>{{ "flash.updated_application_members_permissions" | translate }}</p>
+        """,
+        "category": "success",
+    },
 }
 
 

--- a/js/components/forms/base_form.js
+++ b/js/components/forms/base_form.js
@@ -1,26 +1,28 @@
 import ally from 'ally.js'
 
-import FormMixin from '../../mixins/form'
-import textinput from '../text_input'
-import optionsinput from '../options_input'
-import DateSelector from '../date_selector'
-import MultiStepModalForm from './multi_step_modal_form'
-import multicheckboxinput from '../multi_checkbox_input'
 import checkboxinput from '../checkbox_input'
+import DateSelector from '../date_selector'
+import FormMixin from '../../mixins/form'
 import levelofwarrant from '../levelofwarrant'
 import Modal from '../../mixins/modal'
+import multicheckboxinput from '../multi_checkbox_input'
+import MultiStepModalForm from './multi_step_modal_form'
+import optionsinput from '../options_input'
+import textinput from '../text_input'
+import toggler from '../toggler'
 
 export default {
   name: 'base-form',
   components: {
-    textinput,
-    optionsinput,
-    DateSelector,
-    MultiStepModalForm,
-    multicheckboxinput,
     checkboxinput,
+    DateSelector,
     levelofwarrant,
     Modal,
+    multicheckboxinput,
+    MultiStepModalForm,
+    optionsinput,
+    textinput,
+    toggler,
   },
   mixins: [FormMixin],
 }

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -1,7 +1,10 @@
 import { emitEvent } from '../lib/emitters'
+import FormMixin from '../mixins/form'
 
 export default {
   name: 'optionsinput',
+
+  mixins: [FormMixin],
 
   props: {
     name: String,
@@ -10,6 +13,10 @@ export default {
       default: () => [],
     },
     initialValue: String,
+    watch: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   data: function() {
@@ -27,6 +34,7 @@ export default {
       emitEvent('field-change', this, {
         value: e.target.value,
         name: this.name,
+        watch: this.watch,
       })
       this.showError = false
       this.showValid = true

--- a/js/components/toggler.js
+++ b/js/components/toggler.js
@@ -1,5 +1,6 @@
 import FormMixin from '../mixins/form'
 import textinput from './text_input'
+import optionsinput from './options_input'
 
 export default {
   name: 'toggler',
@@ -8,6 +9,7 @@ export default {
 
   components: {
     textinput,
+    optionsinput,
   },
 
   data: function() {

--- a/js/components/toggler.js
+++ b/js/components/toggler.js
@@ -1,6 +1,6 @@
 import FormMixin from '../mixins/form'
-import textinput from './text_input'
 import optionsinput from './options_input'
+import textinput from './text_input'
 
 export default {
   name: 'toggler',

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -16,8 +16,7 @@ export default {
       const { name, valid, parent_uid } = event
       if (typeof this[name] !== undefined) {
         this.fields[name] = valid
-
-        if (parent_uid === this._uid) {
+        if (event['parent_uid'] === this._uid || event['watch']) {
           this.changed = true
         }
       }

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -39,6 +39,15 @@
 
   .accordion-table__item-content {
     padding: ($gap * 2);
+
+    .usa-input {
+      margin: 0;
+    }
+
+    select {
+      border: none;
+      font-weight: $font-normal;
+    }
   }
 
   .accordion-table__items {

--- a/styles/elements/_tables.scss
+++ b/styles/elements/_tables.scss
@@ -126,6 +126,7 @@ table {
       @include h4;
 
       font-size: $lead-font-size;
+      justify-content: space-between;
       flex: 2;
     }
   }

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -1,13 +1,14 @@
 {% from "components/icon.html" import Icon %}
 {% from "components/tooltip.html" import Tooltip %}
 
-{% macro OptionsInput(field, tooltip, inline=False, label=True, disabled=False) -%}
+{% macro OptionsInput(field, tooltip, inline=False, label=True, disabled=False, watch=False) -%}
   <optionsinput
     name='{{ field.name }}'
     inline-template
     {% if field.errors %}v-bind:initial-errors='{{ field.errors | list }}'{% endif %}
     {% if field.data and field.data != "None" %}v-bind:initial-value="'{{ field.data }}'"{% endif %}
     key='{{ field.name }}'
+    v-bind:watch='{{ watch | string | lower }}'
     >
     <div
       v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">

--- a/templates/fragments/applications/add_new_application_member.html
+++ b/templates/fragments/applications/add_new_application_member.html
@@ -9,23 +9,23 @@
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.first_name, validation='requiredField') }}
+      {{ TextInput(new_member_form.user_data.first_name, validation='requiredField') }}
     </div>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.last_name, validation='requiredField') }}
-    </div>
-  </div>
-  <div class='form-row'>
-    <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.email, validation='email') }}
-    </div>
-    <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.phone_number, validation='usPhone', optional=True) }}
+      {{ TextInput(new_member_form.user_data.last_name, validation='requiredField') }}
     </div>
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.dod_id, validation='dodId') }}
+      {{ TextInput(new_member_form.user_data.email, validation='email') }}
+    </div>
+    <div class='form-col form-col--half'>
+      {{ TextInput(new_member_form.user_data.phone_number, validation='usPhone', optional=True) }}
+    </div>
+  </div>
+  <div class='form-row'>
+    <div class='form-col form-col--half'>
+      {{ TextInput(new_member_form.user_data.dod_id, validation='dodId') }}
     </div>
     <div class='form-col form-col--half'>
     </div>
@@ -61,7 +61,7 @@
             </span>
           </div>
         </div>
-        {% for environment_data in member_form.environment_roles %}
+        {% for environment_data in new_member_form.environment_roles %}
           <optionsinput inline-template
             v-bind:initial-value="'{{ environment_data.role.data | string }}'"
           >
@@ -86,9 +86,9 @@
         {% endfor %}
       </div>
       <h1>{{ "portfolios.applications.members.new.manage_perms" | translate({"application_name": application.name}) }}</h1>
-      {{ CheckboxInput(member_form.permission_sets.perms_team_mgmt, classes="input__inline-fields") }}
-      {% call CheckboxInput(member_form.permission_sets.perms_env_mgmt, classes="input__inline-fields") %}
-        {% set field=member_form.permission_sets.perms_del_env %}
+      {{ CheckboxInput(new_member_form.permission_sets.perms_team_mgmt, classes="input__inline-fields") }}
+      {% call CheckboxInput(new_member_form.permission_sets.perms_env_mgmt, classes="input__inline-fields") %}
+        {% set field=new_member_form.permission_sets.perms_del_env %}
         <nestedcheckboxinput
           name='{{ field.name }}'
           inline-template
@@ -128,7 +128,7 @@
 {% endset %}
 {{ MultiStepModalForm(
     'add-app-mem',
-    member_form,
+    new_member_form,
     url_for("applications.create_member", application_id=application.id),
     [step_one, step_two],
     button_text=("portfolios.admin.add_new_member" | translate),

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -4,7 +4,7 @@
   {% set environment_roles_form = member_form.environment_roles %}
   {% set permissions_form = member_form.permission_sets %}
 
-  <form method='POST' id="team" action='{{ url_for("applications.team", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+  <form method='POST' id="team" action='{{ url_for("applications.update_team", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
     {{ team_form.csrf_token }}
     <toggler inline-template>
       <li class="accordion-table__item">

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -8,9 +8,9 @@
     <li class="accordion-table__item">
       <div class="accordion-table__item-content row">
         <div class="col col--grow">{{ member_form.user_name.data }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_team_mgmt, label=False) }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_env_mgmt, label=False) }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_del_env, label=False) }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_team_mgmt, label=False, watch=True) }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_env_mgmt, label=False, watch=True) }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_del_env, label=False, watch=True) }}</div>
         <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
           {% set open_html %}
             {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_down') }}

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -4,40 +4,44 @@
   {% set environment_roles_form = member_form.environment_roles %}
   {% set permissions_form = member_form.permission_sets %}
 
-  <toggler inline-template>
-    <li class="accordion-table__item">
-      <div class="accordion-table__item-content row">
-        <div class="col col--grow">{{ member_form.user_name.data }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_team_mgmt, label=False, watch=True) }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_env_mgmt, label=False, watch=True) }}</div>
-        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_del_env, label=False, watch=True) }}</div>
-        <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
-          {% set open_html %}
-            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_down') }}
-          {% endset %}
+  <form method='POST' id="team" action='{{ url_for("applications.team", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+    {{ team_form.csrf_token }}
+    <toggler inline-template>
+      <li class="accordion-table__item">
+        <div class="accordion-table__item-content row">
+          <div class="col col--grow">{{ member_form.user_name.data }}</div>
+          <div class="col col--grow">{{ OptionsInput(permissions_form.perms_team_mgmt, label=False, watch=True) }}</div>
+          <div class="col col--grow">{{ OptionsInput(permissions_form.perms_env_mgmt, label=False, watch=True) }}</div>
+          <div class="col col--grow">{{ OptionsInput(permissions_form.perms_del_env, label=False, watch=True) }}</div>
+          <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
+            {% set open_html %}
+              {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_down') }}
+            {% endset %}
 
-          {% set close_html %}
-            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_up') }}
-          {% endset %}
+            {% set close_html %}
+              {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_up') }}
+            {% endset %}
 
-          {{
-            ToggleButton(
-              open_html=open_html,
-              close_html=close_html,
-              section_name="environments"
-            )
-          }}
+            {{
+              ToggleButton(
+                open_html=open_html,
+                close_html=close_html,
+                section_name="environments"
+              )
+            }}
+          </div>
         </div>
-      </div>
-      {% call ToggleSection(section_name="environments") %}
-        <ul>
-          {% for environment_form in environment_roles_form %}
-            <li class="accordion-table__item__expanded">
-              {{ environment_form.environment_name.data }}
-            </li>
-          {% endfor %}
-        </ul>
-      {% endcall %}
-    </li>
-  </toggler>
+        {% call ToggleSection(section_name="environments") %}
+          <ul>
+            {% for environment_form in environment_roles_form %}
+              <li class="accordion-table__item__expanded">
+                {{ environment_form.environment_name.data }}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endcall %}
+      {{ member_form.user_id() }}
+      </li>
+    </toggler>
+  </form>
 {% endfor %}

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -1,11 +1,12 @@
 {% from "components/options_input.html" import OptionsInput %}
 
-{% for member_form in team_form.members %}
-  {% set environment_roles_form = member_form.environment_roles %}
-  {% set permissions_form = member_form.permission_sets %}
+<form method='POST' id="team" action='{{ url_for("applications.update_team", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+  {{ team_form.csrf_token }}
 
-  <form method='POST' id="team" action='{{ url_for("applications.update_team", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
-    {{ team_form.csrf_token }}
+  {% for member_form in team_form.members %}
+    {% set environment_roles_form = member_form.environment_roles %}
+    {% set permissions_form = member_form.permission_sets %}
+
     <toggler inline-template>
       <li class="accordion-table__item">
         <div class="accordion-table__item-content row">
@@ -43,5 +44,5 @@
       {{ member_form.user_id() }}
       </li>
     </toggler>
-  </form>
-{% endfor %}
+  {% endfor %}
+</form>

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -1,0 +1,43 @@
+{% from "components/options_input.html" import OptionsInput %}
+
+{% for member_form in team_form.members %}
+  {% set environment_roles_form = member_form.environment_roles %}
+  {% set permissions_form = member_form.permission_sets %}
+
+  <toggler inline-template>
+    <li class="accordion-table__item">
+      <div class="accordion-table__item-content row">
+        <div class="col col--grow">{{ member_form.user_name.data }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_team_mgmt, label=False) }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_env_mgmt, label=False) }}</div>
+        <div class="col col--grow">{{ OptionsInput(permissions_form.perms_del_env, label=False) }}</div>
+        <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
+          {% set open_html %}
+            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_down') }}
+          {% endset %}
+
+          {% set close_html %}
+            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ environment_roles_form | length }}) {{ Icon('caret_up') }}
+          {% endset %}
+
+          {{
+            ToggleButton(
+              open_html=open_html,
+              close_html=close_html,
+              section_name="environments"
+            )
+          }}
+        </div>
+      </div>
+      {% call ToggleSection(section_name="environments") %}
+        <ul>
+          {% for environment_form in environment_roles_form %}
+            <li class="accordion-table__item__expanded">
+              {{ environment_form.environment_name.data }}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endcall %}
+    </li>
+  </toggler>
+{% endfor %}

--- a/templates/fragments/applications/read_only_team.html
+++ b/templates/fragments/applications/read_only_team.html
@@ -1,0 +1,46 @@
+{% for member in application.members %}
+  {% set user = member.user %}
+  {% set user_info = environment_users[user.id] %}
+  {% set user_permissions = user_info["permissions"] %}
+
+    {% macro PermissionField(value) %}
+      <div class="col col--grow user-permission{% if "Edit" in value %} green{% endif %}">{{ value }}</div>
+    {% endmacro %}
+
+    <toggler inline-template>
+      <li class="accordion-table__item">
+        <div class="accordion-table__item-content row">
+          <div class="col col--grow">{{ user.full_name }}</div>
+          {{ PermissionField(user_permissions["delete_access"]) }}
+          {{ PermissionField(user_permissions["environment_management"]) }}
+          {{ PermissionField(user_permissions["team_management"]) }}
+          <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
+            {% set open_html %}
+            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_down') }}
+            {% endset %}
+
+            {% set close_html %}
+              {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_up') }}
+            {% endset %}
+
+            {{
+              ToggleButton(
+                open_html=open_html,
+                close_html=close_html,
+                section_name="environments"
+              )
+            }}
+          </div>
+      </div>
+      {% call ToggleSection(section_name="environments") %}
+        <ul>
+          {% for environment in user_info["environments"] %}
+            <li class="accordion-table__item__expanded">
+              {{ environment.name }}
+            </li>
+          {% endfor %}
+        </ul>
+      {% endcall %}
+    </li>
+  </toggler>
+{% endfor %}

--- a/templates/fragments/applications/read_only_team.html
+++ b/templates/fragments/applications/read_only_team.html
@@ -3,34 +3,34 @@
   {% set user_info = environment_users[user.id] %}
   {% set user_permissions = user_info["permissions"] %}
 
-    {% macro PermissionField(value) %}
-      <div class="col col--grow user-permission{% if "Edit" in value %} green{% endif %}">{{ value }}</div>
-    {% endmacro %}
+  {% macro PermissionField(value) %}
+    <div class="col col--grow user-permission{% if "Edit" in value %} green{% endif %}">{{ value }}</div>
+  {% endmacro %}
 
-    <toggler inline-template>
-      <li class="accordion-table__item">
-        <div class="accordion-table__item-content row">
-          <div class="col col--grow">{{ user.full_name }}</div>
-          {{ PermissionField(user_permissions["delete_access"]) }}
-          {{ PermissionField(user_permissions["environment_management"]) }}
-          {{ PermissionField(user_permissions["team_management"]) }}
-          <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
-            {% set open_html %}
-            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_down') }}
-            {% endset %}
+  <toggler inline-template>
+    <li class="accordion-table__item">
+      <div class="accordion-table__item-content row">
+        <div class="col col--grow">{{ user.full_name }}</div>
+        {{ PermissionField(user_permissions["delete_access"]) }}
+        {{ PermissionField(user_permissions["environment_management"]) }}
+        {{ PermissionField(user_permissions["team_management"]) }}
+        <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
+          {% set open_html %}
+          {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_down') }}
+          {% endset %}
 
-            {% set close_html %}
-              {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_up') }}
-            {% endset %}
+          {% set close_html %}
+            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_up') }}
+          {% endset %}
 
-            {{
-              ToggleButton(
-                open_html=open_html,
-                close_html=close_html,
-                section_name="environments"
-              )
-            }}
-          </div>
+          {{
+            ToggleButton(
+              open_html=open_html,
+              close_html=close_html,
+              section_name="environments"
+            )
+          }}
+        </div>
       </div>
       {% call ToggleSection(section_name="environments") %}
         <ul>

--- a/templates/fragments/applications/read_only_team.html
+++ b/templates/fragments/applications/read_only_team.html
@@ -1,26 +1,25 @@
-{% for member in application.members %}
-  {% set user = member.user %}
-  {% set user_info = environment_users[user.id] %}
-  {% set user_permissions = user_info["permissions"] %}
+{% for member in team_form.members %}
+  {% set user_permissions = [member.permission_sets.perms_team_mgmt, member.permission_sets.perms_env_mgmt, member.permission_sets.perms_del_env] %}
 
   {% macro PermissionField(value) %}
-    <div class="col col--grow user-permission{% if "Edit" in value %} green{% endif %}">{{ value }}</div>
+    <div class="col col--grow user-permission{% if "Edit" in value or "Yes" in value %} green{% endif %}">{{ value }}</div>
   {% endmacro %}
 
   <toggler inline-template>
     <li class="accordion-table__item">
       <div class="accordion-table__item-content row">
-        <div class="col col--grow">{{ user.full_name }}</div>
-        {{ PermissionField(user_permissions["delete_access"]) }}
-        {{ PermissionField(user_permissions["environment_management"]) }}
-        {{ PermissionField(user_permissions["team_management"]) }}
+        <div class="col col--grow">{{ member.user_name.data }}</div>
+        {% for permission in user_permissions %}
+          {% set perm = dict(permission.choices).get(permission.data) %}
+          {{ PermissionField(perm) }}
+        {% endfor %}
         <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
           {% set open_html %}
-          {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_down') }}
+          {{ "portfolios.applications.team_settings.environments" | translate }} ({{ member.environment_roles | length }}) {{ Icon('caret_down') }}
           {% endset %}
 
           {% set close_html %}
-            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_up') }}
+            {{ "portfolios.applications.team_settings.environments" | translate }} ({{ member.environment_roles | length }}) {{ Icon('caret_up') }}
           {% endset %}
 
           {{
@@ -34,9 +33,9 @@
       </div>
       {% call ToggleSection(section_name="environments") %}
         <ul>
-          {% for environment in user_info["environments"] %}
+          {% for environment in member.environment_roles %}
             <li class="accordion-table__item__expanded">
-              {{ environment.name }}
+              {{ environment.environment_name.data }}
             </li>
           {% endfor %}
         </ul>

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -62,8 +62,7 @@
           </div>
           <ul class="accordion-table__items">
             {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
-              {# edit version goes here #}
-              {% include "fragments/applications/read_only_team.html" %}
+              {% include "fragments/applications/edit_team.html" %}
             {% elif user_can(permissions.VIEW_APPLICATION_MEMBER) %}
               {% include "fragments/applications/read_only_team.html" %}
             {% endif %}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -32,11 +32,11 @@
           {% endif %}
           <header>
             <div class="responsive-table-wrapper__header">
-              <div class="responsive-table-wrapper__title">
+              <div class="responsive-table-wrapper__title row">
                 <div class="h3">
                   {{ "portfolios.applications.team_settings.section.title" | translate({ "application_name": application.name }) }}
                 </div>
-                <a class='icon-link'>
+                <a class="icon-link">
                   {{ Icon('info') }}
                   {{ "portfolios.admin.settings_info" | translate }}
                 </a>

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -61,52 +61,12 @@
             </div>
           </div>
           <ul class="accordion-table__items">
-            {% for member in application.members %}
-              {% set user = member.user %}
-              {% set user_info = environment_users[user.id] %}
-              {% set user_permissions = user_info["permissions"] %}
-
-                {% macro PermissionField(value) %}
-                  <div class="col col--grow user-permission{% if "Edit" in value %} green{% endif %}">{{ value }}</div>
-                {% endmacro %}
-
-                <toggler inline-template>
-                  <li class="accordion-table__item">
-                    <div class="accordion-table__item-content row">
-                      <div class="col col--grow">{{ user.full_name }}</div>
-                      {{ PermissionField(user_permissions["delete_access"]) }}
-                      {{ PermissionField(user_permissions["environment_management"]) }}
-                      {{ PermissionField(user_permissions["team_management"]) }}
-                      <div class="col col--grow icon-link icon-link--large accordion-table__item__toggler">
-                        {% set open_html %}
-                        {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_down') }}
-                        {% endset %}
-
-                        {% set close_html %}
-                          {{ "portfolios.applications.team_settings.environments" | translate }} ({{ user_info['environments'] | length }}) {{ Icon('caret_up') }}
-                        {% endset %}
-
-                        {{
-                          ToggleButton(
-                            open_html=open_html,
-                            close_html=close_html,
-                            section_name="environments"
-                          )
-                        }}
-                      </div>
-                  </div>
-                  {% call ToggleSection(section_name="environments") %}
-                    <ul>
-                      {% for environment in user_info["environments"] %}
-                        <li class="accordion-table__item__expanded">
-                          {{ environment.name }}
-                        </li>
-                      {% endfor %}
-                    </ul>
-                  {% endcall %}
-                </li>
-              </toggler>
-            {% endfor %}
+            {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+              {# edit version goes here #}
+              {% include "fragments/applications/read_only_team.html" %}
+            {% elif user_can(permissions.VIEW_APPLICATION_MEMBER) %}
+              {% include "fragments/applications/read_only_team.html" %}
+            {% endif %}
           </ul>
         </div>
 

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -49,13 +49,13 @@
                 {{ "common.name" | translate }}
               </div>
               <div class="col col--grow">
-                {{ "portfolios.applications.team_settings.section.table.delete_access" | translate }}
+                {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
               </div>
               <div class="col col--grow">
                 {{ "portfolios.applications.team_settings.section.table.environment_management" | translate }}
               </div>
               <div class="col col--grow">
-                {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
+                {{ "portfolios.applications.team_settings.section.table.delete_access" | translate }}
               </div>
               <div class="col col--grow">
                 &nbsp;

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -2,6 +2,7 @@
 
 {% from "components/empty_state.html" import EmptyState %}
 {% from "components/icon.html" import Icon %}
+{% from 'components/save_button.html' import SaveButton %}
 {% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 
 {% set secondary_breadcrumb = 'portfolios.applications.team_settings.title' | translate({ "application_name": application.name }) %}
@@ -24,60 +25,65 @@
     </div>
 
     <section class="member-list application-list" id="application-members">
-      <div class='responsive-table-wrapper panel'>
-        {% if g.matchesPath("application-members") %}
-          {% include "fragments/flash.html" %}
-        {% endif %}
-        <header>
-          <div class="responsive-table-wrapper__header">
-            <div class="responsive-table-wrapper__title">
-              <div class="h3">
-                {{ "portfolios.applications.team_settings.section.title" | translate({ "application_name": application.name }) }}
+      <base-form inline-template>
+        <div class='responsive-table-wrapper panel'>
+          {% if g.matchesPath("application-members") %}
+            {% include "fragments/flash.html" %}
+          {% endif %}
+          <header>
+            <div class="responsive-table-wrapper__header">
+              <div class="responsive-table-wrapper__title">
+                <div class="h3">
+                  {{ "portfolios.applications.team_settings.section.title" | translate({ "application_name": application.name }) }}
+                </div>
+                <a class='icon-link'>
+                  {{ Icon('info') }}
+                  {{ "portfolios.admin.settings_info" | translate }}
+                </a>
+              </div>
+            </header>
+
+          <div class="accordion-table accordion-table-list">
+            <div class="accordion-table__head row">
+              <div class="col col--grow">
+                {{ "common.name" | translate }}
+              </div>
+              <div class="col col--grow">
+                {{ "portfolios.applications.team_settings.section.table.delete_access" | translate }}
+              </div>
+              <div class="col col--grow">
+                {{ "portfolios.applications.team_settings.section.table.environment_management" | translate }}
+              </div>
+              <div class="col col--grow">
+                {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
+              </div>
+              <div class="col col--grow">
+                &nbsp;
               </div>
             </div>
-            <a class='icon-link'>
-              {{ Icon('info') }}
-              {{ "portfolios.admin.settings_info" | translate }}
-            </a>
+            <ul class="accordion-table__items">
+              {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+                {% include "fragments/applications/edit_team.html" %}
+              {% elif user_can(permissions.VIEW_APPLICATION_MEMBER) %}
+                {% include "fragments/applications/read_only_team.html" %}
+              {% endif %}
+            </ul>
           </div>
-        </header>
 
-        <div class="accordion-table accordion-table-list">
-          <div class="accordion-table__head row">
-            <div class="col col--grow">
-              {{ "common.name" | translate }}
-            </div>
-            <div class="col col--grow">
-              {{ "portfolios.applications.team_settings.section.table.delete_access" | translate }}
-            </div>
-            <div class="col col--grow">
-              {{ "portfolios.applications.team_settings.section.table.environment_management" | translate }}
-            </div>
-            <div class="col col--grow">
-              {{ "portfolios.applications.team_settings.section.table.team_management" | translate }}
-            </div>
-            <div class="col col--grow">
-              &nbsp;
-            </div>
-          </div>
-          <ul class="accordion-table__items">
-            {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
-              {% include "fragments/applications/edit_team.html" %}
-            {% elif user_can(permissions.VIEW_APPLICATION_MEMBER) %}
-              {% include "fragments/applications/read_only_team.html" %}
-            {% endif %}
-          </ul>
-        </div>
-
-          <div class="members-table-footer">
+          <div class="panel__footer">
             <div class="action-group save">
+              {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+                {{ SaveButton(text=('common.save' | translate), element="input", form="member-perms") }}
+              {% endif %}
+
               {% if user_can(permissions.CREATE_APPLICATION_MEMBER) %}
                 {% include "fragments/applications/add_new_application_member.html" %}
               {% endif %}
             </div>
           </div>
-        </form>
-      </div>
+
+        </div>
+      </base-form>
     </section>
   {% endif %}
 {% endblock %}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -73,7 +73,7 @@
           <div class="panel__footer">
             <div class="action-group save">
               {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
-                {{ SaveButton(text=('common.save' | translate), element="input", form="member-perms") }}
+                {{ SaveButton(text=('common.save' | translate), element="input", form="team") }}
               {% endif %}
 
               {% if user_can(permissions.CREATE_APPLICATION_MEMBER) %}

--- a/tests/domain/test_application_roles.py
+++ b/tests/domain/test_application_roles.py
@@ -1,4 +1,7 @@
+import pytest
+
 from atst.domain.application_roles import ApplicationRoles
+from atst.domain.exceptions import NotFoundError
 from atst.domain.permission_sets import PermissionSets
 from atst.models import ApplicationRoleStatus
 
@@ -43,6 +46,14 @@ def test_get():
     assert ApplicationRoles.get(user.id, application.id)
     assert app_role.application == application
     assert app_role.user == user
+
+
+def test_get_handles_invalid_id():
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+
+    with pytest.raises(NotFoundError):
+        ApplicationRoles.get(user.id, application.id)
 
 
 def test_update_permission_sets():

--- a/tests/domain/test_application_roles.py
+++ b/tests/domain/test_application_roles.py
@@ -33,3 +33,30 @@ def test_enabled_application_role():
     ApplicationRoles.enable(app_role)
 
     assert app_role.status == ApplicationRoleStatus.ACTIVE
+
+
+def test_get():
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    app_role = ApplicationRoleFactory.create(user=user, application=application)
+
+    assert ApplicationRoles.get(user.id, application.id)
+    assert app_role.application == application
+    assert app_role.user == user
+
+
+def test_update_permission_sets():
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    app_role = ApplicationRoleFactory.create(user=user, application=application)
+
+    view_app = [PermissionSets.get(PermissionSets.VIEW_APPLICATION)]
+    new_perms_names = [
+        PermissionSets.EDIT_APPLICATION_TEAM,
+        PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
+    ]
+    new_perms = PermissionSets.get_many(new_perms_names)
+    # view application permission is included by default
+    assert app_role.permission_sets == view_app
+    assert ApplicationRoles.update_permission_sets(app_role, new_perms_names)
+    assert set(app_role.permission_sets) == set(new_perms + view_app)

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -1,0 +1,16 @@
+from atst.domain.environment_roles import EnvironmentRoles
+
+from tests.factories import *
+
+
+def test_get_for_application_and_user():
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    env1 = EnvironmentFactory.create(application=application)
+    EnvironmentFactory.create(application=application)
+    EnvironmentRoleFactory.create(user=user, environment=env1)
+
+    roles = EnvironmentRoles.get_for_application_and_user(user.id, application.id)
+    assert len(roles) == 1
+    assert roles[0].environment == env1
+    assert roles[0].user == user

--- a/tests/forms/test_team.py
+++ b/tests/forms/test_team.py
@@ -1,0 +1,26 @@
+from wtforms.validators import ValidationError
+import pytest
+
+from atst.domain.permission_sets import PermissionSets
+from atst.forms.team import *
+
+
+def test_permissions_form_permission_sets():
+    form_data = {
+        "perms_env_mgmt": "",
+        "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
+        "perms_del_env": "",
+    }
+    form = PermissionsForm(data=form_data)
+    assert form.validate()
+    assert form.data == [PermissionSets.EDIT_APPLICATION_TEAM]
+
+
+def test_permissions_form_invalid():
+    form_data = {
+        "perms_env_mgmt": "not a real choice",
+        "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
+        "perms_del_env": "",
+    }
+    form = PermissionsForm(data=form_data)
+    assert not form.validate()

--- a/tests/forms/test_team.py
+++ b/tests/forms/test_team.py
@@ -9,7 +9,7 @@ def test_permissions_form_permission_sets():
     form_data = {
         "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
         "perms_env_mgmt": PermissionSets.VIEW_APPLICATION,
-        "perms_del_env": "View only",
+        "perms_del_env": PermissionSets.VIEW_APPLICATION,
     }
     form = PermissionsForm(data=form_data)
 
@@ -17,7 +17,7 @@ def test_permissions_form_permission_sets():
     assert form.data == [
         PermissionSets.EDIT_APPLICATION_TEAM,
         PermissionSets.VIEW_APPLICATION,
-        "View only",
+        PermissionSets.VIEW_APPLICATION,
     ]
 
 
@@ -25,7 +25,7 @@ def test_permissions_form_invalid():
     form_data = {
         "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
         "perms_env_mgmt": "not a real choice",
-        "perms_del_env": "View only",
+        "perms_del_env": PermissionSets.VIEW_APPLICATION,
     }
     form = PermissionsForm(data=form_data)
     assert not form.validate()

--- a/tests/forms/test_team.py
+++ b/tests/forms/test_team.py
@@ -7,20 +7,25 @@ from atst.forms.team import *
 
 def test_permissions_form_permission_sets():
     form_data = {
-        "perms_env_mgmt": "",
         "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
-        "perms_del_env": "",
+        "perms_env_mgmt": PermissionSets.VIEW_APPLICATION,
+        "perms_del_env": "View only",
     }
     form = PermissionsForm(data=form_data)
+
     assert form.validate()
-    assert form.data == [PermissionSets.EDIT_APPLICATION_TEAM]
+    assert form.data == [
+        PermissionSets.EDIT_APPLICATION_TEAM,
+        PermissionSets.VIEW_APPLICATION,
+        "View only",
+    ]
 
 
 def test_permissions_form_invalid():
     form_data = {
-        "perms_env_mgmt": "not a real choice",
         "perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
-        "perms_del_env": "",
+        "perms_env_mgmt": "not a real choice",
+        "perms_del_env": "View only",
     }
     form = PermissionsForm(data=form_data)
     assert not form.validate()

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -10,7 +10,6 @@ def test_application_team(client, user_session):
     user_session(portfolio.owner)
 
     response = client.get(url_for("applications.team", application_id=application.id))
-
     assert response.status_code == 200
 
 

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -1,6 +1,8 @@
 from flask import url_for
 
-from tests.factories import PortfolioFactory, ApplicationFactory, UserFactory
+from atst.domain.permission_sets import PermissionSets
+
+from tests.factories import *
 
 
 def test_application_team(client, user_session):
@@ -11,6 +13,79 @@ def test_application_team(client, user_session):
 
     response = client.get(url_for("applications.team", application_id=application.id))
     assert response.status_code == 200
+
+
+def test_update_team(client, user_session):
+    application = ApplicationFactory.create()
+    owner = application.portfolio.owner
+    app_role = ApplicationRoleFactory.create(
+        application=application, permission_sets=[]
+    )
+    app_user = app_role.user
+    user_session(owner)
+    response = client.post(
+        url_for("applications.update_team", application_id=application.id),
+        data={
+            "members-0-user_id": app_user.id,
+            "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
+            "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
+            "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
+        },
+    )
+
+    assert response.status_code == 302
+    actual_perms_names = [perm.name for perm in app_role.permission_sets]
+    expected_perms_names = [
+        PermissionSets.VIEW_APPLICATION,
+        PermissionSets.EDIT_APPLICATION_TEAM,
+        PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
+        PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
+    ]
+    assert expected_perms_names == actual_perms_names
+
+
+def test_update_team_with_bad_permission_sets(client, user_session):
+    application = ApplicationFactory.create()
+    owner = application.portfolio.owner
+    app_role = ApplicationRoleFactory.create(
+        application=application, permission_sets=[]
+    )
+    app_user = app_role.user
+    permission_sets = app_user.permission_sets
+
+    user_session(owner)
+    response = client.post(
+        url_for("applications.update_team", application_id=application.id),
+        data={
+            "members-0-user_id": app_user.id,
+            "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
+            "members-0-permission_sets-perms_env_mgmt": "some random string",
+        },
+    )
+    assert app_user.permission_sets == permission_sets
+
+
+def test_update_team_with_non_app_user(client, user_session):
+    application = ApplicationFactory.create()
+    owner = application.portfolio.owner
+    app_role = ApplicationRoleFactory.create(
+        application=application, permission_sets=[]
+    )
+    non_app_user = UserFactory.create()
+    app_user = app_role.user
+
+    user_session(owner)
+    response = client.post(
+        url_for("applications.update_team", application_id=application.id),
+        data={
+            "members-0-user_id": non_app_user.id,
+            "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
+            "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
+            "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
+        },
+    )
+
+    assert response.status_code == 404
 
 
 def test_create_member(client, user_session):

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -1,3 +1,4 @@
+import pytest
 from flask import url_for
 
 from atst.domain.permission_sets import PermissionSets
@@ -62,6 +63,7 @@ def test_update_team_with_bad_permission_sets(client, user_session):
             "members-0-permission_sets-perms_env_mgmt": "some random string",
         },
     )
+    assert response.status_code == 400
     assert app_user.permission_sets == permission_sets
 
 

--- a/translations.yaml
+++ b/translations.yaml
@@ -72,6 +72,7 @@ flash:
   portfolio_home: Go to my portfolio home page
   success: Success!
   new_application_member: 'You have successfully invited {user_name} to the team.'
+  updated_application_members_permissions: 'You have successfully updated member permissions.'
 footer:
   about_link_text: Joint Enterprise Defense Infrastructure
   browser_support: JEDI Cloud supported on these web browsers


### PR DESCRIPTION
## Description
This PR sets up permissions editing for users with team management permissions. It creates a form to handle permission changes and environment role changes. A success banner posts when changes are saved.

The Save button is disabled until a change has been made. Because we have nested vue components within the `base-form` component, I needed to add a `watch` option for the `OptionsInput` which emits a Boolean to all of its parents when that component changes. Before this addition, the change was only being tracked by the immediate parent, so a grandparent component (in this case, `base-form`) never knew about changes to grandchildren components.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165060777

## Screenshots
![Screen Shot 2019-05-02 at 3 26 59 PM](https://user-images.githubusercontent.com/42577527/57144579-58424600-6d8f-11e9-906d-7034eeec69d4.png)
<img width="2012" alt="Screen Shot 2019-05-02 at 3 27 07 PM" src="https://user-images.githubusercontent.com/42577527/57144580-58424600-6d8f-11e9-8abc-90f111ed6e67.png">

