### PR TITLE
Change state of pointer when hovering over upload input

### DIFF
--- a/styles/elements/_uploader.scss
+++ b/styles/elements/_uploader.scss
@@ -6,6 +6,7 @@
     border: 1px solid black;
     padding: 0;
     display: block;
+    cursor: pointer;
 
     .upload-button {
       padding: 1rem 1.5rem;
@@ -22,10 +23,9 @@
   }
 
   input {
-    opacity: 0;
+    display: none;
     position: absolute;
     top: 0;
-    cursor: pointer;
   }
 }
 


### PR DESCRIPTION
## Description
Fixes a bug where the pointer reverted to the default in some areas of the upload input. 

The 'Choose file' button (which was hidden using `opacity: 0`) was causing the cursor to use the default pointer when you hovered over it, fixed the issue by changing the input's display to none and changing the cursor of the input's label.

## Pivotal
https://www.pivotaltracker.com/story/show/166744017