### PR TITLE
Use portfolio_role.id for updating primary point of contact.

### DIFF
--- a/atst/forms/portfolio_member.py
+++ b/atst/forms/portfolio_member.py
@@ -80,7 +80,7 @@ class NewForm(BaseForm):
 
 
 class AssignPPOCForm(PermissionsForm):
-    user_id = SelectField(
+    role_id = SelectField(
         label=translate("forms.assign_ppoc.dod_id"),
         validators=[Required()],
         choices=[("", "- Select -")],

--- a/templates/fragments/admin/change_ppoc.html
+++ b/templates/fragments/admin/change_ppoc.html
@@ -22,7 +22,7 @@
     <div class='form-col form-col--half'>
       {{
         OptionsInput(
-          assign_ppoc_form.user_id
+          assign_ppoc_form.role_id
         )
       }}
     </div>


### PR DESCRIPTION
More work on this PT story: https://www.pivotaltracker.com/story/show/160432365

Very small PR to change our PPoC handling.

Our forms should rely on role IDs for displaying user information on the
portfolio page. This way they are decoupled from user table data and can
eventually rely on invitation user data where an invitation has been
sent but a user does not exist yet.