### PR TITLE
Looking up g.portfolio when g.current_user is None raises an error

### DIFF
--- a/atst/utils/context_processors.py
+++ b/atst/utils/context_processors.py
@@ -95,6 +95,9 @@ def user_can_view(permission):
 
 
 def portfolio():
+    if g.current_user is None:
+        return {}
+
     if g.portfolio is not None:
         active_task_orders = [
             task_order for task_order in g.portfolio.task_orders if task_order.is_active


### PR DESCRIPTION
This fixes the error in the [following ticket](https://www.pivotaltracker.com/story/show/165942935).

I've spent some time trying to write a test for it but I'm out of ideas. What I've done while testing on my local is change the `PERMANENT_SESSION_LIFETIME` in `config/base.ini` to something like `10` which forces session expiration after 10 seconds of inactivity.

The error bubbles to [`CSRFError`](https://github.com/dod-ccpo/atst/blob/master/atst/routes/errors.py#L46-L54) so I think the way to write this test would be to send in an expired CSRF token?