### PR TITLE
Funding page CTAs

### DIFF
--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -85,6 +85,14 @@ class TaskOrder(Base, mixins.TimestampsMixin):
         return self.status == Status.UNSIGNED
 
     @property
+    def has_begun(self):
+        return Clock.today() >= self.start_date
+
+    @property
+    def has_ended(self):
+        return Clock.today() >= self.end_date
+
+    @property
     def is_completed(self):
         return all([self.pdf, self.number, len(self.clins)])
 

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -65,12 +65,24 @@ class TaskOrder(Base, mixins.TimestampsMixin):
             raise TypeError("Could not set attachment with invalid type")
 
     @property
+    def is_draft(self):
+        return self.status == Status.DRAFT
+
+    @property
     def is_active(self):
         return self.status == Status.ACTIVE
 
     @property
+    def is_upcoming(self):
+        return self.status == Status.UPCOMING
+
+    @property
     def is_expired(self):
         return self.status == Status.EXPIRED
+
+    @property
+    def is_unsigned(self):
+        return self.status == Status.UNSIGNED
 
     @property
     def is_completed(self):
@@ -145,10 +157,6 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     @property
     def portfolio_name(self):
         return self.portfolio.name
-
-    @property
-    def is_pending(self):
-        return self.status == Status.PENDING
 
     def to_dictionary(self):
         return {

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -82,6 +82,10 @@
   min-width: 10rem;
 }
 
+.task-order-card__buttons .usa-button-secondary {
+  min-width: 14rem;
+}
+
 .task-order-summary {
   margin-top: $gap * 4;
 

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -27,15 +27,15 @@
       {% else %}
         Starts on
       {% endif %}
+      {{ TaskOrderDateTime(task_order.time_created) }}
     {% else %}
       {% if task_order.has_begun %}
         Began
       {% else %}
         Begins
       {% endif %}
+      {{ TaskOrderDateTime(task_order.start_date) }}
     {% endif %}
-
-    {{ TaskOrderDateTime(task_order.start_date) }}
 
     {% if not task_order.is_draft %}
       &nbsp;&nbsp;|&nbsp;&nbsp;

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -6,14 +6,8 @@
 
 {% block portfolio_content %}
 
-{% macro ViewLink(task_order, text="Edit") %}
-  <a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id) }}" class="usa-button">
-    {{ text }}
-  </a>
-{% endmacro %}
-
-{% macro TaskOrderAction(task_order, text="Edit", route="review_task_order", secondary=False) %}
-  <a href="{{ url_for('task_orders.' + route, task_order_id=task_order.id) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
+{% macro TaskOrderAction(task_order, text="Edit", route="review_task_order", secondary=False, modal=None) %}
+  <a href="{{ url_for('task_orders.' + route, task_order_id=task_order.id, modal=modal) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
     {{ text }}
   </a>
 {% endmacro %}
@@ -64,7 +58,7 @@
     {% elif task_order.is_expired %}
       {{ TaskOrderAction(task_order, text="View") }}
     {% elif task_order.is_unsigned %}
-      {{ TaskOrderAction(task_order, text="Sign", secondary=True) }}
+      {{ TaskOrderAction(task_order, text="Sign", secondary=True, modal="submit-to-1") }}
       {{ TaskOrderAction(task_order, text="View") }}
     {% else %}
     {% endif %}

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -7,7 +7,13 @@
 {% block portfolio_content %}
 
 {% macro ViewLink(task_order, text="Edit") %}
-  <a href="{{ url_for('task_orders.view_task_order', task_order_id=task_order.id) }}" class="usa-button">
+  <a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id) }}" class="usa-button">
+    {{ text }}
+  </a>
+{% endmacro %}
+
+{% macro TaskOrderAction(task_order, text="Edit", route="review_task_order", secondary=False) %}
+  <a href="{{ url_for('task_orders.' + route, task_order_id=task_order.id) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
     {{ text }}
   </a>
 {% endmacro %}
@@ -30,12 +36,14 @@
 
 {% macro TaskOrderActions(task_order) %}
   <div class="task-order-card__buttons">
