### PR TITLE
We dont need this in vue template

### DIFF
--- a/templates/components/modal.html
+++ b/templates/components/modal.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 
 {% macro Modal(name, dismissable=False, classes="") -%}
-  <div v-show="this.$root.activeModal === '{{name}}'" v-cloak>
+  <div v-show="$root.activeModal === '{{name}}'" v-cloak>
     <div id='modal--{{name}}' class='modal {% if dismissable %}modal--dismissable{% endif%} {{ classes }}'>
       <div class='modal__container'>
         <div class='modal__dialog' role='dialog' aria-modal='true'>

--- a/templates/components/multi_step_modal_form.html
+++ b/templates/components/multi_step_modal_form.html
@@ -31,7 +31,7 @@
     {% call Modal(name=name, dismissable=dismissable, classes="wide") %}
       <form id="{{ name }}" action="{{ form_action }}" method="POST" v-on:submit="handleSubmit">
         {{ form.csrf_token }}
-        <div v-if="this.$root.activeModal === '{{ name }}'">
+        <div v-if="$root.activeModal === '{{ name }}'">
           {% for step in steps %}
             <div class="modal__form" v-show="step === {{ loop.index0 }}">
               {{ FormSteps(step_count, loop.index) }}


### PR DESCRIPTION
`this` was breaking vue templates in Microsoft Edge

* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165935329)
* [Breaking commit](https://github.com/dod-ccpo/atst/commit/457b1f9523c73466d767fcd366c859b62518729f#diff-91300a21de63234ef6d7d70fed0f90dcL4)