### PR TITLE
Use role ID for app settings table

### DIFF
--- a/atst/domain/application_roles.py
+++ b/atst/domain/application_roles.py
@@ -57,7 +57,7 @@ class ApplicationRoles(object):
                 .one()
             )
         except NoResultFound:
-            raise NotFoundError("portfolio_role")
+            raise NotFoundError("application_role")
 
     @classmethod
     def update_permission_sets(cls, application_role, new_perm_sets_names):

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -6,7 +6,7 @@ from atst.models.environment import Environment
 from atst.models.environment_role import EnvironmentRole
 from atst.models.application import Application
 from atst.domain.environment_roles import EnvironmentRoles
-from atst.domain.users import Users
+from atst.domain.application_roles import ApplicationRoles
 
 from .exceptions import NotFoundError
 
@@ -99,9 +99,9 @@ class Environments(object):
 
         for member in team_roles:
             new_role = member["role_name"]
-            user = Users.get(member["user_id"])
+            app_role = ApplicationRoles.get_by_id(member["application_role_id"])
             Environments.update_env_role(
-                environment=environment, user=user, new_role=new_role
+                environment=environment, user=app_role.user, new_role=new_role
             )
 
     @classmethod

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -114,15 +114,6 @@ class Environments(object):
             )
 
     @classmethod
-    def get_members_by_role(cls, env, role):
-        return (
-            db.session.query(EnvironmentRole)
-            .filter(EnvironmentRole.environment_id == env.id)
-            .filter(EnvironmentRole.role == role)
-            .all()
-        )
-
-    @classmethod
     def revoke_access(cls, environment, target_user):
         EnvironmentRoles.delete(environment.id, target_user.id)
 

--- a/atst/forms/app_settings.py
+++ b/atst/forms/app_settings.py
@@ -6,7 +6,7 @@ from .data import ENV_ROLES, ENV_ROLE_NO_ACCESS as NO_ACCESS
 
 
 class MemberForm(FlaskForm):
-    user_id = HiddenField()
+    application_role_id = HiddenField()
     user_name = StringField()
     role_name = RadioField(choices=ENV_ROLES, default=NO_ACCESS)
 

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -30,54 +30,54 @@ def get_environments_obj_for_app(application):
     return environments_obj
 
 
-def serialize_members(member_list, role):
-    serialized_list = []
-
-    for member in member_list:
-        serialized_list.append(
-            {
-                "user_id": str(member.user_id),
-                "user_name": member.user.full_name,
-                "role_name": role,
-            }
-        )
-
-    return serialized_list
-
-
-def sort_env_users_by_role(env):
-    users_list = []
-    no_access_users = env.application.users - env.users
-    no_access_list = [
-        {"user_id": str(user.id), "user_name": user.full_name, "role_name": NO_ACCESS}
-        for user in no_access_users
-    ]
-    users_list.append({"role": NO_ACCESS, "members": no_access_list})
-
-    for role in CSPRole:
-        users_list.append(
-            {
-                "role": role.value,
-                "members": serialize_members(
-                    Environments.get_members_by_role(env, role.value), role.value
-                ),
-            }
-        )
-
-    return users_list
-
-
 def data_for_app_env_roles_form(application):
-    data = {"envs": []}
-    for environment in application.environments:
-        data["envs"].append(
-            {
-                "env_id": environment.id,
-                "team_roles": sort_env_users_by_role(environment),
-            }
-        )
+    csp_roles = [role.value for role in CSPRole]
+    csp_roles.insert(0, NO_ACCESS)
+    # dictionary for sorting application members by environments
+    # and roles within those environments
+    environments_dict = {
+        e.id: {role_name: [] for role_name in csp_roles}
+        for e in application.environments
+    }
+    for member in application.members:
+        env_ids = set(environments_dict.keys())
+        for env_role in member.environment_roles:
+            role_members_list = environments_dict[env_role.environment_id][
+                env_role.role
+            ]
+            role_members_list.append(
+                {
+                    "user_id": str(member.user.id),
+                    "user_name": member.user_name,
+                    "role_name": env_role.role,
+                }
+            )
+            env_ids.remove(env_role.environment_id)
 
-    return data
+        # any leftover environment IDs are ones the app member
+        # does not have access to
+        for env_id in env_ids:
+            role_members_list = environments_dict[env_id][NO_ACCESS]
+            role_members_list.append(
+                {
+                    "user_id": str(member.user.id),
+                    "user_name": member.user_name,
+                    "role_name": NO_ACCESS,
+                }
+            )
+
+    # transform the data into the shape the form needs
+    nested_data = [
+        {
+            "env_id": env_id,
+            "team_roles": [
+                {"role": role, "members": members} for role, members in roles.items()
+            ],
+        }
+        for env_id, roles in environments_dict.items()
+    ]
+
+    return {"envs": nested_data}
 
 
 def check_users_are_in_application(user_ids, application):

