### PR TITLE
Record adding/removing CCPO users in Activity History

### DIFF
--- a/atst/models/user.py
+++ b/atst/models/user.py
@@ -1,11 +1,13 @@
 from sqlalchemy import and_, String, ForeignKey, Column, Date, Boolean, Table, TIMESTAMP
 from sqlalchemy.orm import relationship
 from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.event import listen
 
 from atst.models import Base, ApplicationRole, types, mixins
 from atst.models.permissions import Permissions
 from atst.models.portfolio_invitation import PortfolioInvitation
 from atst.models.application_invitation import ApplicationInvitation
+from atst.models.mixins.auditable import record_permission_sets_updates
 
 
 users_permission_sets = Table(
@@ -118,3 +120,6 @@ class User(
             for c in self.__table__.columns
             if c.name not in ["id"]
         }
+
+
+listen(User.permission_sets, "bulk_replace", record_permission_sets_updates, raw=True)

--- a/templates/audit_log/events/user.html
+++ b/templates/audit_log/events/user.html
@@ -1,4 +1,11 @@
 {% extends "audit_log/events/_base.html" %}
 
 {% block content %}
+  {% if event.changed_state and 'permission_sets' in event.changed_state.keys() %}
+    {% if event.changed_state['permission_sets'][1] == [] %}
+      CCPO superuser access removed
+    {% else %}
+      CCPO superuser access granted
+    {% endif %}
+  {% endif %}
 {% endblock %}

--- a/tests/domain/test_audit_log.py
+++ b/tests/domain/test_audit_log.py
@@ -5,6 +5,7 @@ from atst.domain.audit_log import AuditLog
 from atst.domain.exceptions import UnauthorizedError
 from atst.domain.permission_sets import PermissionSets
 from atst.domain.portfolios import Portfolios
+from atst.domain.users import Users
 from atst.models.portfolio_role import Status as PortfolioRoleStatus
 from tests.factories import (
     ApplicationFactory,
@@ -117,3 +118,12 @@ def test_get_application_events():
 
     resource_types = [event.resource_type for event in events]
     assert "portfolio" not in resource_types
+
+
+def test_get_all_includes_ccpo_user_changes():
+    user = UserFactory.create()
+    initial_audit_log = AuditLog.get_all_events()
+    Users.give_ccpo_perms(user)
+    Users.revoke_ccpo_perms(user)
+
+    assert len(AuditLog.get_all_events()) == len(initial_audit_log) + 2


### PR DESCRIPTION
## Description
Records changes to user's CCPO superuser status in the Activity History. 

## Pivotal
https://www.pivotaltracker.com/story/show/167766390

## Screenshot
<img width="1532" alt="Screen Shot 2019-08-08 at 3 51 34 PM" src="https://user-images.githubusercontent.com/43828539/62733458-a9984c00-b9f4-11e9-8a10-457ed8375ba6.png">