### PR TITLE
Funding page Task Order statuses

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -1,7 +1,7 @@
 from flask import current_app as app
 
 from atst.database import db
-from atst.models.task_order import TaskOrder
+from atst.models.task_order import TaskOrder, SORT_ORDERING
 from . import BaseDomainClass
 
 
@@ -75,3 +75,10 @@ class TaskOrders(BaseDomainClass):
         if not app.config.get("CLASSIFIED"):
             section_list["funding"] = TaskOrders.UNCLASSIFIED_FUNDING
         return section_list
+
+    @classmethod
+    def sort(cls, task_orders: [TaskOrder]) -> [TaskOrder]:
+        # Sorts a list of task orders on two keys: status (primary) and time_created (secondary)
+        by_time_created = sorted(task_orders, key=lambda to: to.time_created)
+        by_status = sorted(by_time_created, key=lambda to: SORT_ORDERING.get(to.status))
+        return by_status

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -15,7 +15,7 @@ class Status(Enum):
     ACTIVE = "Active"
     UPCOMING = "Upcoming"
     EXPIRED = "Expired"
-    UNSIGNED = "Unsigned"
+    UNSIGNED = "Not signed"
 
 
 SORT_ORDERING = {

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from datetime import date, datetime
+from datetime import date
 
 from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -11,12 +11,10 @@ from atst.models.clin import JEDICLINType
 
 
 class Status(Enum):
-    STARTED = "Started"
-    PENDING = "Pending"
-    ACTIVE = "Active"
-    EXPIRED = "Expired"
     DRAFT = "Draft"
+    ACTIVE = "Active"
     UPCOMING = "Upcoming"
+    EXPIRED = "Expired"
     UNSIGNED = "Unsigned"
 
 
@@ -90,7 +88,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
 
     @property
     def start_date(self):
-        return min((c.start_date for c in self.clins), default=None)
+        return min((c.start_date for c in self.clins), default=self.time_created.date())
 
     @property
     def end_date(self):

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -18,6 +18,14 @@ class Status(Enum):
     UNSIGNED = "Unsigned"
 
 
+SORT_ORDERING = {
+    status: order
+    for (order, status) in enumerate(
+        [Status.DRAFT, Status.ACTIVE, Status.UPCOMING, Status.EXPIRED, Status.UNSIGNED]
+    )
+}
+
+
 class TaskOrder(Base, mixins.TimestampsMixin):
     __tablename__ = "task_orders"
 

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -67,7 +67,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
 
     @property
     def is_completed(self):
-        return True
+        return all([self.pdf, self.number, len(self.clins)])
 
     @property
     def is_signed(self):

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -70,15 +70,11 @@ class TaskOrder(Base, mixins.TimestampsMixin):
 
     @property
     def start_date(self):
-        # TODO: fix task order -- reimplement using CLINs
-        # Faked for display purposes
-        return date.today()
+        return min(c.start_date for c in self.clins)
 
     @property
     def end_date(self):
-        # TODO: fix task order -- reimplement using CLINs
-        # Faked for display purposes
-        return date.today()
+        return max(c.end_date for c in self.clins)
 
     @property
     def days_to_expiration(self):

--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -1,5 +1,3 @@
-from collections import defaultdict
-
 from flask import g, render_template
 
 from . import task_orders_bp
@@ -7,7 +5,6 @@ from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.domain.portfolios import Portfolios
 from atst.domain.task_orders import TaskOrders
 from atst.models import Permissions
-from atst.models.task_order import Status as TaskOrderStatus
 
 
 @task_orders_bp.route("/task_orders/<task_order_id>")
@@ -34,7 +31,5 @@ def review_task_order(task_order_id):
 @user_can(Permissions.VIEW_PORTFOLIO_FUNDING, message="view portfolio funding")
 def portfolio_funding(portfolio_id):
     portfolio = Portfolios.get(g.current_user, portfolio_id)
-
-    return render_template(
-        "portfolios/task_orders/index.html", task_orders=portfolio.task_orders
-    )
+    task_orders = TaskOrders.sort(portfolio.task_orders)
+    return render_template("portfolios/task_orders/index.html", task_orders=task_orders)

--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -38,6 +38,10 @@ def portfolio_funding(portfolio_id):
         Status.ACTIVE: "success",
         Status.UPCOMING: "info",
         Status.EXPIRED: "error",
-        Status.UNSIGNED: "purple"
+        Status.UNSIGNED: "purple",
     }
