### PR TITLE
Catch None values for IsNumber validator

### DIFF
--- a/atst/forms/validators.py
+++ b/atst/forms/validators.py
@@ -32,7 +32,7 @@ def IsNumber(message=translate("forms.validators.is_number_message")):
     def _is_number(form, field):
         try:
             int(field.data)
-        except ValueError:
+        except (ValueError, TypeError):
             raise ValidationError(message)
 
     return _is_number

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -17,7 +17,7 @@ class TestIsNumber:
         dummy_field.data = valid
         validator(dummy_form, dummy_field)
 
-    @pytest.mark.parametrize("invalid", ["12.1", "two", ""])
+    @pytest.mark.parametrize("invalid", ["12.1", "two", "", None])
     def test_IsNumber_rejects_anything_else(self, invalid, dummy_form, dummy_field):
         validator = IsNumber()
         dummy_field.data = invalid


### PR DESCRIPTION
## Description
If a user checked the box to invite an officer on the `Oversight` page of the Task Order form without entering a DOD ID, a server error would occur. The validator, `IsNumber` was only catching `ValueError`s, and the `NoneType` was throwing a `TypeError`.

With this PR, `IsNumber` catches both errors and handles them in the same way -- namely, a validation error is thrown and the user is asked to fill in the DOD ID.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166005243

## Screenshots
<img width="1532" alt="Screen Shot 2019-05-14 at 4 49 00 PM" src="https://user-images.githubusercontent.com/42577527/57731530-dc86aa00-7668-11e9-8bda-1a8ddfaadde8.png">
