### PR TITLE
TO Review page bugs

### DIFF
--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -6,16 +6,10 @@
 
 {% block portfolio_content %}
 
-{% macro TaskOrderReviewButton(task_order, text="Edit", secondary=False, modal=None) %}
-  <a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id, modal=modal) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
-    {{ text }}
-  </a>
-{% endmacro %}
-
-{% macro TaskOrderEditButton(task_order, text="Edit", secondary=False) %}
-  <a href="{{ url_for('task_orders.edit', task_order_id=task_order.id) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
-    {{ text }}
-  </a>
+{% macro TaskOrderButton(task_order, route, text="Edit", secondary=False) %}
+<a href="{{ url_for(route, task_order_id=task_order.id) }}" class="usa-button {{ 'usa-button-secondary' if secondary else '' }}">
+  {{ text }}
+</a>
 {% endmacro %}
 
 {% macro TaskOrderDateTime(dt, className="") %}
@@ -60,14 +54,14 @@
 {% macro TaskOrderActions(task_order) %}
   <div class="task-order-card__buttons">
     {% if task_order.is_draft and user_can(permissions.EDIT_TASK_ORDER_DETAILS) %}
-      {{ TaskOrderEditButton(task_order, text="Edit") }}
+      {{ TaskOrderButton(task_order, "task_orders.edit")}}
     {% elif task_order.is_expired %}
-      {{ TaskOrderReviewButton(task_order, text="View") }}
+      {{ TaskOrderButton(task_order, "task_orders.review_task_order", text="View") }}
     {% elif task_order.is_unsigned %}
       {% if user_can(permissions.EDIT_TASK_ORDER_DETAILS) %}
-        {{ TaskOrderReviewButton(task_order, text="Sign", secondary=True, modal="submit-to-1") }}
+        {{ TaskOrderButton(task_order, "task_orders.form_step_four_review", text="Sign", secondary=True) }}
       {% endif %}
-      {{ TaskOrderReviewButton(task_order, text="View") }}
+      {{ TaskOrderButton(task_order, "task_orders.review_task_order", text="View") }}
     {% endif %}
   </div>
 {% endmacro %}

--- a/templates/portfolios/task_orders/index.html
+++ b/templates/portfolios/task_orders/index.html
@@ -82,7 +82,7 @@
           <h3>Task Order #{{ task_order.number }}</h3>
         </div>
         <div class="card__body">
-          <b>Obligated amount: </b>${{ task_order.total_obligated_funds }}
+          <b>Obligated amount: </b>{{ task_order.total_obligated_funds | dollars }}
         </div>
       </div>
     {% endfor %}

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -8,5 +8,7 @@
       <a href="{{ url_for('task_orders.edit', task_order_id=task_order.id) }}" class="usa-button usa-button-secondary" type="submit">Edit</a>
   {% endcall %}
 
-  {% include "fragments/task_order_review.html" %}
+  <div class="task-order">
+    {% include "fragments/task_order_review.html" %}
+  </div>
 {% endblock %}

--- a/templates/portfolios/task_orders/review.html
+++ b/templates/portfolios/task_orders/review.html
@@ -5,7 +5,9 @@
 {% block portfolio_content %}
 
   {% call StickyCTA(text="Task order details") %}
+    {% if user_can(permissions.EDIT_TASK_ORDER_DETAILS) and not task_order.is_expired %}
       <a href="{{ url_for('task_orders.edit', task_order_id=task_order.id) }}" class="usa-button usa-button-secondary" type="submit">Edit</a>
+    {% endif %}
   {% endcall %}
 
   <div class="task-order">


### PR DESCRIPTION
## Description
This fixes a few issues that slipped through the cracks when we broke the TO into 5 steps:
1. Previously when you clicked the sign button on the TO index page, it opened a modal. We are no longer using a modal to sign the TO so it caused the app to freeze. Removing references to the modal fixed this
2. The template for viewing a TO was never updated, so the formatting was wrong and the edit button was showing on the page even if the TO was expired.
3. Fixes formatting for obligated amount on the TO index page

## Pivotal
https://www.pivotaltracker.com/story/show/167630896
https://www.pivotaltracker.com/story/show/167628215
https://www.pivotaltracker.com/story/show/167630356

## Screenshot
<img width="1525" alt="Screen Shot 2019-08-02 at 3 54 15 PM" src="https://user-images.githubusercontent.com/43828539/62395303-cf79a880-b53d-11e9-82bb-0c1df0bcce51.png">