### PR TITLE
Wire Up Totals Box Functionality

### DIFF
--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -16,6 +16,7 @@ def render_task_orders_edit(portfolio_id=None, task_order_id=None, form=None):
         portfolio_id = task_order.portfolio_id
         render_args["form"] = form or TaskOrderForm(**task_order.to_dictionary())
         render_args["task_order_id"] = task_order_id
+        render_args["task_order"] = task_order
     else:
         render_args["form"] = form or TaskOrderForm()
 

--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -1,6 +1,10 @@
 import DateSelector from './date_selector'
+import { emitEvent } from '../lib/emitters'
 import optionsinput from './options_input'
 import textinput from './text_input'
+
+const JEDI_CLIN_TYPE = "jedi_clin_type"
+const OBLIGATED_AMOUNT = "obligated_amount"
 
 export default {
   name: 'clin-fields',
@@ -17,6 +21,7 @@ export default {
       type: Number,
       default: 0,
     },
+    initialClinType: String,
   },
 
   data: function() {
@@ -27,7 +32,12 @@ export default {
       clinIndex: this.initialClinIndex,
       indexOffset: this.initialLoaCount,
       loas: loas,
+      clinType: this.initialClinType,
     }
+  },
+
+  mounted: function() {
+    this.$root.$on('field-change', this.handleFieldChange)
   },
 
   methods: {
@@ -37,6 +47,21 @@ export default {
 
     loaIndex: function(index) {
       return index + this.indexOffset - 1
+    },
+
+    handleFieldChange: function(event) {
+      if (this._uid === event.parent_uid) {
+        if (event.name.includes(JEDI_CLIN_TYPE)) {
+          this.clinType = event.value
+        }
+        else if (event.name.includes(OBLIGATED_AMOUNT)) {
+          emitEvent('clin-change', this, {
+            clinType: this.clinType,
+            amount: event.value,
+          })
+        }
+      }
+
     },
   },
 }

--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -3,8 +3,8 @@ import { emitEvent } from '../lib/emitters'
 import optionsinput from './options_input'
 import textinput from './text_input'
 
-const JEDI_CLIN_TYPE = "jedi_clin_type"
-const OBLIGATED_AMOUNT = "obligated_amount"
+const JEDI_CLIN_TYPE = 'jedi_clin_type'
+const OBLIGATED_AMOUNT = 'obligated_amount'
 
 export default {
   name: 'clin-fields',
@@ -22,6 +22,10 @@ export default {
       default: 0,
     },
     initialClinType: String,
+    initialAmount: {
+      type: Number,
+      default: 0,
+    },
   },
 
   data: function() {
@@ -40,6 +44,14 @@ export default {
     this.$root.$on('field-change', this.handleFieldChange)
   },
 
+  created: function() {
+    emitEvent('clin-change', this, {
+      id: this._uid,
+      clinType: this.clinType,
+      amount: this.initialAmount,
+    })
+  },
+
   methods: {
     addLoa: function(event) {
       ++this.loas
@@ -56,12 +68,12 @@ export default {
         }
         else if (event.name.includes(OBLIGATED_AMOUNT)) {
           emitEvent('clin-change', this, {
+            id: this._uid,
             clinType: this.clinType,
-            amount: event.value,
+            amount: parseFloat(event.value),
           })
         }
       }
-
     },
   },
 }

--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -37,6 +37,7 @@ export default {
       indexOffset: this.initialLoaCount,
       loas: loas,
       clinType: this.initialClinType,
+      amount: this.initialAmount || 0,
     }
   },
 
@@ -61,17 +62,22 @@ export default {
       return index + this.indexOffset - 1
     },
 
+    clinChangeEvent: function() {
+      emitEvent('clin-change', this, {
+        id: this._uid,
+        clinType: this.clinType,
+        amount: this.amount,
+      })
+    },
+
     handleFieldChange: function(event) {
       if (this._uid === event.parent_uid) {
         if (event.name.includes(JEDI_CLIN_TYPE)) {
           this.clinType = event.value
-        }
-        else if (event.name.includes(OBLIGATED_AMOUNT)) {
-          emitEvent('clin-change', this, {
-            id: this._uid,
-            clinType: this.clinType,
-            amount: parseFloat(event.value),
-          })
+          this.clinChangeEvent()
+        } else if (event.name.includes(OBLIGATED_AMOUNT)) {
+          this.amount = parseFloat(event.value)
+          this.clinChangeEvent()
         }
       }
     },

