### PR TITLE
fixes #167077646, clin type 3 not added to obligated total

### DIFF
--- a/js/components/forms/to_form.js
+++ b/js/components/forms/to_form.js
@@ -63,7 +63,7 @@ export default {
       let newObligated = 0
       Object.values(this.clinChildren).forEach(function(clin) {
         newTotal += clin.amount
-        if (clin.type.includes('1', '3')) {
+        if (clin.type.includes('1') || clin.type.includes('3')) {
           newObligated += clin.amount
         }
       })


### PR DESCRIPTION
Description
---
Fixes a bug where CLIN type 3 funds were not being added to the Obligated Total. This functionality will likely change in the future anyways, but here it is for now.

Pivotal
---
https://www.pivotaltracker.com/story/show/167077646
