### PR TITLE
Fix audit log pagination urls

### DIFF
--- a/atst/filters.py
+++ b/atst/filters.py
@@ -4,6 +4,7 @@ from atst.utils.localization import translate
 from flask import render_template
 from jinja2 import contextfilter
 from jinja2.exceptions import TemplateNotFound
+from urllib.parse import urlparse, urlunparse, parse_qs, urlencode
 
 
 def iconSvg(name):
@@ -17,6 +18,17 @@ def dollars(value):
     except ValueError:
         numberValue = 0
     return "${:,.2f}".format(numberValue)
+
+
+def with_extra_params(url, **params):
+    """
+    Takes an existing url and safely appends additional query parms.
+    """
+    parsed_url = urlparse(url)
+    parsed_params = parse_qs(parsed_url.query)
+    new_params = {**parsed_params, **params}
+    parsed_url = parsed_url._replace(query=urlencode(new_params))
+    return urlunparse(parsed_url)
 
 
 def usPhone(number):
@@ -63,6 +75,7 @@ def register_filters(app):
     app.jinja_env.filters["dateFromString"] = dateFromString
     app.jinja_env.filters["pageWindow"] = pageWindow
     app.jinja_env.filters["renderAuditEvent"] = renderAuditEvent
+    app.jinja_env.filters["withExtraParams"] = with_extra_params
 
     @contextfilter
     def translateWithoutCache(context, *kwargs):

--- a/templates/components/pagination.html
+++ b/templates/components/pagination.html
@@ -11,7 +11,7 @@
     {% set button_class = button_class + "usa-button-secondary" %}
   {% endif %}
 
-    <a id="{{ label }}" type="button" class="{{ button_class }}" href="{{ url if not disabled else 'null' }}">{{ label }}</a>
+    <a id="{{ label }}" type="button" class="{{ button_class }}" href="{{ url |withExtraParams(page=i) if not disabled else 'null' }}">{{ label }}</a>
 {%- endmacro %}
 
 {% macro Pagination(pagination, url) -%}


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166683704

# Description
A bug was causing each page button in the pagination controls to have the same url, meaning that each button linked to the first page.

Instead of rearchitecting the pagination components, I decide to build a filter that will safely (using a bunch of functions from `urllib.parse`) add query params to a url. I think this is a fine approach, but I understand that it may be controversial.