### PR TITLE
Fix error when removing application member

### DIFF
--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -128,15 +128,11 @@ class Applications(BaseDomainClass):
         return invitation
 
     @classmethod
-    def remove_member(cls, application, user_id):
-        application_role = ApplicationRoles.get(
-            user_id=user_id, application_id=application.id
-        )
-
+    def remove_member(cls, application_role):
         application_role.status = ApplicationRoleStatus.DISABLED
         application_role.deleted = True
 
-        for env in application.environments:
+        for env in application_role.application.environments:
             EnvironmentRoles.delete(
                 application_role_id=application_role.id, environment_id=env.id
             )

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -188,16 +188,11 @@ def create_member(application_id):
 @user_can(Permissions.DELETE_APPLICATION_MEMBER, message="remove application member")
 def remove_member(application_id, application_role_id):
     application_role = ApplicationRoles.get_by_id(application_role_id)
-
-    user_name = "a user"
-    if application_role.user:
-        user_name = application_role.user.full_name
-
     Applications.remove_member(application_role)
 
     flash(
         "application_member_removed",
-        user_name=user_name,
+        user_name=application_role.user_name,
         application_name=g.application.name,
     )
 

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -189,14 +189,15 @@ def create_member(application_id):
 def remove_member(application_id, application_role_id):
     application_role = ApplicationRoles.get_by_id(application_role_id)
 
-    Applications.remove_member(
-        application=g.application, user_id=application_role.user_id
-    )
-    user = Users.get(application_role.user_id)
+    user_name = "a user"
+    if application_role.user:
+        user_name = application_role.user.full_name
+
+    Applications.remove_member(application_role)
 
     flash(
         "application_member_removed",
-        user_name=user.full_name,
+        user_name=user_name,
         application_name=g.application.name,
     )
 

--- a/atst/routes/applications/team.py
+++ b/atst/routes/applications/team.py
@@ -9,7 +9,6 @@ from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.environments import Environments
 from atst.domain.exceptions import AlreadyExistsError
 from atst.domain.permission_sets import PermissionSets
-from atst.domain.users import Users
 from atst.forms.application_member import NewForm as NewMemberForm
 from atst.forms.team import TeamForm
 from atst.models import Permissions

--- a/tests/domain/test_applications.py
+++ b/tests/domain/test_applications.py
@@ -147,7 +147,7 @@ def test_remove_member():
         user_id=user.id, application_id=application.id
     )
 
-    Applications.remove_member(application=application, user_id=member_role.user.id)
+    Applications.remove_member(member_role)
 
     assert (
         ApplicationRoles.get(user_id=user.id, application_id=application.id).status

--- a/tests/routes/applications/test_team.py
+++ b/tests/routes/applications/test_team.py
@@ -218,6 +218,30 @@ def test_remove_member_success(client, user_session):
     )
 
 
+def test_remove_new_member_success(client, user_session):
+    application = ApplicationFactory.create()
+    application_role = ApplicationRoleFactory.create(application=application, user=None)
+
+    user_session(application.portfolio.owner)
+
+    response = client.post(
+        url_for(
+            "applications.remove_member",
+            application_id=application.id,
+            application_role_id=application_role.id,
+        )
+    )
+
+    assert response.status_code == 302
+    assert response.location == url_for(
+        "applications.team",
+        _anchor="application-members",
+        _external=True,
+        application_id=application.id,
+        fragment="application-members",
+    )
+
+
 def test_remove_member_failure(client, user_session):
     user = UserFactory.create()
     application = ApplicationFactory.create()


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166544215

# Description
There was a bug that was causing the `applications.remove_member` route to error out. The cause was that we were attempting to query for the `ApplicationRole`'s user, which doesn't exist if the user hasn't yet accepted their invitation. Since we were only querying for the user in order to get their name for a flash message, we could just get that information from the invitation instead.

# Screenshot
<img width="2118" alt="Screen Shot 2019-06-10 at 4 51 24 PM" src="https://user-images.githubusercontent.com/38955572/59226155-60687f00-8ba0-11e9-9f3b-90732a45122e.png">
