### PR TITLE
Use application_role_id on environment_roles.

### DIFF
--- a/alembic/versions/d2390c547dca_environment_roles_has_relation_to_.py
+++ b/alembic/versions/d2390c547dca_environment_roles_has_relation_to_.py
@@ -1,0 +1,54 @@
+"""environment_roles has relation to application_roles
+
+Revision ID: d2390c547dca
+Revises: ab1167fc8260
+Create Date: 2019-05-29 12:34:45.928219
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'd2390c547dca'
+down_revision = 'ab1167fc8260'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    conn = op.get_bind()
+    op.add_column('environment_roles', sa.Column('application_role_id', postgresql.UUID(as_uuid=True), nullable=True))
+    op.drop_index('environments_role_user_environment', table_name='environment_roles')
+    op.create_index('environments_role_user_environment', 'environment_roles', ['application_role_id', 'environment_id'], unique=True)
+    op.drop_constraint('environment_roles_user_id_fkey', 'environment_roles', type_='foreignkey')
+    op.create_foreign_key("environment_roles_application_roles_fkey", 'environment_roles', 'application_roles', ['application_role_id'], ['id'])
+    conn.execute("""
+UPDATE environment_roles er
+SET application_role_id = application_roles.id
+FROM environments, applications, application_roles
+WHERE
+    environment_id = environments.id AND
+    applications.id = environments.application_id AND
+    application_roles.application_id = applications.id AND
+    er.user_id = application_roles.user_id;
+""")
+    op.alter_column('environment_roles', "application_role_id", nullable=False)
+    op.drop_column('environment_roles', 'user_id')
+
+
+def downgrade():
+    conn = op.get_bind()
+    op.add_column('environment_roles', sa.Column('user_id', postgresql.UUID(), autoincrement=False, nullable=True))
+    op.drop_constraint("environment_roles_application_roles_fkey", 'environment_roles', type_='foreignkey')
+    op.create_foreign_key('environment_roles_user_id_fkey', 'environment_roles', 'users', ['user_id'], ['id'])
+    op.drop_index('environments_role_user_environment', table_name='environment_roles')
+    op.create_index('environments_role_user_environment', 'environment_roles', ['user_id', 'environment_id'], unique=True)
+    conn.execute("""
+UPDATE environment_roles
+SET user_id = application_roles.user_id
+FROM application_roles
+WHERE application_role_id = application_roles.id
+""")
+    op.alter_column('environment_roles', "user_id", nullable=False)
+    op.drop_column('environment_roles', 'application_role_id')

--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -98,7 +98,9 @@ class Applications(BaseDomainClass):
             role = env_role_data.get("role")
             if role:
                 environment = Environments.get(env_role_data.get("environment_id"))
-                Environments.add_member(environment, user, env_role_data.get("role"))
+                Environments.add_member(
+                    environment, application_role, env_role_data.get("role")
+                )
 
         return application_role
 
@@ -110,8 +112,11 @@ class Applications(BaseDomainClass):
 
         application_role.status = ApplicationRoleStatus.DISABLED
         application_role.deleted = True
-        db.session.add(application_role)
-        db.session.commit()
 
         for env in application.environments:
-            EnvironmentRoles.delete(user_id=user_id, environment_id=env.id)
+            EnvironmentRoles.delete(
+                application_role_id=application_role.id, environment_id=env.id
+            )
+
+        db.session.add(application_role)
+        db.session.commit()

--- a/atst/domain/csp/cloud.py
+++ b/atst/domain/csp/cloud.py
@@ -75,7 +75,7 @@ class MockCloudProvider(CloudProviderInterface):
     def get_access_token(self, environment_role):
         # for now, just create a mock token using the user and environment
         # cloud IDs and the name of the role in the environment
-        user_id = environment_role.user.cloud_id or ""
+        user_id = environment_role.application_role.user.cloud_id or ""
         env_id = environment_role.environment.cloud_id or ""
         role_details = environment_role.role
         return "::".join([user_id, env_id, role_details])

--- a/atst/domain/environment_roles.py
+++ b/atst/domain/environment_roles.py
@@ -1,24 +1,27 @@
 from flask import current_app as app
 
 from atst.database import db
-from atst.models import EnvironmentRole, Application, Environment
+from atst.models import EnvironmentRole, ApplicationRole
 
 
 class EnvironmentRoles(object):
     @classmethod
-    def create(cls, user, environment, role):
-        env_role = EnvironmentRole(user=user, environment=environment, role=role)
-        if not user.cloud_id:
-            user.cloud_id = app.csp.cloud.create_user(user)
+    def create(cls, application_role, environment, role):
+        env_role = EnvironmentRole(
+            application_role=application_role, environment=environment, role=role
+        )
+        # TODO: move cloud_id behavior to invitation acceptance
+        # if not user.cloud_id:
+        #     user.cloud_id = app.csp.cloud.create_user(user)
         app.csp.cloud.create_role(env_role)
         return env_role
 
     @classmethod
-    def get(cls, user_id, environment_id):
+    def get(cls, application_role_id, environment_id):
         existing_env_role = (
             db.session.query(EnvironmentRole)
             .filter(
-                EnvironmentRole.user_id == user_id,
+                EnvironmentRole.application_role_id == application_role_id,
                 EnvironmentRole.environment_id == environment_id,
             )
             .one_or_none()
@@ -26,8 +29,21 @@ class EnvironmentRoles(object):
         return existing_env_role
 
     @classmethod
-    def delete(cls, user_id, environment_id):
-        existing_env_role = EnvironmentRoles.get(user_id, environment_id)
+    def get_by_user_and_environment(cls, user_id, environment_id):
+        existing_env_role = (
+            db.session.query(EnvironmentRole)
+            .join(ApplicationRole)
+            .filter(
+                ApplicationRole.user_id == user_id,
+                EnvironmentRole.environment_id == environment_id,
+            )
+            .one_or_none()
+        )
+        return existing_env_role
+
+    @classmethod
+    def delete(cls, application_role_id, environment_id):
+        existing_env_role = EnvironmentRoles.get(application_role_id, environment_id)
         if existing_env_role:
             app.csp.cloud.delete_role(existing_env_role)
             db.session.delete(existing_env_role)
@@ -37,14 +53,10 @@ class EnvironmentRoles(object):
             return False
 
     @classmethod
-    def get_for_application_and_user(cls, user_id, application_id):
+    def get_for_application_member(cls, application_role_id):
         return (
             db.session.query(EnvironmentRole)
-            .join(Environment)
-            .join(Application, Environment.application_id == Application.id)
-            .filter(EnvironmentRole.user_id == user_id)
-            .filter(Application.id == application_id)
-            .filter(EnvironmentRole.environment_id == Environment.id)
+            .filter(EnvironmentRole.application_role_id == application_role_id)
             .filter(EnvironmentRole.deleted != True)
             .all()
         )

--- a/atst/models/application_role.py
+++ b/atst/models/application_role.py
@@ -1,14 +1,12 @@
 from enum import Enum
 from sqlalchemy import Index, ForeignKey, Column, Enum as SQLAEnum, Table
 from sqlalchemy.dialects.postgresql import UUID
-from sqlalchemy.orm import object_session, relationship
+from sqlalchemy.orm import relationship
 from sqlalchemy.event import listen
 
 from atst.utils import first_or_none
 from atst.models import Base, mixins
 from atst.models.mixins.auditable import record_permission_sets_updates
-from atst.models.environment import Environment
-from atst.models.environment_role import EnvironmentRole
 from .types import Id
 
 
@@ -92,22 +90,6 @@ class ApplicationRole(
             "application": self.application.name,
             "portfolio": self.application.portfolio.name,
         }
-
-    @property
-    def environment_roles(self):
-        if getattr(self, "_environment_roles", None) is None:
-            roles = (
-                object_session(self)
-                .query(EnvironmentRole)
-                .join(Environment, Environment.application_id == self.application_id)
-                .filter(EnvironmentRole.environment_id == Environment.id)
-                .filter(EnvironmentRole.user_id == self.user_id)
-                .all()
-            )
-
-            setattr(self, "_environment_roles", roles)
-
-        return self._environment_roles
 
 
 Index(

--- a/atst/models/environment.py
+++ b/atst/models/environment.py
@@ -21,7 +21,7 @@ class Environment(
 
     @property
     def users(self):
-        return {r.user for r in self.roles}
+        return {r.application_role.user for r in self.roles}
 
     @property
     def num_users(self):

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -26,12 +26,14 @@ class EnvironmentRole(
 
     role = Column(String())
 
-    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
-    user = relationship("User", backref="environment_roles")
+    application_role_id = Column(
+        UUID(as_uuid=True), ForeignKey("application_roles.id"), nullable=False
+    )
+    application_role = relationship("ApplicationRole", backref="environment_roles")
 
     def __repr__(self):
         return "<EnvironmentRole(role='{}', user='{}', environment='{}', id='{}')>".format(
-            self.role, self.user.full_name, self.environment.name, self.id
+            self.role, self.application_role.user_name, self.environment.name, self.id
         )
 
     @property
@@ -53,8 +55,8 @@ class EnvironmentRole(
     @property
     def event_details(self):
         return {
-            "updated_user_name": self.user.displayname,
-            "updated_user_id": str(self.user_id),
+            "updated_user_name": self.application_role.user_name,
+            "updated_application_role_id": str(self.application_role_id),
             "role": self.role,
             "environment": self.environment.displayname,
             "environment_id": str(self.environment_id),
@@ -67,7 +69,7 @@ class EnvironmentRole(
 
 Index(
     "environments_role_user_environment",
-    EnvironmentRole.user_id,
+    EnvironmentRole.application_role_id,
     EnvironmentRole.environment_id,
     unique=True,
 )

--- a/atst/models/portfolio_role.py
+++ b/atst/models/portfolio_role.py
@@ -7,11 +7,7 @@ from sqlalchemy.event import listen
 from atst.models import Base, mixins
 from .types import Id
 
-from atst.database import db
 from atst.utils import first_or_none
-from atst.models.environment_role import EnvironmentRole
-from atst.models.application import Application
-from atst.models.environment import Environment
 from atst.models.mixins.auditable import record_permission_sets_updates
 
 
@@ -125,34 +121,6 @@ class PortfolioRole(
     @property
     def is_active(self):
         return self.status == Status.ACTIVE
-
-    @property
-    def num_environment_roles(self):
-        return (
-            db.session.query(EnvironmentRole)
-            .join(EnvironmentRole.environment)
-            .join(Environment.application)
-            .join(Application.portfolio)
-            .filter(Application.portfolio_id == self.portfolio_id)
-            .filter(EnvironmentRole.user_id == self.user_id)
-            .count()
-        )
-
-    @property
-    def environment_roles(self):
-        return (
-            db.session.query(EnvironmentRole)
-            .join(EnvironmentRole.environment)
-            .join(Environment.application)
-            .join(Application.portfolio)
-            .filter(Application.portfolio_id == self.portfolio_id)
-            .filter(EnvironmentRole.user_id == self.user_id)
-            .all()
-        )
-
-    @property
-    def has_environment_roles(self):
-        return self.num_environment_roles > 0
 
     @property
     def can_resend_invitation(self):

--- a/atst/routes/applications/__init__.py
+++ b/atst/routes/applications/__init__.py
@@ -17,7 +17,7 @@ applications_bp.context_processor(portfolio_context_processor)
 
 
 def wrap_environment_role_lookup(user, environment_id=None, **kwargs):
-    env_role = EnvironmentRoles.get(user.id, environment_id)
+    env_role = EnvironmentRoles.get_by_user_and_environment(user.id, environment_id)
     if not env_role:
         raise UnauthorizedError(user, "access environment {}".format(environment_id))
 
@@ -27,7 +27,9 @@ def wrap_environment_role_lookup(user, environment_id=None, **kwargs):
 @applications_bp.route("/environments/<environment_id>/access")
 @user_can(None, override=wrap_environment_role_lookup, message="access environment")
 def access_environment(environment_id):
-    env_role = EnvironmentRoles.get(g.current_user.id, environment_id)
+    env_role = EnvironmentRoles.get_by_user_and_environment(
+        g.current_user.id, environment_id
+    )
     token = app.csp.cloud.get_access_token(env_role)
 
     return redirect(url_for("atst.csp_environment_access", token=token))

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -38,9 +38,7 @@ def get_team_form(application):
                 member, PermissionSets.DELETE_APPLICATION_ENVIRONMENTS
             ),
         }
-        roles = EnvironmentRoles.get_for_application_and_user(
-            member.user.id, application.id
-        )
+        roles = EnvironmentRoles.get_for_application_member(member.id)
         environment_roles = [
             {
                 "environment_id": str(role.environment.id),
@@ -110,7 +108,7 @@ def update_team(application_id):
                     environment_role_form.environment_id.data
                 )
                 Environments.update_env_role(
-                    environment, app_role.user, environment_role_form.data.get("role")
+                    environment, app_role, environment_role_form.data.get("role")
                 )
 
         flash("updated_application_team_settings", application_name=application.name)

--- a/atst/routes/portfolios/members.py
+++ b/atst/routes/portfolios/members.py
@@ -11,21 +11,6 @@ from atst.models.permissions import Permissions
 from atst.utils.flash import formatted_flash as flash
 
 
-def serialize_portfolio_role(portfolio_role):
-    return {
-        "name": portfolio_role.user_name,
-        "status": portfolio_role.display_status,
-        "id": portfolio_role.user_id,
-        "role": "admin",
-        "num_env": portfolio_role.num_environment_roles,
-        "edit_link": url_for(
-            "portfolios.view_member",
-            portfolio_id=portfolio_role.portfolio_id,
-            member_id=portfolio_role.user_id,
-        ),
-    }
-
-
 @portfolios_bp.route("/portfolios/<portfolio_id>/members/new", methods=["POST"])
 @user_can(Permissions.CREATE_PORTFOLIO_USERS, message="create new portfolio member")
 def create_member(portfolio_id):

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -225,7 +225,7 @@ def add_applications_to_portfolio(portfolio):
                     last_name=user_data["last_name"],
                 )
 
-            ApplicationRoles.create(
+            app_role = ApplicationRoles.create(
                 user=user,
                 application=application,
                 permission_set_names=[PermissionSets.EDIT_APPLICATION_TEAM],
@@ -237,7 +237,9 @@ def add_applications_to_portfolio(portfolio):
             )
             for env in user_environments:
                 role = random.choice([e.value for e in CSPRole])
-                EnvironmentRoles.create(user=user, environment=env, role=role)
+                EnvironmentRoles.create(
+                    application_role=app_role, environment=env, role=role
+                )
 
 
 def create_demo_portfolio(name, data):

--- a/tests/domain/test_applications.py
+++ b/tests/domain/test_applications.py
@@ -128,7 +128,7 @@ def test_create_member():
     # view application AND edit application team
     assert len(member_role.permission_sets) == 2
 
-    env_roles = member_role.user.environment_roles
+    env_roles = member_role.environment_roles
     assert len(env_roles) == 1
     assert env_roles[0].environment == env1
 
@@ -165,7 +165,9 @@ def test_remove_member():
     user = UserFactory.create()
     member_role = ApplicationRoleFactory.create(application=application, user=user)
     environment = EnvironmentFactory.create(application=application)
-    environment_role = EnvironmentRoleFactory.create(user=user, environment=environment)
+    environment_role = EnvironmentRoleFactory.create(
+        application_role=member_role, environment=environment
+    )
 
     assert member_role == ApplicationRoles.get(
         user_id=user.id, application_id=application.id
@@ -181,4 +183,9 @@ def test_remove_member():
     #
     # TODO: Why does above raise NotFoundError and this returns None
     #
-    assert EnvironmentRoles.get(user_id=user.id, environment_id=environment.id) == None
+    assert (
+        EnvironmentRoles.get(
+            application_role_id=member_role.id, environment_id=environment.id
+        )
+        is None
+    )

--- a/tests/domain/test_audit_log.py
+++ b/tests/domain/test_audit_log.py
@@ -84,7 +84,7 @@ def test_get_portfolio_events_includes_app_and_env_events():
 
     # add environment level events
     env = EnvironmentFactory.create(application=application)
-    env_role = EnvironmentRoleFactory.create(environment=env, user=app_role.user)
+    env_role = EnvironmentRoleFactory.create(environment=env, application_role=app_role)
     portfolio_app_and_env_events = AuditLog.get_portfolio_events(portfolio)
     assert len(portfolio_and_app_events) < len(portfolio_app_and_env_events)
 
@@ -106,7 +106,7 @@ def test_get_application_events():
     app_role = ApplicationRoleFactory.create(application=application)
     app_invite = ApplicationInvitationFactory.create(role=app_role)
     env = EnvironmentFactory.create(application=application)
-    env_role = EnvironmentRoleFactory.create(environment=env, user=app_role.user)
+    env_role = EnvironmentRoleFactory.create(environment=env, application_role=app_role)
     # add rando app
     rando_app = ApplicationFactory.create(portfolio=portfolio)
 

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -1,26 +1,90 @@
+import pytest
+from unittest.mock import MagicMock
+
 from atst.domain.environment_roles import EnvironmentRoles
 
 from tests.factories import *
 
 
-def test_get_for_application_and_user():
+@pytest.fixture
+def application_role():
     user = UserFactory.create()
     application = ApplicationFactory.create()
-    env1 = EnvironmentFactory.create(application=application)
-    EnvironmentFactory.create(application=application)
-    EnvironmentRoleFactory.create(user=user, environment=env1)
+    return ApplicationRoleFactory.create(application=application, user=user)
 
-    roles = EnvironmentRoles.get_for_application_and_user(user.id, application.id)
+
+@pytest.fixture
+def environment(application_role):
+    return EnvironmentFactory.create(application=application_role.application)
+
+
+def test_create(application_role, environment, monkeypatch):
+    mock_create_role = MagicMock()
+    monkeypatch.setattr(
+        "atst.domain.environment_roles.app.csp.cloud.create_role", mock_create_role
+    )
+
+    environment_role = EnvironmentRoles.create(
+        application_role, environment, "network admin"
+    )
+    assert environment_role.application_role == application_role
+    assert environment_role.environment == environment
+    assert environment_role.role == "network admin"
+    mock_create_role.assert_called_with(environment_role)
+
+
+def test_get(application_role, environment):
+    EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment
+    )
+
+    environment_role = EnvironmentRoles.get(application_role.id, environment.id)
+    assert environment_role
+    assert environment_role.application_role == application_role
+    assert environment_role.environment == environment
+
+
+def test_get_by_user_and_environment(application_role, environment):
+    expected_role = EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment
+    )
+    actual_role = EnvironmentRoles.get_by_user_and_environment(
+        application_role.user.id, environment.id
+    )
+    assert expected_role == actual_role
+
+
+def test_delete(application_role, environment, monkeypatch):
+    mock_delete_role = MagicMock()
+    monkeypatch.setattr(
+        "atst.domain.environment_roles.app.csp.cloud.delete_role", mock_delete_role
+    )
+
+    environment_role = EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment
+    )
+    assert EnvironmentRoles.delete(application_role.id, environment.id)
+    mock_delete_role.assert_called_with(environment_role)
+    assert not EnvironmentRoles.delete(application_role.id, environment.id)
+
+
+def test_get_for_application_member(application_role, environment):
+    EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment
+    )
+
+    roles = EnvironmentRoles.get_for_application_member(application_role.id)
     assert len(roles) == 1
-    assert roles[0].environment == env1
-    assert roles[0].user == user
+    assert roles[0].environment == environment
+    assert roles[0].application_role == application_role
 
 
-def test_get_for_application_and_user_does_not_return_deleted():
-    user = UserFactory.create()
-    application = ApplicationFactory.create()
-    env1 = EnvironmentFactory.create(application=application)
-    EnvironmentRoleFactory.create(user=user, environment=env1, deleted=True)
+def test_get_for_application_member_does_not_return_deleted(
+    application_role, environment
+):
+    EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment, deleted=True
+    )
 
-    roles = EnvironmentRoles.get_for_application_and_user(user.id, application.id)
+    roles = EnvironmentRoles.get_for_application_member(application_role.id)
     assert len(roles) == 0

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -111,29 +111,6 @@ def test_scoped_portfolio_for_admin_missing_view_apps_perms(portfolio_owner, por
     assert len(scoped_portfolio.applications) == 0
 
 
-@pytest.mark.skip(reason="should be reworked pending application member changes")
-def test_scoped_portfolio_only_returns_a_users_applications_and_environments(
-    portfolio, portfolio_owner
-):
-    new_application = Applications.create(
-        portfolio, "My Application", "My application", ["dev", "staging", "prod"]
-    )
-    Applications.create(
-        portfolio, "My Application 2", "My application 2", ["dev", "staging", "prod"]
-    )
-    developer = UserFactory.create()
-    dev_environment = Environments.add_member(
-        new_application.environments[0], developer, "developer"
-    )
-
-    scoped_portfolio = Portfolios.get(developer, portfolio.id)
-
-    # Should only return the application and environment in which the user has an
-    # environment role.
-    assert scoped_portfolio.applications == [new_application]
-    assert scoped_portfolio.applications[0].environments == [dev_environment]
-
-
 def test_scoped_portfolio_returns_all_applications_for_portfolio_admin(
     portfolio, portfolio_owner
 ):

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -45,6 +45,8 @@ def test_environment_roles():
     environment = EnvironmentFactory.create(application=application)
     user = UserFactory.create()
     application_role = ApplicationRoleFactory.create(application=application, user=user)
-    environment_role = EnvironmentRoleFactory.create(environment=environment, user=user)
+    environment_role = EnvironmentRoleFactory.create(
+        environment=environment, application_role=application_role
+    )
 
     assert application_role.environment_roles == [environment_role]

--- a/tests/models/test_environments.py
+++ b/tests/models/test_environments.py
@@ -3,13 +3,7 @@ from atst.models.environment_role import CSPRole
 from atst.domain.environments import Environments
 from atst.domain.applications import Applications
 
-from tests.factories import (
-    PortfolioFactory,
-    UserFactory,
-    EnvironmentFactory,
-    ApplicationFactory,
-    ApplicationRoleFactory,
-)
+from tests.factories import *
 
 
 def test_add_user_to_environment():
@@ -22,9 +16,13 @@ def test_add_user_to_environment():
     )
     dev_environment = application.environments[0]
 
-    ApplicationRoleFactory.create(user=developer, application=application)
-    dev_environment = Environments.add_member(
-        dev_environment, developer, CSPRole.BASIC_ACCESS.value
+    application_role = ApplicationRoleFactory.create(
+        user=developer, application=application
+    )
+    EnvironmentRoleFactory.create(
+        application_role=application_role,
+        environment=dev_environment,
+        role=CSPRole.BASIC_ACCESS.value,
     )
     assert developer in dev_environment.users
 

--- a/tests/routes/applications/test_init.py
+++ b/tests/routes/applications/test_init.py
@@ -1,33 +1,16 @@
 from flask import url_for, get_flashed_messages
 
-from tests.factories import (
-    UserFactory,
-    PortfolioFactory,
-    PortfolioRoleFactory,
-    EnvironmentRoleFactory,
-    EnvironmentFactory,
-    ApplicationFactory,
-)
-
-from atst.domain.applications import Applications
-from atst.domain.portfolios import Portfolios
-from atst.models.portfolio_role import Status as PortfolioRoleStatus
-
-from tests.utils import captured_templates
-
-
-def create_environment(user):
-    portfolio = PortfolioFactory.create()
-    portfolio_role = PortfolioRoleFactory.create(portfolio=portfolio, user=user)
-    application = ApplicationFactory.create(portfolio=portfolio)
-    return EnvironmentFactory.create(application=application, name="new environment!")
+from tests.factories import *
 
 
 def test_environment_access_with_env_role(client, user_session):
     user = UserFactory.create()
-    environment = create_environment(user)
-    env_role = EnvironmentRoleFactory.create(
-        user=user, environment=environment, role="developer"
+    environment = EnvironmentFactory.create()
+    app_role = ApplicationRoleFactory.create(
+        user=user, application=environment.application
+    )
+    EnvironmentRoleFactory.create(
+        application_role=app_role, environment=environment, role="developer"
     )
     user_session(user)
     response = client.get(
@@ -39,7 +22,7 @@ def test_environment_access_with_env_role(client, user_session):
 
 def test_environment_access_with_no_role(client, user_session):
     user = UserFactory.create()
-    environment = create_environment(user)
+    environment = EnvironmentFactory.create()
     user_session(user)
     response = client.get(
         url_for("applications.access_environment", environment_id=environment.id)

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -94,7 +94,9 @@ def test_update_team_environment_roles(client, user_session):
     )
     environment = EnvironmentFactory.create(application=application)
     env_role = EnvironmentRoleFactory.create(
-        user=app_role.user, environment=environment, role=CSPRole.NETWORK_ADMIN.value
+        application_role=app_role,
+        environment=environment,
+        role=CSPRole.NETWORK_ADMIN.value,
     )
     user_session(owner)
     response = client.post(
@@ -121,7 +123,9 @@ def test_update_team_revoke_environment_access(client, user_session, db, session
     )
     environment = EnvironmentFactory.create(application=application)
     env_role = EnvironmentRoleFactory.create(
-        user=app_role.user, environment=environment, role=CSPRole.BASIC_ACCESS.value
+        application_role=app_role,
+        environment=environment,
+        role=CSPRole.BASIC_ACCESS.value,
     )
     user_session(owner)
     response = client.post(
@@ -177,8 +181,11 @@ def test_create_member(client, user_session):
     assert response.location == expected_url
     assert len(user.application_roles) == 1
     assert user.application_roles[0].application == application
-    assert len(user.environment_roles) == 1
-    assert user.environment_roles[0].environment == env
+    environment_roles = [
+        er for ar in user.application_roles for er in ar.environment_roles
+    ]
+    assert len(environment_roles) == 1
+    assert environment_roles[0].environment == env
 
 
 def test_remove_member_success(client, user_session):

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -10,18 +10,7 @@ from atst.domain.auth import UNPROTECTED_ROUTES as _NO_LOGIN_REQUIRED
 from atst.domain.permission_sets import PermissionSets
 from atst.models import CSPRole, PortfolioRoleStatus, ApplicationRoleStatus
 
-from tests.factories import (
-    AttachmentFactory,
-    ApplicationFactory,
-    ApplicationRoleFactory,
-    EnvironmentFactory,
-    EnvironmentRoleFactory,
-    PortfolioInvitationFactory,
-    PortfolioFactory,
-    PortfolioRoleFactory,
-    TaskOrderFactory,
-    UserFactory,
-)
+from tests.factories import *
 
 _NO_ACCESS_CHECK_REQUIRED = _NO_LOGIN_REQUIRED + [
     "task_orders.get_started",  # all users can start a new TO
@@ -265,11 +254,6 @@ def test_application_settings_access(get_url_assert_status):
         applications=[{"name": "Mos Eisley", "description": "Where Han shot first"}],
     )
     app = portfolio.applications[0]
-    env = EnvironmentFactory.create(application=app)
-    env_role = EnvironmentRoleFactory.create(
-        environment=env, role=CSPRole.NETWORK_ADMIN.value
-    )
-    ApplicationRoleFactory.create(application=app, user=env_role.user)
 
     url = url_for("applications.settings", application_id=app.id)
     get_url_assert_status(ccpo, url, 200)


### PR DESCRIPTION
In the future, an `application_invitation` will not refer to a `user` until someone accepts the invitation; they'll only reference an `application_role`. When a user is invited to an application, the inviter can specify the environments the invitee should have access to.  For this to be possible, an `environment_role` should reference an `application_role`, because no `user` entity will be known at that time.

In addition to updating all the models and domain methods necessary for this change, this commit deletes unused code and tests that were dependent on `environment_roles` having a `user_id` foreign key.
