### PR TITLE
Fix app member checkbox alignment in Chrome

### DIFF
--- a/styles/sections/_application_edit.scss
+++ b/styles/sections/_application_edit.scss
@@ -26,6 +26,10 @@
   input[type="checkbox"] + label::before {
     margin-left: 0;
   }
+
+  .input__inline-fields {
+    text-align: left;
+  }
 }
 
 .app-team-settings-link {


### PR DESCRIPTION
# Pivotal
https://www.pivotaltracker.com/story/show/166455356

# Description
This was kind of fixed in a previous PR, but still broken in Chrome for some reason.

# Screenshot (from Chrome)
<img width="837" alt="Screen Shot 2019-06-20 at 10 33 42 AM" src="https://user-images.githubusercontent.com/38955572/59861627-34db5680-934f-11e9-8ae8-98a08bcc150d.png">
