### PR TITLE
Update team count on apps page

### DIFF
--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -28,7 +28,8 @@
       action_label='Add a new application' if can_create_applications else None,
       action_href=url_for('applications.new', portfolio_id=portfolio.id) if can_create_applications else None,
       icon='cloud',
-      sub_message=None if can_create_applications else 'Please contact your JEDI Cloud portfolio administrator to set up a new application.'
+      sub_message=None if can_create_applications else 'Please contact your JEDI Cloud portfolio administrator to set up a new application.',
+      add_perms=can_create_applications
     ) }}
 
   {% else %}

--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -54,7 +54,7 @@
                   <a
                     href="{{ url_for('applications.team', application_id=application.id) }}"
                     class='icon-link'>
-                      <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.users | length }})</span>
+                      <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.members | length }})</span>
                     </a>
                     <div class='separator'></div>
                   {% endif %}

--- a/templates/portfolios/reports/index.html
+++ b/templates/portfolios/reports/index.html
@@ -143,7 +143,8 @@
       action_label='Add a new application' if can_create_applications else None,
       action_href=url_for('applications.new', portfolio_id=portfolio.id) if can_create_applications else None,
       icon='chart',
-      sub_message=message
+      sub_message=message,
+      add_perms=can_create_applications
     ) }}
   {% else %}
 


### PR DESCRIPTION
## Description
Fixes bug where the team members count was not being updated. 
Fixes another bug where the `EmptyState` macro was not always checking if a user has create perms when displaying the button to add a new application

## Pivotal
https://www.pivotaltracker.com/story/show/167074318
https://www.pivotaltracker.com/story/show/167290210