### PR TITLE
Raise error if CRL download fails.

### DIFF
--- a/tests/domain/csp/test_files.py
+++ b/tests/domain/csp/test_files.py
@@ -1,8 +1,13 @@
 import os
 import pytest
 from werkzeug.datastructures import FileStorage
+from unittest.mock import Mock
 
-from atst.domain.csp.files import RackspaceFileProvider
+from atst.domain.csp.files import (
+    CSPFileError,
+    RackspaceFileProvider,
+    RackspaceCRLProvider,
+)
 from atst.domain.exceptions import UploadError
 
 from tests.mocks import PDF_FILENAME
@@ -55,3 +60,16 @@ def test_downloading_uploaded_object(uploader, pdf_upload):
     pdf_content = pdf_upload.read()
 
     assert stream_content == pdf_content
+
+
+def test_crl_download_fails(app, monkeypatch):
+    mock_object = Mock()
+    mock_object.download.return_value = False
+    monkeypatch.setattr(
+        "atst.domain.csp.files.RackspaceCRLProvider.object", mock_object
+    )
+
+    rs_crl_provider = RackspaceCRLProvider(app)
+
+    with pytest.raises(CSPFileError):
+        rs_crl_provider.sync_crls()


### PR DESCRIPTION
PT card: https://www.pivotaltracker.com/story/show/166039596

The download method for Libcloud objects returns a boolean, which means
that our CRL download could fail silently. The RackspaceCRLProvider
would not raise an error until it tried to open the full path for the
downloaded resource. This checks the return status of the download call
and raises an error if the download failed. For reference:

https://libcloud.readthedocs.io/en/latest/storage/api.html#libcloud.storage.base.StorageDriver.download_object