### PR TITLE
Filter out deleted application environment roles

### DIFF
--- a/atst/models/application_role.py
+++ b/atst/models/application_role.py
@@ -51,6 +51,11 @@ class ApplicationRole(
         "PermissionSet", secondary=application_roles_permission_sets
     )
 
+    environment_roles = relationship(
+        "EnvironmentRole",
+        primaryjoin="and_(EnvironmentRole.application_role_id==ApplicationRole.id, EnvironmentRole.deleted==False)",
+    )
+
     @property
     def user_name(self):
         if self.user:

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -29,7 +29,7 @@ class EnvironmentRole(
     application_role_id = Column(
         UUID(as_uuid=True), ForeignKey("application_roles.id"), nullable=False
     )
-    application_role = relationship("ApplicationRole", backref="environment_roles")
+    application_role = relationship("ApplicationRole")
 
     def __repr__(self):
         return "<EnvironmentRole(role='{}', user='{}', environment='{}', id='{}')>".format(

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -42,11 +42,15 @@ def test_has_application_role_history(session):
 
 def test_environment_roles():
     application = ApplicationFactory.create()
-    environment = EnvironmentFactory.create(application=application)
+    environment1 = EnvironmentFactory.create(application=application)
+    environment2 = EnvironmentFactory.create(application=application)
     user = UserFactory.create()
     application_role = ApplicationRoleFactory.create(application=application, user=user)
-    environment_role = EnvironmentRoleFactory.create(
-        environment=environment, application_role=application_role
+    environment_role1 = EnvironmentRoleFactory.create(
+        environment=environment1, application_role=application_role
+    )
+    EnvironmentRoleFactory.create(
+        environment=environment2, application_role=application_role, deleted=True
     )
 
-    assert application_role.environment_roles == [environment_role]
+    assert application_role.environment_roles == [environment_role1]


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/166469506

An `ApplicationRole` should filter deleted, dependent `environment_roles`. This was causing errors when an environment was deleted because we iterate the team's `ApplicationRole`s and dependent `EnvironmentRole`s to build the data for that page. This caused errors when an app role referred to an env role that was soft-deleted.