### PR TITLE
Fix deleting application members from the team page

### DIFF
--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -170,12 +170,17 @@ def create_member(application_id):
 
 
 @applications_bp.route(
-    "/applications/<application_id>/members/<user_id>/delete", methods=["POST"]
+    "/applications/<application_id>/members/<application_role_id>/delete",
+    methods=["POST"],
 )
 @user_can(Permissions.DELETE_APPLICATION_MEMBER, message="remove application member")
-def remove_member(application_id, user_id):
-    Applications.remove_member(application=g.application, user_id=user_id)
-    user = Users.get(user_id)
+def remove_member(application_id, application_role_id):
+    application_role = ApplicationRoles.get_by_id(application_role_id)
+
+    Applications.remove_member(
+        application=g.application, user_id=application_role.user_id
+    )
+    user = Users.get(application_role.user_id)
 
     flash(
         "application_member_removed",

--- a/templates/portfolios/applications/team.html
+++ b/templates/portfolios/applications/team.html
@@ -129,7 +129,7 @@
               DeleteConfirmation(
                 modal_id=delete_modal_id,
                 delete_text=('portfolios.applications.remove_member.button' | translate),
-                delete_action=url_for('applications.remove_member', application_id=application.id, user_id=member_form.data.user_id),
+                delete_action=url_for('applications.remove_member', application_id=application.id, application_role_id=member_form.data.role_id),
                 form=member_form
               )
             }}

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -190,7 +190,9 @@ def test_remove_member_success(client, user_session):
 
     response = client.post(
         url_for(
-            "applications.remove_member", application_id=application.id, user_id=user.id
+            "applications.remove_member",
+            application_id=application.id,
+            application_role_id=application_role.id,
         )
     )
 
@@ -214,7 +216,7 @@ def test_remove_member_failure(client, user_session):
         url_for(
             "applications.remove_member",
             application_id=application.id,
-            user_id=uuid.uuid4(),
+            application_role_id=uuid.uuid4(),
         )
     )
 


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/166291167)

### Steps to reproduce
1. Go to the team settings page
2. expand the environments toggle for a user
3. click Remove member