### PR TITLE
Fix validation quirks in Portfolio form

### DIFF
--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -18,12 +18,17 @@ export default {
       default: false,
     },
     optional: Boolean,
+    nullOption: {
+      type: String,
+      default: ''
+    }
   },
 
   created: function() {
     emitEvent('field-mount', this, {
       optional: this.optional,
       name: this.name,
+      valid: this._isValid(this.value)
     })
   },
 
@@ -41,13 +46,18 @@ export default {
     onInput: function(e) {
       this.showError = false
       this.showValid = true
+      this.value = e.target.value
 
       emitEvent('field-change', this, {
         value: e.target.value,
         name: this.name,
         watch: this.watch,
-        valid: this.showValid,
+        valid: this._isValid(e.target.value)
       })
     },
+
+    _isValid: function(value) {
+      return this.optional || value !== this.nullOption
+    }
   },
 }

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -20,15 +20,15 @@ export default {
     optional: Boolean,
     nullOption: {
       type: String,
-      default: ''
-    }
+      default: '',
+    },
   },
 
   created: function() {
     emitEvent('field-mount', this, {
       optional: this.optional,
       name: this.name,
-      valid: this._isValid(this.value)
+      valid: this._isValid(this.value),
     })
   },
 
@@ -52,12 +52,12 @@ export default {
         value: e.target.value,
         name: this.name,
         watch: this.watch,
-        valid: this._isValid(e.target.value)
+        valid: this._isValid(e.target.value),
       })
     },
 
     _isValid: function(value) {
       return this.optional || value !== this.nullOption
-    }
+    },
   },
 }

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -70,7 +70,7 @@ export default {
     emitEvent('field-mount', this, {
       optional: this.optional,
       name: this.name,
-      valid: this._isValid(this.value)
+      valid: this._isValid(this.value),
     })
   },
 
@@ -150,6 +150,6 @@ export default {
       }
 
       return valid
-    }
+    },
   },
 }

--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -70,6 +70,7 @@ export default {
     emitEvent('field-mount', this, {
       optional: this.optional,
       name: this.name,
+      valid: this._isValid(this.value)
     })
   },
 
@@ -103,15 +104,7 @@ export default {
 
     //
     _checkIfValid: function({ value, invalidate = false }) {
-      // Validate the value
-      let valid = this._validate(value)
-
-      if (!this.modified && this.initialErrors && this.initialErrors.length) {
-        valid = false
-      } else if (this.optional && value === '') {
-        valid = true
-      }
-
+      const valid = this._isValid(value)
       if (this.modified) {
         this.validationError = inputValidations[this.validation].validationError
       }
@@ -144,5 +137,19 @@ export default {
     _validate: function(value) {
       return inputValidations[this.validation].match.test(this._rawValue(value))
     },
+
+    _isValid: function(value) {
+      let valid = this._validate(value)
+
+      if (!this.modified && this.initialErrors && this.initialErrors.length) {
+        valid = false
+      } else if (this.optional && value === '') {
+        valid = true
+      } else if (!this.optional && value === '') {
+        valid = false
+      }
+
+      return valid
+    }
   },
 }

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -25,8 +25,8 @@ export default {
     },
 
     handleFieldMount: function(event) {
-      const { name, optional } = event
-      this.fields[name] = optional
+      const { name, optional, valid } = event
+      this.fields[name] = optional || valid
     },
 
     validateForm: function() {

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -10,6 +10,7 @@
     key='{{ field.name }}'
     v-bind:watch='{{ watch | string | lower }}'
     v-bind:optional={{ optional|lower }}
+    v-bind:null-option="'{{ field.default }}'"
     >
     <div
       v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">

--- a/templates/portfolios/new.html
+++ b/templates/portfolios/new.html
@@ -8,6 +8,7 @@
 {% block content %}
 
 <main class="usa-section usa-content">
+  {% include "fragments/flash.html" %}
   <h1>New Portfolio Form</h1>
   <base-form inline-template>
     <form id="portfolio-create" action="{{ url_for('portfolios.create_portfolio') }}" method="POST">


### PR DESCRIPTION
- Blank fields should be considered invalid, even if they've been changed
- When the form is submitted with errors, fields that were previously valid should still be considered valid
- Show "you've got errors" flash message at the top of the form

This PR includes some changes to our shared Vue components (text_input and options_input). I did a quick peek on some of the other forms, and they look ok to me.