### PR TITLE
/home no longer redirects and has add portfolio button

### DIFF
--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -58,34 +58,7 @@ def helpdocs(doc=None):
 
 @bp.route("/home")
 def home():
-    user = g.current_user
-    num_portfolios = len([role for role in user.portfolio_roles if role.is_active])
-
-    if num_portfolios == 0:
-        return redirect(url_for("portfolios.portfolios"))
-    elif num_portfolios == 1:
-        portfolio_role = user.portfolio_roles[0]
-        portfolio_id = portfolio_role.portfolio.id
-        is_portfolio_owner = "portfolio_poc" in [
-            ps.name for ps in portfolio_role.permission_sets
-        ]
-
-        if is_portfolio_owner:
-            return redirect(url_for("portfolios.reports", portfolio_id=portfolio_id))
-        else:
-            return redirect(
-                url_for(
-                    "applications.portfolio_applications", portfolio_id=portfolio_id
-                )
-            )
-    else:
-        portfolios = Portfolios.for_user(g.current_user)
-        first_portfolio = sorted(portfolios, key=lambda portfolio: portfolio.name)[0]
-        return redirect(
-            url_for(
-                "applications.portfolio_applications", portfolio_id=first_portfolio.id
-            )
-        )
+    return render_template("home.html")
 
 
 @bp.route("/styleguide")

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,11 +4,11 @@
 
 <main class="usa-section usa-content">
 
-<h1>Home</h1>
+  <a href="" class="usa-button-primary">
+    {{ "home.add_portfolio_button_text" | translate }}
+  </a>
 
 </main>
 
 {% endblock %}
-
-
 

--- a/tests/routes/test_home.py
+++ b/tests/routes/test_home.py
@@ -1,62 +1,16 @@
 import pytest
 
-from tests.factories import UserFactory, PortfolioFactory
-from atst.domain.portfolios import Portfolios
-from atst.models.portfolio_role import Status as PortfolioRoleStatus
+from flask import url_for
+
+from tests.factories import UserFactory
+from atst.utils.localization import translate
 
 
-def test_portfolio_owner_with_one_portfolio_redirected_to_reports(client, user_session):
-    portfolio = PortfolioFactory.create()
-
-    user_session(portfolio.owner)
-    response = client.get("/home", follow_redirects=False)
-
-    assert "/portfolios/{}/reports".format(portfolio.id) in response.location
-
-
-def test_portfolio_owner_with_more_than_one_portfolio_redirected_to_portfolios(
-    client, user_session
-):
-    owner = UserFactory.create()
-    PortfolioFactory.create(owner=owner)
-    PortfolioFactory.create(owner=owner)
-
-    user_session(owner)
-    response = client.get("/home", follow_redirects=False)
-
-    assert "/portfolios" in response.location
-
-
-def test_non_owner_user_with_one_portfolio_redirected_to_portfolio_applications(
-    client, user_session
-):
+def test_home_route(client, user_session):
     user = UserFactory.create()
-    portfolio = PortfolioFactory.create()
-    Portfolios._create_portfolio_role(
-        user, portfolio, status=PortfolioRoleStatus.ACTIVE
-    )
-
     user_session(user)
-    response = client.get("/home", follow_redirects=False)
 
-    assert "/portfolios/{}/applications".format(portfolio.id) in response.location
+    response = client.get(url_for("atst.home"))
 
-
-def test_non_owner_user_with_mulitple_portfolios_redirected_to_portfolios(
-    client, user_session
-):
-    user = UserFactory.create()
-    portfolios = []
-    for _ in range(3):
-        portfolio = PortfolioFactory.create()
-        portfolios.append(portfolio)
-        role = Portfolios._create_portfolio_role(
-            user, portfolio, status=PortfolioRoleStatus.ACTIVE
-        )
-
-    user_session(user)
-    response = client.get("/home", follow_redirects=False)
-
-    alphabetically_first_portfolio = sorted(portfolios, key=lambda p: p.name)[0]
-    assert "/portfolios" in response.location
-    assert str(alphabetically_first_portfolio.id) in response.location
+    assert response.status_code == 200
+    assert translate("home.add_portfolio_button_text").encode("utf8") in response.data

--- a/translations.yaml
+++ b/translations.yaml
@@ -17,6 +17,8 @@ base_public:
   header_title: JEDI Cloud
   login: Log in
   title_tag: JEDI Cloud
+home:
+  add_portfolio_button_text: Add New Portfolio
 common:
   back: Back
   cancel: Cancel


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/166330641)

### Questions

Does the "Add new portfolio" endpoint exist? I think we will need to add that in with a follow up PR?

### Acceptance Criteria 

> When a user logs into AT-AT, instead of being taken to a portfolio, they 
> should be taken to a landing page.
>
> For now that page has a placeholder for future help text, and a large button 
> reading "Add New Portfolio."