### PR TITLE
Force lodash resolution to higher patch version

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,9 @@
     "prettier": "^1.16.1",
     "vue-template-compiler": "2.5.15"
   },
+  "resolutions": {
+    "parcel-bundler/**/lodash": "^4.17.13"
+  },
   "browserslist": [
     "last 3 version",
     "> 5%",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5555,10 +5555,10 @@ lodash.without@~4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.4, lodash@~4.17.10:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.4, lodash@~4.17.10:
+  version "4.17.14"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.14.tgz#9ce487ae66c96254fe20b599f21b6816028078ba"
+  integrity sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==
 
 log-symbols@^2.2.0:
   version "2.2.0"


### PR DESCRIPTION
## Description
This forces our dependencies to use a version of lodash that includes a fix for this vulnerability: https://snyk.io/vuln/SNYK-JS-LODASH-73638

## Pivotal
https://www.pivotaltracker.com/story/show/167295195