### PR TITLE
Some environments might not have associated users.

### DIFF
--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -21,8 +21,8 @@ def get_environments_obj_for_app(application):
             "id": env.id,
             "name": env.name,
             "edit_form": EditEnvironmentForm(obj=env),
-            "member_count": len(env.users),
-            "members": [user.full_name for user in env.users],
+            "member_count": len(env.roles),
+            "members": [env_role.application_role.user_name for env_role in env.roles],
         }
         environments_obj.append(env_data)
 

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -1,15 +1,7 @@
 import pytest
 from flask import url_for, get_flashed_messages
 
-from tests.factories import (
-    UserFactory,
-    PortfolioFactory,
-    PortfolioRoleFactory,
-    EnvironmentRoleFactory,
-    EnvironmentFactory,
-    ApplicationFactory,
-    ApplicationRoleFactory,
-)
+from tests.factories import *
 
 from atst.domain.applications import Applications
 from atst.domain.environment_roles import EnvironmentRoles
@@ -102,7 +94,8 @@ def test_edit_application_environments_obj(app, client, user_session):
     env_role1 = EnvironmentRoleFactory.create(
         application_role=app_role1, environment=env, role=CSPRole.BASIC_ACCESS.value
     )
-    app_role2 = ApplicationRoleFactory.create(application=application)
+    app_role2 = ApplicationRoleFactory.create(application=application, user=None)
+    invite = ApplicationInvitationFactory.create(role=app_role2)
     env_role2 = EnvironmentRoleFactory.create(
         application_role=app_role2, environment=env, role=CSPRole.NETWORK_ADMIN.value
     )


### PR DESCRIPTION
There was a bug in the application settings route that threw an error if
an environment role and its associated application role did not have an
associated user. Updated to check for the user name on the application role.

To reproduce the bug on master, invite a new application member. Do not accept the invite for that member. Then navigate to the app settings page.