### PR TITLE
Clear checkbox on TO signature modal when it is closed

### DIFF
--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -4,7 +4,7 @@ from . import task_orders_bp
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.domain.portfolios import Portfolios
 from atst.domain.task_orders import TaskOrders
-from atst.forms.task_order import TaskOrderForm, SignatureForm
+from atst.forms.task_order import SignatureForm
 from atst.models import Permissions
 from atst.models.task_order import Status as TaskOrderStatus
 from atst.utils.flash import formatted_flash as flash
@@ -14,12 +14,10 @@ from atst.utils.flash import formatted_flash as flash
 @user_can(Permissions.VIEW_TASK_ORDER_DETAILS, message="review task order details")
 def review_task_order(task_order_id):
     task_order = TaskOrders.get(task_order_id)
-    to_form = TaskOrderForm(number=task_order.number)
     signature_form = SignatureForm()
     return render_template(
         "portfolios/task_orders/review.html",
         task_order=task_order,
-        to_form=to_form,
         signature_form=signature_form,
     )
 

--- a/js/components/submit_confirmation.js
+++ b/js/components/submit_confirmation.js
@@ -10,12 +10,19 @@ export default {
   data: function() {
     return {
       valid: false,
+      checked: false,
     }
   },
 
   methods: {
     toggleValid: function() {
       this.valid = !this.valid
+    },
+
+    handleClose: function() {
+      this.$root.closeModal(this.name)
+      this.checked = false
+      this.valid = false
     },
   },
 }

--- a/templates/components/submit_confirmation.html
+++ b/templates/components/submit_confirmation.html
@@ -14,7 +14,14 @@
           ) }}
         </label>
         <div v-on:change="toggleValid" class="checkbox">
-          {{ CheckboxInput(field=form.signature) }}
+          <div class='usa-input'>
+            <fieldset data-ally-disabled="true" class="usa-input__choices">
+              <legend>
+                {{ form.signature(**{"v-model": "checked"}) }}
+                {{ form.signature.label | safe }}
+              </legend>
+            </fieldset>
+          </div>
         </div>
       </div>
       <div class="action-group">
@@ -24,7 +31,7 @@
             {{ submit_text }}
           </button>
         </form>
-        <button v-on:click="$root.closeModal('{{ modal_id }}')" class="usa-button usa-button-secondary">{{ "common.cancel" | translate }}</button>
+        <button v-on:click="handleClose" class="usa-button usa-button-secondary">{{ "common.cancel" | translate }}</button>
       </div>
     </div>
   </submit-confirmation>


### PR DESCRIPTION
## Description
Updates the TO signature modal so that when you cancel out of the modal, the checkbox is reset.

## Pivotal
https://www.pivotaltracker.com/story/show/166636970