### PR TITLE
Show app settings and team links for users with app role only

### DIFF
--- a/templates/portfolios/applications/index.html
+++ b/templates/portfolios/applications/index.html
@@ -45,20 +45,16 @@
                 <h3 class='icon-link accordion__title' v-on:click="toggleSection('{{ section_name }}')">{{ application.name }}</h3>
                 <span class='accordion__description'>{{ application.description }}</span>
                 <div class='accordion__actions'>
-                  {% if user_can(permissions.VIEW_APPLICATION) %}
-                    <a class='icon-link' href='{{ url_for("applications.settings", application_id=application.id) }}'>
-                      <span>{{ "portfolios.applications.app_settings_text" | translate }}</span>
-                    </a>
-                    <div class='separator'></div>
-                  {% endif %}
-                  {% if user_can(permissions.VIEW_PORTFOLIO_USERS) %}
+                  <a class='icon-link' href='{{ url_for("applications.settings", application_id=application.id) }}'>
+                    <span>{{ "portfolios.applications.app_settings_text" | translate }}</span>
+                  </a>
+                  <div class='separator'></div>
                   <a
                     href="{{ url_for('applications.team', application_id=application.id) }}"
                     class='icon-link'>
-                      <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.members | length }})</span>
-                    </a>
-                    <div class='separator'></div>
-                  {% endif %}
+                    <span>{{ "portfolios.applications.team_text" | translate }} ({{ application.members | length }})</span>
+                  </a>
+                  <div class='separator'></div>
                   <a class='icon-link triangle-box' v-on:click="toggleSection('{{ section_name }}')">
                     <span>Environments ({{ application.environments|length }})</span>
                     <span v-if="selectedSection === '{{ section_name }}'">

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -80,7 +80,7 @@
         {% include "fragments/flash.html" %}
       {% endif %}
 
-      {% if user_can(permissions.EDIT_APPLICATION) %}
+      {% if user_can(permissions.EDIT_ENVIRONMENT) %}
         {% include "fragments/applications/edit_environments.html" %}
 
         {% if user_can(permissions.CREATE_ENVIRONMENT) %}


### PR DESCRIPTION
## Description
Fixes a bug where the links for app settings and team settings were not appearing for users without a portfolio role. 

## Pivotal
https://www.pivotaltracker.com/story/show/167630115