### PR TITLE
Fix spacing on Funding page

### DIFF
--- a/styles/elements/_card.scss
+++ b/styles/elements/_card.scss
@@ -8,6 +8,8 @@
     display: flex;
     align-items: baseline;
     justify-content: space-around;
+    height: 55px;
+    align-items: center;
 
     .card__status-spacer {
       flex-grow: 10;


### PR DESCRIPTION
## Description
Fixes inconsistent spacing on the Funding page by setting the height on the div that contains the TO status and buttons. Previously if the card did not have a button to edit or view the TO the spacing under the status label was too small. 

## Pivotal
https://www.pivotaltracker.com/story/show/166764643

## Screenshot
<img width="1552" alt="Screen Shot 2019-07-15 at 12 04 28 PM" src="https://user-images.githubusercontent.com/43828539/61230803-c93f9b80-a6f8-11e9-9d91-071b2b779038.png">