### PR TITLE
Application members should not see deleted applications.

### DIFF
--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -63,6 +63,7 @@ class Applications(BaseDomainClass):
 
         for role in application.roles:
             role.deleted = True
+            role.status = ApplicationRoleStatus.DISABLED
             db.session.add(role)
 
         db.session.add(application)

--- a/atst/domain/portfolios/query.py
+++ b/atst/domain/portfolios/query.py
@@ -35,6 +35,7 @@ class PortfoliosQuery(Query):
                                     ApplicationRole.status
                                     == ApplicationRoleStatus.ACTIVE
                                 )
+                                .filter(ApplicationRole.deleted == False)
                                 .subquery()
                             )
                         )

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -225,3 +225,18 @@ def test_for_user_does_not_include_deleted_portfolios():
     user = UserFactory.create()
     PortfolioFactory.create(owner=user, deleted=True)
     assert len(Portfolios.for_user(user)) == 0
+
+
+def test_for_user_does_not_include_deleted_application_roles():
+    user1 = UserFactory.create()
+    user2 = UserFactory.create()
+    portfolio = PortfolioFactory.create()
+    app = ApplicationFactory.create(portfolio=portfolio)
+    ApplicationRoleFactory.create(
+        status=ApplicationRoleStatus.ACTIVE, user=user1, application=app
+    )
+    assert len(Portfolios.for_user(user1)) == 1
+    ApplicationRoleFactory.create(
+        status=ApplicationRoleStatus.ACTIVE, user=user2, application=app, deleted=True
+    )
+    assert len(Portfolios.for_user(user2)) == 0


### PR DESCRIPTION
This updates the `Portfolios.for_user` method to screen out deleted
ApplicationRole entities. For extra assurance, we also mark application
roles as disabled when they are deleted.

PT story: https://www.pivotaltracker.com/story/show/167299614