### PR TITLE
Delete an application member

### DIFF
--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -3,6 +3,7 @@ from sqlalchemy.orm.exc import NoResultFound
 from atst.database import db
 from . import BaseDomainClass
 from atst.domain.application_roles import ApplicationRoles
+from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.environments import Environments
 from atst.domain.exceptions import NotFoundError
 from atst.domain.users import Users
@@ -100,3 +101,15 @@ class Applications(BaseDomainClass):
                 Environments.add_member(environment, user, env_role_data.get("role"))
 
         return application_role
+
+    @classmethod
+    def remove_member(cls, application, user):
+        application_role = ApplicationRoles.get(
+            user_id=user.id, application_id=application.id
+        )
+
+        db.session.delete(application_role)
+        db.session.commit()
+
+        for env in application.environments:
+            EnvironmentRoles.delete(user_id=user.id, environment_id=env.id)

--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -103,13 +103,13 @@ class Applications(BaseDomainClass):
         return application_role
 
     @classmethod
-    def remove_member(cls, application, user):
+    def remove_member(cls, application, user_id):
         application_role = ApplicationRoles.get(
-            user_id=user.id, application_id=application.id
+            user_id=user_id, application_id=application.id
         )
 
         db.session.delete(application_role)
         db.session.commit()
 
         for env in application.environments:
-            EnvironmentRoles.delete(user_id=user.id, environment_id=env.id)
+            EnvironmentRoles.delete(user_id=user_id, environment_id=env.id)

--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -108,7 +108,8 @@ class Applications(BaseDomainClass):
             user_id=user_id, application_id=application.id
         )
 
-        db.session.delete(application_role)
+        application_role.status = ApplicationRoleStatus.DISABLED
+        db.session.add(application_role)
         db.session.commit()
 
         for env in application.environments:

--- a/atst/domain/permission_sets.py
+++ b/atst/domain/permission_sets.py
@@ -88,6 +88,7 @@ _PORTFOLIO_APP_MGMT_PERMISSION_SETS = [
             Permissions.CREATE_APPLICATION,
             Permissions.DELETE_APPLICATION,
             Permissions.EDIT_APPLICATION_MEMBER,
+            Permissions.DELETE_APPLICATION_MEMBER,
             Permissions.CREATE_APPLICATION_MEMBER,
             Permissions.EDIT_ENVIRONMENT,
             Permissions.CREATE_ENVIRONMENT,
@@ -205,6 +206,7 @@ _APPLICATION_TEAM_PERMISSION_SET = {
     "display_name": "Manage team",
     "permissions": [
         Permissions.EDIT_APPLICATION_MEMBER,
+        Permissions.DELETE_APPLICATION_MEMBER,
         Permissions.CREATE_APPLICATION_MEMBER,
         Permissions.ASSIGN_ENVIRONMENT_MEMBER,
     ],

--- a/atst/models/permissions.py
+++ b/atst/models/permissions.py
@@ -11,6 +11,7 @@ class Permissions(object):
     DELETE_APPLICATION = "delete_application"
     VIEW_APPLICATION_MEMBER = "view_application_member"
     EDIT_APPLICATION_MEMBER = "edit_application_member"
+    DELETE_APPLICATION_MEMBER = "delete_application_member"
     CREATE_APPLICATION_MEMBER = "create_application_member"
     VIEW_ENVIRONMENT = "view_environment"
     EDIT_ENVIRONMENT = "edit_environment"

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -158,3 +158,31 @@ def create_member(application_id):
             _anchor="application-members",
         )
     )
+
+
+@applications_bp.route(
+    "/applications/<application_id>/members/<user_id>/delete", methods=["POST"]
+)
+# TODO: Is this correct??
+@user_can(Permissions.EDIT_APPLICATION_MEMBER, message="remove application member")
+def remove_member(application_id, user_id):
+    application_role = ApplicationRoles.get(
+        application_id=application_id, user_id=user_id
+    )
+
+    Applications.remove_member(application=g.application, user=application_role.user)
+
+    flash(
+        "application_member_removed",
+        user_name=application_role.user.full_name,
+        application_name=g.application.name,
+    )
+
+    return redirect(
+        url_for(
+            "applications.team",
+            _anchor="application-members",
+            application_id=g.application.id,
+            fragment="application-members",
+        )
+    )

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -8,6 +8,7 @@ from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.exceptions import AlreadyExistsError
 from atst.domain.permission_sets import PermissionSets
+from atst.domain.users import Users
 from atst.forms.application_member import NewForm as NewMemberForm
 from atst.forms.team import TeamForm
 from atst.models import Permissions
@@ -166,15 +167,12 @@ def create_member(application_id):
 # TODO: Is this correct??
 @user_can(Permissions.EDIT_APPLICATION_MEMBER, message="remove application member")
 def remove_member(application_id, user_id):