--- a/js/components/forms/to_form.js
+++ b/js/components/forms/to_form.js
@@ -26,6 +26,8 @@ export default {
 
   props: {
     initialClinCount: Number,
+    initialObligated: Number,
+    initialTotal: Number,
   },
 
   data: function() {
@@ -35,8 +37,8 @@ export default {
     return {
       clins,
       clinIndex,
-      totalClinAmount: 0,
-      additionalObligatedAmount: 0,
+      obligated: this.initialObligated || 0,
+      total: this.initialTotal || 0,
     }
   },
 
@@ -51,9 +53,9 @@ export default {
     },
 
     calculateClinAmounts: function (event) {
-      this.totalClinAmount += parseFloat(event.amount - this.totalClinAmount)
+      this.total += parseFloat(event.amount - this.total)
       if (event.clinType.includes('1') || event.clinType.includes('3')) {
-        this.additionalObligatedAmount += parseFloat(event.amount - this.additionalObligatedAmount)
+        this.obligated += parseFloat(event.amount - this.obligated)
       }
     },
   },

--- a/js/components/forms/to_form.js
+++ b/js/components/forms/to_form.js
@@ -61,14 +61,12 @@ export default {
 
       let newTotal = 0
       let newObligated = 0
-      Object.values(this.clinChildren).forEach(
-        function(clin) {
-          newTotal += clin.amount
-          if (clin.type.includes('1', '3')) {
-            newObligated += clin.amount
-          }
+      Object.values(this.clinChildren).forEach(function(clin) {
+        newTotal += clin.amount
+        if (clin.type.includes('1', '3')) {
+          newObligated += clin.amount
         }
-      )
+      })
       this.total = newTotal
       this.obligated = newObligated
     },

--- a/js/components/forms/to_form.js
+++ b/js/components/forms/to_form.js
@@ -39,6 +39,7 @@ export default {
       clinIndex,
       obligated: this.initialObligated || 0,
       total: this.initialTotal || 0,
+      clinChildren: {},
     }
   },
 
@@ -52,11 +53,24 @@ export default {
       ++this.clinIndex
     },
 
-    calculateClinAmounts: function (event) {
-      this.total += parseFloat(event.amount - this.total)
-      if (event.clinType.includes('1') || event.clinType.includes('3')) {
-        this.obligated += parseFloat(event.amount - this.obligated)
+    calculateClinAmounts: function(event) {
+      this.clinChildren[event.id] = {
+        amount: event.amount,
+        type: event.clinType,
       }
+
+      let newTotal = 0
+      let newObligated = 0
+      Object.values(this.clinChildren).forEach(
+        function(clin) {
+          newTotal += clin.amount
+          if (clin.type.includes('1', '3')) {
+            newObligated += clin.amount
+          }
+        }
+      )
+      this.total = newTotal
+      this.obligated = newObligated
     },
   },
 

--- a/js/components/forms/to_form.js
+++ b/js/components/forms/to_form.js
@@ -6,6 +6,7 @@ import FormMixin from '../../mixins/form'
 import optionsinput from '../options_input'
 import SemiCollapsibleText from '../semi_collapsible_text'
 import textinput from '../text_input'
+import TotalsBox from '../totals_box'
 import uploadinput from '../upload_input'
 
 export default {
@@ -19,6 +20,7 @@ export default {
     optionsinput,
     SemiCollapsibleText,
     textinput,
+    TotalsBox,
     uploadinput,
   },
 
@@ -33,13 +35,26 @@ export default {
     return {
       clins,
       clinIndex,
+      totalClinAmount: 0,
+      additionalObligatedAmount: 0,
     }
+  },
+
+  mounted: function() {
+    this.$root.$on('clin-change', this.calculateClinAmounts)
   },
 
   methods: {
     addClin: function(event) {
       ++this.clins
       ++this.clinIndex
+    },
+
+    calculateClinAmounts: function (event) {
+      this.totalClinAmount += parseFloat(event.amount - this.totalClinAmount)
+      if (event.clinType.includes('1') || event.clinType.includes('3')) {
+        this.additionalObligatedAmount += parseFloat(event.amount - this.additionalObligatedAmount)
+      }
     },
   },
 

--- a/js/components/totals_box.js
+++ b/js/components/totals_box.js
@@ -5,18 +5,16 @@ export default {
 
   props: {
     name: String,
-    additionalObligated: Number,
-    additionalContractAmount: Number,
+    obligated: Number,
+    contractAmount: Number,
   },
 
-  data: function() {
-    return {
-      obligated: formatDollars(
-        this.additionalObligated
-      ),
-      contractAmount: formatDollars(
-        this.additionalContractAmount
-      ),
-    }
+  computed: {
+    formattedObligated: function () {
+      return formatDollars(this.obligated)
+    },
+    formattedContractAmount: function () {
+      return formatDollars(this.contractAmount)
+    },
   },
 }

--- a/js/components/totals_box.js
+++ b/js/components/totals_box.js
@@ -1,0 +1,22 @@
+import { formatDollars } from '../lib/dollars'
+
+export default {
+  name: 'totalsbox',
+
+  props: {
+    name: String,
+    additionalObligated: Number,
+    additionalContractAmount: Number,
+  },
+
+  data: function() {
+    return {
+      obligated: formatDollars(
+        this.additionalObligated
+      ),
+      contractAmount: formatDollars(
+        this.additionalContractAmount
+      ),
+    }
+  },
+}

--- a/js/components/totals_box.js
+++ b/js/components/totals_box.js
@@ -10,10 +10,10 @@ export default {
   },
 
   computed: {
-    formattedObligated: function () {
+    formattedObligated: function() {
       return formatDollars(this.obligated)
     },
-    formattedContractAmount: function () {
+    formattedContractAmount: function() {
       return formatDollars(this.contractAmount)
     },
   },

--- a/js/index.js
+++ b/js/index.js
@@ -41,6 +41,7 @@ import DeleteConfirmation from './components/delete_confirmation'
 import NewEnvironment from './components/forms/new_environment'
 import EnvironmentRole from './components/environment_role'
 import SemiCollapsibleText from './components/semi_collapsible_text'
+import TotalsBox from './components/totals_box'
 import ToForm from './components/forms/to_form'
 import ClinFields from './components/clin_fields'
 
@@ -85,6 +86,7 @@ const app = new Vue({
     NewEnvironment,
     EnvironmentRole,
     SemiCollapsibleText,
+    TotalsBox,
     ToForm,
     ClinFields,
   },

--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -60,6 +60,7 @@
     v-bind:initial-clin-index='{{ index }}'
     v-bind:initial-loa-count="{{ fields.loas.data | length }}"
     v-bind:initial-clin-type="'{{ fields.jedi_clin_type.data }}'"
+    v-bind:initial-amount='{{ fields.obligated_amount.data }}'
     inline-template>
     <div>
       <div class="form-row">
@@ -159,7 +160,10 @@
 
                 <div v-for="clin in clins">
                   <hr v-if="clinIndex !== 0">
-                  <clin-fields v-bind:initial-clin-index='clinIndex' inline-template>
+                  <clin-fields
+                    v-bind:initial-clin-index='clinIndex'
+                    v-bind:initial-clin-type="'JEDICLINType.JEDI_CLIN_1'"
+                    inline-template>
                     <div>
                       <div class="form-row">
                         <div class="form-col form-col--two-thirds">
@@ -214,6 +218,7 @@
                               </template>
                             </div>
                           </textinput>
+
                         </div>
                       </div>
 
@@ -398,14 +403,14 @@
             v-bind:contract-amount='total'
             >
               <div class="col totals-box">
-                  <div class="h4">Total obligated funds</div>
-                  <div class="h3" v-html="formattedObligated"></div>
-                  <div>This is the funding allocated to cloud services. It may be 100% or a portion of the total task order budget.</div>
+                <div class="h4">Total obligated funds</div>
+                <div class="h3" v-html="formattedObligated"></div>
+                <div>This is the funding allocated to cloud services. It may be 100% or a portion of the total task order budget.</div>
 
-                  <hr>
+                <hr>
 
-                  <div class="h4">Total contract amount</div>
-                  <div class="h3" v-html="formattedContractAmount"></div>
+                <div class="h4">Total contract amount</div>
+                <div class="h3" v-html="formattedContractAmount"></div>
                 <div>This is the value of all funds obligated for this contract, including -- but not limited to -- funds obligated for the cloud.</div>
               </div>
             </totals-box>

--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -384,6 +384,25 @@
             </div>
             {{ TotalsBox(task_order=task_order) }}
           </div>
+
+          <totals-box
+            inline-template
+            v-bind:additional-obligated='additionalObligatedAmount'
+            v-bind:additional-contract-amount='totalClinAmount'
+            >
+            <div class="col totals-box">
+                <div class="h4">Total obligated funds</div>
+                <div class="h3">!{ obligated }</div>
+                <div>This is the funding allocated to cloud services. It may be 100% or a portion of the total task order budget.</div>
+
+                <hr>
+
+                <div class="h4">Total contract amount</div>
+                <div class="h3">!{ contractAmount }</div>
+              <div>This is the value of all funds obligated for this contract, including -- but not limited to -- funds obligated for the cloud.</div>
+            </div>
+          </totals-box>
+
         </div>
       </div>
     </to-form>

--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -59,6 +59,7 @@
   <clin-fields
     v-bind:initial-clin-index='{{ index }}'
     v-bind:initial-loa-count="{{ fields.loas.data | length }}"
+    v-bind:initial-clin-type="'{{ fields.jedi_clin_type.data }}'"
     inline-template>
     <div>
       <div class="form-row">
@@ -102,7 +103,15 @@
   {% endif %}
   <form id="new-task-order" action='{{ action }}' method="POST" autocomplete="off" enctype="multipart/form-data">
     {{ form.csrf_token }}
-    <to-form inline-template v-bind:initial-clin-count="{{ form.clins.data | length }}">
+
+    {% set obligated = task_order.total_obligated_funds if task_order else 0 %}
+    {% set total = task_order.total_contract_amount if task_order else 0 %}
+
+    <to-form
+      inline-template
+      v-bind:initial-obligated='{{ obligated }}'
+      v-bind:initial-total='{{ total }}'
+      v-bind:initial-clin-count="{{ form.clins.data | length }}">
       <div>
         {% call StickyCTA(text="Add Funding") %}
           <span class="action-group">
@@ -382,26 +391,26 @@
                 </div>
               {{ UploadInput(form.pdf, watch=True) }}
             </div>
-            {{ TotalsBox(task_order=task_order) }}
-          </div>
 
-          <totals-box
+            <totals-box
             inline-template
-            v-bind:additional-obligated='additionalObligatedAmount'
-            v-bind:additional-contract-amount='totalClinAmount'
+            v-bind:obligated='obligated'
+            v-bind:contract-amount='total'
             >
-            <div class="col totals-box">
-                <div class="h4">Total obligated funds</div>
-                <div class="h3">!{ obligated }</div>
-                <div>This is the funding allocated to cloud services. It may be 100% or a portion of the total task order budget.</div>
+              <div class="col totals-box">
+                  <div class="h4">Total obligated funds</div>
+                  <div class="h3" v-html="formattedObligated"></div>
+                  <div>This is the funding allocated to cloud services. It may be 100% or a portion of the total task order budget.</div>
 
-                <hr>
+                  <hr>
 
-                <div class="h4">Total contract amount</div>
-                <div class="h3">!{ contractAmount }</div>
-              <div>This is the value of all funds obligated for this contract, including -- but not limited to -- funds obligated for the cloud.</div>
-            </div>
-          </totals-box>
+                  <div class="h4">Total contract amount</div>
+                  <div class="h3" v-html="formattedContractAmount"></div>
+                <div>This is the value of all funds obligated for this contract, including -- but not limited to -- funds obligated for the cloud.</div>
+              </div>
+            </totals-box>
+
+          </div>
 
         </div>
       </div>


### PR DESCRIPTION
## Description
The totals on the Totals Box were not reactive to user changes on the page. Now when a user changes the CLIN's amount, the appropriate totals are changed in the box, based on the JEDI CLIN type. 

Additionally, if the user changes a CLIN's type, the totals also update accordingly.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166330777

## Screenshots
![Screen Shot 2019-06-17 at 10 16 50 AM](https://user-images.githubusercontent.com/42577527/59611365-2f7cd280-90e9-11e9-8fc6-4cf4f39907a9.png)
