### PR TITLE
Fix Totals Box display on IE11

### DIFF
--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -64,7 +64,7 @@
     margin-left: $gap * 6;
     margin-top: $gap * 3;
     width: 35%;
-    height: fit-content;
+    display: table;
     background-color: $color-gray-lightest;
   }
 


### PR DESCRIPTION
## Description
The Totals Box height was extending to the bottom of the page. This PR uses `display: table;` to fit the height to the box's content.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166765706

## Screenshots
![Screen Shot 2019-06-18 at 11 26 50 AM](https://user-images.githubusercontent.com/42577527/59698543-e3e82880-91bd-11e9-868a-dbd15737620c.png)