-    return render_template("portfolios/task_orders/index.html", task_orders=task_orders, label_colors=label_colors)
+    return render_template(
+        "portfolios/task_orders/index.html",
+        task_orders=task_orders,
+        label_colors=label_colors,
+    )

--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -34,19 +34,7 @@ def review_task_order(task_order_id):
 @user_can(Permissions.VIEW_PORTFOLIO_FUNDING, message="view portfolio funding")
 def portfolio_funding(portfolio_id):
     portfolio = Portfolios.get(g.current_user, portfolio_id)
-    task_orders_by_status = defaultdict(list)
-
-    for task_order in portfolio.task_orders:
-        task_orders_by_status[task_order.status].append(task_order)
-
-    active_task_orders = task_orders_by_status.get(TaskOrderStatus.ACTIVE, [])
 
     return render_template(
-        "portfolios/task_orders/index.html",
-        pending_task_orders=(
-            task_orders_by_status.get(TaskOrderStatus.STARTED, [])
-            + task_orders_by_status.get(TaskOrderStatus.PENDING, [])
-        ),
-        active_task_orders=active_task_orders,
-        expired_task_orders=task_orders_by_status.get(TaskOrderStatus.EXPIRED, []),
+        "portfolios/task_orders/index.html", task_orders=portfolio.task_orders
     )

--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -4,6 +4,7 @@ from . import task_orders_bp
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.domain.portfolios import Portfolios
 from atst.domain.task_orders import TaskOrders
+from atst.models.task_order import Status
 from atst.models import Permissions
 
 
@@ -32,4 +33,11 @@ def review_task_order(task_order_id):
 def portfolio_funding(portfolio_id):
     portfolio = Portfolios.get(g.current_user, portfolio_id)
     task_orders = TaskOrders.sort(portfolio.task_orders)
-    return render_template("portfolios/task_orders/index.html", task_orders=task_orders)
+    label_colors = {
+        Status.DRAFT: "warning",
+        Status.ACTIVE: "success",
+        Status.UPCOMING: "info",
+        Status.EXPIRED: "error",
+        Status.UNSIGNED: "purple"
+    }
+    return render_template("portfolios/task_orders/index.html", task_orders=task_orders, label_colors=label_colors)

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -174,7 +174,9 @@ def add_task_orders_to_portfolio(portfolio):
     clins = [
         CLINFactory.build(task_order=unsigned_to, start_date=today, end_date=today),
         CLINFactory.build(task_order=upcoming_to, start_date=future, end_date=future),
-        CLINFactory.build(task_order=expired_to, start_date=yesterday, end_date=yesterday),
+        CLINFactory.build(
+            task_order=expired_to, start_date=yesterday, end_date=yesterday
+        ),
         CLINFactory.build(task_order=active_to, start_date=yesterday, end_date=future),
     ]
 

--- a/styles/elements/_labels.scss
+++ b/styles/elements/_labels.scss
@@ -33,4 +33,8 @@
   &.label--success {
     background-color: $color-green;
   }
