### PR TITLE
Change `More/Less` anchor styling

### DIFF
--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -49,11 +49,15 @@
 
 .semi-collapsed {
   overflow: hidden;
-  height: $gap * 5.5;
+  height: 5.1rem;
 }
 
 .more {
-  margin-top: -2.5rem;
+  margin-top: -4.4rem;
+  padding-left: 1.25rem;
+  background-color: $color-offwhite;
+  position: relative;
+  cursor: pointer;
 }
 
 .green {

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -10,9 +10,9 @@
 
     <semi-collapsible-text inline-template>
       <div>
-        <div v-bind:class="{ 'semi-collapsed' : !open }">
+        <p v-bind:class="{ 'semi-collapsed' : !open }">
           Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </div>
+        </p>
         <a v-on:click='toggle' v-show="!open" class="right more">More{{ Icon('caret_down') }}</a>
         <a v-on:click='toggle' v-show="open" class="right more">Less{{ Icon('caret_up') }}</a>
       </div>
@@ -22,7 +22,7 @@
 
 
   <div class="h1">Review your task order</div>
-  <div>Check to make sure the information you entered is correct. After submission, you will confirm this task order was signed by a contracting officer. Thereafter, you will be informed as soon as CCPO completes their review.</div>
+  <p>Check to make sure the information you entered is correct. After submission, you will confirm this task order was signed by a contracting officer. Thereafter, you will be informed as soon as CCPO completes their review.</p>
   <div class="row">
     <div class="col">
       <div class="h4">Task order number - 10 digit found in your system of record</div>


### PR DESCRIPTION
## Description
The open/close anchor was overlapping with some of the paragraph text, depending on what words were in the paragraph. This PR gives a background color to the anchor so that there is never text overlap, along with some padding and height changes that make the whole `semi-collapsible-text` look nicer.

## Screenshots
![Screen Shot 2019-06-05 at 3 56 11 PM](https://user-images.githubusercontent.com/42577527/58985990-7c3be180-87aa-11e9-80a8-83538d0a15b0.png)

![Screen Shot 2019-06-05 at 3 55 59 PM](https://user-images.githubusercontent.com/42577527/58986005-8067ff00-87aa-11e9-9022-a47114bf406b.png)

