### PR TITLE
Activate next buttons on TO form

### DIFF
--- a/js/components/checkbox_input.js
+++ b/js/components/checkbox_input.js
@@ -19,11 +19,20 @@ export default {
     }
   },
 
+  created: function() {
+    emitEvent('field-mount', this, {
+      optional: this.optional,
+      name: this.name,
+      valid: this.isChecked,
+    })
+  },
+
   methods: {
     onInput: function(e) {
       emitEvent('field-change', this, {
         value: e.target.checked,
         name: this.name,
+        valid: this.isChecked,
       })
     },
   },

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -1,6 +1,10 @@
 export default {
   props: {
     initialSelectedSection: String,
+    hasChanges: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   mounted: function() {
@@ -62,12 +66,5 @@ export default {
       fields: {},
       invalid: true,
     }
-  },
-
-  props: {
-    hasChanges: {
-      type: Boolean,
-      default: false,
-    },
   },
 }

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -50,9 +50,11 @@ export default {
 
   computed: {
     canSave: function() {
-      if (!this.invalid) {
+      const formValid = !this.invalid
+
+      if (formValid) {
         return true
-      } else if (this.changed && !this.invalid) {
+      } else if (this.changed && formValid) {
         return true
       } else {
         return false

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -44,6 +44,18 @@ export default {
     },
   },
 
+  computed: {
+    canSave: function() {
+      if (!this.invalid) {
+        return true
+      } else if (this.changed && !this.invalid) {
+        return true
+      } else {
+        return false
+      }
+    },
+  },
+
   data: function() {
     return {
       changed: this.hasChanges,

--- a/templates/task_orders/builder_base.html
+++ b/templates/task_orders/builder_base.html
@@ -13,7 +13,7 @@
             <input
               type="submit"
               tabindex="0"
-              :disabled="!changed"
+              :disabled="!canSave"
               value="{{ next_button_text }}"
               form="to_form"
               class="usa-button usa-button-primary">


### PR DESCRIPTION
## Description
Fixes an issue when a page is valid but no changes have been made to the form the 'Next' button is disabled. 
This was solved by adding the computed property `canSave` to the form mixin, which is used to set whether or not the Next button is disabled. Also updated the checkbox input vue component to emit an event on mount and whether or not it is valid on field-change, the same as has been implemented on other input vue components.

## Pivotal
https://www.pivotaltracker.com/story/show/167235253