### PR TITLE
Env roles bug fix

### DIFF
--- a/atst/forms/application_member.py
+++ b/atst/forms/application_member.py
@@ -19,6 +19,13 @@ class EnvironmentForm(FlaskForm):
         filters=[lambda x: None if x == "None" else x],
     )
 
+    @property
+    def data(self):
+        _data = super().data
+        if "role" in _data and _data["role"] == NO_ACCESS:
+            _data["role"] = None
+        return _data
+
 
 class PermissionsForm(FlaskForm):
     perms_env_mgmt = BooleanField(

--- a/atst/forms/data.py
+++ b/atst/forms/data.py
@@ -113,7 +113,7 @@ TEAM_EXPERIENCE = [
 
 ENV_ROLE_NO_ACCESS = "No Access"
 ENV_ROLES = [(role.value, role.value) for role in CSPRole] + [
-    (ENV_ROLE_NO_ACCESS, "No access")
+    (ENV_ROLE_NO_ACCESS, ENV_ROLE_NO_ACCESS)
 ]
 
 JEDI_CLIN_TYPES = [

--- a/atst/forms/team.py
+++ b/atst/forms/team.py
@@ -3,7 +3,7 @@ from wtforms.fields import FormField, FieldList, HiddenField, RadioField, String
 from wtforms.validators import Required
 
 from .application_member import EnvironmentForm as BaseEnvironmentForm
-from .data import ENV_ROLES, ENV_ROLE_NO_ACCESS as NO_ACCESS
+from .data import ENV_ROLES
 from .forms import BaseForm
 from atst.forms.fields import SelectField
 from atst.domain.permission_sets import PermissionSets
@@ -17,13 +17,6 @@ class EnvironmentForm(BaseEnvironmentForm):
         default=None,
         filters=[lambda x: None if x == "None" else x],
     )
-
-    @property
-    def data(self):
-        _data = super().data
-        if "role" in _data and _data["role"] == NO_ACCESS:
-            _data["role"] = None
-        return _data
 
 
 class PermissionsForm(FlaskForm):

--- a/tests/forms/test_application_member.py
+++ b/tests/forms/test_application_member.py
@@ -22,7 +22,7 @@ def test_environment_form_default_no_access():
     assert form.data == {
         "environment_id": 123,
         "environment_name": "testing",
-        "role": NO_ACCESS,
+        "role": None,
     }
 
 


### PR DESCRIPTION
## Description
There was an issue when a new member was added to an application -- environment roles were being created with the role `No Access`, but an env role should be created if the user does not have access to the env. This was happening because `No Access` was not being properly filtered and converted to `None` by the form.
I fixed the issue by moving the data property into the EnvironmentForm that is used in the NewForm (creates a new app member), so now the form properly handles the value `No Access`.

## Pivotal
https://www.pivotaltracker.com/story/show/165793573