### PR TITLE
Fix position of checkboxes

### DIFF
--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -224,4 +224,10 @@ body {
   .usa-input .checkbox {
     margin-left: 3rem;
   }
+
+  input[type="checkbox"] {
+    + label::before {
+      margin-left: -3rem;
+    }
+  }
 }

--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -51,7 +51,6 @@
     input[type="checkbox"] {
       + label::before {
         box-shadow: 0 0 0 2px $state-color;
-        margin-left: -3rem;
       }
     }
   }


### PR DESCRIPTION
Just a small styling issue that @montana-mil and I found.

Before:
<img width="679" alt="Screen Shot 2019-06-12 at 4 31 45 PM" src="https://user-images.githubusercontent.com/38955572/59384216-b0c21700-8d2f-11e9-8071-cbdecd11b35a.png">

After:
<img width="678" alt="Screen Shot 2019-06-12 at 4 31 34 PM" src="https://user-images.githubusercontent.com/38955572/59384198-ab64cc80-8d2f-11e9-8956-e5395f96bada.png">
