### PR TITLE
User can't access TO form review or signature pages with incomplete TO

### DIFF
--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -1,5 +1,4 @@
 import datetime
-from flask import current_app as app
 
 from atst.database import db
 from atst.models.clin import CLIN
@@ -10,10 +9,6 @@ from . import BaseDomainClass
 class TaskOrders(BaseDomainClass):
     model = TaskOrder
     resource_name = "task_order"
-
-    SECTIONS = {"app_info": ["portfolio_name"], "funding": [], "oversight": []}
-
-    UNCLASSIFIED_FUNDING = []
 
     @classmethod
     def create(cls, creator, portfolio_id, number, clins, pdf):
@@ -69,43 +64,6 @@ class TaskOrders(BaseDomainClass):
             )
             db.session.add(clin)
             db.session.commit()
-
-    @classmethod
-    def section_completion_status(cls, task_order, section):
-        if section in TaskOrders.mission_owner_sections():
-            passed = []
-            failed = []
-
-            for attr in TaskOrders.SECTIONS[section]:
-                if getattr(task_order, attr) is not None:
-                    passed.append(attr)
-                else:
-                    failed.append(attr)
-
-            if not failed:
-                return "complete"
-            elif passed and failed:
-                return "draft"
-
-        return "incomplete"
-
-    @classmethod
-    def all_sections_complete(cls, task_order):
-        for section in TaskOrders.SECTIONS.keys():
-            if (
-                TaskOrders.section_completion_status(task_order, section)
-                is not "complete"
-            ):
-                return False
-
-        return True
-
-    @classmethod
-    def mission_owner_sections(cls):
-        section_list = TaskOrders.SECTIONS
-        if not app.config.get("CLASSIFIED"):
-            section_list["funding"] = TaskOrders.UNCLASSIFIED_FUNDING
-        return section_list
 
     @classmethod
     def sort(cls, task_orders: [TaskOrder]) -> [TaskOrder]:

--- a/atst/routes/task_orders/new.py
+++ b/atst/routes/task_orders/new.py
@@ -2,6 +2,7 @@ from flask import g, redirect, render_template, request as http_request, url_for
 
 from . import task_orders_bp
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
+from atst.domain.exceptions import NoAccessError
 from atst.domain.task_orders import TaskOrders
 from atst.forms.task_order import TaskOrderForm, SignatureForm
 from atst.models.permissions import Permissions
@@ -128,6 +129,11 @@ def submit_form_step_three_add_clins(task_order_id):
 @task_orders_bp.route("/task_orders/<task_order_id>/form/step_4")
 @user_can(Permissions.CREATE_TASK_ORDER, message="view task order form")
 def form_step_four_review(task_order_id):
+    task_order = TaskOrders.get(task_order_id)
+
+    if task_order.is_completed == False:
+        raise NoAccessError("task order form review")
+
     return render_task_orders_edit(
         "task_orders/step_4.html", task_order_id=task_order_id
     )
@@ -136,6 +142,11 @@ def form_step_four_review(task_order_id):
 @task_orders_bp.route("/task_orders/<task_order_id>/form/step_5")
 @user_can(Permissions.CREATE_TASK_ORDER, message="view task order form")
 def form_step_five_confirm_signature(task_order_id):
+    task_order = TaskOrders.get(task_order_id)
+
+    if task_order.is_completed == False:
+        raise NoAccessError("task order form signature")
+
     return render_task_orders_edit(
         "task_orders/step_5.html", task_order_id=task_order_id, form=SignatureForm()
     )

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -467,7 +467,11 @@ def test_task_orders_new_get_routes(get_url_assert_status):
     rando = user_with()
 
     portfolio = PortfolioFactory.create(owner=owner)
-    task_order = TaskOrderFactory.create(portfolio=portfolio, creator=owner)
+    task_order = TaskOrderFactory.create(
+        creator=owner,
+        portfolio=portfolio,
+        create_clins=["1234567890123456789012345678901234567890123"],
+    )
 
     for route in get_routes:
         url = url_for(route, task_order_id=task_order.id)


### PR DESCRIPTION
## Description
Adds a check to a user cannot access the TO form review or signature pages unless the TO is complete. This will prevent the data from getting into a weird state and causing issues. 

## Pivotal
https://www.pivotaltracker.com/story/show/167235253