### PR TITLE
Home page fixes

### DIFF
--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -64,7 +64,7 @@
     }
 
     svg > path {
-      transform: translate(0,5px);
+      transform: translate(0, 5px);
     }
   }
 }

--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -47,17 +47,26 @@
   }
 }
 
-.semi-collapsed {
-  overflow: hidden;
-  height: 5.1rem;
+.section-description {
+  font-size: $lead-font-size;
 }
 
 .more {
-  margin-top: -4.4rem;
-  padding-left: 1.25rem;
-  background-color: $color-offwhite;
-  position: relative;
   cursor: pointer;
+  margin-left: 1rem;
+
+  .icon {
+    width: 1rem;
+    margin: 0 0 0 0.5rem;
+
+    svg * {
+      fill: $color-blue;
+    }
+
+    svg > path {
+      transform: translate(0,5px);
+    }
+  }
 }
 
 .green {

--- a/styles/sections/_home.scss
+++ b/styles/sections/_home.scss
@@ -28,7 +28,7 @@
   }
 
   .links {
-    justify-content: normal;
+    justify-content: flex-start;
 
     .icon-link:first-child {
       padding-left: 0;

--- a/templates/components/semi_collapsible_text.html
+++ b/templates/components/semi_collapsible_text.html
@@ -1,14 +1,28 @@
 {% from "components/icon.html" import Icon %}
 
-{% macro SemiCollapsibleText(paragraph) -%}
+{% macro SemiCollapsibleText(first_half=None, second_half=None) -%}
 
   <semi-collapsible-text inline-template>
     <div>
-      <p v-bind:class="{ 'semi-collapsed' : !open }">
-        {{ paragraph }}
+      {% if first_half is none %}
+       {% set first_half="Aenean lacinia bibendum nulla sed consectetur. Sed posuere consectetur est at lobortis. Fusce dapibus an, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo." %}
+      {% endif %}
+      {% if second_half is none %}
+       {% set second_half="Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip." %}
+      {% endif %}
+      <p class="section-description" v-if="open">
+        {{ first_half }}
+        {{ second_half }}
+        <a v-on:click='toggle' v-show="open" class="more">
+          Less{{ Icon('caret_up') }}
+        </a>
       </p>
-      <a v-on:click='toggle' v-show="!open" class="right more">More{{ Icon('caret_down') }}</a>
-      <a v-on:click='toggle' v-show="open" class="right more">Less{{ Icon('caret_up') }}</a>
+      <p class="section-description" v-else>
+        {{ first_half }}
+        <a v-on:click='toggle' class="more">
+          More{{ Icon('caret_down') }}
+        </a>
+      </p>
     </div>
   </semi-collapsible-text>
 

--- a/templates/home.html
+++ b/templates/home.html
@@ -2,6 +2,7 @@
 
 {% from "components/sticky_cta.html" import StickyCTA %}
 {% from "components/icon.html" import Icon %}
+{% from "components/semi_collapsible_text.html" import SemiCollapsibleText %}
 
 {% block content %}
 
@@ -23,15 +24,7 @@
 
     <h1>{{ "home.head" | translate }}</h1>
 
-    <semi-collapsible-text inline-template>
-      <div>
-        <p v-bind:class="{ 'semi-collapsed' : !open }">
-          Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
-        </p>
-        <a v-on:click='toggle' v-show="!open" class="right more">More{{ Icon('caret_down') }}</a>
-        <a v-on:click='toggle' v-show="open" class="right more">Less{{ Icon('caret_up') }}</a>
-      </div>
-    </semi-collapsible-text>
+    {{ SemiCollapsibleText() }}
 
     <div class="your-project">
       <h2 class="h3">{{ "home.your_project" | translate }}</h2>

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -28,9 +28,7 @@
 
   <div class="task-order-summary">
 
-    {% set description = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." %}
-
-    {{ SemiCollapsibleText(paragraph=description) }}
+    {{ SemiCollapsibleText() }}
 
     <hr>
 


### PR DESCRIPTION
Fixes some issues with the PT story for the home page: https://www.pivotaltracker.com/story/show/166330633

I changed the way the less/more description field operates. Based on the designs, Rachel and I agreed that the more/less links should sit inline with the text. This simplifies the styling.