### PR TITLE
Add validations and error states for TO upload form

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": null,
     "lines": null
   },
-  "generated_at": "2019-08-13T09:59:21Z",
+  "generated_at": "2019-08-14T14:39:14Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -169,7 +169,7 @@
         "hashed_secret": "e4f14805dfd1e6af030359090c535e149e6b4207",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 30,
+        "line_number": 32,
         "type": "Hex High Entropy String"
       }
     ],

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -74,7 +74,9 @@ class AttachmentForm(BaseForm):
     object_name = HiddenField(
         id="attachment_object_name",
         validators=[
-            Length(max=40, message=translate("forms.attachment.object_name.length_error"))
+            Length(
+                max=40, message=translate("forms.attachment.object_name.length_error")
+            )
         ],
     )
     accept = ".pdf,application/pdf"

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -71,7 +71,12 @@ class AttachmentForm(BaseForm):
             Length(max=100, message="Filename may be no longer than 100 characters.")
         ],
     )
-    object_name = HiddenField(id="attachment_object_name", validators=[Length(max=40)])
+    object_name = HiddenField(
+        id="attachment_object_name",
+        validators=[
+            Length(max=40, message="Object name may be no longer than 40 characters.")
+        ],
+    )
     accept = ".pdf,application/pdf"
 
     def validate(self, *args, **kwargs):

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -68,13 +68,13 @@ class AttachmentForm(BaseForm):
     filename = HiddenField(
         id="attachment_filename",
         validators=[
-            Length(max=100, message="Filename may be no longer than 100 characters.")
+            Length(max=100, message=translate("forms.attachment.filename.length_error"))
         ],
     )
     object_name = HiddenField(
         id="attachment_object_name",
         validators=[
-            Length(max=40, message="Object name may be no longer than 40 characters.")
+            Length(max=40, message=translate("forms.attachment.object_name.length_error"))
         ],
     )
     accept = ".pdf,application/pdf"

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -7,7 +7,7 @@ from wtforms.fields import (
     HiddenField,
 )
 from wtforms.fields.html5 import DateField
-from wtforms.validators import Required, Optional
+from wtforms.validators import Required, Optional, Length
 from flask_wtf import FlaskForm
 
 from .data import JEDI_CLIN_TYPES
@@ -65,8 +65,13 @@ class CLINForm(FlaskForm):
 
 
 class AttachmentForm(BaseForm):
-    filename = HiddenField(id="attachment_filename")
-    object_name = HiddenField(id="attachment_object_name")
+    filename = HiddenField(
+        id="attachment_filename",
+        validators=[
+            Length(max=100, message="Filename may be no longer than 100 characters.")
+        ],
+    )
+    object_name = HiddenField(id="attachment_object_name", validators=[Length(max=40)])
     accept = ".pdf,application/pdf"
 
 

--- a/atst/forms/task_order.py
+++ b/atst/forms/task_order.py
@@ -74,6 +74,9 @@ class AttachmentForm(BaseForm):
     object_name = HiddenField(id="attachment_object_name", validators=[Length(max=40)])
     accept = ".pdf,application/pdf"
 
+    def validate(self, *args, **kwargs):
+        return super().validate(*args, **{**kwargs, "flash_invalid": False})
+
 
 class TaskOrderForm(BaseForm):
     number = StringField(label=translate("forms.task_order.number_description"))

--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -72,7 +72,7 @@ export default {
         this.$refs.attachmentObjectName.value = this.objectName
       } else {
         this.showErrors = true
-        this.uploadError = 'Your file failed to upload. Please try again later.'
+        this.uploadError = true
       }
 
       this.changed = true
@@ -91,6 +91,7 @@ export default {
         this.$refs.attachmentInput.value = null
       }
       this.showErrors = false