--- a/js/components/__tests__/edit_environment_role.test.js
+++ b/js/components/__tests__/edit_environment_role.test.js
@@ -9,13 +9,13 @@ describe('EditEnvironmentRole', () => {
       {
         role: NO_ACCESS,
         members: [
-          { role_name: null, user_id: '123' },
-          { role_name: null, user_id: '456' },
+          { role_name: null, application_role_id: '123' },
+          { role_name: null, application_role_id: '456' },
         ],
       },
       {
         role: 'Basic Access',
-        members: [{ role_name: 'Basic Access', user_id: '789' }],
+        members: [{ role_name: 'Basic Access', application_role_id: '789' }],
       },
       {
         role: 'Network Admin',
@@ -24,13 +24,15 @@ describe('EditEnvironmentRole', () => {
       {
         role: 'Business Read-only',
         members: [
-          { role_name: 'Business Read-only', user_id: '012' },
-          { role_name: 'Business Read-only', user_id: '345' },
+          { role_name: 'Business Read-only', application_role_id: '012' },
+          { role_name: 'Business Read-only', application_role_id: '345' },
         ],
       },
       {
         role: 'Technical Read-only',
-        members: [{ role_name: 'Technical Read-only', user_id: '678' }],
+        members: [
+          { role_name: 'Technical Read-only', application_role_id: '678' },
+        ],
       },
     ]
 
@@ -53,7 +55,7 @@ describe('EditEnvironmentRole', () => {
 
     expect(member_data).toEqual({
       role_name: 'Technical Read-only',
-      user_id: '678',
+      application_role_id: '678',
     })
   })
 
@@ -73,7 +75,7 @@ describe('EditEnvironmentRole', () => {
     })
 
     expect(techRole.members.length).toEqual(1)
-    wrapper.vm.addUser({ user_id: '901' }, 'Technical Read-only')
+    wrapper.vm.addUser({ application_role_id: '901' }, 'Technical Read-only')
     expect(techRole.members.length).toEqual(2)
   })
 

--- a/js/components/forms/edit_environment_role.js
+++ b/js/components/forms/edit_environment_role.js
@@ -57,7 +57,7 @@ export const EditEnvironmentRole = {
     getUserInfo: function(userId) {
       for (let role of this.roleCategories) {
         for (let member of role.members) {
-          if (member.user_id === userId) {
+          if (member.application_role_id === userId) {
             return member
           }
         }
@@ -67,7 +67,7 @@ export const EditEnvironmentRole = {
     removeUser: function(userId) {
       for (let role of this.roleCategories) {
         role.members = role.members.filter(member => {
-          return member.user_id !== userId
+          return member.application_role_id !== userId
         })
         if (!role.members) {
           role.members = []

--- a/templates/fragments/applications/edit_environment_team_form.html
+++ b/templates/fragments/applications/edit_environment_team_form.html
@@ -36,11 +36,11 @@
                 v-bind:class="{'unassigned': checkNoAccess(member.role_name)}">
                 <span v-html='member.user_name'>
                 </span>
-                <span v-on:click="toggleSection(member.user_id)" class="icon-link right">
+                <span v-on:click="toggleSection(member.application_role_id)" class="icon-link right">
                   {{ Icon('edit', classes="icon--medium") }}
                 </span>
                 <div
-                  v-show="selectedSection === member.user_id"
+                  v-show="selectedSection === member.application_role_id"
                   class='environment-role__user-field'>
                   <div class="usa-input">
                     <fieldset
@@ -56,7 +56,7 @@
                             v-bind:name="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-role_name'"
                             v-bind:id="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-role_name-' + roleinputindex"
                             type="radio"
-                            v-bind:user-id='member.user_id'
+                            v-bind:user-id='member.application_role_id'
                             v-bind:value='roleCategory.role'>
                           <label
                             v-bind:for="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-role_name-' + roleinputindex">
@@ -71,10 +71,10 @@
                   </div>
                 </div>
                 <input
-                  v-bind:id="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-user_id'"
-                  v-bind:name="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-user_id'"
+                  v-bind:id="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-application_role_id'"
+                  v-bind:name="'envs-{{ loop.index0 }}-team_roles-' + roleindex + '-members-' + memberindex + '-application_role_id'"
                   type="hidden"
-                  v-bind:value='member.user_id'>
+                  v-bind:value='member.application_role_id'>
               </li>
             </ul>
           </div>

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -136,36 +136,6 @@ def test_update_env_roles_by_member():
     assert not EnvironmentRoles.get(user.id, testing.id)
 
 
-def test_get_members_by_role(db):
-    environment = EnvironmentFactory.create()
-    env_role_1 = EnvironmentRoleFactory.create(
-        environment=environment, role=CSPRole.BASIC_ACCESS.value
-    )
-    env_role_2 = EnvironmentRoleFactory.create(
-        environment=environment, role=CSPRole.TECHNICAL_READ.value
-    )
-    env_role_3 = EnvironmentRoleFactory.create(
-        environment=environment, role=CSPRole.TECHNICAL_READ.value
-    )
-    rando_env = EnvironmentFactory.create()
-    rando_env_role = EnvironmentRoleFactory.create(
-        environment=rando_env, role=CSPRole.BASIC_ACCESS.value
-    )
-
-    basic_access_members = Environments.get_members_by_role(
-        environment, CSPRole.BASIC_ACCESS.value
-    )
-    technical_read_members = Environments.get_members_by_role(
-        environment, CSPRole.TECHNICAL_READ.value
-    )
-    assert basic_access_members == [env_role_1]
-    assert rando_env_role not in basic_access_members
-    assert technical_read_members == [env_role_2, env_role_3]
-    assert (
-        Environments.get_members_by_role(environment, CSPRole.BUSINESS_READ.value) == []
-    )
-
-
 def test_get_scoped_environments(db):
     developer = UserFactory.create()
     portfolio = PortfolioFactory.create(

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -67,28 +67,35 @@ def test_update_env_roles_by_environment():
     env_role_1 = EnvironmentRoleFactory.create(
         environment=environment, role=CSPRole.BASIC_ACCESS.value
     )
+    app_role_1 = ApplicationRoleFactory.create(
+        user=env_role_1.user, application=environment.application
+    )
     env_role_2 = EnvironmentRoleFactory.create(
         environment=environment, role=CSPRole.NETWORK_ADMIN.value
+    )
+    app_role_2 = ApplicationRoleFactory.create(
+        user=env_role_2.user, application=environment.application
     )
     env_role_3 = EnvironmentRoleFactory.create(
         environment=environment, role=CSPRole.TECHNICAL_READ.value
     )
-    for user in [env_role_1.user, env_role_2.user, env_role_3.user]:
-        ApplicationRoleFactory.create(user=user, application=environment.application)
+    app_role_3 = ApplicationRoleFactory.create(
+        user=env_role_3.user, application=environment.application
+    )
 
     team_roles = [
         {
-            "user_id": env_role_1.user.id,
+            "application_role_id": app_role_1.id,
             "user_name": env_role_1.user.full_name,
             "role_name": CSPRole.BUSINESS_READ.value,
         },
         {
-            "user_id": env_role_2.user.id,
+            "application_role_id": app_role_2.id,
             "user_name": env_role_2.user.full_name,
             "role_name": CSPRole.NETWORK_ADMIN.value,
         },
         {
-            "user_id": env_role_3.user.id,
+            "application_role_id": app_role_3.id,
             "user_name": env_role_3.user.full_name,
             "role_name": None,
         },

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -1,7 +1,7 @@
 from atst.domain.permission_sets import PermissionSets
 from atst.models.audit_event import AuditEvent
 
-from tests.factories import PortfolioFactory, UserFactory
+from tests.factories import *
 
 
 def test_has_application_role_history(session):
@@ -38,3 +38,13 @@ def test_has_application_role_history(session):
     old_state, new_state = changed_event.changed_state["permission_sets"]
     assert old_state == [PermissionSets.VIEW_APPLICATION]
     assert new_state == [PermissionSets.EDIT_APPLICATION_TEAM]
+
+
+def test_environment_roles():
+    application = ApplicationFactory.create()
+    environment = EnvironmentFactory.create(application=application)
+    user = UserFactory.create()
+    application_role = ApplicationRoleFactory.create(application=application, user=user)
+    environment_role = EnvironmentRoleFactory.create(environment=environment, user=user)
+
+    assert application_role.environment_roles == [environment_role]


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/160432365

Similar to #841 and #843 . This is the last form using `user_id` as a hiddent field. Per #841:

>Our forms should rely on role IDs for displaying user information on the [application settings] page. This way they are decoupled from user table data and can eventually rely on invitation user data where an invitation has been sent but a user does not exist yet.

This one required more changes to switch to using the `ApplicationRole.id`. I added a `ApplicationRole.environment_roles` property so that each app role knows its dependent environment roles. Then, we can loop the app members and their environment roles to build the data for the app settings form. Because of this, I revised the function that builds the app settings form data.