-    {% if task_order.is_pending %}
-      {{ ViewLink(task_order, text="Edit") }}
-    {% elif task_order.is_active %}
-      {{ ViewLink(task_order, text="Modify") }}
+    {% if task_order.is_draft %}
+      {{ TaskOrderAction(task_order, text="Edit") }}
+    {% elif task_order.is_expired %}
+      {{ TaskOrderAction(task_order, text="View") }}
+    {% elif task_order.is_unsigned %}
+      {{ TaskOrderAction(task_order, text="Sign", secondary=True) }}
+      {{ TaskOrderAction(task_order, text="View") }}
     {% else %}
-      {{ ViewLink(task_order, text="View") }}
     {% endif %}
   </div>
 {% endmacro %}

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -6,8 +6,14 @@
 
 {% block portfolio_content %}
 
-{% macro TaskOrderAction(task_order, text="Edit", route="review_task_order", secondary=False, modal=None) %}
-  <a href="{{ url_for('task_orders.' + route, task_order_id=task_order.id, modal=modal) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
+{% macro TaskOrderReviewButton(task_order, text="Edit", secondary=False, modal=None) %}
+  <a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id, modal=modal) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
+    {{ text }}
+  </a>
+{% endmacro %}
+
+{% macro TaskOrderEditButton(task_order, text="Edit", secondary=False) %}
+  <a href="{{ url_for('task_orders.edit', portfolio_id=task_order.portfolio_id, task_order_id=task_order.id) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
     {{ text }}
   </a>
 {% endmacro %}
@@ -54,12 +60,12 @@
 {% macro TaskOrderActions(task_order) %}
   <div class="task-order-card__buttons">
     {% if task_order.is_draft %}
-      {{ TaskOrderAction(task_order, text="Edit") }}
+      {{ TaskOrderEditButton(task_order, text="Edit") }}
     {% elif task_order.is_expired %}
-      {{ TaskOrderAction(task_order, text="View") }}
+      {{ TaskOrderReviewButton(task_order, text="View") }}
     {% elif task_order.is_unsigned %}
-      {{ TaskOrderAction(task_order, text="Sign", secondary=True, modal="submit-to-1") }}
-      {{ TaskOrderAction(task_order, text="View") }}
+      {{ TaskOrderReviewButton(task_order, text="Sign", secondary=True, modal="submit-to-1") }}
+      {{ TaskOrderReviewButton(task_order, text="View") }}
     {% else %}
     {% endif %}
   </div>

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -24,12 +24,35 @@
 
 {% macro TaskOrderDate(task_order) %}
   <span class="datetime">
-    {% if task_order.is_active %}
-      Began {{ TaskOrderDateTime(task_order.start_date) }} &nbsp;&nbsp;|&nbsp;&nbsp; Ends {{ TaskOrderDateTime(task_order.end_date) }}
-    {% elif task_order.is_expired %}
-      Started {{ TaskOrderDateTime(task_order.start_date) }} &nbsp;&nbsp;|&nbsp;&nbsp; Ended {{ TaskOrderDateTime(task_order.end_date) }}
+    <!-- Draft: {Begins, Began} start_date -->
+    <!-- Everything else: {Starts, Started} start_date | {Ends, Ended} end_date -->
+
+    {% if task_order.is_draft %}
+      {% if task_order.has_begun %}
+        Started on
+      {% else %}
+        Starts on
+      {% endif %}
     {% else %}
-      Started {{ TaskOrderDateTime(task_order.start_date) }}
+      {% if task_order.has_begun %}
+        Began
+      {% else %}
+        Begins
+      {% endif %}
+    {% endif %}
+
+    {{ TaskOrderDateTime(task_order.start_date) }}
+
+    {% if not task_order.is_draft %}
+      &nbsp;&nbsp;|&nbsp;&nbsp;
+
+      {% if task_order.has_ended %}
+        Ended
+      {% else %}
+        Ends
+      {% endif %}
+
+      {{ TaskOrderDateTime(task_order.end_date) }}
     {% endif %}
   </span>
 {% endmacro %}


### PR DESCRIPTION
# Pivotal
A second PR for this story: https://www.pivotaltracker.com/n/projects/2160940/stories/166330906

# Description
Update the CTAs (buttons) for task orders on the funding page. Will look incomplete, since we've decided to omit buttons for pages that don't yet exist.

I also updated the `begins x | ends y` text to match the designs.

# Screenshot
<img width="1287" alt="Screen Shot 2019-06-11 at 2 52 09 PM" src="https://user-images.githubusercontent.com/38955572/59298669-0677c000-8c59-11e9-94c0-82a348448c09.png">
