### PR TITLE
Logout message on session expiration visiting /logout

### DIFF
--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -120,6 +120,7 @@ def logout():
     _logout()
     response = make_response(redirect(url_for(".root")))
     response.set_cookie("expandSidenav", "", expires=0)
+    flash("logged_out")
     return response
 
 


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/166472937)

## Steps to Reproduce

```
    Login as any user
    Allow 10 minutes to pass without doing anything in AT-AT
    Return to AT-AT and click the Logout button
```

## Actual Behavior/Result

User returns to the CAC Login page, but there is no banner indicating that the user successfully logged out.

## Expected Behavior/Result

On logout, the user should be notified that they are successfully logged out of AT-AT.