### PR TITLE
Fix Obligated Amount Masking Issues

### DIFF
--- a/js/components/text_input.js
+++ b/js/components/text_input.js
@@ -103,7 +103,8 @@ export default {
       this.value = e.target.value.trim()
 
       if (this.validation === 'dollars') {
-        this.value = formatDollars(this._rawValue(e.target.value))
+        let value = Number.isNaN(e.target.value) ? '0' : e.target.value
+        this.value = formatDollars(this._rawValue(value))
       }
     },
 

--- a/js/components/totals_box.js
+++ b/js/components/totals_box.js
@@ -11,10 +11,16 @@ export default {
 
   computed: {
     formattedObligated: function() {
-      return formatDollars(this.obligated)
+      return formatDollars(this._filterNaN(this.obligated))
     },
     formattedContractAmount: function() {
-      return formatDollars(this.contractAmount)
+      return formatDollars(this._filterNaN(this.contractAmount))
+    },
+  },
+
+  methods: {
+    _filterNaN: function(value) {
+      return Number.isNaN(value) ? 0 : value
     },
   },
 }

--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -356,7 +356,12 @@
                         </fieldset>
                       </date-selector>
 
-                      <textinput :name="'clins-' + clinIndex + '-obligated_amount'" validation="dollars" :watch='true' inline-template>
+                      <textinput
+                        v-cloak
+                        inline-template
+                        :name="'clins-' + clinIndex + '-obligated_amount'"
+                        validation="dollars"
+                        :watch='true'>
                         <div class="usa-input usa-input--validation--dollars noMaxWidth">
                           <label :for="name">
                             <div class="usa-input__title">Funds obligated for cloud</div>
@@ -373,7 +378,7 @@
                             v-bind:pipe='pipe'
                             v-bind:keep-char-positions='keepCharPositions'
                             v-bind:aria-invalid='showError'
-                            v-bind:show-mask='true'
+                            v-bind:show-mask='false'
                             type='text'
                             :id='name'
                             ref='input'>


### PR DESCRIPTION
## Description
This PR fixes two issues. When there was no value for the obligated amount on the funding page, an `_` was showing up next to the `$`. We fixed this by removing initial masking. 

The second issue was that if the user clicked into the input, then navigated away, a `NaN` would show in the input. That meant that the TotalsBox would also show `NaN`. Now, in that case, the TotalsBox shows `$0.00` and the obligated amount input shows an error.

## Pivotal Tracker
https://www.pivotaltracker.com/story/show/166771971

## Screenshots
Initial
<img width="2012" alt="Screen Shot 2019-06-19 at 10 43 37 AM" src="https://user-images.githubusercontent.com/42577527/59775765-b4015980-927f-11e9-9716-bd33442959f6.png">

On input
<img width="2012" alt="Screen Shot 2019-06-19 at 10 43 43 AM" src="https://user-images.githubusercontent.com/42577527/59775758-b06dd280-927f-11e9-9962-40595101b3fe.png">

On blur
<img width="2012" alt="Screen Shot 2019-06-19 at 10 43 48 AM" src="https://user-images.githubusercontent.com/42577527/59775736-a77d0100-927f-11e9-947c-d3d045273852.png">
