### PR TITLE
Apply config changes for CSP file uploads.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
           requires:
             - app_setup
       - azure-acr/build_and_push_image:
+          extra-build-args: "--build-arg CSP=azure"
           login-server-name: "${AZURE_SERVER_NAME}"
           registry-name: pwatat
           repo: atat
@@ -175,6 +176,7 @@ workflows:
               only:
                 - master
       - aws-ecr/build_and_push_image:
+          extra-build-args: "--build-arg CSP=aws"
           repo: atat
           tag: "${CIRCLE_SHA1}"
           requires:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.7.3-alpine3.9 AS builder
 
+ARG CSP
+
 RUN mkdir -p /install/.venv
 WORKDIR /install
 
@@ -32,10 +34,11 @@ RUN apk update && \
 COPY . .
 
 # Install app dependencies
-RUN pip install pipenv uwsgi && \
+RUN ./script/write_dotenv && \
+      pip install pipenv uwsgi && \
       PIPENV_VENV_IN_PROJECT=1 pipenv install && \
       yarn install && \
-      cp -r ./node_modules/uswds/src/fonts ./static/ && \
+      cp -rf ./node_modules/uswds/src/fonts ./static/ && \
       yarn build
 
 ## NEW IMAGE

--- a/atst/domain/csp/file_uploads.py
+++ b/atst/domain/csp/file_uploads.py
@@ -79,7 +79,7 @@ class AwsUploader(Uploader):
             "s3",
             aws_access_key_id=self.access_key_id,
             aws_secret_access_key=self.secret_key,
-            config=boto3.session.Config(
+            config=self.boto3.session.Config(
                 signature_version="s3v4", region_name=self.region_name
             ),
         )

--- a/config/base.ini
+++ b/config/base.ini
@@ -6,6 +6,7 @@ COOKIE_SECRET = some-secret-please-replace
 DISABLE_CRL_CHECK = false
 CRL_FAIL_OPEN = false
 CRL_STORAGE_CONTAINER = crls
+CSP=mock
 DEBUG = true
 ENVIRONMENT = dev
 LOG_JSON = false

--- a/deploy/aws/atst-envvars-configmap.yml
+++ b/deploy/aws/atst-envvars-configmap.yml
@@ -11,3 +11,4 @@ data:
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi.ini
   CRL_STORAGE_PROVIDER: CLOUDFILES
   LOG_JSON: "true"
+  CSP: aws

--- a/deploy/azure/atst-envvars-configmap.yml
+++ b/deploy/azure/atst-envvars-configmap.yml
@@ -11,3 +11,4 @@ data:
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi.ini
   CRL_STORAGE_PROVIDER: CLOUDFILES
   LOG_JSON: "true"
+  CSP: azure

--- a/deploy/docker/sample.nginx.conf
+++ b/deploy/docker/sample.nginx.conf
@@ -1,0 +1,24 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #charset koi8-r;
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        try_files $uri @app;
+    }
+
+    location @app {
+        include uwsgi_params;
+        uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
+        uwsgi_param HTTP_X_SSL_CLIENT_VERIFY $ssl_client_verify;
+        uwsgi_param HTTP_X_SSL_CLIENT_CERT $ssl_client_raw_cert;
+        uwsgi_param HTTP_X_SSL_CLIENT_S_DN $ssl_client_s_dn;
+        uwsgi_param HTTP_X_SSL_CLIENT_S_DN_LEGACY $ssl_client_s_dn_legacy;
+        uwsgi_param HTTP_X_SSL_CLIENT_I_DN $ssl_client_i_dn;
+        uwsgi_param HTTP_X_SSL_CLIENT_I_DN_LEGACY $ssl_client_i_dn_legacy;
+        uwsgi_param HTTP_X_REQUEST_ID $request_id;
+    }
+}
+

--- a/script/write_dotenv
+++ b/script/write_dotenv
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+if [ -z "${CSP+is_set}" ]; then
+  CSP=mock
+fi
+
+if [ $CSP = "aws" ]; then
+  echo "CLOUD_PROVIDER=aws" > .env
+elif [ $CSP = "azure" ]; then
+  echo "CLOUD_PROVIDER=azure\nAZURE_ACCOUNT_NAME=atat\nAZURE_CONTAINER_NAME=task-order-pdfs" > .env
+else
+  echo "CLOUD_PROVIDER=mock" > .env
+fi


### PR DESCRIPTION
This applies configuration changes for the Flask app and adds changes to the Dockerfile so that the build can make a CSP-specific JS bundle. It adds `write_dotenv` script that creates the appropriate `.env` file for the `parcel` bundler depending on how the `CSP` environment variable is set.

- Configure K8s environment variables for Flask CSP usage
- Supply default CSP config setting to Flask app
- Declare the CSP arg in the Dockerfile
- Supply extra Docker build args to CD
- Fix top-level reference to boto3 in file_upload module
- Add back missing sample NGINX config for docker-compose build