### PR TITLE
Place submit button inside form element for portfolio admin table

### DIFF
--- a/templates/fragments/admin/portfolio_members.html
+++ b/templates/fragments/admin/portfolio_members.html
@@ -55,25 +55,26 @@
 
           </table>
         </div>
-      {% endif %}
-      </form>
+        {% endif %}
 
-      <div class="panel__footer">
-        <div class="action-group save">
-          {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
-            {{ SaveButton(text=('common.save' | translate), element="input", form="member-perms") }}
-          {% endif %}
+        <div class="panel__footer">
+          <div class="action-group save">
+            {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
+              {{ SaveButton(text=('common.save' | translate), element="input", form="member-perms") }}
+            {% endif %}
 
-          {% if user_can(permissions.CREATE_PORTFOLIO_USERS) %}
-            {% include "fragments/admin/add_new_portfolio_member.html" %}
-            <a class="icon-link modal-link" v-on:click="openModal('add-port-mem')">
-              {{ "portfolios.admin.add_new_member" | translate }}
-
-              {{ Icon("plus") }}
-            </a>
-          {% endif %}
+            {% if user_can(permissions.CREATE_PORTFOLIO_USERS) %}
+              <a class="icon-link modal-link" v-on:click="openModal('add-port-mem')">
+                {{ "portfolios.admin.add_new_member" | translate }}
+                {{ Icon("plus") }}
+              </a>
+            {% endif %}
+          </div>
         </div>
-      </div>
+      </form>
+      {% if user_can(permissions.CREATE_PORTFOLIO_USERS) %}
+        {% include "fragments/admin/add_new_portfolio_member.html" %}
+      {% endif %}
 
     {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
       {% for member in portfolio.members %}


### PR DESCRIPTION
For this PT bug: https://www.pivotaltracker.com/story/show/166043900

The problem is that the submit button is outside the `form` element, which is not supported by our earlier target browsers. This rearranges the template slightly to put the submit button inside the form. It also moves the new member modal outside of the form element so that the new member form will continue to work.