### PR TITLE
Use application_role.id to reference users in team page forms.

### DIFF
--- a/atst/domain/application_roles.py
+++ b/atst/domain/application_roles.py
@@ -48,6 +48,18 @@ class ApplicationRoles(object):
         return app_role
 
     @classmethod
+    def get_by_id(cls, id_):
+        try:
+            return (
+                db.session.query(ApplicationRole)
+                .filter(ApplicationRole.id == id_)
+                .filter(ApplicationRole.status != ApplicationRoleStatus.DISABLED)
+                .one()
+            )
+        except NoResultFound:
+            raise NotFoundError("portfolio_role")
+
+    @classmethod
     def update_permission_sets(cls, application_role, new_perm_sets_names):
         application_role.permission_sets = ApplicationRoles._permission_sets_for_names(
             new_perm_sets_names

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -61,7 +61,7 @@ class PermissionsForm(FlaskForm):
 
 
 class MemberForm(FlaskForm):
-    user_id = HiddenField(validators=[Required()])
+    role_id = HiddenField(validators=[Required()])
     user_name = StringField()
     environment_roles = FieldList(FormField(EnvironmentForm))
     permission_sets = FormField(PermissionsForm)

--- a/templates/fragments/applications/edit_team.html
+++ b/templates/fragments/applications/edit_team.html
@@ -92,7 +92,7 @@
           {% endif %}
         </div>
       {% endcall %}
-      {{ member_form.user_id() }}
+      {{ member_form.role_id() }}
     </li>
   </toggler>
 {% endfor %}

--- a/tests/domain/test_application_roles.py
+++ b/tests/domain/test_application_roles.py
@@ -71,3 +71,15 @@ def test_update_permission_sets():
     assert app_role.permission_sets == view_app
     assert ApplicationRoles.update_permission_sets(app_role, new_perms_names)
     assert set(app_role.permission_sets) == set(new_perms + view_app)
+
+
+def test_get_by_id():
+    user = UserFactory.create()
+    application = ApplicationFactory.create()
+    app_role = ApplicationRoleFactory.create(user=user, application=application)
+
+    assert ApplicationRoles.get_by_id(app_role.id) == app_role
+    app_role.status = ApplicationRoleStatus.DISABLED
+
+    with pytest.raises(NotFoundError):
+        ApplicationRoles.get_by_id(app_role.id)

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -25,12 +25,11 @@ def test_update_team_permissions(client, user_session):
     app_role = ApplicationRoleFactory.create(
         application=application, permission_sets=[]
     )
-    app_user = app_role.user
     user_session(owner)
     response = client.post(
         url_for("applications.update_team", application_id=application.id),
         data={
-            "members-0-user_id": app_user.id,
+            "members-0-role_id": app_role.id,
             "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
             "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
             "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
@@ -54,36 +53,30 @@ def test_update_team_with_bad_permission_sets(client, user_session):
     app_role = ApplicationRoleFactory.create(
         application=application, permission_sets=[]
     )
-    app_user = app_role.user
-    permission_sets = app_user.permission_sets
+    permission_sets = app_role.permission_sets
 
     user_session(owner)
     response = client.post(
         url_for("applications.update_team", application_id=application.id),
         data={
-            "members-0-user_id": app_user.id,
+            "members-0-role_id": app_role.id,
             "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
             "members-0-permission_sets-perms_env_mgmt": "some random string",
         },
     )
     assert response.status_code == 400
-    assert app_user.permission_sets == permission_sets
+    assert app_role.permission_sets == permission_sets
 
 
 def test_update_team_with_non_app_user(client, user_session):
     application = ApplicationFactory.create()
     owner = application.portfolio.owner
-    app_role = ApplicationRoleFactory.create(
-        application=application, permission_sets=[]
-    )
-    non_app_user = UserFactory.create()
-    app_user = app_role.user
 
     user_session(owner)
     response = client.post(
         url_for("applications.update_team", application_id=application.id),
         data={
-            "members-0-user_id": non_app_user.id,
+            "members-0-role_id": str(uuid.uuid4()),
             "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
             "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
             "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
@@ -99,16 +92,15 @@ def test_update_team_environment_roles(client, user_session):
     app_role = ApplicationRoleFactory.create(
         application=application, permission_sets=[]
     )
-    app_user = app_role.user
     environment = EnvironmentFactory.create(application=application)
     env_role = EnvironmentRoleFactory.create(
-        user=app_user, environment=environment, role=CSPRole.NETWORK_ADMIN.value
+        user=app_role.user, environment=environment, role=CSPRole.NETWORK_ADMIN.value
     )
     user_session(owner)
     response = client.post(
         url_for("applications.update_team", application_id=application.id),
         data={
-            "members-0-user_id": app_user.id,
+            "members-0-role_id": app_role.id,
             "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
             "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
             "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,
@@ -127,16 +119,15 @@ def test_update_team_revoke_environment_access(client, user_session, db, session
     app_role = ApplicationRoleFactory.create(
         application=application, permission_sets=[]
     )
-    app_user = app_role.user
     environment = EnvironmentFactory.create(application=application)
     env_role = EnvironmentRoleFactory.create(
-        user=app_user, environment=environment, role=CSPRole.BASIC_ACCESS.value
+        user=app_role.user, environment=environment, role=CSPRole.BASIC_ACCESS.value
     )
     user_session(owner)
     response = client.post(
         url_for("applications.update_team", application_id=application.id),
         data={
-            "members-0-user_id": app_user.id,
+            "members-0-role_id": app_role.id,
             "members-0-permission_sets-perms_team_mgmt": PermissionSets.EDIT_APPLICATION_TEAM,
             "members-0-permission_sets-perms_env_mgmt": PermissionSets.EDIT_APPLICATION_ENVIRONMENTS,
             "members-0-permission_sets-perms_del_env": PermissionSets.DELETE_APPLICATION_ENVIRONMENTS,


### PR DESCRIPTION
More work on this PT story: https://www.pivotaltracker.com/story/show/160432365

Very small PR to change our user/role ID handling for the members form on the application team page. Membership in a resource should be decoupled from the users table.