### PR TITLE
Fix newline issues in script/write_dotenv.

### DIFF
--- a/script/write_dotenv
+++ b/script/write_dotenv
@@ -7,7 +7,11 @@ fi
 if [ $CSP = "aws" ]; then
   echo "CLOUD_PROVIDER=aws" > .env
 elif [ $CSP = "azure" ]; then
-  echo "CLOUD_PROVIDER=azure\nAZURE_ACCOUNT_NAME=atat\nAZURE_CONTAINER_NAME=task-order-pdfs" > .env
+  cat << EOF > .env
+CLOUD_PROVIDER=azure
+AZURE_ACCOUNT_NAME=atat
+AZURE_CONTAINER_NAME=task-order-pdfs
+EOF
 else
   echo "CLOUD_PROVIDER=mock" > .env
 fi


### PR DESCRIPTION
In `sh` on Alpine Linux in our Docker images, the newline characters in
the script were being interpreted as literals. This substitutes a
HEREDOC instead.