### PR TITLE
Update team members number on app index page

### DIFF
--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -109,6 +109,7 @@ class Applications(BaseDomainClass):
         )
 
         application_role.status = ApplicationRoleStatus.DISABLED
+        application_role.deleted = True
         db.session.add(application_role)
         db.session.commit()
 

--- a/atst/models/application.py
+++ b/atst/models/application.py
@@ -33,7 +33,7 @@ class Application(
 
     @property
     def users(self):
-        return set(role.user for role in self.roles)
+        return set(role.user for role in self.members)
 
     @property
     def members(self):

--- a/atst/models/application.py
+++ b/atst/models/application.py
@@ -1,15 +1,9 @@
 from sqlalchemy import Column, ForeignKey, String
-from sqlalchemy.orm import relationship
+from sqlalchemy.orm import relationship, synonym
 
 from atst.models import Base
 from atst.models.types import Id
 from atst.models import mixins
-
-from atst.models.application_role import (
-    ApplicationRole,
-    Status as ApplicationRoleStatuses,
-)
-from atst.database import db
 
 
 class Application(
@@ -28,25 +22,15 @@ class Application(
         back_populates="application",
         primaryjoin="and_(Environment.application_id==Application.id, Environment.deleted==False)",
     )
-    # TODO: filter condition on this relationship?
-    roles = relationship("ApplicationRole")
+    roles = relationship(
+        "ApplicationRole",
+        primaryjoin="and_(ApplicationRole.application_id==Application.id, ApplicationRole.deleted==False)",
+    )
+    members = synonym("roles")
 
     @property
     def users(self):
         return set(role.user for role in self.members)
-
-    @property
-    def members(self):
-        return (
-            db.session.query(ApplicationRole)
-            .filter(ApplicationRole.application_id == self.id)
-            .filter(ApplicationRole.status != ApplicationRoleStatuses.DISABLED)
-            .all()
-        )
-
-    @property
-    def num_users(self):
-        return len(self.users)
 
     @property
     def displayname(self):

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -54,7 +54,7 @@
                   <a
                     href="{{ url_for('applications.team', application_id=application.id) }}"
                     class='icon-link'>
-                      <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.num_users }})</span>
+                      <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.users | length }})</span>
                     </a>
                     <div class='separator'></div>
                   {% endif %}

--- a/tests/models/test_application.py
+++ b/tests/models/test_application.py
@@ -8,16 +8,6 @@ from tests.factories import (
 )
 
 
-def test_application_num_users():
-    application = ApplicationFactory.create(
-        environments=[{"name": "dev"}, {"name": "staging"}, {"name": "prod"}]
-    )
-    assert application.num_users == 0
-
-    ApplicationRoleFactory.create(application=application)
-    assert application.num_users == 1
-
-
 def test_application_environments_excludes_deleted():
     app = ApplicationFactory.create()
     env = EnvironmentFactory.create(application=app)


### PR DESCRIPTION
## Description
Fixes a bug where the team members number was not updating after you delete an app member. This was happening because we were not filtering out the deleted members when displaying the number of members. 

## Pivotal
https://www.pivotaltracker.com/story/show/166031343