### PR TITLE
Page for CCPO users list

### DIFF
--- a/atst/domain/permission_sets.py
+++ b/atst/domain/permission_sets.py
@@ -17,7 +17,7 @@ class PermissionSets(object):
     EDIT_PORTFOLIO_ADMIN = "edit_portfolio_admin"
     PORTFOLIO_POC = "portfolio_poc"
     VIEW_AUDIT_LOG = "view_audit_log"
-    EDIT_CCPO_USERS = "edit_ccpo_users"
+    MANAGE_CCPO_USERS = "manage_ccpo_users"
 
     VIEW_APPLICATION = "view_application"
     EDIT_APPLICATION_ENVIRONMENTS = "edit_application_environments"
@@ -59,7 +59,7 @@ ATAT_PERMISSION_SETS = [
         "permissions": [Permissions.VIEW_AUDIT_LOG],
     },
     {
-        "name": PermissionSets.EDIT_CCPO_USERS,
+        "name": PermissionSets.MANAGE_CCPO_USERS,
         "display_name": "View Audit Log",
         "description": "",
         "permissions": [

--- a/atst/domain/permission_sets.py
+++ b/atst/domain/permission_sets.py
@@ -17,6 +17,7 @@ class PermissionSets(object):
     EDIT_PORTFOLIO_ADMIN = "edit_portfolio_admin"
     PORTFOLIO_POC = "portfolio_poc"
     VIEW_AUDIT_LOG = "view_audit_log"
+    EDIT_CCPO_USERS = "edit_ccpo_users"
 
     VIEW_APPLICATION = "view_application"
     EDIT_APPLICATION_ENVIRONMENTS = "edit_application_environments"
@@ -56,7 +57,17 @@ ATAT_PERMISSION_SETS = [
         "display_name": "View Audit Log",
         "description": "",
         "permissions": [Permissions.VIEW_AUDIT_LOG],
-    }
+    },
+    {
+        "name": PermissionSets.EDIT_CCPO_USERS,
+        "display_name": "View Audit Log",
+        "description": "",
+        "permissions": [
+            Permissions.VIEW_CCPO_USER,
+            Permissions.EDIT_CCPO_USER,
+            Permissions.DELETE_CCPO_USER,
+        ],
+    },
 ]
 
 _PORTFOLIO_BASIC_PERMISSION_SETS = [

--- a/atst/domain/users.py
+++ b/atst/domain/users.py
@@ -29,6 +29,10 @@ class Users(object):
         return user
 
     @classmethod
+    def get_ccpo_users(cls):
+        return db.session.query(User).filter(User.permission_sets != None).all()
+
+    @classmethod
     def create(cls, dod_id, permission_sets=None, **kwargs):
         if permission_sets:
             permission_sets = PermissionSets.get_many(permission_sets)

--- a/atst/models/permissions.py
+++ b/atst/models/permissions.py
@@ -1,5 +1,9 @@
 class Permissions(object):
+    # ccpo permissions
     VIEW_AUDIT_LOG = "view_audit_log"
+    VIEW_CCPO_USER = "view_ccpo_user"
+    EDIT_CCPO_USER = "edit_ccpo_user"
+    DELETE_CCPO_USER = "delete_ccpo_user"
 
     # base portfolio perms
     VIEW_PORTFOLIO = "view_portfolio"

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -132,6 +132,12 @@ def activity_history():
     return render_template("audit_log/audit_log.html", audit_events=audit_events)
 
 
+@bp.route("/ccpo-users")
+@user_can(Permissions.VIEW_CCPO_USER, message="view ccpo users")
+def ccpo_users():
+    return render_template("ccpo/users.html")
+
+
 @bp.route("/about")
 def about():
     return render_template("about.html")

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -135,7 +135,8 @@ def activity_history():
 @bp.route("/ccpo-users")
 @user_can(Permissions.VIEW_CCPO_USER, message="view ccpo users")
 def ccpo_users():
-    return render_template("ccpo/users.html")
+    users = Users.get_ccpo_users()
+    return render_template("ccpo/users.html", users=users)
 
 
 @bp.route("/about")

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -31,6 +31,7 @@ _ALL_PERMS = [
     PermissionSets.EDIT_PORTFOLIO_ADMIN,
     PermissionSets.PORTFOLIO_POC,
     PermissionSets.VIEW_AUDIT_LOG,
+    PermissionSets.EDIT_CCPO_USERS,
 ]
 
 

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -31,7 +31,7 @@ _ALL_PERMS = [
     PermissionSets.EDIT_PORTFOLIO_ADMIN,
     PermissionSets.PORTFOLIO_POC,
     PermissionSets.VIEW_AUDIT_LOG,
-    PermissionSets.EDIT_CCPO_USERS,
+    PermissionSets.MANAGE_CCPO_USERS,
 ]
 
 

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div class='col'>
+
+  CCPO Stuff goes here
+
+</div>
+{% endblock %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -2,8 +2,26 @@
 
 {% block content %}
 <div class='col'>
-
-  CCPO Stuff goes here
-
+  <div class="h2">
+    CCPO Users
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>DoD ID</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for user in users %}
+        <tr>
+          <td>{{ user.full_name }}</td>
+          <td>{{ user.email }}</td>
+          <td>{{ user.dod_id }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
 </div>
 {% endblock %}

--- a/tests/domain/test_users.py
+++ b/tests/domain/test_users.py
@@ -74,3 +74,14 @@ def test_update_user_with_last_login():
     last_login = new_user.last_login
     Users.update_last_login(new_user)
     assert new_user.last_login > last_login
+
+
+def test_get_ccpo_users():
+    ccpo_1 = UserFactory.create_ccpo()
+    ccpo_2 = UserFactory.create_ccpo()
+    rando = UserFactory.create()
+
+    ccpo_users = Users.get_ccpo_users()
+    assert ccpo_1 in ccpo_users
+    assert ccpo_2 in ccpo_users
+    assert rando not in ccpo_users

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -122,7 +122,7 @@ def test_atst_activity_history_access(get_url_assert_status):
 
 # atst.ccpo_users
 def test_atst_ccpo_users_access(get_url_assert_status):
-    ccpo = user_with(PermissionSets.EDIT_CCPO_USERS)
+    ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
     url = url_for("atst.ccpo_users")

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -120,6 +120,16 @@ def test_atst_activity_history_access(get_url_assert_status):
     get_url_assert_status(rando, url, 404)
 
 
+# atst.ccpo_users
+def test_atst_ccpo_users_access(get_url_assert_status):
+    ccpo = user_with(PermissionSets.EDIT_CCPO_USERS)
+    rando = user_with()
+
+    url = url_for("atst.ccpo_users")
+    get_url_assert_status(ccpo, url, 200)
+    get_url_assert_status(rando, url, 404)
+
+
 # applications.access_environment
 def test_applications_access_environment_access(get_url_assert_status):
     dev = UserFactory.create()


### PR DESCRIPTION
## Description
Creates a page where a CCPO user can view a list of all of the CCPO users.  Adds new permissions to the `ATAT_PERMISSION_SETS` that correspond with the ability to view/edit/add/remove CCPO users.

When testing locally, you will need to reset your database so Sam (the CCPO user) gets the new CCPO permissions.

## Pivotal
https://www.pivotaltracker.com/story/show/167498650

## Screenshot
<img width="1111" alt="Screen Shot 2019-08-05 at 4 19 22 PM" src="https://user-images.githubusercontent.com/43828539/62492540-d8b48080-b79c-11e9-954a-8b2761c7bd82.png">