### PR TITLE
Upload fixes

### DIFF
--- a/atst/forms/validators.py
+++ b/atst/forms/validators.py
@@ -1,7 +1,10 @@
+from datetime import datetime
 import re
+
+from werkzeug.datastructures import FileStorage
 from wtforms.validators import ValidationError, StopValidation
 import pendulum
-from datetime import datetime
+
 from atst.utils.localization import translate
 
 
@@ -103,7 +106,7 @@ def RequiredIf(criteria_function, message=translate("forms.validators.is_require
 
 def FileLength(max_length=50000000, message=None):
     def _file_length(_form, field):
-        if field.data is None:
+        if field.data is None or not isinstance(field.data, FileStorage):
             return True
 
         content = field.data.read()

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -42,7 +42,12 @@ def edit(portfolio_id, task_order_id=None):
 def update(portfolio_id, task_order_id=None):
     form_data = {**http_request.form, **http_request.files}
 
-    form = TaskOrderForm(form_data)
+    form = None
+    if task_order_id:
+        task_order = TaskOrders.get(task_order_id)
+        form = TaskOrderForm(form_data, obj=task_order)
+    else:
+        form = TaskOrderForm(form_data)
 
     if form.validate():
         task_order = None

--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -26,24 +26,27 @@ export default {
 
   data: function() {
     return {
+      hasInitialData: !!this.initialData,
       attachment: this.initialData || null,
       showErrors: this.initialErrors,
+      changed: false,
     }
   },
 
   methods: {
-    showUploadInput: function() {
-      this.showUpload = true
-    },
     addAttachment: function(e) {
       this.attachment = e.target.value
       this.showErrors = false
+      this.changed = true
     },
     removeAttachment: function(e) {
       e.preventDefault()
       this.attachment = null
-      this.$refs.attachmentInput.value = null
+      if (this.$refs.attachmentInput) {
+        this.$refs.attachmentInput.value = null
+      }
       this.showErrors = false
+      this.changed = true
     },
   },
 
@@ -55,6 +58,9 @@ export default {
     },
     hasAttachment: function() {
       return !!this.attachment
+    },
+    hideInput: function() {
+      return this.hasInitialData && !this.changed
     },
   },
 }

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -20,7 +20,7 @@
         {{ field.label }}
       {% endif %}
       {{ field.description }}
-      <div class="upload-widget">
+      <div v-if="!hideInput" class="upload-widget">
         <label class="upload-label" for="{{ field.name }}">
           <span class="upload-button">
             Browse

--- a/tests/forms/test_validators.py
+++ b/tests/forms/test_validators.py
@@ -100,3 +100,6 @@ class TestFileLength:
 
         with pytest.raises(ValidationError):
             validator(dummy_form, dummy_field)
+
+        dummy_field.data = "random string"
+        assert validator(dummy_form, dummy_field)

--- a/tests/routes/task_orders/test_new.py
+++ b/tests/routes/task_orders/test_new.py
@@ -145,7 +145,7 @@ def test_task_orders_update_pdf(
 def test_task_orders_update_delete_pdf(client, user_session, portfolio, pdf_upload):
     user_session(portfolio.owner)
     task_order = TaskOrderFactory.create(pdf=pdf_upload)
-    data = {"number": "0123456789", "pdf": None}
+    data = {"number": "0123456789", "pdf": ""}
     response = client.post(
         url_for(
             "task_orders.update", portfolio_id=portfolio.id, task_order_id=task_order.id


### PR DESCRIPTION
This fixes two issues with the TO uploader. I'm just going to put the commit messages here:

One:

Only raise FileLength validation error on files

Two:

Display and overwrite task order uploads correctly.

- Populate the POSTed form with additional data from the existing TO model. This way the pdf attachment has to be explicitly overwritten.
- Adjust the frontend so that if there is an existing PDF, it only sends a file input back if the user removes the existing PDF.