### PR TITLE
Persist PDF upload

### DIFF
--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -39,6 +39,7 @@
           id="{{ field.name }}"
           name="{{ field.name }}"
           aria-label="Task Order Upload"
+          v-bind:value="attachment"
           type="file">
       </div>
       {% for error in field.errors %}


### PR DESCRIPTION
## Description
Fixes a bug where if you edited a TO that already had a PDF uploaded, the PDF would be removed.

## Pivotal
https://www.pivotaltracker.com/story/show/167078680