### PR TITLE
SSL/TLS and Authentication for Kubernetes Clusters

### DIFF
--- a/k8s/aws/atst-nginx-configmap.yml
+++ b/k8s/aws/atst-nginx-configmap.yml
@@ -7,6 +7,16 @@ metadata:
 data:
   nginx-config: |-
     server {
+        listen 8342;
+        server_name aws.atat.code.mil;
+        return 301 https://$host$request_uri;
+    }
+    server {
+        listen 8343;
+        server_name auth-aws.atat.code.mil;
+        return 301 https://$host$request_uri;
+    }
+    server {
         server_name aws.atat.code.mil;
         # access_log /var/log/nginx/access.log json;
         listen 8442 ssl;

--- a/k8s/aws/atst-nginx-configmap.yml
+++ b/k8s/aws/atst-nginx-configmap.yml
@@ -9,11 +9,10 @@ data:
     server {
         server_name aws.atat.code.mil;
         # access_log /var/log/nginx/access.log json;
-        listen 8442;
-        listen [::]:8442 ipv6only=on;
-        # if ($http_x_forwarded_proto != 'https') {
-        #     return 301 https://$host$request_uri;
-        # }
+        listen 8442 ssl;
+        listen [::]:8442 ssl ipv6only=on;
+        ssl_certificate /etc/ssl/private/atat.crt;
+        ssl_certificate_key /etc/ssl/private/atat.key;
         location /login-redirect {
             return 301 https://auth-aws.atat.code.mil$request_uri;
         }
@@ -39,29 +38,14 @@ data:
     server {
         # access_log /var/log/nginx/access.log json;
         server_name auth-aws.atat.code.mil;
-        listen 8443;
-        listen [::]:8443 ipv6only=on;
-        # SSL server certificate and private key
-        # ssl_certificate /etc/ssl/private/auth.atat.crt;
-        # ssl_certificate_key /etc/ssl/private/auth.atat.key;
-        # Set SSL protocols, ciphers, and related options
-        # ssl_protocols TLSv1.3 TLSv1.2;
-        # ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-        # ssl_prefer_server_ciphers on;
-        # ssl_ecdh_curve secp384r1;
-        # ssl_dhparam /etc/ssl/dhparam.pem;
-        # SSL session options
-        # ssl_session_timeout 4h;
-        # ssl_session_cache shared:SSL:10m;   # 1mb = ~4000 sessions
-        # ssl_session_tickets off;
-        # OCSP Stapling
-        # ssl_stapling on;
-        # ssl_stapling_verify on;
-        # resolver 8.8.8.8 8.8.4.4;
+        listen 8443 ssl;
+        listen [::]:8443 ssl ipv6only=on;
+        ssl_certificate /etc/ssl/private/atat.crt;
+        ssl_certificate_key /etc/ssl/private/atat.key;
         # Request and validate client certificate
-        # ssl_verify_client on;
-        # ssl_verify_depth 10;
-        # ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 10;
+        ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {
@@ -73,12 +57,12 @@ data:
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
-            # uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
-            # uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
-            # uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
-            # uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
-            # uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
-            # uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+            uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
+            uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
             uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }

--- a/k8s/aws/aws.yml
+++ b/k8s/aws/aws.yml
@@ -47,8 +47,12 @@ spec:
         - name: nginx
           image: nginx:alpine
           ports:
+            - containerPort: 8342
+              name: main-upgrade
             - containerPort: 8442
               name: main
+            - containerPort: 8343
+              name: auth-upgrade
             - containerPort: 8443
               name: auth
           volumeMounts:
@@ -169,8 +173,12 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   ports:
+  - port: 80
+    targetPort: 8342
+    name: http
   - port: 443
     targetPort: 8442
+    name: https
   selector:
     role: web
   type: LoadBalancer
@@ -186,8 +194,12 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   ports:
+  - port: 80
+    targetPort: 8343
+    name: http
   - port: 443
     targetPort: 8443
+    name: https
   selector:
     role: web
   type: LoadBalancer

--- a/k8s/aws/aws.yml
+++ b/k8s/aws/aws.yml
@@ -60,6 +60,10 @@ spec:
             - name: nginx-htpasswd
               mountPath: "/etc/nginx/.htpasswd"
               subPath: .htpasswd
+            - name: tls
+              mountPath: "/etc/ssl/private"
+            - name: nginx-client-ca-bundle
+              mountPath: "/etc/ssl/"
       volumes:
         - name: atst-config
           secret:
@@ -90,6 +94,16 @@ spec:
             items:
             - key: htpasswd
               path: .htpasswd
+              mode: 0640
+        - name: tls
+          secret:
+            secretName: aws-atat-code-mil-tls
+            items:
+            - key: tls.crt
+              path: atat.crt
+              mode: 0644
+            - key: tls.key
+              path: atat.key
               mode: 0640
 ---
 apiVersion: extensions/v1beta1
@@ -155,7 +169,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   ports:
-  - port: 80
+  - port: 443
     targetPort: 8442
   selector:
     role: web
@@ -172,7 +186,7 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
 spec:
   ports:
-  - port: 80
+  - port: 443
     targetPort: 8443
   selector:
     role: web

--- a/k8s/aws/aws.yml
+++ b/k8s/aws/aws.yml
@@ -57,6 +57,9 @@ spec:
               subPath: atst.conf
             - name: uwsgi-socket-dir
               mountPath: "/var/run/uwsgi"
+            - name: nginx-htpasswd
+              mountPath: "/etc/nginx/.htpasswd"
+              subPath: .htpasswd
       volumes:
         - name: atst-config
           secret:
@@ -81,6 +84,13 @@ spec:
         - name: uwsgi-socket-dir
           emptyDir:
             medium: Memory
+        - name: nginx-htpasswd
+          secret:
+            secretName: atst-nginx-htpasswd
+            items:
+            - key: htpasswd
+              path: .htpasswd
+              mode: 0640
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/k8s/azure/atst-nginx-configmap.yml
+++ b/k8s/azure/atst-nginx-configmap.yml
@@ -9,11 +9,10 @@ data:
     server {
         server_name azure.atat.code.mil;
         # access_log /var/log/nginx/access.log json;
-        listen 8442;
-        listen [::]:8442 ipv6only=on;
-        # if ($http_x_forwarded_proto != 'https') {
-        #     return 301 https://$host$request_uri;
-        # }
+        listen 8442 ssl;
+        listen [::]:8442 ssl ipv6only=on;
+        ssl_certificate /etc/ssl/private/atat.crt;
+        ssl_certificate_key /etc/ssl/private/atat.key;
         location /login-redirect {
             return 301 https://auth-azure.atat.code.mil$request_uri;
         }
@@ -39,29 +38,14 @@ data:
     server {
         # access_log /var/log/nginx/access.log json;
         server_name auth-azure.atat.code.mil;
-        listen 8443;
-        listen [::]:8443 ipv6only=on;
-        # SSL server certificate and private key
-        # ssl_certificate /etc/ssl/private/auth.atat.crt;
-        # ssl_certificate_key /etc/ssl/private/auth.atat.key;
-        # Set SSL protocols, ciphers, and related options
-        # ssl_protocols TLSv1.3 TLSv1.2;
-        # ssl_ciphers 'ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256';
-        # ssl_prefer_server_ciphers on;
-        # ssl_ecdh_curve secp384r1;
-        # ssl_dhparam /etc/ssl/dhparam.pem;
-        # SSL session options
-        # ssl_session_timeout 4h;
-        # ssl_session_cache shared:SSL:10m;   # 1mb = ~4000 sessions
-        # ssl_session_tickets off;
-        # OCSP Stapling
-        # ssl_stapling on;
-        # ssl_stapling_verify on;
-        # resolver 8.8.8.8 8.8.4.4;
+        listen 8443 ssl;
+        listen [::]:8443 ssl ipv6only=on;
+        ssl_certificate /etc/ssl/private/atat.crt;
+        ssl_certificate_key /etc/ssl/private/atat.key;
         # Request and validate client certificate
-        # ssl_verify_client on;
-        # ssl_verify_depth 10;
-        # ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
+        ssl_verify_client on;
+        ssl_verify_depth 10;
+        ssl_client_certificate /etc/ssl/client-ca-bundle.pem;
         # Guard against HTTPS -> HTTP downgrade
         add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; always";
         location / {
@@ -73,12 +57,12 @@ data:
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
-            # uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
-            # uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
-            # uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
-            # uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
-            # uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
-            # uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+            uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
+            uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
+            uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
             uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }

--- a/k8s/azure/atst-nginx-configmap.yml
+++ b/k8s/azure/atst-nginx-configmap.yml
@@ -7,6 +7,16 @@ metadata:
 data:
   nginx-config: |-
     server {
+        listen 8342;
+        server_name azure.atat.code.mil;
+        return 301 https://$host$request_uri;
+    }
+    server {
+        listen 8343;
+        server_name auth-azure.atat.code.mil;
+        return 301 https://$host$request_uri;
+    }
+    server {
         server_name azure.atat.code.mil;
         # access_log /var/log/nginx/access.log json;
         listen 8442 ssl;

--- a/k8s/azure/azure.yml
+++ b/k8s/azure/azure.yml
@@ -60,6 +60,10 @@ spec:
             - name: nginx-htpasswd
               mountPath: "/etc/nginx/.htpasswd"
               subPath: .htpasswd
+            - name: tls
+              mountPath: "/etc/ssl/private"
+            - name: nginx-client-ca-bundle
+              mountPath: "/etc/ssl/"
       volumes:
         - name: atst-config
           secret:
@@ -90,6 +94,16 @@ spec:
             items:
             - key: htpasswd
               path: .htpasswd
+              mode: 0640
+        - name: tls
+          secret:
+            secretName: azure-atat-code-mil-tls
+            items:
+            - key: tls.crt
+              path: atat.crt
+              mode: 0644
+            - key: tls.key
+              path: atat.key
               mode: 0640
 ---
 apiVersion: extensions/v1beta1
@@ -154,7 +168,7 @@ metadata:
 spec:
   loadBalancerIP: 13.92.235.6
   ports:
-  - port: 80
+  - port: 443
     targetPort: 8442
   selector:
     role: web
@@ -170,7 +184,7 @@ metadata:
 spec:
   loadBalancerIP: 23.100.24.41
   ports:
-  - port: 80
+  - port: 443
     targetPort: 8443
   selector:
     role: web

--- a/k8s/azure/azure.yml
+++ b/k8s/azure/azure.yml
@@ -47,8 +47,12 @@ spec:
         - name: nginx
           image: nginx:alpine
           ports:
+            - containerPort: 8342
+              name: main-upgrade
             - containerPort: 8442
               name: main
+            - containerPort: 8343
+              name: auth-upgrade
             - containerPort: 8443
               name: auth
           volumeMounts:
@@ -168,8 +172,12 @@ metadata:
 spec:
   loadBalancerIP: 13.92.235.6
   ports:
+  - port: 80
+    targetPort: 8342
+    name: http
   - port: 443
     targetPort: 8442
+    name: https
   selector:
     role: web
   type: LoadBalancer
@@ -184,8 +192,12 @@ metadata:
 spec:
   loadBalancerIP: 23.100.24.41
   ports:
+  - port: 80
+    targetPort: 8343
+    name: http
   - port: 443
     targetPort: 8443
+    name: https
   selector:
     role: web
   type: LoadBalancer

--- a/k8s/azure/azure.yml
+++ b/k8s/azure/azure.yml
@@ -57,6 +57,9 @@ spec:
               subPath: atst.conf
             - name: uwsgi-socket-dir
               mountPath: "/var/run/uwsgi"
+            - name: nginx-htpasswd
+              mountPath: "/etc/nginx/.htpasswd"
+              subPath: .htpasswd
       volumes:
         - name: atst-config
           secret:
@@ -81,6 +84,13 @@ spec:
         - name: uwsgi-socket-dir
           emptyDir:
             medium: Memory
+        - name: nginx-htpasswd
+          secret:
+            secretName: atst-nginx-htpasswd
+            items:
+            - key: htpasswd
+              path: .htpasswd
+              mode: 0640
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
This PR adds config for two things:
- Password protection for the `/login-dev` endpoint
- Kubernetes SSL/TLS configuration for both the domain certificates and client authentication
These changes have all been applied to the clusters.

I obtained one-time certs from LetsEncrypt. You can verify that HTTPS is enabled by visiting:
- https://azure.atat.code.mil
- https://aws.atat.code.mil

You can verify that client authentication is working by clicking through to the CAC auth on both sites. You should get a 400 error from NGINX (i.e., you failed to provide a valid client certificate) unless you have a CAC.

To verify that auth is enabled on the `/login-dev` endpoint, hit that route for both sites and enter the password information for the `atat` user.

Refer to the commit messages for more implementation details.