### PR TITLE
Delete modals arent dismissable

### DIFF
--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -100,7 +100,7 @@
           </li>
         </toggler>
 
-        {% call Modal(name=delete_environment_modal_id, dismissable=True) %}
+        {% call Modal(name=delete_environment_modal_id) %}
           <h1>
             {{ 'fragments.edit_environment_team_form.delete_environment_title' | translate }}
           </h1>

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -116,7 +116,7 @@
       {% if user_can(permissions.DELETE_APPLICATION_MEMBER) %}
         {% for member_form in team_form.members %}
           {% set delete_modal_id = "delete-user-{}".format(member_form.id) %}
-          {% call Modal(name=delete_modal_id, dismissable=True) %}
+          {% call Modal(name=delete_modal_id) %}
             <h1>
               {{ "portfolios.applications.remove_member.header" | translate }}
             </h1>


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/165868250)

**Modals:** Delete environment & delete member from application

### Steps to reproduce
1. Click on app settings within a portfolio you have edit access to
2. Click the red trashcan next to an environment

### Actual
The modal shows with a close link in the upper right

### Expected
The modal should only have the Cancel link as the opt-out option. 

See screenshot.

