### PR TITLE
Only show first error message on application form

### DIFF
--- a/js/components/forms/new_application.js
+++ b/js/components/forms/new_application.js
@@ -1,5 +1,6 @@
 import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
+import * as R from "ramda"
 
 const createEnvironment = name => ({ name })
 
@@ -35,12 +36,12 @@ export default {
           message: 'Provide at least one environment name.',
         },
         {
-          func: this.envNamesAreUnique,
-          message: 'Environment names must be unique.',
-        },
-        {
           func: this.environmentsHaveNames,
           message: 'Environment names cannot be empty.',
+        },
+        {
+          func: this.envNamesAreUnique,
+          message: 'Environment names must be unique.',
         },
       ],
       errors: [],
@@ -66,13 +67,12 @@ export default {
     },
 
     validate: function() {
-      this.errors = this.validations
-        .map(validation => {
-          if (!validation.func()) {
-            return validation.message
-          }
-        })
-        .filter(Boolean)
+      // Only take first error message
+      this.errors = R.pipe(
+        R.map((validation) => !validation.func() ? validation.message : undefined),
+        R.filter(Boolean),
+        R.take(1)
+      )(this.validations)
     },
 
     hasEnvironments: function() {

--- a/js/components/forms/new_application.js
+++ b/js/components/forms/new_application.js
@@ -1,6 +1,6 @@
 import FormMixin from '../../mixins/form'
 import textinput from '../text_input'
-import * as R from "ramda"
+import * as R from 'ramda'
 
 const createEnvironment = name => ({ name })
 
@@ -69,7 +69,9 @@ export default {
     validate: function() {
       // Only take first error message
       this.errors = R.pipe(
-        R.map((validation) => !validation.func() ? validation.message : undefined),
+        R.map(validation =>
+          !validation.func() ? validation.message : undefined
+        ),
         R.filter(Boolean),
         R.take(1)
       )(this.validations)


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166544558

# Description
The application form was sometimes showing multiple stacked error messages. Now we only display the error message of the first failing validation.

My original idea was to only display the first error message, but the awkward Vue / jinja integration in the `Alert` macro made that a little tricky. Let me know if you have any better ideas.

# Screenshot
<img width="1672" alt="Screen Shot 2019-06-12 at 2 22 54 PM" src="https://user-images.githubusercontent.com/38955572/59376648-81ef7500-8d1e-11e9-92a6-e1f2c02ea6b7.png">
