### PR TITLE
Add CCPO user

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -18,6 +18,7 @@ from atst.routes.applications import applications_bp
 from atst.routes.dev import bp as dev_routes
 from atst.routes.users import bp as user_routes
 from atst.routes.errors import make_error_pages
+from atst.routes.ccpo import bp as ccpo_routes
 from atst.domain.authnid.crl import CRLCache, NoOpCRLCache
 from atst.domain.auth import apply_authentication
 from atst.domain.authz import Authorization
@@ -78,6 +79,7 @@ def make_app(config):
     app.register_blueprint(task_orders_bp)
     app.register_blueprint(applications_bp)
     app.register_blueprint(user_routes)
+    app.register_blueprint(ccpo_routes)
 
     if ENV != "prod":
         app.register_blueprint(dev_routes)

--- a/atst/domain/permission_sets.py
+++ b/atst/domain/permission_sets.py
@@ -64,6 +64,7 @@ ATAT_PERMISSION_SETS = [
         "description": "",
         "permissions": [
             Permissions.VIEW_CCPO_USER,
+            Permissions.CREATE_CCPO_USER,
             Permissions.EDIT_CCPO_USER,
             Permissions.DELETE_CCPO_USER,
         ],

--- a/atst/domain/users.py
+++ b/atst/domain/users.py
@@ -88,6 +88,18 @@ class Users(object):
         return user
 
     @classmethod
+    def update_ccpo_permissions(cls, user, add_perms=False):
+        if add_perms:
+            permission_sets = PermissionSets.get_all()
+        else:
+            permission_sets = []
+
+        user.permission_sets = permission_sets
+        db.session.add(user)
+        db.session.commit()
+        return user
+
+    @classmethod
     def update_last_login(cls, user):
         user.last_login = datetime.now()
         db.session.add(user)

--- a/atst/domain/users.py
+++ b/atst/domain/users.py
@@ -88,13 +88,15 @@ class Users(object):
         return user
 
     @classmethod
-    def update_ccpo_permissions(cls, user, add_perms=False):
-        if add_perms:
-            permission_sets = PermissionSets.get_all()
-        else:
-            permission_sets = []
+    def give_ccpo_perms(cls, user):
+        user.permission_sets = PermissionSets.get_all()
+        db.session.add(user)
+        db.session.commit()
+        return user
 
-        user.permission_sets = permission_sets
+    @classmethod
+    def revoke_ccpo_perms(cls, user):
+        user.permission_sets = []
         db.session.add(user)
         db.session.commit()
         return user

--- a/atst/forms/ccpo_user.py
+++ b/atst/forms/ccpo_user.py
@@ -1,0 +1,13 @@
+from flask_wtf import FlaskForm
+from wtforms.validators import Required, Length
+from wtforms.fields import StringField
+
+from atst.forms.validators import IsNumber
+from atst.utils.localization import translate
+
+
+class CCPOUserForm(FlaskForm):
+    dod_id = StringField(
+        translate("forms.new_member.dod_id_label"),
+        validators=[Required(), Length(min=10), IsNumber()],
+    )

--- a/atst/forms/ccpo_user.py
+++ b/atst/forms/ccpo_user.py
@@ -9,5 +9,5 @@ from atst.utils.localization import translate
 class CCPOUserForm(FlaskForm):
     dod_id = StringField(
         translate("forms.new_member.dod_id_label"),
-        validators=[Required(), Length(min=10), IsNumber()],
+        validators=[Required(), Length(min=10, max=10), IsNumber()],
     )

--- a/atst/models/permissions.py
+++ b/atst/models/permissions.py
@@ -2,6 +2,7 @@ class Permissions(object):
     # ccpo permissions
     VIEW_AUDIT_LOG = "view_audit_log"
     VIEW_CCPO_USER = "view_ccpo_user"
+    CREATE_CCPO_USER = "create_ccpo_user"
     EDIT_CCPO_USER = "edit_ccpo_user"
     DELETE_CCPO_USER = "delete_ccpo_user"
 

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -24,10 +24,12 @@ from atst.domain.common import Paginator
 from atst.domain.portfolios import Portfolios
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
 from atst.models.permissions import Permissions
+from atst.utils.context_processors import atat as atat_context_processor
 from atst.utils.flash import formatted_flash as flash
 
 
 bp = Blueprint("atst", __name__)
+bp.context_processor(atat_context_processor)
 
 
 @bp.route("/")

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -128,50 +128,6 @@ def logout():
     return response
 
 
-@bp.route("/activity-history")
-@user_can(Permissions.VIEW_AUDIT_LOG, message="view activity log")
-def activity_history():
-    pagination_opts = Paginator.get_pagination_opts(request)
-    audit_events = AuditLog.get_all_events(pagination_opts)
-    return render_template("audit_log/audit_log.html", audit_events=audit_events)
-
-
-@bp.route("/ccpo-users")
-@user_can(Permissions.VIEW_CCPO_USER, message="view ccpo users")
-def ccpo_users():
-    users = Users.get_ccpo_users()
-    return render_template("ccpo/users.html", users=users)
-
-
-@bp.route("/ccpo-users/new")
-@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def add_new_ccpo_user():
-    form = CCPOUserForm()
-    return render_template("ccpo/add_user.html", form=form)
-
-
-@bp.route("/ccpo-users/new", methods=["POST"])
-@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def submit_add_new_ccpo_user():
-    try:
-        new_user = Users.get_by_dod_id(request.form["dod_id"])
-        form = CCPOUserForm(obj=new_user)
-    except NotFoundError:
-        new_user = None
-        form = CCPOUserForm()
-
-    return render_template("ccpo/confirm_user.html", new_user=new_user, form=form)
-
-
-@bp.route("/ccpo-users/confirm-new", methods=["POST"])
-@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def confirm_new_ccpo_user():
-    user = Users.get_by_dod_id(request.form["dod_id"])
-    Users.update_ccpo_permissions(user, add_perms=True)
-    flash("ccpo_user_added", user_name=user.full_name)
-    return redirect(url_for("atst.ccpo_users"))
-
-
 @bp.route("/about")
 def about():
     return render_template("about.html")

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -154,7 +154,7 @@ def add_new_ccpo_user():
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
 def submit_add_new_ccpo_user():
     try:
-        new_user = Users.get_by_dod_id(request.form['dod_id'])
+        new_user = Users.get_by_dod_id(request.form["dod_id"])
         form = CCPOUserForm(obj=new_user)
     except NotFoundError:
         new_user = None
@@ -166,9 +166,9 @@ def submit_add_new_ccpo_user():
 @bp.route("/ccpo-users/confirm-new", methods=["POST"])
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
 def confirm_new_ccpo_user():
-    new_user = Users.get_by_dod_id(request.form['dod_id'])
-    # give new perms here
-    # flash w/ success message
+    user = Users.get_by_dod_id(request.form["dod_id"])
+    Users.update_ccpo_permissions(user, add_perms=True)
+    flash("ccpo_user_added", user_name=user.full_name)
     return redirect(url_for("atst.ccpo_users"))
 
 

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -21,8 +21,10 @@ from atst.domain.authnid import AuthenticationContext
 from atst.domain.audit_log import AuditLog
 from atst.domain.auth import logout as _logout
 from atst.domain.common import Paginator
+from atst.domain.exceptions import NotFoundError
 from atst.domain.portfolios import Portfolios
 from atst.domain.authz.decorator import user_can_access_decorator as user_can
+from atst.forms.ccpo_user import CCPOUserForm
 from atst.models.permissions import Permissions
 from atst.utils.context_processors import atat as atat_context_processor
 from atst.utils.flash import formatted_flash as flash
@@ -139,6 +141,35 @@ def activity_history():
 def ccpo_users():
     users = Users.get_ccpo_users()
     return render_template("ccpo/users.html", users=users)
+
+
+@bp.route("/ccpo-users/new")
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def add_new_ccpo_user():
+    form = CCPOUserForm()
+    return render_template("ccpo/add_user.html", form=form)
+
+
+@bp.route("/ccpo-users/new", methods=["POST"])
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def submit_add_new_ccpo_user():
+    try:
+        new_user = Users.get_by_dod_id(request.form['dod_id'])
+        form = CCPOUserForm(obj=new_user)
+    except NotFoundError:
+        new_user = None
+        form = CCPOUserForm()
+
+    return render_template("ccpo/confirm_user.html", new_user=new_user, form=form)
+
+
+@bp.route("/ccpo-users/confirm-new", methods=["POST"])
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def confirm_new_ccpo_user():
+    new_user = Users.get_by_dod_id(request.form['dod_id'])
+    # give new perms here
+    # flash w/ success message
+    return redirect(url_for("atst.ccpo_users"))
 
 
 @bp.route("/about")

--- a/atst/routes/__init__.py
+++ b/atst/routes/__init__.py
@@ -18,20 +18,11 @@ from werkzeug.exceptions import NotFound
 
 from atst.domain.users import Users
 from atst.domain.authnid import AuthenticationContext
-from atst.domain.audit_log import AuditLog
 from atst.domain.auth import logout as _logout
-from atst.domain.common import Paginator
-from atst.domain.exceptions import NotFoundError
-from atst.domain.portfolios import Portfolios
-from atst.domain.authz.decorator import user_can_access_decorator as user_can
-from atst.forms.ccpo_user import CCPOUserForm
-from atst.models.permissions import Permissions
-from atst.utils.context_processors import atat as atat_context_processor
 from atst.utils.flash import formatted_flash as flash
 
 
 bp = Blueprint("atst", __name__)
-bp.context_processor(atat_context_processor)
 
 
 @bp.route("/")

--- a/atst/routes/ccpo.py
+++ b/atst/routes/ccpo.py
@@ -53,6 +53,6 @@ def submit_add_new_ccpo_user():
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
 def confirm_new_ccpo_user():
     user = Users.get_by_dod_id(request.form["dod_id"])
-    Users.update_ccpo_permissions(user, add_perms=True)
+    Users.give_ccpo_perms(user)
     flash("ccpo_user_added", user_name=user.full_name)
     return redirect(url_for("ccpo.ccpo_users"))

--- a/atst/routes/ccpo.py
+++ b/atst/routes/ccpo.py
@@ -24,21 +24,21 @@ def activity_history():
 
 @bp.route("/ccpo-users")
 @user_can(Permissions.VIEW_CCPO_USER, message="view ccpo users")
-def ccpo_users():
+def users():
     users = Users.get_ccpo_users()
     return render_template("ccpo/users.html", users=users)
 
 
 @bp.route("/ccpo-users/new")
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def add_new_ccpo_user():
+def add_new_user():
     form = CCPOUserForm()
     return render_template("ccpo/add_user.html", form=form)
 
 
 @bp.route("/ccpo-users/new", methods=["POST"])
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def submit_add_new_ccpo_user():
+def submit_new_user():
     try:
         new_user = Users.get_by_dod_id(request.form["dod_id"])
         form = CCPOUserForm(obj=new_user)
@@ -51,8 +51,8 @@ def submit_add_new_ccpo_user():
 
 @bp.route("/ccpo-users/confirm-new", methods=["POST"])
 @user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
-def confirm_new_ccpo_user():
+def confirm_new_user():
     user = Users.get_by_dod_id(request.form["dod_id"])
     Users.give_ccpo_perms(user)
     flash("ccpo_user_added", user_name=user.full_name)
-    return redirect(url_for("ccpo.ccpo_users"))
+    return redirect(url_for("ccpo.users"))

--- a/atst/routes/ccpo.py
+++ b/atst/routes/ccpo.py
@@ -43,8 +43,8 @@ def submit_new_user():
         new_user = Users.get_by_dod_id(request.form["dod_id"])
         form = CCPOUserForm(obj=new_user)
     except NotFoundError:
-        new_user = None
-        form = CCPOUserForm()
+        flash("ccpo_user_not_found")
+        return redirect(url_for("ccpo.users"))
 
     return render_template("ccpo/confirm_user.html", new_user=new_user, form=form)
 

--- a/atst/routes/ccpo.py
+++ b/atst/routes/ccpo.py
@@ -1,0 +1,58 @@
+from flask import Blueprint, render_template, redirect, url_for, request
+from atst.domain.users import Users
+from atst.domain.audit_log import AuditLog
+from atst.domain.common import Paginator
+from atst.domain.exceptions import NotFoundError
+from atst.domain.authz.decorator import user_can_access_decorator as user_can
+from atst.forms.ccpo_user import CCPOUserForm
+from atst.models.permissions import Permissions
+from atst.utils.context_processors import atat as atat_context_processor
+from atst.utils.flash import formatted_flash as flash
+
+
+bp = Blueprint("ccpo", __name__)
+bp.context_processor(atat_context_processor)
+
+
+@bp.route("/activity-history")
+@user_can(Permissions.VIEW_AUDIT_LOG, message="view activity log")
+def activity_history():
+    pagination_opts = Paginator.get_pagination_opts(request)
+    audit_events = AuditLog.get_all_events(pagination_opts)
+    return render_template("audit_log/audit_log.html", audit_events=audit_events)
+
+
+@bp.route("/ccpo-users")
+@user_can(Permissions.VIEW_CCPO_USER, message="view ccpo users")
+def ccpo_users():
+    users = Users.get_ccpo_users()
+    return render_template("ccpo/users.html", users=users)
+
+
+@bp.route("/ccpo-users/new")
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def add_new_ccpo_user():
+    form = CCPOUserForm()
+    return render_template("ccpo/add_user.html", form=form)
+
+
+@bp.route("/ccpo-users/new", methods=["POST"])
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def submit_add_new_ccpo_user():
+    try:
+        new_user = Users.get_by_dod_id(request.form["dod_id"])
+        form = CCPOUserForm(obj=new_user)
+    except NotFoundError:
+        new_user = None
+        form = CCPOUserForm()
+
+    return render_template("ccpo/confirm_user.html", new_user=new_user, form=form)
+
+
+@bp.route("/ccpo-users/confirm-new", methods=["POST"])
+@user_can(Permissions.CREATE_CCPO_USER, message="create ccpo user")
+def confirm_new_ccpo_user():
+    user = Users.get_by_dod_id(request.form["dod_id"])
+    Users.update_ccpo_permissions(user, add_perms=True)
+    flash("ccpo_user_added", user_name=user.full_name)
+    return redirect(url_for("ccpo.ccpo_users"))

--- a/atst/utils/context_processors.py
+++ b/atst/utils/context_processors.py
@@ -119,3 +119,10 @@ def portfolio():
         "funding_end_date": funding_end_date,
         "funded": funded,
     }
