### PR TITLE
More styling fixes

### DIFF
--- a/styles/components/_usa_banner.scss
+++ b/styles/components/_usa_banner.scss
@@ -2,7 +2,7 @@
   display: flex;
   align-items: center;
   padding: ($gap / 2) $gap;
-  z-index: 5;
+  z-index: 15;
 
   img {
     flex-grow: 0;

--- a/styles/sections/_task_order.scss
+++ b/styles/sections/_task_order.scss
@@ -35,10 +35,24 @@
     margin-top: 1rem;
     table-layout: fixed;
 
-    td {
-      overflow: hidden;
+    th {
       white-space: nowrap;
-      text-overflow: ellipsis;
+      word-wrap: normal;
+      padding: 0.8rem;
+
+      &.task-order__clin-amount {
+        width: 25%;
+      }
+    }
+
+    td {
+      padding: 0.8rem;
+
+      &.task-order__loa {
+        overflow: hidden;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+      }
     }
   }
 

--- a/templates/fragments/task_order_review.html
+++ b/templates/fragments/task_order_review.html
@@ -39,7 +39,7 @@
           <table class="fixed-table-wrapper">
             <thead>
               <tr>
-                <th>{{ "task_orders.review.clins.amount" | translate }}</th>
+                <th class="task-order__clin-amount">{{ "task_orders.review.clins.amount" | translate }}</th>
                 <th>{{ "task_orders.review.clins.obligated" | translate }}</th>
                 <th>{{ "task_orders.review.clins.pop_start" | translate }}</th>
                 <th>{{ "task_orders.review.clins.pop_end" | translate }}</th>
@@ -59,7 +59,7 @@
                 </td>
                 <td>{{ clin.start_date | formattedDate }}</td>
                 <td>{{ clin.end_date | formattedDate }}</td>
-                <td>
+                <td class="task-order__loa">
                   {% for loa in clin.loas %}
                     <span title='{{ loa }}'>
                       {{ loa }}


### PR DESCRIPTION
## Description
Fixes tooltip hiding behind the sticky header and the numbers and dates being truncated in the TO review table

## Pivotal
https://www.pivotaltracker.com/story/show/167280465
https://www.pivotaltracker.com/story/show/167609376

## Screenshots
<img width="1807" alt="Screen Shot 2019-08-06 at 12 02 32 PM" src="https://user-images.githubusercontent.com/43828539/62556064-1cad9100-b842-11e9-9c6b-3ab3074bb39d.png">
<img width="1807" alt="Screen Shot 2019-08-06 at 12 02 27 PM" src="https://user-images.githubusercontent.com/43828539/62556072-1fa88180-b842-11e9-9e54-795f3d58f098.png">