### PR TITLE
Do not return deactivated portfolios in Portfolios.for_user

### DIFF
--- a/atst/domain/portfolios/query.py
+++ b/atst/domain/portfolios/query.py
@@ -48,6 +48,7 @@ class PortfoliosQuery(Query):
                     ),
                 )
             )
+            .filter(Portfolio.deleted == False)
             .order_by(Portfolio.name.asc())
             .all()
         )

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -219,3 +219,9 @@ def test_delete_failure_with_applications():
         Portfolios.delete(portfolio=portfolio)
 
     assert not portfolio.deleted
+
+
+def test_for_user_does_not_include_deleted_portfolios():
+    user = UserFactory.create()
+    PortfolioFactory.create(owner=user, deleted=True)
+    assert len(Portfolios.for_user(user)) == 0


### PR DESCRIPTION
PT story: https://www.pivotaltracker.com/story/show/166794081

This is straightforward: we were not screening out deactivated portfolios when getting a list of portfolios available to a given user.