### PR TITLE
Add update route to list of routes for showing the funding icon

### DIFF
--- a/templates/portfolios/header.html
+++ b/templates/portfolios/header.html
@@ -27,7 +27,7 @@
       icon='funding',
       text='navigation.portfolio_navigation.breadcrumbs.funding' | translate,
       url=url_for("task_orders.portfolio_funding", portfolio_id=portfolio.id),
-      active=request.url_rule.endpoint in ["task_orders.portfolio_funding", "task_orders.review_task_order", "task_orders.edit"],
+      active=request.url_rule.endpoint in ["task_orders.portfolio_funding", "task_orders.review_task_order", "task_orders.edit", "task_orders.update"],
     ) }}
     {{ Link(
       icon='applications',


### PR DESCRIPTION
## Description
The funding icon was not blue when the page re-rendered after submitting bad data. Fixed by adding the update route to the list of routes for showing the funding icon.

## Pivotal
https://www.pivotaltracker.com/story/show/166744192

## Screenshot
<img width="1841" alt="Screen Shot 2019-07-12 at 3 19 38 PM" src="https://user-images.githubusercontent.com/43828539/61153196-88594400-a4b8-11e9-9260-a8541a9031be.png">