+
+  &.label--purple {
+    background-color: $color-purple;
+  }
 }

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -73,6 +73,9 @@
 .task-order-card .label {
   font-size: $small-font-size;
   margin-right: 2 * $gap;
+  min-width: 7rem;
+  display: flex;
+  justify-content: space-around;
 }
 
 .task-order-card__buttons .usa-button {

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -45,7 +45,7 @@
     {% for task_order in task_orders %}
       <div class="card task-order-card">
         <div class="card__status">
-          <span class='label label--{{ label }}'>{{ task_order.display_status }}</span>
+          <span class='label label--{{ label_colors[task_order.status] }}'>{{ task_order.display_status }}</span>
           {{ TaskOrderDate(task_order) }}
           <span class="card__status-spacer"></span>
           <span class="card__button">

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -70,25 +70,15 @@
 
 <div class="portfolio-funding">
 
-  {% if not active_task_orders and not pending_task_orders %}
+  {% if task_orders  %}
+    {{ TaskOrderList(task_orders) }}
+  {% else %}
     {{ EmptyState(
       'This portfolio doesn’t have any active or pending task orders.',
       action_label='Add a New Task Order',
       action_href=url_for('task_orders.edit', portfolio_id=portfolio.id),
       icon='cloud',
     ) }}
-  {% endif %}
-
-  {% if pending_task_orders %}
-    {{ TaskOrderList(pending_task_orders, label='warning') }}
-  {% endif %}
-
-  {% if active_task_orders %}
-    {{ TaskOrderList(active_task_orders, label='success') }}
-  {% endif %}
-
-  {% if expired_task_orders %}
-    {{ TaskOrderList(expired_task_orders, label='error') }}
   {% endif %}
 </div>
 

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -1,17 +1,77 @@
 import pytest
+from datetime import date, timedelta
 
-from atst.domain.task_orders import TaskOrders, TaskOrderError
-from atst.domain.exceptions import UnauthorizedError
-from atst.domain.permission_sets import PermissionSets
-from atst.domain.portfolio_roles import PortfolioRoles
+from atst.domain.task_orders import TaskOrders
 from atst.models.attachment import Attachment
+from tests.factories import TaskOrderFactory, CLINFactory
 
-from tests.factories import (
-    TaskOrderFactory,
-    UserFactory,
-    PortfolioRoleFactory,
-    PortfolioFactory,
-)
+
+def test_task_order_sorting():
+    """
+    Task orders should be listed first by status, and then by time_created.
+    """
+
+    today = date.today()
+    yesterday = today - timedelta(days=1)
+    future = today + timedelta(days=100)
+
+    task_orders = [
+        # Draft
+        TaskOrderFactory.create(pdf=None),
+        TaskOrderFactory.create(pdf=None),
+        TaskOrderFactory.create(pdf=None),
+        # Active
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=future)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=future)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=future)],
+        ),
+        # Upcoming
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=future, end_date=future)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=future, end_date=future)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=future, end_date=future)],
+        ),
+        # Expired
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=yesterday)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=yesterday)],
+        ),
+        TaskOrderFactory.create(
+            signed_at=yesterday,
+            clins=[CLINFactory.create(start_date=yesterday, end_date=yesterday)],
+        ),
+        # Unsigned
+        TaskOrderFactory.create(
+            clins=[CLINFactory.create(start_date=today, end_date=today)]
+        ),
+        TaskOrderFactory.create(
+            clins=[CLINFactory.create(start_date=today, end_date=today)]
+        ),
+        TaskOrderFactory.create(
+            clins=[CLINFactory.create(start_date=today, end_date=today)]
+        ),
+    ]
+
+    assert TaskOrders.sort(task_orders) == task_orders
 
 
 @pytest.mark.skip(reason="Need to reimplement after new TO form is created")

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -278,7 +278,7 @@ class CLINFactory(Base):
     start_date = datetime.date.today()
     end_date = factory.LazyFunction(random_future_date)
     obligated_amount = random.randint(100, 999999)