+
+
+def atat():
+    return {
+        "permissions": Permissions,
+        "user_can": user_can_view,
+    }

--- a/atst/utils/context_processors.py
+++ b/atst/utils/context_processors.py
@@ -122,7 +122,4 @@ def portfolio():
 
 
 def atat():
-    return {
-        "permissions": Permissions,
-        "user_can": user_can_view,
-    }
+    return {"permissions": Permissions, "user_can": user_can_view}

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -35,6 +35,11 @@ MESSAGES = {
         "message_template": "You have successfully given {{ user_name }} CCPO permissions.",
         "category": "success",
     },
+    "ccpo_user_not_found": {
+        "title_template": translate("ccpo.form.user_not_found_title"),
+        "message_template": translate("ccpo.form.user_not_found_text"),
+        "category": "info",
+    },
     "environment_added": {
         "title_template": translate("flash.success"),
         "message_template": """

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -30,6 +30,11 @@ MESSAGES = {
         "message_template": "You have successfully deleted {{ user_name }} from {{ application_name }}",
         "category": "success",
     },
+    "ccpo_user_added": {
+        "title_template": translate("flash.success"),
+        "message_template": "You have successfully given {{ user_name }} CCPO permissions.",
+        "category": "success",
+    },
     "environment_added": {
         "title_template": translate("flash.success"),
         "message_template": """

--- a/templates/audit_log/audit_log.html
+++ b/templates/audit_log/audit_log.html
@@ -4,6 +4,6 @@
 {% block content %}
   <div v-cloak>
     {% include "fragments/audit_events_log.html" %}
-    {{ Pagination(audit_events, url_for('atst.activity_history'))}}
+    {{ Pagination(audit_events, url_for('ccpo.activity_history'))}}
   </div>
 {% endblock %}

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -1,0 +1,27 @@
+{% extends "base.html" %}
+
+{% from "components/text_input.html" import TextInput %}
+
+{% block content %}
+  {% set ccpo_user_form = "add-ccpo-user-form" %}
+
+  <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.submit_add_new_ccpo_user') }}" method="POST">
+    {{ form.csrf_token }}
+    <div class="modal__form--header">
+      <h1>Add new CCPO user</h1>
+    </div>
+    <div class='form-row'>
+      <div class='form-col'>
+        {{ TextInput(form.dod_id, validation='dodId') }}
+      </div>
+    </div>
+    <div class='action-group'>
+      <input
+          type='submit'
+          v-bind:disabled="invalid"
+          class='action-group__action usa-button'
+          value='Next'>
+      <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+    </div>
+  </form>
+{% endblock %}

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -3,25 +3,23 @@
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
-  {% set ccpo_user_form = "add-ccpo-user-form" %}
-
-  <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.submit_add_new_ccpo_user') }}" method="POST">
+  <form id="add-ccpo-user-form" action="{{ url_for('atst.submit_add_new_ccpo_user') }}" method="POST">
     {{ form.csrf_token }}
-    <div class="modal__form--header">
-      <h1>Add new CCPO user</h1>
-    </div>
+    <h1>Add new CCPO user</h1>
     <div class='form-row'>
-      <div class='form-col'>
+      <div class='form-col form-col--two-thirds'>
         {{ TextInput(form.dod_id, validation='dodId') }}
       </div>
-    </div>
-    <div class='action-group'>
-      <input
-          type='submit'
-          v-bind:disabled="invalid"
-          class='action-group__action usa-button'
-          value='Next'>
-      <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+      <div class="form-col form-col--third">
+        <div class='action-group'>
+          <input
+              type='submit'
+              v-bind:disabled="invalid"
+              class='action-group__action usa-button'
+              value='Next'>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+        </div>
+      </div>
     </div>
   </form>
 {% endblock %}

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -3,7 +3,7 @@
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
-  <form id="add-ccpo-user-form" action="{{ url_for('atst.submit_add_new_ccpo_user') }}" method="POST">
+  <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_add_new_ccpo_user') }}" method="POST">
     {{ form.csrf_token }}
     <h1>Add new CCPO user</h1>
     <div class='form-row'>
@@ -17,7 +17,7 @@
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
               value='Next'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
         </div>
       </div>
     </div>

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -5,7 +5,7 @@
 {% block content %}
   <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_add_new_ccpo_user') }}" method="POST">
     {{ form.csrf_token }}
-    <h1>Add new CCPO user</h1>
+    <h1>{{ "ccpo.form.add_user_title" | translate }}</h1>
     <div class='form-row'>
       <div class='form-col form-col--two-thirds'>
         {{ TextInput(form.dod_id, validation='dodId') }}
@@ -16,7 +16,7 @@
               type='submit'
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
-              value='Next'>
+              value='{{ "common.next" | translate }}'>
           <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
         </div>
       </div>

--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -3,7 +3,7 @@
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
-  <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_add_new_ccpo_user') }}" method="POST">
+  <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_new_user') }}" method="POST">
     {{ form.csrf_token }}
     <h1>{{ "ccpo.form.add_user_title" | translate }}</h1>
     <div class='form-row'>
@@ -17,7 +17,7 @@
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
               value='{{ "common.next" | translate }}'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">{{ "common.cancel" | translate }}</a>
         </div>
       </div>
     </div>

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -5,11 +5,8 @@
 
 {% block content %}
   {% if new_user %}
-    {% set ccpo_user_form = "add-ccpo-user-form" %}
-
     {% call Alert('Confirm new CCPO user') %}
-
-      <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
+      <form id="add-ccpo-user-form" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
         {{ form.csrf_token }}
         <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
         <div>
@@ -35,13 +32,11 @@
     {% endcall %}
   {% else %}
     {% call Alert('User not found') %}
-      <div>
-        To add someone as a CCPO user, they must already have an ATAT account.
-        <div class='action-group'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">
-            Return to list of CCPO users
-          </a>
-        </div>
+      To add someone as a CCPO user, they must already have an ATAT account.
+      <div class='action-group'>
+        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">
+          Return to list of CCPO users
+        </a>
       </div>
     {% endcall %}
   {% endif %}

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -31,7 +31,7 @@
       </form>
     {% endcall %}
   {% else %}
-    {% call Alert('User not found') %}
+    {% call Alert('forms.ccpo_user.user_not_found' | translate) %}
       To add someone as a CCPO user, they must already have an ATAT account.
       <div class='action-group'>
         <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -6,7 +6,7 @@
 {% block content %}
   {% if new_user %}
     {% call Alert('ccpo.form.confirm_user_title' | translate) %}
-      <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_ccpo_user') }}" method="POST">
+      <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_user') }}" method="POST">
         {{ form.csrf_token }}
         <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
         <div>
@@ -26,7 +26,7 @@
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
               value='{{ "ccpo.form.confirm_button" | translate }}'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
             {{ "common.cancel" | translate }}
           </a>
         </div>
@@ -38,7 +38,7 @@
         {{ "ccpo.form.user_not_found_text" | translate }}
       </p>
       <div class='action-group'>
-        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">
+        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
           {{ "ccpo.form.return_link" | translate }}
         </a>
       </div>

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -30,15 +30,5 @@
         </a>
       </div>
     </form>
-  {% else %}
-    <h3>{{ 'ccpo.form.user_not_found_title' | translate }}</h3>
-    <p>
-      {{ "ccpo.form.user_not_found_text" | translate }}
-    </p>
-    <div class='action-group'>
-      <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
-        {{ "ccpo.form.return_link" | translate }}
-      </a>
-    </div>
   {% endif %}
 {% endblock %}

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -1,0 +1,35 @@
+{% extends "base.html" %}
+
+{% from "components/alert.html" import Alert %}
+{% from "components/text_input.html" import TextInput %}
+
+{% block content %}
+  {% set ccpo_user_form = "add-ccpo-user-form" %}
+
+  {% call Alert('Confirm new CCPO user') %}
+
+    <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
+      {{ form.csrf_token }}
+      <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
+      <div>
+        <p>
+          Please confirm that the user details below match the user being given CCPO permissions.
+        </p>
+        <p>
+          {{ new_user.full_name }}
+        </p>
+        <p>
+          {{ new_user.email }}
+        </p>
+      </div>
+      <div class='action-group'>
+        <input
+            type='submit'
+            v-bind:disabled="invalid"
+            class='action-group__action usa-button'
+            value='Confirm and Add User'>
+        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+      </div>
+    </form>
+  {% endcall %}
+{% endblock %}

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -6,7 +6,7 @@
 {% block content %}
   {% if new_user %}
     {% call Alert('Confirm new CCPO user') %}
-      <form id="add-ccpo-user-form" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
+      <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_ccpo_user') }}" method="POST">
         {{ form.csrf_token }}
         <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
         <div>
@@ -26,7 +26,7 @@
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
               value='Confirm and Add User'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
         </div>
       </form>
     {% endcall %}
@@ -34,7 +34,7 @@
     {% call Alert('User not found') %}
       To add someone as a CCPO user, they must already have an ATAT account.
       <div class='action-group'>
-        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">
+        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">
           Return to list of CCPO users
         </a>
       </div>

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -4,32 +4,45 @@
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
-  {% set ccpo_user_form = "add-ccpo-user-form" %}
+  {% if new_user %}
+    {% set ccpo_user_form = "add-ccpo-user-form" %}
 
-  {% call Alert('Confirm new CCPO user') %}
+    {% call Alert('Confirm new CCPO user') %}
 
-    <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
-      {{ form.csrf_token }}
-      <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
+      <form id="{{ ccpo_user_form }}" action="{{ url_for('atst.confirm_new_ccpo_user') }}" method="POST">
+        {{ form.csrf_token }}
+        <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
+        <div>
+          <p>
+            Please confirm that the user details below match the user being given CCPO permissions.
+          </p>
+          <p>
+            {{ new_user.full_name }}
+          </p>
+          <p>
+            {{ new_user.email }}
+          </p>
+        </div>
+        <div class='action-group'>
+          <input
+              type='submit'
+              v-bind:disabled="invalid"
+              class='action-group__action usa-button'
+              value='Confirm and Add User'>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+        </div>
+      </form>
+    {% endcall %}
+  {% else %}
+    {% call Alert('User not found') %}
       <div>
-        <p>
-          Please confirm that the user details below match the user being given CCPO permissions.
-        </p>
-        <p>
-          {{ new_user.full_name }}
-        </p>
-        <p>
-          {{ new_user.email }}
-        </p>
+        To add someone as a CCPO user, they must already have an ATAT account.
+        <div class='action-group'>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">
+            Return to list of CCPO users
+          </a>
+        </div>
       </div>
-      <div class='action-group'>
-        <input
-            type='submit'
-            v-bind:disabled="invalid"
-            class='action-group__action usa-button'
-            value='Confirm and Add User'>
-        <a class='action-group__action icon-link icon-link--default' href="{{ url_for('atst.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
-      </div>
-    </form>
-  {% endcall %}
+    {% endcall %}
+  {% endif %}
 {% endblock %}

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -1,47 +1,44 @@
 {% extends "base.html" %}
 
-{% from "components/alert.html" import Alert %}
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
   {% if new_user %}
-    {% call Alert('ccpo.form.confirm_user_title' | translate) %}
-      <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_user') }}" method="POST">
-        {{ form.csrf_token }}
-        <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
-        <div>
-          <p>
-            {{ "ccpo.form.confirm_user_text" | translate }}
-          </p>
-          <p>
-            {{ new_user.full_name }}
-          </p>
-          <p>
-            {{ new_user.email }}
-          </p>
-        </div>
-        <div class='action-group'>
-          <input
-              type='submit'
-              v-bind:disabled="invalid"
-              class='action-group__action usa-button'
-              value='{{ "ccpo.form.confirm_button" | translate }}'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
-            {{ "common.cancel" | translate }}
-          </a>
-        </div>
-      </form>
-    {% endcall %}
-  {% else %}
-    {% call Alert('ccpo.form.user_not_found_title' | translate) %}
-      <p>
-        {{ "ccpo.form.user_not_found_text" | translate }}
-      </p>
+    <h3>{{ 'ccpo.form.confirm_user_title' | translate }}</h3>
+    <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_user') }}" method="POST">
+      {{ form.csrf_token }}
+      <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
+      <div>
+        <p>
+          {{ "ccpo.form.confirm_user_text" | translate }}
+        </p>
+        <p>
+          {{ new_user.full_name }}
+        </p>
+        <p>
+          {{ new_user.email }}
+        </p>
+      </div>
       <div class='action-group'>
+        <input
+            type='submit'
+            v-bind:disabled="invalid"
+            class='action-group__action usa-button'
+            value='{{ "ccpo.form.confirm_button" | translate }}'>
         <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
-          {{ "ccpo.form.return_link" | translate }}
+          {{ "common.cancel" | translate }}
         </a>
       </div>
-    {% endcall %}
+    </form>
+  {% else %}
+    <h3>{{ 'ccpo.form.user_not_found_title' | translate }}</h3>
+    <p>
+      {{ "ccpo.form.user_not_found_text" | translate }}
+    </p>
+    <div class='action-group'>
+      <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">
+        {{ "ccpo.form.return_link" | translate }}
+      </a>
+    </div>
   {% endif %}
 {% endblock %}

--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -5,13 +5,13 @@
 
 {% block content %}
   {% if new_user %}
-    {% call Alert('Confirm new CCPO user') %}
+    {% call Alert('ccpo.form.confirm_user_title' | translate) %}
       <form id="add-ccpo-user-form" action="{{ url_for('ccpo.confirm_new_ccpo_user') }}" method="POST">
         {{ form.csrf_token }}
         <input type="hidden" name="dod_id" value="{{ form.dod_id.data }}">
         <div>
           <p>
-            Please confirm that the user details below match the user being given CCPO permissions.
+            {{ "ccpo.form.confirm_user_text" | translate }}
           </p>
           <p>
             {{ new_user.full_name }}
@@ -25,17 +25,21 @@
               type='submit'
               v-bind:disabled="invalid"
               class='action-group__action usa-button'
-              value='Confirm and Add User'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">{{ "common.cancel" | translate }}</a>
+              value='{{ "ccpo.form.confirm_button" | translate }}'>
+          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">
+            {{ "common.cancel" | translate }}
+          </a>
         </div>
       </form>
     {% endcall %}
   {% else %}
-    {% call Alert('forms.ccpo_user.user_not_found' | translate) %}
-      To add someone as a CCPO user, they must already have an ATAT account.
+    {% call Alert('ccpo.form.user_not_found_title' | translate) %}
+      <p>
+        {{ "ccpo.form.user_not_found_text" | translate }}
+      </p>
       <div class='action-group'>
         <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.ccpo_users') }}">
-          Return to list of CCPO users
+          {{ "ccpo.form.return_link" | translate }}
         </a>
       </div>
     {% endcall %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -5,7 +5,7 @@
 {% block content %}
   <div class='col'>
     <div class="h2">
-      CCPO Users
+      {{ "ccpo.users_title" | translate }}
     </div>
 
     {% include "fragments/flash.html" %}
@@ -13,9 +13,9 @@
     <table>
       <thead>
         <tr>
-          <th>Name</th>
-          <th>Email</th>
-          <th>DoD ID</th>
+          <th>{{ "ccpo.name_heading" | translate }}</th>
+          <th>{{ "ccpo.email_heading" | translate }}</th>
+          <th>{{ "ccpo.dod_id_heading" | translate }}</th>
         </tr>
       </thead>
       <tbody>
@@ -32,7 +32,7 @@
 
   {% if user_can(permissions.CREATE_CCPO_USER) %}
     <a class="icon-link modal-link" href="{{ url_for('ccpo.add_new_ccpo_user')}}">
-      Add new CCPO user {{ Icon("plus") }}
+      {{ "ccpo.add_user" | translate }} {{ Icon("plus") }}
     </a>
   {% endif %}
 

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -31,7 +31,7 @@
   </div>
 
   {% if user_can(permissions.CREATE_CCPO_USER) %}
-    <a class="icon-link modal-link" href="{{ url_for('ccpo.add_new_ccpo_user')}}">
+    <a class="icon-link modal-link" href="{{ url_for('ccpo.add_new_user')}}">
       {{ "ccpo.add_user" | translate }} {{ Icon("plus") }}
     </a>
   {% endif %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -28,7 +28,7 @@
   </div>
 
   {% if user_can(permissions.CREATE_CCPO_USER) %}
-    <a class="icon-link modal-link" v-on:click="openModal()">
+    <a class="icon-link modal-link" href="{{ url_for('atst.add_new_ccpo_user')}}">
       Add new CCPO user {{ Icon("plus") }}
     </a>
   {% endif %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -31,7 +31,7 @@
   </div>
 
   {% if user_can(permissions.CREATE_CCPO_USER) %}
-    <a class="icon-link modal-link" href="{{ url_for('atst.add_new_ccpo_user')}}">
+    <a class="icon-link modal-link" href="{{ url_for('ccpo.add_new_ccpo_user')}}">
       Add new CCPO user {{ Icon("plus") }}
     </a>
   {% endif %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -13,9 +13,9 @@
     <table>
       <thead>
         <tr>
-          <th>{{ "ccpo.name_heading" | translate }}</th>
-          <th>{{ "ccpo.email_heading" | translate }}</th>
-          <th>{{ "ccpo.dod_id_heading" | translate }}</th>
+          <th>{{ "common.name" | translate }}</th>
+          <th>{{ "common.email" | translate }}</th>
+          <th>{{ "common.dod_id" | translate }}</th>
         </tr>
       </thead>
       <tbody>
@@ -31,7 +31,7 @@
   </div>
 
   {% if user_can(permissions.CREATE_CCPO_USER) %}
-    <a class="icon-link modal-link" href="{{ url_for('ccpo.add_new_user')}}">
+    <a class="icon-link" href="{{ url_for('ccpo.add_new_user')}}">
       {{ "ccpo.add_user" | translate }} {{ Icon("plus") }}
     </a>
   {% endif %}

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -7,6 +7,9 @@
     <div class="h2">
       CCPO Users
     </div>
+
+    {% include "fragments/flash.html" %}
+
     <table>
       <thead>
         <tr>

--- a/templates/ccpo/users.html
+++ b/templates/ccpo/users.html
@@ -1,27 +1,36 @@
 {% extends "base.html" %}
 
+{% from "components/icon.html" import Icon %}
+
 {% block content %}
-<div class='col'>
-  <div class="h2">
-    CCPO Users
-  </div>
-  <table>
-    <thead>
-      <tr>
-        <th>Name</th>
-        <th>Email</th>
-        <th>DoD ID</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for user in users %}
+  <div class='col'>
+    <div class="h2">
+      CCPO Users
+    </div>
+    <table>
+      <thead>
         <tr>
-          <td>{{ user.full_name }}</td>
-          <td>{{ user.email }}</td>
-          <td>{{ user.dod_id }}</td>
+          <th>Name</th>
+          <th>Email</th>
+          <th>DoD ID</th>
         </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-</div>
+      </thead>
+      <tbody>
+        {% for user in users %}
+          <tr>
+            <td>{{ user.full_name }}</td>
+            <td>{{ user.email }}</td>
+            <td>{{ user.dod_id }}</td>
+          </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+
+  {% if user_can(permissions.CREATE_CCPO_USER) %}
+    <a class="icon-link modal-link" v-on:click="openModal()">
+      Add new CCPO user {{ Icon("plus") }}
+    </a>
+  {% endif %}
+
 {% endblock %}

--- a/tests/domain/test_users.py
+++ b/tests/domain/test_users.py
@@ -87,13 +87,15 @@ def test_get_ccpo_users():
     assert rando not in ccpo_users
 
 
-def test_update_ccpo_permissions():
+def test_give_ccpo_perms():
     rando = UserFactory.create()
-    Users.update_ccpo_permissions(rando, add_perms=True)
-
-    ccpo = UserFactory.create_ccpo()
-    Users.update_ccpo_permissions(ccpo)
-
+    Users.give_ccpo_perms(rando)
     ccpo_users = Users.get_ccpo_users()
     assert rando in ccpo_users
+
+
+def test_revoke_ccpo_perms():
+    ccpo = UserFactory.create_ccpo()
+    Users.revoke_ccpo_perms(ccpo)
+    ccpo_users = Users.get_ccpo_users()
     assert ccpo not in ccpo_users

--- a/tests/domain/test_users.py
+++ b/tests/domain/test_users.py
@@ -85,3 +85,15 @@ def test_get_ccpo_users():
     assert ccpo_1 in ccpo_users
     assert ccpo_2 in ccpo_users
     assert rando not in ccpo_users
+
+
+def test_update_ccpo_permissions():
+    rando = UserFactory.create()
+    Users.update_ccpo_permissions(rando, add_perms=True)
+
+    ccpo = UserFactory.create_ccpo()
+    Users.update_ccpo_permissions(ccpo)
+
+    ccpo_users = Users.get_ccpo_users()
+    assert rando in ccpo_users
+    assert ccpo not in ccpo_users

--- a/tests/routes/test_ccpo.py
+++ b/tests/routes/test_ccpo.py
@@ -1,0 +1,54 @@
+from flask import url_for
+
+from atst.utils.localization import translate
+
+from tests.factories import UserFactory
+
+
+def test_ccpo_users(user_session, client):
+    ccpo = UserFactory.create_ccpo()
+    user_session(ccpo)
+    response = client.get(url_for("ccpo.ccpo_users"))
+    assert ccpo.email in response.data.decode()
+
+
+def test_submit_add_new_ccpo_user(user_session, client):
+    ccpo = UserFactory.create_ccpo()
+    new_user = UserFactory.create()
+    random_dod_id = "1234567890"
+    user_session(ccpo)
+
+    # give new_user CCPO permissions
+    response = client.post(
+        url_for("ccpo.submit_add_new_ccpo_user"), data={"dod_id": new_user.dod_id}
+    )
+    assert new_user.email in response.data.decode()
+
+    # give person with out ATAT account CCPO permissions
+    response = client.post(
+        url_for("ccpo.submit_add_new_ccpo_user"), data={"dod_id": random_dod_id}
+    )
+    assert translate("forms.ccpo_user.user_not_found") in response.data.decode()
+
+
+def test_confirm_new_ccpo_user(user_session, client):
+    ccpo = UserFactory.create_ccpo()
+    new_user = UserFactory.create()
+    random_dod_id = "1234567890"
+    user_session(ccpo)
+
+    # give new_user CCPO permissions
+    response = client.post(
+        url_for("ccpo.confirm_new_ccpo_user"),
+        data={"dod_id": new_user.dod_id},
+        follow_redirects=True,
+    )
+    assert new_user.dod_id in response.data.decode()
+
+    # give person with out ATAT account CCPO permissions
+    response = client.post(
+        url_for("ccpo.confirm_new_ccpo_user"),
+        data={"dod_id": random_dod_id},
+        follow_redirects=True,
+    )
+    assert random_dod_id not in response.data.decode()

--- a/tests/routes/test_ccpo.py
+++ b/tests/routes/test_ccpo.py
@@ -24,11 +24,11 @@ def test_submit_new_user(user_session, client):
     )
     assert new_user.email in response.data.decode()
 
-    # give person with out ATAT account CCPO permissions
+    # give person without ATAT account CCPO permissions
     response = client.post(
         url_for("ccpo.submit_new_user"), data={"dod_id": random_dod_id}
     )
-    assert translate("ccpo.form.user_not_found_title") in response.data.decode()
+    assert url_for("ccpo.users") in response.location
 
 
 def test_confirm_new_user(user_session, client):

--- a/tests/routes/test_ccpo.py
+++ b/tests/routes/test_ccpo.py
@@ -8,11 +8,11 @@ from tests.factories import UserFactory
 def test_ccpo_users(user_session, client):
     ccpo = UserFactory.create_ccpo()
     user_session(ccpo)
-    response = client.get(url_for("ccpo.ccpo_users"))
+    response = client.get(url_for("ccpo.users"))
     assert ccpo.email in response.data.decode()
 
 
-def test_submit_add_new_ccpo_user(user_session, client):
+def test_submit_new_user(user_session, client):
     ccpo = UserFactory.create_ccpo()
     new_user = UserFactory.create()
     random_dod_id = "1234567890"
@@ -20,18 +20,18 @@ def test_submit_add_new_ccpo_user(user_session, client):
 
     # give new_user CCPO permissions
     response = client.post(
-        url_for("ccpo.submit_add_new_ccpo_user"), data={"dod_id": new_user.dod_id}
+        url_for("ccpo.submit_new_user"), data={"dod_id": new_user.dod_id}
     )
     assert new_user.email in response.data.decode()
 
     # give person with out ATAT account CCPO permissions
     response = client.post(
-        url_for("ccpo.submit_add_new_ccpo_user"), data={"dod_id": random_dod_id}
+        url_for("ccpo.submit_new_user"), data={"dod_id": random_dod_id}
     )
     assert translate("ccpo.form.user_not_found_title") in response.data.decode()
 
 
-def test_confirm_new_ccpo_user(user_session, client):
+def test_confirm_new_user(user_session, client):
     ccpo = UserFactory.create_ccpo()
     new_user = UserFactory.create()
     random_dod_id = "1234567890"
@@ -39,7 +39,7 @@ def test_confirm_new_ccpo_user(user_session, client):
 
     # give new_user CCPO permissions
     response = client.post(
-        url_for("ccpo.confirm_new_ccpo_user"),
+        url_for("ccpo.confirm_new_user"),
         data={"dod_id": new_user.dod_id},
         follow_redirects=True,
     )
@@ -47,7 +47,7 @@ def test_confirm_new_ccpo_user(user_session, client):
 
     # give person with out ATAT account CCPO permissions
     response = client.post(
-        url_for("ccpo.confirm_new_ccpo_user"),
+        url_for("ccpo.confirm_new_user"),
         data={"dod_id": random_dod_id},
         follow_redirects=True,
     )

--- a/tests/routes/test_ccpo.py
+++ b/tests/routes/test_ccpo.py
@@ -28,7 +28,7 @@ def test_submit_add_new_ccpo_user(user_session, client):
     response = client.post(
         url_for("ccpo.submit_add_new_ccpo_user"), data={"dod_id": random_dod_id}
     )
-    assert translate("forms.ccpo_user.user_not_found") in response.data.decode()
+    assert translate("ccpo.form.user_not_found_title") in response.data.decode()
 
 
 def test_confirm_new_ccpo_user(user_session, client):

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -120,43 +120,43 @@ def test_atst_activity_history_access(get_url_assert_status):
     get_url_assert_status(rando, url, 404)
 
 
-# ccpo.ccpo_users
-def test_ccpo_ccpo_users_access(get_url_assert_status):
+# ccpo.users
+def test_ccpo_users_access(get_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("ccpo.ccpo_users")
+    url = url_for("ccpo.users")
     get_url_assert_status(ccpo, url, 200)
     get_url_assert_status(rando, url, 404)
 
 
-# ccpo.add_new_ccpo_user
-def test_ccpo_add_new_ccpo_user_access(get_url_assert_status):
+# ccpo.add_new_user
+def test_ccpo_add_new_user_access(get_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("ccpo.add_new_ccpo_user")
+    url = url_for("ccpo.add_new_user")
     get_url_assert_status(ccpo, url, 200)
     get_url_assert_status(rando, url, 404)
 
 
-# ccpo.submit_add_new_ccpo_user
-def test_ccpo_submit_add_new_ccpo_user_access(post_url_assert_status):
+# ccpo.submit_new_user
+def test_ccpo_submit_new_user_access(post_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("ccpo.submit_add_new_ccpo_user")
+    url = url_for("ccpo.submit_new_user")
     post_url_assert_status(ccpo, url, 200, data={"dod_id": "1234567890"})
     post_url_assert_status(rando, url, 404, data={"dod_id": "1234567890"})
 
 
-# ccpo.confirm_new_ccpo_user
-def test_ccpo_confirm_new_ccpo_user_access(post_url_assert_status):
+# ccpo.confirm_new_user
+def test_ccpo_confirm_new_user_access(post_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
     user = UserFactory.create()
 
-    url = url_for("ccpo.confirm_new_ccpo_user")
+    url = url_for("ccpo.confirm_new_user")
     post_url_assert_status(ccpo, url, 302, data={"dod_id": user.dod_id})
     post_url_assert_status(rando, url, 404, data={"dod_id": user.dod_id})
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -110,53 +110,53 @@ def post_url_assert_status(client, user_session):
     return _get_url_assert_status
 
 
-# atst.activity_history
+# ccpo.activity_history
 def test_atst_activity_history_access(get_url_assert_status):
     ccpo = user_with(PermissionSets.VIEW_AUDIT_LOG)
     rando = user_with()
 
-    url = url_for("atst.activity_history")
+    url = url_for("ccpo.activity_history")
     get_url_assert_status(ccpo, url, 200)
     get_url_assert_status(rando, url, 404)
 
 
-# atst.ccpo_users
-def test_atst_ccpo_users_access(get_url_assert_status):
+# ccpo.ccpo_users
+def test_ccpo_ccpo_users_access(get_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("atst.ccpo_users")
+    url = url_for("ccpo.ccpo_users")
     get_url_assert_status(ccpo, url, 200)
     get_url_assert_status(rando, url, 404)
 
 
-# atst.add_new_ccpo_user
-def test_atst_add_new_ccpo_user_access(get_url_assert_status):
+# ccpo.add_new_ccpo_user
+def test_ccpo_add_new_ccpo_user_access(get_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("atst.add_new_ccpo_user")
+    url = url_for("ccpo.add_new_ccpo_user")
     get_url_assert_status(ccpo, url, 200)
     get_url_assert_status(rando, url, 404)
 
 
-# atst.submit_add_new_ccpo_user
-def test_atst_submit_add_new_ccpo_user_access(post_url_assert_status):
+# ccpo.submit_add_new_ccpo_user
+def test_ccpo_submit_add_new_ccpo_user_access(post_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
 
-    url = url_for("atst.submit_add_new_ccpo_user")
+    url = url_for("ccpo.submit_add_new_ccpo_user")
     post_url_assert_status(ccpo, url, 200, data={"dod_id": "1234567890"})
     post_url_assert_status(rando, url, 404, data={"dod_id": "1234567890"})
 
 
-# atst.confirm_new_ccpo_user
-def test_atst_confirm_new_ccpo_user_access(post_url_assert_status):
+# ccpo.confirm_new_ccpo_user
+def test_ccpo_confirm_new_ccpo_user_access(post_url_assert_status):
     ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
     rando = user_with()
     user = UserFactory.create()
 
-    url = url_for("atst.confirm_new_ccpo_user")
+    url = url_for("ccpo.confirm_new_ccpo_user")
     post_url_assert_status(ccpo, url, 302, data={"dod_id": user.dod_id})
     post_url_assert_status(rando, url, 404, data={"dod_id": user.dod_id})
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -146,7 +146,7 @@ def test_ccpo_submit_new_user_access(post_url_assert_status):
     rando = user_with()
 
     url = url_for("ccpo.submit_new_user")
-    post_url_assert_status(ccpo, url, 200, data={"dod_id": "1234567890"})
+    post_url_assert_status(ccpo, url, 302, data={"dod_id": "1234567890"})
     post_url_assert_status(rando, url, 404, data={"dod_id": "1234567890"})
 
 

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -130,6 +130,37 @@ def test_atst_ccpo_users_access(get_url_assert_status):
     get_url_assert_status(rando, url, 404)
 
 
+# atst.add_new_ccpo_user
+def test_atst_add_new_ccpo_user_access(get_url_assert_status):
+    ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
+    rando = user_with()
+
+    url = url_for("atst.add_new_ccpo_user")
+    get_url_assert_status(ccpo, url, 200)
+    get_url_assert_status(rando, url, 404)
+
+
+# atst.submit_add_new_ccpo_user
+def test_atst_submit_add_new_ccpo_user_access(post_url_assert_status):
+    ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
+    rando = user_with()
+
+    url = url_for("atst.submit_add_new_ccpo_user")
+    post_url_assert_status(ccpo, url, 200, data={"dod_id": "1234567890"})
+    post_url_assert_status(rando, url, 404, data={"dod_id": "1234567890"})
+
+
+# atst.confirm_new_ccpo_user
+def test_atst_confirm_new_ccpo_user_access(post_url_assert_status):
+    ccpo = user_with(PermissionSets.MANAGE_CCPO_USERS)
+    rando = user_with()
+    user = UserFactory.create()
+
+    url = url_for("atst.confirm_new_ccpo_user")
+    post_url_assert_status(ccpo, url, 302, data={"dod_id": user.dod_id})
+    post_url_assert_status(rando, url, 404, data={"dod_id": user.dod_id})
+
+
 # applications.access_environment
 def test_applications_access_environment_access(get_url_assert_status):
     dev = UserFactory.create()

--- a/translations.yaml
+++ b/translations.yaml
@@ -103,6 +103,8 @@ forms:
     name_label: Name
   assign_ppoc:
     dod_id: 'Select new primary point of contact:'
+  ccpo_user:
+    user_not_found: "User not found"
   environments:
     name_label: Environment Name
   edit_user:

--- a/translations.yaml
+++ b/translations.yaml
@@ -26,6 +26,20 @@ home:
   applications_descrip: ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
   reports_descrip: enim ad minim veniam, quis nostrud exercitation ullamco
   admin_descrip: aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+ccpo:
+  users_title: CCPO Users
+  name_heading: Name
+  email_heading: Email
+  dod_id_heading: DoD ID
+  add_user: Add new CCPO user
+  form:
+    add_user_title: Add new CCPO user
+    confirm_user_title: Confirm new CCPO user
+    confirm_user_text: Please confirm that the user details below match the user being given CCPO permissions.
+    confirm_button: Confirm and Add User
+    return_link: Return to list of CCPO users
+    user_not_found_title: User not found
+    user_not_found_text: To add someone as a CCPO user, they must already have an ATAT account.
 common:
   cancel: Cancel
   close: Close
@@ -36,6 +50,7 @@ common:
   delete_confirm: 'Please type the word {word} to confirm:'
   edit: Edit
   members: Members
+  next: Next
   'yes': 'Yes'
   'no': 'No'
   response_label: Response required
@@ -103,8 +118,6 @@ forms:
     name_label: Name
   assign_ppoc:
     dod_id: 'Select new primary point of contact:'
-  ccpo_user:
-    user_not_found: "User not found"
   environments:
     name_label: Environment Name
   edit_user:

--- a/translations.yaml
+++ b/translations.yaml
@@ -28,9 +28,6 @@ home:
   admin_descrip: aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
 ccpo:
   users_title: CCPO Users
-  name_heading: Name
-  email_heading: Email
-  dod_id_heading: DoD ID
   add_user: Add new CCPO user
   form:
     add_user_title: Add new CCPO user
@@ -48,8 +45,11 @@ common:
   delete: Delete
   deactivate: Deactivate
   delete_confirm: 'Please type the word {word} to confirm:'
+  dod_id: DoD ID
   edit: Edit
+  email: Email
   members: Members
+  name: Name
   next: Next
   'yes': 'Yes'
   'no': 'No'
@@ -60,7 +60,6 @@ common:
   resource_names:
     environments: Environments
   choose_role: Choose a role
-  name: Name
 components:
   date_selector:
     day: Day


### PR DESCRIPTION
## Description
Adds the functionality to give an existing ATAT user CCPO permissions. This PR covers only the form to add CCPO users, adding the permissions changes to the activity history will be implemented in a later PR.

## Pivotal
https://www.pivotaltracker.com/story/show/167716505

## Screenshots
<img width="1164" alt="Screen Shot 2019-08-08 at 11 43 18 AM" src="https://user-images.githubusercontent.com/43828539/62717452-eb63cb00-b9d1-11e9-99e6-41900a410e87.png">
<img width="1164" alt="Screen Shot 2019-08-08 at 11 43 22 AM" src="https://user-images.githubusercontent.com/43828539/62717454-ec94f800-b9d1-11e9-9672-eb4de8f5775a.png">
<img width="1164" alt="Screen Shot 2019-08-08 at 11 43 39 AM" src="https://user-images.githubusercontent.com/43828539/62717457-ee5ebb80-b9d1-11e9-8ae1-7ec61f5c25cd.png">