-    application_role = ApplicationRoles.get(
-        application_id=application_id, user_id=user_id
-    )
-
-    Applications.remove_member(application=g.application, user=application_role.user)
+    Applications.remove_member(application=g.application, user_id=user_id)
+    user = Users.get(user_id)
 
     flash(
         "application_member_removed",
-        user_name=application_role.user.full_name,
+        user_name=user.full_name,
         application_name=g.application.name,
     )
 

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -164,8 +164,7 @@ def create_member(application_id):
 @applications_bp.route(
     "/applications/<application_id>/members/<user_id>/delete", methods=["POST"]
 )
-# TODO: Is this correct??
-@user_can(Permissions.EDIT_APPLICATION_MEMBER, message="remove application member")
+@user_can(Permissions.DELETE_APPLICATION_MEMBER, message="remove application member")
 def remove_member(application_id, user_id):
     Applications.remove_member(application=g.application, user_id=user_id)
     user = Users.get(user_id)

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -2,6 +2,11 @@ from flask import flash, render_template_string
 from atst.utils.localization import translate
 
 MESSAGES = {
+    "application_member_removed": {
+        "title_template": "Team member removed from application",
+        "message_template": "You have successfully deleted {{ user_name }} from {{ application_name }}",
+        "category": "success",
+    },
     "environment_deleted": {
         "title_template": "{{ environment_name }} deleted",
         "message_template": 'The environment "{{ environment_name }}" has been deleted',

--- a/js/components/forms/base_form.js
+++ b/js/components/forms/base_form.js
@@ -1,12 +1,12 @@
 import ally from 'ally.js'
 
-import checkboxinput from '../checkbox_input'
 import DateSelector from '../date_selector'
 import FormMixin from '../../mixins/form'
-import levelofwarrant from '../levelofwarrant'
 import Modal from '../../mixins/modal'
-import multicheckboxinput from '../multi_checkbox_input'
 import MultiStepModalForm from './multi_step_modal_form'
+import checkboxinput from '../checkbox_input'
+import levelofwarrant from '../levelofwarrant'
+import multicheckboxinput from '../multi_checkbox_input'
 import optionsinput from '../options_input'
 import textinput from '../text_input'
 import toggler from '../toggler'
@@ -14,12 +14,12 @@ import toggler from '../toggler'
 export default {
   name: 'base-form',
   components: {
-    checkboxinput,
     DateSelector,
-    levelofwarrant,
     Modal,
-    multicheckboxinput,
     MultiStepModalForm,
+    checkboxinput,
+    levelofwarrant,
+    multicheckboxinput,
     optionsinput,
     textinput,
     toggler,

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -39,7 +39,7 @@
               {{ environment_form.environment_name.data }}
             </li>
           {% endfor %}
-          {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+          {% if user_can(permissions.DELETE_APPLICATION_MEMBER) %}
             <li class="accordion-table__item__expanded action-group">
               <span class="usa-button button-danger" v-on:click="openModal('{{ delete_modal_id }}')">
                 {{ "portfolios.members.archive_button" | translate }}

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -3,6 +3,7 @@
 {{ team_form.csrf_token }}
 
 {% for member_form in team_form.members %}
+  {% set delete_modal_id = "delete-user-{}".format(member_form.id) %}
   {% set environment_roles_form = member_form.environment_roles %}
   {% set permissions_form = member_form.permission_sets %}
 
@@ -38,6 +39,13 @@
               {{ environment_form.environment_name.data }}
             </li>
           {% endfor %}
+          {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+            <li class="accordion-table__item__expanded action-group">
+              <span class="usa-button button-danger" v-on:click="openModal('{{ delete_modal_id }}')">
+                {{ "portfolios.members.archive_button" | translate }}
+              </span>
+            </li>
+          {% endif %}
         </ul>
       {% endcall %}
     {{ member_form.user_id() }}

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -89,8 +89,8 @@
 
       {{
         Alert(
-          title="portfolios.applications.delete.alert.title" | translate,
-          message="portfolios.applications.delete.alert.message" | translate,
+          title=("components.modal.destructive_title" | translate),
+          message=("portfolios.applications.delete.alert.message" | translate),
           level="warning"
         )
       }}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -113,7 +113,7 @@
         </form>
       </base-form>
 
-      {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+      {% if user_can(permissions.DELETE_APPLICATION_MEMBER) %}
         {% for member_form in team_form.members %}
           {% set delete_modal_id = "delete-user-{}".format(member_form.id) %}
           {% call Modal(name=delete_modal_id, dismissable=True) %}

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -123,7 +123,7 @@
 
             {{
               Alert(
-                title=("portfolios.applications.remove_member.alert.title" | translate),
+                title=("components.modal.destructive_title" | translate),
                 message=("portfolios.applications.remove_member.alert.message" | translate({"user_name": member_form.user_name.data})),
                 level="warning"
               )

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -6,6 +6,9 @@
 {% from "components/toggle_list.html" import ToggleButton, ToggleSection %}
 {% from "components/multi_step_modal_form.html" import MultiStepModalForm %}
 {% import "fragments/applications/new_member_modal_content.html" as member_steps %}
+{% from "components/alert.html" import Alert %}
+{% from "components/delete_confirmation.html" import DeleteConfirmation %}
+{% from "components/modal.html" import Modal %}
 
 {% set secondary_breadcrumb = 'portfolios.applications.team_settings.title' | translate({ "application_name": application.name }) %}
 
@@ -109,6 +112,35 @@
           </div>
         </form>
       </base-form>
+
+      {% if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
+        {% for member_form in team_form.members %}
+          {% set delete_modal_id = "delete-user-{}".format(member_form.id) %}
+          {% call Modal(name=delete_modal_id, dismissable=True) %}
+            <h1>
+              {{ "portfolios.applications.remove_member.header" | translate }}
+            </h1>
+
+            {{
+              Alert(
+                title=("portfolios.applications.remove_member.alert.title" | translate),
+                message=("portfolios.applications.remove_member.alert.message" | translate({"user_name": member_form.user_name.data})),
+                level="warning"
+              )
+            }}
+
+            {{
+              DeleteConfirmation(
+                modal_id=delete_modal_id,
+                delete_text=('portfolios.applications.remove_member.button' | translate),
+                delete_action=url_for('applications.remove_member', application_id=application.id, user_id=member_form.data.user_id),
+                form=member_form
+              )
+            }}
+          {% endcall %}
+        {% endfor %}
+      {% endif %}
+
       {% if user_can(permissions.CREATE_APPLICATION_MEMBER) %}
         {% import "fragments/applications/new_member_modal_content.html" as member_steps %}
         {{ MultiStepModalForm(

--- a/tests/domain/test_applications.py
+++ b/tests/domain/test_applications.py
@@ -171,7 +171,7 @@ def test_remove_member():
         user_id=user.id, application_id=application.id
     )
 
-    Applications.remove_member(application=application, user=member_role.user)
+    Applications.remove_member(application=application, user_id=member_role.user.id)
 
     with pytest.raises(NotFoundError):
         ApplicationRoles.get(user_id=user.id, application_id=application.id)

--- a/tests/domain/test_applications.py
+++ b/tests/domain/test_applications.py
@@ -173,8 +173,10 @@ def test_remove_member():
 
     Applications.remove_member(application=application, user_id=member_role.user.id)
 
-    with pytest.raises(NotFoundError):
-        ApplicationRoles.get(user_id=user.id, application_id=application.id)
+    assert (
+        ApplicationRoles.get(user_id=user.id, application_id=application.id).status
+        == ApplicationRoleStatus.DISABLED
+    )
 
     #
     # TODO: Why does above raise NotFoundError and this returns None

--- a/translations.yaml
+++ b/translations.yaml
@@ -419,13 +419,11 @@ portfolios:
     remove_member:
       alert:
         message: '{user_name} will no longer be able to access this application'
-        title: Warning! This action is permanent.
       button: Remove member
       header: Are you sure you want to remove this team member?
     delete:
       alert:
         message: You will lose access to this application and all of its reporting and metrics tools. The activity log will be retained.
-        title: Warning! This action is permanent.
       button: Delete application
       header: Are you sure you want to delete this application?
     environments:

--- a/translations.yaml
+++ b/translations.yaml
@@ -416,6 +416,12 @@ portfolios:
     app_settings_text: App settings
     create_button_text: Create
     csp_console_text: CSP console
+    remove_member:
+      alert:
+        message: '{user_name} will no longer be able to access this application'
+        title: Warning! This action is permanent.
+      button: Remove member
+      header: Are you sure you want to remove this team member?
     delete:
       alert:
         message: You will lose access to this application and all of its reporting and metrics tools. The activity log will be retained.


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165062523)

```gherkin
Scenario: 
Given I am logged in as a user with Edit Team privs on an application and looking at the Team settings page
When I click Delete Member,
Then I see a modal per the design,
And the modal has a warning banner reading "Warning! This action is permanent. {Username} will no longer be able to access this application,"
And there is text reading "Please type the word 'DELETE' to confirm:",
And there is a text box,
And there is a Delete User button that is grayed out until/unless the text box contains 'delete' (case insensitive),
And there is a cancel button,
Then I click Delete User,
Then I am taken back to the page I was on, to the table I was at, with a success banner - "You have successfully deleted {username} from {Application-name}"
And the user is set to No Access for all environments in the application.
```