+      this.uploadError = false
       this.changed = true
 
       emitEvent('field-change', this, {

--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -68,7 +68,6 @@ export default {
       const response = await this.uploader.upload(file, this.objectName)
       if (response.ok) {
         this.attachment = e.target.value
-        this.showErrors = false
         this.$refs.attachmentFilename.value = file.name
         this.$refs.attachmentObjectName.value = this.objectName
       } else {

--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -48,6 +48,7 @@ export default {
       attachment: this.initialData || null,
       showErrors: this.initialErrors,
       changed: false,
+      uploadError: null,
     }
   },
 
@@ -63,15 +64,16 @@ export default {
   methods: {
     addAttachment: async function(e) {
       const file = e.target.files[0]
-      try {
-        await this.uploader.upload(file, this.objectName)
+
+      const response = await this.uploader.upload(file, this.objectName)
+      if (response.ok) {
         this.attachment = e.target.value
         this.showErrors = false
         this.$refs.attachmentFilename.value = file.name
         this.$refs.attachmentObjectName.value = this.objectName
-      } catch (err) {
-        console.log(err)
+      } else {
         this.showErrors = true
+        this.uploadError = 'Your file failed to upload. Please try again later.'
       }
 
       this.changed = true

--- a/js/lib/upload.js
+++ b/js/lib/upload.js
@@ -70,7 +70,7 @@ class MockUploader {
   }
 
   async upload(file, objectName) {
-    return Promise.resolve({})
+    return Promise.resolve({ ok: true })
   }
 }
 

--- a/js/test_templates/upload_input_error_template.html
+++ b/js/test_templates/upload_input_error_template.html
@@ -25,14 +25,6 @@
           <span class="upload-button">
             Browse
           </span>
-          
-            <span v-show="showErrors">
-      <span class="icon icon--alert icon-validation" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" fill="#fdb81e">
-  <path d="M8 16c-4.411 0-8-3.589-8-8s3.589-8 8-8 8 3.589 8 8-3.589 8-8 8zM8 2C4.691 2 2 4.691 2 8s2.691 6 6 6 6-2.691 6-6-2.691-6-6-6zm0 8c-.552 0-1-.447-1-1V4c0-.552.448-1 1-1s1 .448 1 1v5c0 .553-.448 1-1 1zm0 3c-.26 0-.52-.11-.71-.29-.18-.19-.29-.45-.29-.71 0-.271.11-.521.29-.71.38-.37 1.05-.37 1.42 0 .18.189.29.45.29.71s-.11.52-.29.71c-.19.18-.45.29-.71.29z"/>
-</svg>
-</span>
-  </span>
-          
         </label>
         <input
           v-on:change="addAttachment"
@@ -46,8 +38,11 @@
           <input type="hidden" name="pdf-filename" id="pdf-filename" ref="attachmentFilename">
           <input type="hidden" name="pdf-object_name" id="pdf-object_name" ref="attachmentObjectName">
       </div>
+      <template v-if="uploadError">
+        <span class="usa-input__message">There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.</span>
+      </template>
       
-        <span v-show="showErrors" class="usa-input__message">[&#39;Test Error Message&#39;]</span>
+        <span class="usa-input__message">Test Error Message</span>
       
     </div>
   </div>

--- a/js/test_templates/upload_input_template.html
+++ b/js/test_templates/upload_input_template.html
@@ -25,7 +25,6 @@
           <span class="upload-button">
             Browse
           </span>
-          
         </label>
         <input
           v-on:change="addAttachment"
@@ -39,6 +38,9 @@
           <input type="hidden" name="pdf-filename" id="pdf-filename" ref="attachmentFilename">
           <input type="hidden" name="pdf-object_name" id="pdf-object_name" ref="attachmentObjectName">
       </div>
+      <template v-if="uploadError">
+        <span class="usa-input__message">There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.</span>
+      </template>
       
     </div>
   </div>

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -5,6 +5,7 @@ from datetime import timedelta, date, timedelta
 import random
 from faker import Faker
 from werkzeug.datastructures import FileStorage
+from uuid import uuid4
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.append(parent_dir)
@@ -30,9 +31,9 @@ from atst.routes.dev import _DEV_USERS as DEV_USERS
 
 from tests.factories import (
     random_service_branch,
-    random_task_order_number,
     TaskOrderFactory,
     CLINFactory,
+    AttachmentFactory
 )
 
 fake = Faker()
@@ -167,20 +168,19 @@ def add_task_orders_to_portfolio(portfolio):
     yesterday = today - timedelta(days=1)
     five_days = timedelta(days=5)
 
-    with open("tests/fixtures/sample.pdf", "rb") as fp:
-        pdf = FileStorage(fp, content_type="application/pdf")
+    pdf = {"filename": "sample_task_order.pdf", "object_name": str(uuid4())}
 
-        draft_to = TaskOrderFactory.build(portfolio=portfolio, pdf=None)
-        unsigned_to = TaskOrderFactory.build(portfolio=portfolio, pdf=pdf)
-        upcoming_to = TaskOrderFactory.build(
-            portfolio=portfolio, signed_at=yesterday, pdf=pdf
-        )
-        expired_to = TaskOrderFactory.build(
-            portfolio=portfolio, signed_at=yesterday, pdf=pdf
-        )
-        active_to = TaskOrderFactory.build(
-            portfolio=portfolio, signed_at=yesterday, pdf=pdf
-        )
+    draft_to = TaskOrderFactory.build(portfolio=portfolio, pdf=None)
+    unsigned_to = TaskOrderFactory.build(portfolio=portfolio, pdf=pdf)
+    upcoming_to = TaskOrderFactory.build(
+        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+    )
+    expired_to = TaskOrderFactory.build(
+        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+    )
+    active_to = TaskOrderFactory.build(
+        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+    )
 
     clins = [
         CLINFactory.build(

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -33,7 +33,7 @@ from tests.factories import (
     random_service_branch,
     TaskOrderFactory,
     CLINFactory,
-    AttachmentFactory
+    AttachmentFactory,
 )
 
 fake = Faker()

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -1,7 +1,7 @@
 # Add root application dir to the python path
 import os
 import sys
-from datetime import timedelta, date, timedelta
+from datetime import timedelta, date
 import random
 from faker import Faker
 from werkzeug.datastructures import FileStorage
@@ -168,18 +168,19 @@ def add_task_orders_to_portfolio(portfolio):
     yesterday = today - timedelta(days=1)
     five_days = timedelta(days=5)
 
-    pdf = {"filename": "sample_task_order.pdf", "object_name": str(uuid4())}
+    def build_pdf():
+        return {"filename": "sample_task_order.pdf", "object_name": str(uuid4())}
 
     draft_to = TaskOrderFactory.build(portfolio=portfolio, pdf=None)
-    unsigned_to = TaskOrderFactory.build(portfolio=portfolio, pdf=pdf)
+    unsigned_to = TaskOrderFactory.build(portfolio=portfolio, pdf=build_pdf())
     upcoming_to = TaskOrderFactory.build(
-        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+        portfolio=portfolio, signed_at=yesterday, pdf=build_pdf()
     )
     expired_to = TaskOrderFactory.build(
-        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+        portfolio=portfolio, signed_at=yesterday, pdf=build_pdf()
     )
     active_to = TaskOrderFactory.build(
-        portfolio=portfolio, signed_at=yesterday, pdf=pdf
+        portfolio=portfolio, signed_at=yesterday, pdf=build_pdf()
     )
 
     clins = [

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -30,9 +30,6 @@
           <span class="upload-button">
             Browse
           </span>
-          {% if field.errors %}
-            <span v-show="showErrors">{{ Icon('alert',classes="icon-validation") }}</span>
-          {% endif %}
         </label>
         <input
           v-on:change="addAttachment"
@@ -46,8 +43,11 @@
           <input type="hidden" name="{{ field.filename.name }}" id="{{ field.filename.name }}" ref="attachmentFilename">
           <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName">
       </div>
-      {% for error, error_message in field.errors.items() %}
-        <span v-show="showErrors" class="usa-input__message">{{error_message}}</span>
+      <template v-if="uploadError">
+        <span v-show="showErrors" class="usa-input__message">!{uploadError}</span>
+      </template>
+      {% for error, error_messages in field.errors.items() %}
+        <span v-show="showErrors" class="usa-input__message">{{error_messages[0]}}.</span>
       {% endfor %}
     </div>
   </div>

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -44,7 +44,7 @@
           <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName">
       </div>
       <template v-if="uploadError">
-        <span class="usa-input__message">There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.</span>
+        <span class="usa-input__message">{{ "forms.task_order.upload_error" | translate }}</span>
       </template>
       {% for error, error_messages in field.errors.items() %}
         <span class="usa-input__message">{{error_messages[0]}}</span>

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -44,10 +44,10 @@
           <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName">
       </div>
       <template v-if="uploadError">
-        <span v-show="showErrors" class="usa-input__message">!{uploadError}</span>
+        <span class="usa-input__message">There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.</span>
       </template>
       {% for error, error_messages in field.errors.items() %}
-        <span v-show="showErrors" class="usa-input__message">{{error_messages[0]}}.</span>
+        <span class="usa-input__message">{{error_messages[0]}}</span>
       {% endfor %}
     </div>
   </div>

--- a/tests/routes/task_orders/test_new.py
+++ b/tests/routes/task_orders/test_new.py
@@ -1,6 +1,7 @@
 import pytest
 from flask import url_for, get_flashed_messages
 from datetime import timedelta, date
+from uuid import uuid4
 
 from atst.domain.task_orders import TaskOrders
 from atst.models.task_order import Status as TaskOrderStatus
@@ -10,8 +11,8 @@ from tests.factories import CLINFactory, PortfolioFactory, TaskOrderFactory, Use
 from tests.utils import captured_templates
 
 
-def build_pdf_form_data(filename="sample.pdf", object_name="object_name"):
-    return {"pdf-filename": filename, "pdf-object_name": object_name}
+def build_pdf_form_data(filename="sample.pdf", object_name=None):
+    return {"pdf-filename": filename, "pdf-object_name": object_name or uuid4()}
 
 
 @pytest.fixture

--- a/translations.yaml
+++ b/translations.yaml
@@ -145,7 +145,13 @@ forms:
   portfolio:
     name_label: Portfolio name
     name_length_validation_message: Portfolio names can be between 4-100 characters
+  attachment:
+    object_name:
+      length_error: Object name may be no longer than 40 characters.
+    filename:
+      length_error: Filename may be no longer than 100 characters.
   task_order:
+    upload_error: There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.
     app_migration:
       both: 'Yes, migrating from both an on-premise data center <strong>and</strong> another cloud provider'
       cloud: 'Yes, migrating from another cloud provider'


### PR DESCRIPTION
Adds validations for both hidden fields of the TO file upload form (filename and object_name). Also adds an error state to the form when there's an error uploading the file to the CSP.

I threw in a small fix to `scripts/seed_sample.py`.

<img width="954" alt="Screen Shot 2019-08-13 at 1 40 12 PM" src="https://user-images.githubusercontent.com/38955572/62964802-bc829600-bdd1-11e9-9548-c80271b41ccc.png">
