### PR TITLE
Use No Access as default role value for app users

### DIFF
--- a/atst/forms/application_member.py
+++ b/atst/forms/application_member.py
@@ -3,9 +3,9 @@ from wtforms.fields import FormField, FieldList, HiddenField, BooleanField
 
 from .forms import BaseForm
 from .member import NewForm as BaseNewMemberForm
-from .data import ENV_ROLES
-from atst.forms.fields import SelectField
+from .data import ENV_ROLES, ENV_ROLE_NO_ACCESS as NO_ACCESS
 from atst.domain.permission_sets import PermissionSets
+from atst.forms.fields import SelectField
 from atst.utils.localization import translate
 
 
@@ -15,7 +15,7 @@ class EnvironmentForm(FlaskForm):
     role = SelectField(
         environment_name,
         choices=ENV_ROLES,
-        default=None,
+        default=NO_ACCESS,
         filters=[lambda x: None if x == "None" else x],
     )
 

--- a/tests/forms/test_application_member.py
+++ b/tests/forms/test_application_member.py
@@ -1,0 +1,36 @@
+from wtforms.validators import ValidationError
+
+from atst.forms.data import ENV_ROLES, ENV_ROLE_NO_ACCESS as NO_ACCESS
+from atst.forms.application_member import *
+
+
+def test_environment_form():
+    form_data = {
+        "environment_id": 123,
+        "environment_name": "testing",
+        "role": ENV_ROLES[0][0],
+    }
+    form = EnvironmentForm(data=form_data)
+    assert form.validate()
+
+
+def test_environment_form_default_no_access():
+    form_data = {"environment_id": 123, "environment_name": "testing"}
+    form = EnvironmentForm(data=form_data)
+
+    assert form.validate()
+    assert form.data == {
+        "environment_id": 123,
+        "environment_name": "testing",
+        "role": NO_ACCESS,
+    }
+
+
+def test_environment_form_invalid():
+    form_data = {
+        "environment_id": 123,
+        "environment_name": "testing",
+        "role": "not a real choice",
+    }
+    form = EnvironmentForm(data=form_data)
+    assert not form.validate()

--- a/tests/forms/test_team.py
+++ b/tests/forms/test_team.py
@@ -1,5 +1,4 @@
 from wtforms.validators import ValidationError
-import pytest
 
 from atst.domain.permission_sets import PermissionSets
 from atst.forms.team import *


### PR DESCRIPTION
## Description
If a user attempted to add a new application member via the app settings table and did not choose a role for each environment, the user would not be added. The default value given for roles with unspecified selections was `None`, which caused the form to fail validation. This PR makes the default value `NO_ACCESS` and adds some unit tests for the `EnvironmentForm`.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166131929