### PR TITLE
TO Review Page

### DIFF
--- a/atst/models/clin.py
+++ b/atst/models/clin.py
@@ -28,6 +28,15 @@ class CLIN(Base, mixins.TimestampsMixin):
     obligated_amount = Column(Numeric(scale=2), nullable=False)
     jedi_clin_type = Column(SQLAEnum(JEDICLINType, native_enum=False), nullable=False)
 
+    #
+    # NOTE: For now obligated CLINS are CLIN 1 + CLIN 3
+    #
+    def is_obligated(self):
+        return self.jedi_clin_type in [
+            JEDICLINType.JEDI_CLIN_1,
+            JEDICLINType.JEDI_CLIN_3,
+        ]
+
     def to_dictionary(self):
         return {
             c.name: getattr(self, c.name)

--- a/styles/elements/_icon_link.scss
+++ b/styles/elements/_icon_link.scss
@@ -82,6 +82,12 @@
     @include icon-link-color($color-black-light, $color-gray-lightest);
   }
 
+  &.icon-link--download {
+    @include icon-link-color($color-black) .icon {
+      @include icon-color($color-green);
+    }
+  }
+
   &.icon-link--disabled {
     opacity: 0.3;
     text-decoration: none;

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -34,66 +34,74 @@
 
     <hr>
 
-  <div class="h1">Review your task order</div>
-  <p>Check to make sure the information you entered is correct. After submission, you will confirm this task order was signed by a contracting officer. Thereafter, you will be informed as soon as CCPO completes their review.</p>
+  <div class="h1">
+    {{ "task_orders.review.review_your_task_order" | translate }}
+  </div>
+  <p>
+    {{ "task_orders.review.check_paragraph" | translate }}
+  </p>
   <div class="row">
     <div class="col">
-      <div class="h4">Task order number - 10 digit found in your system of record</div>
+      <div class="h4">
+        {{ "task_orders.review.task_order_number" | translate }}
+      </div>
       <div>{{task_order.number}}</div>
 
       <hr>
 
-      <div class="h3">Funding summary</div>
-      <div>CLIN 1: Unclassified Cloud Services 001</div>
+      <div class="h3">
+        {{ "task_orders.review.funding_summary" | translate }}
+      </div>
+
+      {% for clin in task_order.clins %}
+        <div>
+          {{ "{}".format(clin.jedi_clin_type) | translate}}
+        </div>
         <table>
           <thead>
             <tr>
-              <th>Amount</th>
-              <th>Obligated</th>
-              <th>PoP Start</th>
-              <th>PoP End</th>
-              <th>LOA</th>
+              <th>{{ "task_orders.review.clins.amount" | translate }}</th>
+              <th>{{ "task_orders.review.clins.obligated" | translate }}</th>
+              <th>{{ "task_orders.review.clins.pop_start" | translate }}</th>
+              <th>{{ "task_orders.review.clins.pop_end" | translate }}</th>
+              <th>{{ "task_orders.review.clins.loa" | translate }}</th>
             </tr>
           </thead>
 
           <tbody>
             <tr>
-              <td>$500,000</td>
-              <td>Yes</td>
-              <td>9/07/19</td>
-              <td>9/07/20</td>
-              <td>34820394</td>
+              <td>{{ clin.obligated_amount | dollars }}</td>
+              <td>
+                {% if clin.is_obligated() %}
+                  {{ "common.yes" | translate }}
+                {% else %}
+                  {{ "common.no" | translate }}
+                {% endif %}
+              </td>
+              <td>{{ clin.start_date | formattedDate }}</td>
+              <td>{{ clin.end_date | formattedDate }}</td>
+              <td>
+                {% for loa in clin.loas %}
+                  {{ loa }}
+                  <br />
+                {% endfor %}
+              </td>
             </tr>
           </tbody>
         </table>
-
-      <div>CLIN 2: Unclassified Cloud Services 002</div>
-        <table>
-          <thead>
-            <tr>
-              <th>Amount</th>
-              <th>Obligated</th>
-              <th>PoP Start</th>
-              <th>PoP End</th>
-              <th>LOA</th>
-            </tr>
-          </thead>
-
-          <tbody>
-            <tr>
-              <td>$300,000</td>
-              <td>No</td>
-              <td>9/08/20</td>
-              <td>9/08/21</td>
-              <td>q9384751934</td>
-            </tr>
-          </tbody>
-        </table>
+      {% endfor %}
 
       <hr>
 
-      <div class="h3">Supporting document</div>
-      <div class="h4">{{ Icon('ok',classes="icon-validation") }}document</div>
+      <div class="h3">
+        {{ "task_orders.review.supporting_document.title" | translate }}
+      </div>
+      <div class="h4">
+        <a class="icon-link icon-link--download" href="{{ url_for('task_orders.download_task_order_pdf', task_order_id=task_order.id) }}">
+          {{ Icon('check-circle-solid') }}
+          {{ task_order.pdf.filename }}
+        </a>
+      </div>
     </div>
 
     {{ TotalsBox(task_order=task_order) }}

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -22,7 +22,7 @@
   {% endcall %}
 
   {% call StickyCTA(text="Review Funding") %}
-      <a href="{{ url_for("task_orders.edit", portfolio_id=portfolio.id) }}" class="usa-button usa-button-secondary" type="submit">Edit</a>
+      <a href="{{ url_for("task_orders.edit", portfolio_id=portfolio.id, task_order_id=task_order.id) }}" class="usa-button usa-button-secondary" type="submit">Edit</a>
       <a v-on:click="openModal('submit-to-1')" class="usa-button usa-button-primary" type="submit">Submit task order</a>
   {% endcall %}
 

--- a/tests/models/test_clin.py
+++ b/tests/models/test_clin.py
@@ -1,0 +1,18 @@
+from atst.models import CLIN
+from atst.models.clin import JEDICLINType
+
+from tests.factories import *
+
+
+def test_is_obligated():
+    clin_1 = CLINFactory.create(jedi_clin_type=JEDICLINType.JEDI_CLIN_1)
+    assert clin_1.is_obligated()
+
+    clin_2 = CLINFactory.create(jedi_clin_type=JEDICLINType.JEDI_CLIN_2)
+    assert not clin_2.is_obligated()
+
+    clin_3 = CLINFactory.create(jedi_clin_type=JEDICLINType.JEDI_CLIN_3)
+    assert clin_3.is_obligated()
+
+    clin_4 = CLINFactory.create(jedi_clin_type=JEDICLINType.JEDI_CLIN_4)
+    assert not clin_4.is_obligated()

--- a/translations.yaml
+++ b/translations.yaml
@@ -41,6 +41,8 @@ common:
   hide: Hide
   manage: manage
   members: Members
+  'yes': 'Yes'
+  'no': 'No'
   officer_helpers:
     underscore_to_friendly:
       contracting_officer: Contracting Officer
@@ -606,6 +608,19 @@ requests:
     questions_title_text: Questions related to JEDI Cloud migration
     rationalization_software_systems_tooltip: Rationalization is the DoD process to determine whether the application should move to the cloud.
 task_orders:
+  review:
+    review_your_task_order: Review your task order
+    funding_summary: Funding summary
+    task_order_number: Task order number - 10 digit found in your system of record
+    check_paragraph: Check to make sure the information you entered is correct. After submission, you will confirm this task order was signed by a contracting officer. Thereafter, you will be informed as soon as CCPO completes their review.
+    supporting_document:
+      title: Supporting document
+    clins:
+      amount: Amount
+      obligated: Obligated
+      pop_start: PoP Start
+      pop_end: PoP End
+      loa: LOA
   form:
     draft_alert_title: Your information has been saved
     draft_alert_message: You can return to the Task Order Builder to enter missing information. Once you are finished, you’ll be ready to submit this request.
@@ -731,6 +746,11 @@ task_orders:
       security: '<strong>Security Officer ({security_officer})</strong> completes a Security Requirements Document. <a href="#">Send a reminder</a>'
       sign: '<strong>Contracting Officer ({contracting_officer})</strong> verifies funding to unlock cloud services.'
     whats_next: Here are the remaining steps to get your task order approved.
+JEDICLINType:
+  JEDI_CLIN_1: 'CLIN 1:'
+  JEDI_CLIN_2: 'CLIN 2: Classified Cloud Services - 0002'
+  JEDI_CLIN_3: 'CLIN 3:'
+  JEDI_CLIN_4: 'CLIN 4:'
 testing:
   example_string: Hello World
   example_with_variables: 'Hello, {name}!'


### PR DESCRIPTION
* [Pivotal Tracker](https://www.pivotaltracker.com/story/show/166330688)

---

https://thinkcompany.invisionapp.com/share/PMS9FDI2QEW#/screens/366030080

read-only data
supporting document info is a link

### Why
I want to review the information I have entered for my Task Order before I sign and submit it to ATAT.

**As a Portfolio Funding user**
**I want ** to review my TO information
**So that ** I can ensure it is correct before I sign

### Acceptance Criteria

```gherkin
Scenario: A user has completed the TO entry page
Given I have completed the basic funding form and am on that form page
When I click "Review task order"
Then I am taken to a review page that displays all of the information previously entered for the TO
And I can download the TO documentation PDF that was previously uploaded
And when I click the "Modify" button I am taken back to the "Add funding page", where I can make changes
And when I click "Submit Task Order" in the stick nav bar I am taken to the Submission Modal (see https://www.pivotaltracker.com/story/show/166330884).
```

**Notes:**
The "supporting document" file name is a link for download.