### PR TITLE
Add New Environment via app settings

### DIFF
--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -169,6 +169,19 @@ def update(application_id):
             environments_obj=get_environments_obj_for_app(application=application),
         )
 
+@applications_bp.route("/applications/<application_id>/add_environment", methods=["POST"])
+@user_can(Permissions.EDIT_APPLICATION, message="add application environment")
+def add_environment(application_id):
+    application = Applications.get(application_id)
+    form = ApplicationForm(http_request.form)
+
+    return render_template(
+        "portfolios/applications/settings.html",
+        application=application,
+        form=form,
+        environments_obj=get_environments_obj_for_app(application=application),
+    )
+
 
 @applications_bp.route("/environments/<environment_id>/roles", methods=["POST"])
 @user_can(Permissions.ASSIGN_ENVIRONMENT_MEMBER, message="update environment roles")

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -159,7 +159,7 @@ def new_environment(application_id):
     if env_form.validate():
         Environments.create(application=application, name=env_form.name.data)
 
-        flash("application_environments_updated")
+        flash("environment_added", environment_name=env_form.data["name"])
 
         return redirect(
             url_for(

--- a/atst/utils/context_processors.py
+++ b/atst/utils/context_processors.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm.exc import NoResultFound
 
 from atst.database import db
 from atst.domain.authz import Authorization
+from atst.domain.exceptions import NotFoundError
 from atst.domain.portfolios.scopes import ScopedPortfolio
 from atst.models import (
     Application,

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -12,6 +12,13 @@ MESSAGES = {
         "message_template": "Application environment members have been updated",
         "category": "success",
     },
+    "environment_added": {
+        "title_template": translate("flash.success"),
+        "message_template": """
+            {{ "flash.environment_added" | translate({ "env_name": environment_name }) }}
+        """,
+        "category": "success",
+    },
     "application_environments_updated": {
         "title_template": "Application environments updated",
         "message_template": "Application environments have been updated",
@@ -24,7 +31,7 @@ MESSAGES = {
     },
     "invitation_resent": {
         "title_template": "Invitation resent",
-        "message_template": "The {{ officer_type }}  has been resent instructions to join this portfolio.",
+        "message_template": "The {{ officer_type }} has been resent instructions to join this portfolio.",
         "category": "success",
     },
     "task_order_draft": {

--- a/js/components/forms/new_environment.js
+++ b/js/components/forms/new_environment.js
@@ -1,0 +1,24 @@
+import FormMixin from '../../mixins/form'
+import textinput from '../text_input'
+
+export default {
+  name: 'new-environment',
+
+  mixins: [FormMixin],
+
+  components: {
+    textinput,
+  },
+
+  data: function() {
+    return {
+      open: false,
+    }
+  },
+
+  methods: {
+    toggle: function() {
+      this.open = !this.open
+    },
+  },
+}

--- a/js/index.js
+++ b/js/index.js
@@ -38,6 +38,7 @@ import SidenavToggler from './components/sidenav_toggler'
 import KoReview from './components/forms/ko_review'
 import BaseForm from './components/forms/base_form'
 import DeleteConfirmation from './components/delete_confirmation'
+import NewEnvironment from './components/forms/new_environment'
 
 Vue.config.productionTip = false
 
@@ -78,6 +79,7 @@ const app = new Vue({
     BaseForm,
     DeleteConfirmation,
     nestedcheckboxinput,
+    NewEnvironment,
   },
 
   mounted: function() {

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -42,12 +42,30 @@
 
     .usa-input {
       margin: 0;
+
+      .icon-validation {
+        left: 135%;
+      }
+    }
+
+    #name {
+      max-width: none;
+      border-color: black;
+    }
+
+    .usa-alert {
+      margin: 2.5rem 0;
     }
 
     select {
       border: none;
       font-weight: $font-normal;
     }
+  }
+
+  .new-env {
+    margin-top: 5rem;
+    padding: 0 5rem;;
   }
 
   .accordion-table__items {

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -65,7 +65,7 @@
 
   .new-env {
     margin-top: 5rem;
-    padding: 0 5rem;;
+    padding: 0 5rem;
   }
 
   .accordion-table__items {

--- a/templates/components/delete_confirmation.html
+++ b/templates/components/delete_confirmation.html
@@ -17,7 +17,7 @@
           </button>
         </form>
         <div class="action-group">
-          <a v-on:click="deleteText = ''; $root.closeModal({{ modal_id }})" class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
+          <a v-on:click="deleteText = ''; $root.closeModal('{{ modal_id }}')" class="action-group__action icon-link icon-link--default">{{ "common.cancel" | translate }}</a>
         </div>
       </div>
     </div>

--- a/templates/fragments/applications/add_new_environment.html
+++ b/templates/fragments/applications/add_new_environment.html
@@ -1,0 +1,33 @@
+{% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
+
+<form method='POST' id="add-new-env" action='{{ url_for("applications.add_environment", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+  {{ form.csrf_token }}
+
+  <toggler inline-template>
+    <div>
+      {% set add_env_link %}
+        <a class='icon-link'>
+          {{ "portfolios.applications.add_environment" | translate }}
+          {{ Icon('plus') }}
+        </a>
+      {% endset %}
+
+      {% call ToggleSection(section_name="add-new-environment") %}
+        <div class="accordion-table__item-content">
+          <span>{{ "portfolios.applications.create_new_env" | translate }}</span>
+          <div>{{ "portfolios.applications.create_new_env_info" | translate }}</div>
+          <span>{{ "portfolios.applications.enter_env_name" | translate }}</span>
+        </div>
+      {% endcall %}
+
+      {{
+        ToggleButton(
+          open_html=add_env_link,
+          close_html=add_env_link,
+          section_name="add-new-environment"
+        )
+      }}
+    </div>
+  </toggler>
+
+</form>

--- a/templates/fragments/applications/add_new_environment.html
+++ b/templates/fragments/applications/add_new_environment.html
@@ -1,3 +1,4 @@
+{% from "components/alert.html" import Alert %}
 {% from 'components/save_button.html' import SaveButton %}
 {% from "components/text_input.html" import TextInput %}
 {% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
@@ -8,26 +9,41 @@
   <toggler inline-template>
     <div>
       {% set add_env_link %}
-        <a class='icon-link'>
-          {{ "portfolios.applications.add_environment" | translate }}
-          {{ Icon('plus') }}
-        </a>
+      <div class="panel__footer">
+        <div class="action-group">
+          <a class='icon-link'>
+            {{ "portfolios.applications.add_environment" | translate }}
+            {{ Icon('plus') }}
+          </a>
+        </div>
+      </div>
       {% endset %}
 
       {% call ToggleSection(section_name="add-new-environment") %}
-        <div class="accordion-table__item-content">
-          <span>{{ "portfolios.applications.create_new_env" | translate }}</span>
-          <div>{{ "portfolios.applications.create_new_env_info" | translate }}</div>
-          <span>{{ "portfolios.applications.enter_env_name" | translate }}</span>
-            {{ TextInput(new_env_form.name) }}
+        <div class="accordion-table__item-content new-env">
+          <div class="h3">{{ "portfolios.applications.create_new_env" | translate }}</div>
+          {{ Alert('',
+            message=("portfolios.applications.create_new_env_info" | translate )
+          ) }}
+          <div class="h4">{{ "portfolios.applications.enter_env_name" | translate }}</div>
+            {{ TextInput(new_env_form.name, label="") }}
         </div>
-        {{ SaveButton(text=('common.save' | translate), element="input", form="add-new-env") }}
+        <div class="panel__footer">
+          <div class="action-group">
+            <div class='action-group-cancel'>
+              <a class='action-group-cancel__action icon-link icon-link--default' v-on:click="toggleSection('members')">
+                {{ "common.cancel" | translate }}
+              </a>
+              {{ SaveButton(text=('common.save' | translate), element="input", form="add-new-env") }}
+            </div>
+          </div>
+        </div>
       {% endcall %}
 
       {{
         ToggleButton(
           open_html=add_env_link,
-          close_html=add_env_link,
+          close_html="",
           section_name="add-new-environment"
         )
       }}

--- a/templates/fragments/applications/add_new_environment.html
+++ b/templates/fragments/applications/add_new_environment.html
@@ -1,7 +1,9 @@
+{% from 'components/save_button.html' import SaveButton %}
+{% from "components/text_input.html" import TextInput %}
 {% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 
-<form method='POST' id="add-new-env" action='{{ url_for("applications.add_environment", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
-  {{ form.csrf_token }}
+<form method='POST' id="add-new-env" action='{{ url_for("applications.new_environment", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+  {{ new_env_form.csrf_token }}
 
   <toggler inline-template>
     <div>
@@ -17,7 +19,9 @@
           <span>{{ "portfolios.applications.create_new_env" | translate }}</span>
           <div>{{ "portfolios.applications.create_new_env_info" | translate }}</div>
           <span>{{ "portfolios.applications.enter_env_name" | translate }}</span>
+            {{ TextInput(new_env_form.name) }}
         </div>
+        {{ SaveButton(text=('common.save' | translate), element="input", form="add-new-env") }}
       {% endcall %}
 
       {{

--- a/templates/fragments/applications/add_new_environment.html
+++ b/templates/fragments/applications/add_new_environment.html
@@ -1,53 +1,42 @@
 {% from "components/alert.html" import Alert %}
 {% from 'components/save_button.html' import SaveButton %}
 {% from "components/text_input.html" import TextInput %}
-{% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 
-<form method='POST' id="add-new-env" action='{{ url_for("applications.new_environment", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
-  {{ new_env_form.csrf_token }}
+<new-environment inline-template>
+  <div>
+    <div v-if="open">
+      <form method='POST' id="add-new-env" action='{{ url_for("applications.new_environment", application_id=application.id) }}' autocomplete="off" enctype="multipart/form-data">
+        {{ new_env_form.csrf_token }}
 
-  <toggler inline-template>
-    <div>
-      {% set add_env_link %}
-      <div class="panel__footer">
-        <div class="action-group">
-          <a class='icon-link'>
-            {{ "portfolios.applications.add_environment" | translate }}
-            {{ Icon('plus') }}
-          </a>
-        </div>
-      </div>
-      {% endset %}
-
-      {% call ToggleSection(section_name="add-new-environment") %}
         <div class="accordion-table__item-content new-env">
           {{ Alert(
             title=("portfolios.applications.create_new_env" | translate),
             message=("portfolios.applications.create_new_env_info" | translate )
           ) }}
           <div class="h4">{{ "portfolios.applications.enter_env_name" | translate }}</div>
-            {{ TextInput(new_env_form.name, label="") }}
+            {{ TextInput(new_env_form.name, label="", validation="requiredField") }}
         </div>
         <div class="panel__footer">
           <div class="action-group">
             <div class='action-group-cancel'>
-              <a class='action-group-cancel__action icon-link icon-link--default' v-on:click="toggleSection('members')">
+              <a class='action-group-cancel__action icon-link icon-link--default' v-on:click="toggle">
                 {{ "common.cancel" | translate }}
               </a>
               {{ SaveButton(text=('common.save' | translate), element="input", form="add-new-env") }}
             </div>
           </div>
         </div>
-      {% endcall %}
-
-      {{
-        ToggleButton(
-          open_html=add_env_link,
-          close_html="",
-          section_name="add-new-environment"
-        )
-      }}
+      </form>
     </div>
-  </toggler>
 
-</form>
+    <div v-else class="panel__footer">
+      <div class="action-group">
+        <a class='icon-link' v-on:click="toggle">
+          {{ "portfolios.applications.add_environment" | translate }}
+          {{ Icon('plus') }}
+        </a>
+      </div>
+    </div>
+  </div>
+</new-environment>
+

--- a/templates/fragments/applications/add_new_environment.html
+++ b/templates/fragments/applications/add_new_environment.html
@@ -21,8 +21,8 @@
 
       {% call ToggleSection(section_name="add-new-environment") %}
         <div class="accordion-table__item-content new-env">
-          <div class="h3">{{ "portfolios.applications.create_new_env" | translate }}</div>
-          {{ Alert('',
+          {{ Alert(
+            title=("portfolios.applications.create_new_env" | translate),
             message=("portfolios.applications.create_new_env_info" | translate )
           ) }}
           <div class="h4">{{ "portfolios.applications.enter_env_name" | translate }}</div>

--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -128,9 +128,6 @@
 </div>
 <div class="panel__footer">
   <div class="action-group">
-    <a class='icon-link'>
-      {{ "portfolios.applications.add_environment" | translate }}
-      {{ Icon('plus') }}
-    </a>
+
   </div>
 </div>

--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -126,8 +126,3 @@
     </ul>
   </div>
 </div>
-<div class="panel__footer">
-  <div class="action-group">
-
-  </div>
-</div>

--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -115,10 +115,10 @@
 
           {{
             DeleteConfirmation(
-              modal_id=delete_modal_environment_id,
+              modal_id=delete_environment_modal_id,
               delete_text=('portfolios.applications.environments.delete.button' | translate),
               delete_action= url_for('applications.delete_environment', environment_id=env['id']),
-              form=form
+              form=edit_form
             )
           }}
         {% endcall %}

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -1,4 +1,5 @@
 {% from "components/options_input.html" import OptionsInput %}
+{% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 
 {{ team_form.csrf_token }}
 

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -69,6 +69,10 @@
       {% if user_can(permissions.EDIT_APPLICATION) %}
         {% include "fragments/applications/edit_environments.html" %}
 
+        {% if user_can(permissions.CREATE_ENVIRONMENT) %}
+          {% include "fragments/applications/add_new_environment.html" %}
+        {% endif %}
+
       {% elif user_can(permissions.VIEW_ENVIRONMENT) %}
         {% include "fragments/applications/read_only_environments.html" %}
       {% endif %}

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -16,13 +16,13 @@
     <div class="panel">
       <div class="panel__content">
 
-        {{ form.csrf_token }}
+        {{ application_form.csrf_token }}
         <p>
           {{ "fragments.edit_application_form.explain" | translate }}
         </p>
         <div class="form-row">
           <div class="form-col form-col--two-thirds">
-            {{ TextInput(form.name) }}
+            {{ TextInput(application_form.name) }}
           </div>
           <div class="form-col form-col--third">
             {% if user_can(permissions.DELETE_APPLICATION) %}
@@ -45,7 +45,7 @@
         </div>
         <div class="form-row">
           <div class="form-col form-col--two-thirds">
-            {{ TextInput(form.description, paragraph=True) }}
+            {{ TextInput(application_form.description, paragraph=True) }}
           </div>
           <div class="form-col form-col--third">
             &nbsp;
@@ -96,7 +96,7 @@
           modal_id=delete_modal_environment_id,
           delete_text=('portfolios.applications.delete.button' | translate),
           delete_action= url_for('applications.delete', application_id=application.id),
-          form=form
+          form=application_form
         )
       }}
     {% endcall %}

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -93,7 +93,7 @@
 
       {{
         DeleteConfirmation(
-          modal_id=delete_modal_environment_id,
+          modal_id="delete_application",
           delete_text=('portfolios.applications.delete.button' | translate),
           delete_action= url_for('applications.delete', application_id=application.id),
           form=application_form

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -1,10 +1,8 @@
 {% extends "portfolios/applications/base.html" %}
 
-{% from "components/empty_state.html" import EmptyState %}
 {% from "components/icon.html" import Icon %}
-{% from 'components/save_button.html' import SaveButton %}
-{% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 {% from "components/multi_step_modal_form.html" import MultiStepModalForm %}
+{% from 'components/save_button.html' import SaveButton %}
 {% import "fragments/applications/new_member_modal_content.html" as member_steps %}
 
 {% set secondary_breadcrumb = 'portfolios.applications.team_settings.title' | translate({ "application_name": application.name }) %}

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -54,7 +54,7 @@ def test_updating_application_environments_success(client, user_session):
     assert environment.name == "new name a"
 
 
-def test_updating_application_environments_failure(client, user_session):
+def test_update_environment_failure(client, user_session):
     portfolio = PortfolioFactory.create()
     application = ApplicationFactory.create(portfolio=portfolio)
     environment = EnvironmentFactory.create(
@@ -389,6 +389,38 @@ def test_delete_application(client, user_session):
     # app and envs are soft deleted
     assert len(port.applications) == 0
     assert len(application.environments) == 0
+
+
+def test_new_environment(client, user_session):
+    user = UserFactory.create()
+    portfolio = PortfolioFactory(owner=user)
+    application = ApplicationFactory.create(portfolio=portfolio)
+    num_envs = len(application.environments)
+
+    user_session(user)
+    response = client.post(
+        url_for("applications.new_environment", application_id=application.id),
+        data={"name": "dabea"},
+    )
+
+    assert response.status_code == 302
+    assert len(application.environments) == num_envs + 1
+
+
+def test_new_environment_with_bad_data(client, user_session):
+    user = UserFactory.create()
+    portfolio = PortfolioFactory(owner=user)
+    application = ApplicationFactory.create(portfolio=portfolio)
+    num_envs = len(application.environments)
+
+    user_session(user)
+    response = client.post(
+        url_for("applications.new_environment", application_id=application.id),
+        data={"name": None},
+    )
+
+    assert response.status_code == 400
+    assert len(application.environments) == num_envs
 
 
 def test_delete_environment(client, user_session):

--- a/translations.yaml
+++ b/translations.yaml
@@ -69,6 +69,7 @@ flash:
   congrats: Congrats!
   delete_member_success: 'You have successfully deleted {member_name} from the portfolio.'
   deleted_member: Portfolio member deleted
+  environment_added: 'The environment "{env_name}" has been added to the application.'
   login_required_message: After you log in, you will be redirected to your destination page.
   login_required_title: Log in required
   new_portfolio: You've created a new JEDI portfolio and jump-started your first task order!

--- a/translations.yaml
+++ b/translations.yaml
@@ -420,6 +420,8 @@ portfolios:
     add_another_environment: Add another environment
     app_settings_text: App settings
     create_button_text: Create
+    create_new_env: Create a new environment.
+    create_new_env_info: Creating an environment gives you access to the Cloud Service Provider. This environment will function within the constraints of the task order, and any costs will be billed against the portfolio.
     csp_console_text: CSP console
     delete:
       alert:
@@ -427,6 +429,7 @@ portfolios:
         title: Warning! This action is permanent.
       button: Delete application
       header: Are you sure you want to delete this application?
+    enter_env_name: "Enter environment name:"
     environments:
       name: Name
       delete:


### PR DESCRIPTION
## Description
This PR adds functionality to the "Add new Environment" button at the bottom of the app settings table.

This also fixes a bug with the multistep modals that would freeze the site if the user canceled out of the modal.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/165516875
modal bug: https://www.pivotaltracker.com/story/show/165935002

## Screenshots
![Screen Shot 2019-05-13 at 11 42 22 AM](https://user-images.githubusercontent.com/42577527/57635091-86d0d580-7574-11e9-9de0-036ca7562d1e.png)
![Screen Shot 2019-05-13 at 11 42 56 AM](https://user-images.githubusercontent.com/42577527/57635092-86d0d580-7574-11e9-8412-c227f5b762b5.png)
<img width="2012" alt="Screen Shot 2019-05-13 at 11 44 19 AM" src="https://user-images.githubusercontent.com/42577527/57635105-8afcf300-7574-11e9-8e04-1c23e4ed2dc6.png">
