### PR TITLE
Check to make sure clins complete

### DIFF
--- a/atst/models/clin.py
+++ b/atst/models/clin.py
@@ -37,6 +37,19 @@ class CLIN(Base, mixins.TimestampsMixin):
             JEDICLINType.JEDI_CLIN_3,
         ]
 
+    @property
+    def is_completed(self):
+        return all(
+            [
+                self.number,
+                self.start_date,
+                self.end_date,
+                self.obligated_amount,
+                self.jedi_clin_type,
+                len(self.loas),
+            ]
+        )
+
     def to_dictionary(self):
         return {
             c.name: getattr(self, c.name)

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -93,8 +93,12 @@ class TaskOrder(Base, mixins.TimestampsMixin):
         return self.start_date is not None and Clock.today() >= self.end_date
 
     @property
+    def clins_are_completed(self):
+        return all([len(self.clins), (clin.is_completed for clin in self.clins)])
+
+    @property
     def is_completed(self):
-        return all([self.pdf, self.number, len(self.clins)])
+        return all([self.pdf, self.number, self.clins_are_completed])
 
     @property
     def is_signed(self):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -297,6 +297,7 @@ class CLINFactory(Base):
     jedi_clin_type = factory.LazyFunction(
         lambda *args: random.choice(list(clin.JEDICLINType))
     )
+    loas = factory.LazyFunction(random_loa_numbers)
 
 
 class NotificationRecipientFactory(Base):

--- a/tests/models/test_clin.py
+++ b/tests/models/test_clin.py
@@ -16,3 +16,8 @@ def test_is_obligated():
 
     clin_4 = CLINFactory.create(jedi_clin_type=JEDICLINType.JEDI_CLIN_4)
     assert not clin_4.is_obligated()
+
+
+def test_is_completed():
+    assert CLINFactory.create().is_completed
+    assert not CLINFactory.create(loas=[]).is_completed

--- a/tests/models/test_task_order.py
+++ b/tests/models/test_task_order.py
@@ -46,6 +46,12 @@ def test_task_order_completed():
     assert not TaskOrderFactory.create(number=None).is_completed
 
 
+def test_task_order_clins_are_completed():
+    assert TaskOrderFactory.create(clins=[CLINFactory.create()]).clins_are_completed
+    assert not TaskOrderFactory.create().clins_are_completed
+    assert not TaskOrderFactory.create(clins=[]).clins_are_completed
+
+
 class TestTaskOrderStatus:
     @patch("atst.models.TaskOrder.is_completed", new_callable=PropertyMock)
     @patch("atst.models.TaskOrder.is_signed", new_callable=PropertyMock)


### PR DESCRIPTION
## Description
Adds in a check so that a TO without complete CLIN data is not considered completed. 

## Pivotal
https://www.pivotaltracker.com/story/show/167233673
https://www.pivotaltracker.com/story/show/167224368