### PR TITLE
Give the label a max width to prevent text overflow in ie and edge

### DIFF
--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -18,6 +18,10 @@ body {
   .modal__container {
     height: 100vh;
     max-height: 100vh;
+
+    .usa-input .usa-input__choices label {
+      max-width: 62rem;
+    }
   }
 
   .modal__dialog {


### PR DESCRIPTION
## Description
The text for the checkbox label on the task order submit modal was overflowing on IE11 and Edge. Fixed here!

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166330884

## Screenshot
Edge:
![Screen Shot 2019-06-17 at 3 13 32 PM](https://user-images.githubusercontent.com/42577527/59630395-36b8d600-9113-11e9-9eb1-a5bfc890b392.png)
IE11:
![Screen Shot 2019-06-17 at 3 16 24 PM](https://user-images.githubusercontent.com/42577527/59630396-36b8d600-9113-11e9-973e-3013db99945d.png)
