### PR TITLE
Fix IE11 Bug

### DIFF
--- a/templates/task_orders/edit.html
+++ b/templates/task_orders/edit.html
@@ -57,9 +57,9 @@
 
   <clin-fields
     v-bind:initial-clin-index='{{ index }}'
-    v-bind:initial-loa-count="{{ fields.loas.data | length }}"
+    v-bind:initial-loa-count="{{ fields.loas.data | length or 0 }}"
     v-bind:initial-clin-type="'{{ fields.jedi_clin_type.data }}'"
-    v-bind:initial-amount='{{ fields.obligated_amount.data }}'
+    v-bind:initial-amount='{{ fields.obligated_amount.data or 0 }}'
     inline-template>
     <div>
       <div class="form-row">
@@ -115,7 +115,6 @@
       <div>
         {% call StickyCTA(text=('task_orders.form.sticky_header_text' | translate )) %}
           <span class="action-group">
-            <!-- todo: implement the review button -->
             <input
               type="submit"
               formaction="{{ review_action }}"


### PR DESCRIPTION
## Description
There was an issue when saving an incomplete TO - None was getting passed as a value into the clinFields vue component, which was causing errors and the form to completely disappear in ie11! 
Added in a default values for the fields that could be None fixed the issue.

## Pivotal
https://www.pivotaltracker.com/story/show/166765246