### PR TITLE
Allow capital letters in email TLD

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -36,7 +36,7 @@ export default {
   },
   email: {
     mask: emailMask,
-    match: /^.+@[^.].*\.[a-z]{2,10}$/,
+    match: /^.+@[^.].*\.[a-zA-Z]{2,10}$/,
     unmask: [],
     validationError: 'Please enter a valid e-mail address',
   },


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166544445

# Description
Update email validation to allow capital letters in the TLD section (.COM, for example).

# Screenshot
<img width="827" alt="Screen Shot 2019-06-11 at 3 37 38 PM" src="https://user-images.githubusercontent.com/38955572/59303709-c1f22180-8c64-11e9-9026-00b9b0ff1df0.png">
