### PR TITLE
Allow creation of new users in dev mode

### DIFF
--- a/atst/domain/auth.py
+++ b/atst/domain/auth.py
@@ -6,6 +6,7 @@ from atst.domain.users import Users
 UNPROTECTED_ROUTES = [
     "atst.root",
     "dev.login_dev",
+    "dev.dev_new_user",
     "atst.login_redirect",
     "atst.logout",
     "atst.unauthorized",

--- a/atst/routes/dev.py
+++ b/atst/routes/dev.py
@@ -164,16 +164,7 @@ def dev_new_user():
     except NotFoundError:
         pass
 
-    new_user = {
-        "first_name": first_name,
-        "last_name": last_name,
-        "email": "{}@example.com".format(first_name),
-        "service_branch": random_service_branch(),
-        "phone_number": "1234567890",
-        "citizenship": "United States",
-        "designation": "Military",
-        "date_latest_training": pendulum.date(2018, 1, 1),
-    }
+    new_user = {"first_name": first_name, "last_name": last_name}
 
     created_user = Users.create(dod_id, **new_user)
 


### PR DESCRIPTION
## Description

Makes 2 changes to support creating new users in dev mode:
* Adds a new route, `/dev-new-user` which takes `first_name`, `last_name`, and `dod_id` query parameters (all required), creates the new user and logs you in as that user.
* Adds the ability to pass a `dod_id` query parameter to `/login-dev` to login as a user if they exist in the db

## Pivotal
https://www.pivotaltracker.com/story/show/167785247