### PR TITLE
Fix CLIN type display

### DIFF
--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -18,8 +18,18 @@ from atst.forms.validators import FileLength
 from atst.utils.localization import translate
 
 
+def coerce_enum(enum_inst):
+    if getattr(enum_inst, "value", None):
+        return enum_inst.value
+    else:
+        return enum_inst
+
+
 class CLINForm(FlaskForm):
-    jedi_clin_type = SelectField("CLIN type", choices=JEDI_CLIN_TYPES)
+    jedi_clin_type = SelectField(
+        "CLIN type", choices=JEDI_CLIN_TYPES, coerce=coerce_enum
+    )
+
     number = StringField(label="CLIN", validators=[Required()])
     start_date = DateField(
         translate("forms.task_order.start_date_label"),

--- a/atst/models/__init__.py
+++ b/atst/models/__init__.py
@@ -8,7 +8,7 @@ from .application_invitation import ApplicationInvitation
 from .application_role import ApplicationRole, Status as ApplicationRoleStatus
 from .attachment import Attachment
 from .audit_event import AuditEvent
-from .clin import CLIN
+from .clin import CLIN, JEDICLINType
 from .environment import Environment
 from .environment_role import EnvironmentRole, CSPRole
 from .notification_recipient import NotificationRecipient

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -14,7 +14,7 @@ def render_task_orders_edit(portfolio_id=None, task_order_id=None, form=None):
     if task_order_id:
         task_order = TaskOrders.get(task_order_id)
         portfolio_id = task_order.portfolio_id
-        render_args["form"] = form or TaskOrderForm(**task_order.to_dictionary())
+        render_args["form"] = form or TaskOrderForm(obj=task_order)
         render_args["task_order_id"] = task_order_id
         render_args["task_order"] = task_order
     else:

--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -169,7 +169,7 @@
                   <hr v-if="clinIndex !== 0">
                   <clin-fields
                     v-bind:initial-clin-index='clinIndex'
-                    v-bind:initial-clin-type="'JEDICLINType.JEDI_CLIN_1'"
+                    v-bind:initial-clin-type="'JEDI_CLIN_1'"
                     inline-template>
                     <div>
                       <div class="form-row">

--- a/tests/forms/test_task_order.py
+++ b/tests/forms/test_task_order.py
@@ -1,0 +1,11 @@
+from atst.forms.task_order import CLINForm
+from atst.models import JEDICLINType
+
+import tests.factories as factories
+
+
+def test_clin_form_jedi_clin_type():
+    jedi_type = JEDICLINType.JEDI_CLIN_2
+    clin = factories.CLINFactory.create(jedi_clin_type=jedi_type)
+    clin_form = CLINForm(obj=clin)
+    assert clin_form.jedi_clin_type.data == jedi_type.value


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/166765021

Fixes a bug where the CLIN type was not displaying correctly for saved TOs.

The enum for the CLIN type needs to be coerced in the form data so that the `jedi_clin_field` data is the value of the enum option. Previously the `jedi_clin_field` was being populated with a stringified representation of the enum, like `JEDICLINType.JEDI_CLIN_1`.