-    jedi_clin_type = random.choice([e for e in clin.JEDICLINType])
+    jedi_clin_type = random.choice(list(clin.JEDICLINType))
 
 
 class NotificationRecipientFactory(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -278,7 +278,7 @@ class CLINFactory(Base):
     start_date = datetime.date.today()
     end_date = factory.LazyFunction(random_future_date)
     obligated_amount = random.randint(100, 999999)
-    jedi_clin_type = random.choice([e.value for e in clin.JEDICLINType])
+    jedi_clin_type = random.choice([e for e in clin.JEDICLINType])
 
 
 class NotificationRecipientFactory(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -267,6 +267,7 @@ class TaskOrderFactory(Base):
 
     portfolio = factory.SubFactory(PortfolioFactory)
     number = factory.LazyFunction(random_task_order_number)
+    _pdf = factory.SubFactory(AttachmentFactory)
 
 
 class CLINFactory(Base):

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -17,36 +17,42 @@ from tests.factories import (
 from tests.mocks import PDF_FILENAME
 
 
-class TestPeriodOfPerformance:
-    def test_period_of_performance_is_first_to_last_clin(self):
-        start_date = date(2019, 6, 6)
-        end_date = date(2020, 6, 6)
+def test_period_of_performance_is_first_to_last_clin():
+    start_date = date(2019, 6, 6)
+    end_date = date(2020, 6, 6)
 
-        intermediate_start_date = date(2019, 7, 1)
-        intermediate_end_date = date(2020, 3, 1)
+    intermediate_start_date = date(2019, 7, 1)
+    intermediate_end_date = date(2020, 3, 1)
 
-        task_order = TaskOrderFactory.create(
-            clins=[
-                CLINFactory.create(
-                    start_date=intermediate_start_date, end_date=intermediate_end_date
-                ),
-                CLINFactory.create(
-                    start_date=start_date, end_date=intermediate_end_date
-                ),
-                CLINFactory.create(
-                    start_date=intermediate_start_date, end_date=intermediate_end_date
-                ),
-                CLINFactory.create(
-                    start_date=intermediate_start_date, end_date=end_date
-                ),
-                CLINFactory.create(
-                    start_date=intermediate_start_date, end_date=intermediate_end_date
-                ),
-            ]
-        )
+    task_order = TaskOrderFactory.create(
+        clins=[
+            CLINFactory.create(
+                start_date=intermediate_start_date, end_date=intermediate_end_date
+            ),
+            CLINFactory.create(
+                start_date=start_date, end_date=intermediate_end_date
+            ),
+            CLINFactory.create(
+                start_date=intermediate_start_date, end_date=intermediate_end_date
+            ),
+            CLINFactory.create(
+                start_date=intermediate_start_date, end_date=end_date
+            ),
+            CLINFactory.create(
+                start_date=intermediate_start_date, end_date=intermediate_end_date
+            ),
+        ]
+    )
 
-        assert task_order.start_date == start_date
-        assert task_order.end_date == end_date
+    assert task_order.start_date == start_date
+    assert task_order.end_date == end_date
+
+
+def test_task_order_completed():
+    assert TaskOrderFactory.create(clins=[CLINFactory.create()]).is_completed
+    assert not TaskOrderFactory.create().is_completed
+    assert not TaskOrderFactory.create(clins=[]).is_completed
+    assert not TaskOrderFactory.create(number=None).is_completed
 
 
 class TestTaskOrderStatus:

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -1,6 +1,8 @@
 from werkzeug.datastructures import FileStorage
 import pytest
-from datetime import date
+from datetime import date, datetime
+from unittest.mock import Mock, patch, PropertyMock
+import pendulum
 
 from atst.models import *
 from atst.models.clin import JEDICLINType
@@ -48,25 +50,73 @@ class TestPeriodOfPerformance:
 
 
 class TestTaskOrderStatus:
-    @pytest.mark.skip(reason="Reimplement after adding CLINs")
-    def test_started_status(self):
+    @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)
+    def test_draft_status(self, is_signed, is_completed):
+        # Given that I have a TO that is neither completed nor signed
         to = TaskOrder()
-        assert to.status == Status.STARTED
+        is_signed.return_value = False
+        is_completed.return_value = False
 
-    @pytest.mark.skip(reason="See if still needed after implementing CLINs")
-    def test_pending_status(self):
-        to = TaskOrder(number="42")
-        assert to.status == Status.PENDING
+        assert to.status == Status.DRAFT
 
-    @pytest.mark.skip(reason="See if still needed after implementing CLINs")
-    def test_active_status(self):
-        to = TaskOrder(number="42")
+    @patch("atst.models.TaskOrder.end_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.start_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)
+    def test_active_status(self, is_signed, is_completed, start_date, end_date):
+        # Given that I have a signed TO and today is within its start_date and end_date
+        today = pendulum.today().date()
+        to = TaskOrder()
+
+        start_date.return_value = today.subtract(days=1)
+        end_date.return_value = today.add(days=1)
+        is_signed.return_value = True
+        is_completed.return_value = True
+
+        # Its status should be active
         assert to.status == Status.ACTIVE
 
-    @pytest.mark.skip(reason="See if still needed after implementing CLINs")
-    def test_expired_status(self):
-        to = TaskOrder(number="42")
+    @patch("atst.models.TaskOrder.end_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.start_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)
+    def test_upcoming_status(self, is_signed, is_completed, start_date, end_date):
+        # Given that I have a signed TO and today is before its start_date
+        to = TaskOrder()
+        start_date.return_value = pendulum.today().add(days=1).date()
+        end_date.return_value = pendulum.today().add(days=2).date()
+        is_signed.return_value = True
+        is_completed.return_value = True
+
+        # Its status should be upcoming
+        assert to.status == Status.UPCOMING
+
+    @patch("atst.models.TaskOrder.start_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.end_date", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)
+    def test_expired_status(self, is_signed, is_completed, end_date, start_date):
+        # Given that I have a signed TO and today is after its expiration date
+        to = TaskOrder()
+        end_date.return_value = pendulum.today().subtract(days=1).date()
+        start_date.return_value = pendulum.today().subtract(days=2).date()
+        is_signed.return_value = True
+        is_completed.return_value = True
+
+        # Its status should be expired
         assert to.status == Status.EXPIRED
+
+    @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
+    @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)
+    def test_unsigned_status(self, is_signed, is_completed):
+        # Given that I have a TO that is completed but not signed
+        to = TaskOrder(signed_at=pendulum.now().subtract(days=1))
+        is_completed.return_value = True
+        is_signed.return_value = False
+
+        # Its status should be unsigned
+        assert to.status == Status.UNSIGNED
 
 
 class TestBudget:

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -29,15 +29,11 @@ def test_period_of_performance_is_first_to_last_clin():
             CLINFactory.create(
                 start_date=intermediate_start_date, end_date=intermediate_end_date
             ),
-            CLINFactory.create(
-                start_date=start_date, end_date=intermediate_end_date
-            ),
+            CLINFactory.create(start_date=start_date, end_date=intermediate_end_date),
             CLINFactory.create(
                 start_date=intermediate_start_date, end_date=intermediate_end_date
             ),
-            CLINFactory.create(
-                start_date=intermediate_start_date, end_date=end_date
-            ),
+            CLINFactory.create(start_date=intermediate_start_date, end_date=end_date),
             CLINFactory.create(
                 start_date=intermediate_start_date, end_date=intermediate_end_date
             ),

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -1,5 +1,6 @@
 from werkzeug.datastructures import FileStorage
-import pytest, datetime
+import pytest
+from datetime import date
 
 from atst.models import *
 from atst.models.clin import JEDICLINType
@@ -12,6 +13,38 @@ from tests.factories import (
     TaskOrderFactory,
 )
 from tests.mocks import PDF_FILENAME
+
+
+class TestPeriodOfPerformance:
+    def test_period_of_performance_is_first_to_last_clin(self):
+        start_date = date(2019, 6, 6)
+        end_date = date(2020, 6, 6)
+
+        intermediate_start_date = date(2019, 7, 1)
+        intermediate_end_date = date(2020, 3, 1)
+
+        task_order = TaskOrderFactory.create(
+            clins=[
+                CLINFactory.create(
+                    start_date=intermediate_start_date, end_date=intermediate_end_date
+                ),
+                CLINFactory.create(
+                    start_date=start_date, end_date=intermediate_end_date
+                ),
+                CLINFactory.create(
+                    start_date=intermediate_start_date, end_date=intermediate_end_date
+                ),
+                CLINFactory.create(
+                    start_date=intermediate_start_date, end_date=end_date
+                ),
+                CLINFactory.create(
+                    start_date=intermediate_start_date, end_date=intermediate_end_date
+                ),
+            ]
+        )
+
+        assert task_order.start_date == start_date
+        assert task_order.end_date == end_date
 
 
 class TestTaskOrderStatus:

--- a/tests/routes/portfolios/test_index.py
+++ b/tests/routes/portfolios/test_index.py
@@ -100,8 +100,6 @@ def test_portfolio_reports(client, user_session):
     response = client.get(url_for("portfolios.reports", portfolio_id=portfolio.id))
     assert response.status_code == 200
     assert portfolio.name in response.data.decode()
-    expiration_date = task_order.end_date.strftime("%Y-%m-%d")
-    assert expiration_date in response.data.decode()
 
 
 def test_portfolio_reports_with_mock_portfolio(client, user_session):


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166468879

# Description

Implement new designs for the task order funding page. Includes:

- new CLIN-based task order statuses (draft, unsigned, upcoming, active, expired)
- new sorting method for task orders (by status, then by time_created)
- new colors for status labels

# Screenshot

<img width="2376" alt="Screen Shot 2019-06-10 at 1 37 33 PM" src="https://user-images.githubusercontent.com/2583229/59214360-f2628e80-8b84-11e9-80dd-7cfdecbf3a92.png">

# Notes

If you're wondering why I took kind of a strange approach in seed_sample.py, it's because I ran in to some weird issues while trying to create TaskOrders with CLINs, and was only able to get it to work by creating the CLINs separately from the TaskOrders. If I created CLINs directly on the task order, like so,
```
TaskOrderFactory.create(..., clins=[CLINFactory.create(...)])
```
the resulting TO would sometimes include a CLIN, and sometimes wouldn't. Not sure why.