### PR TITLE
Center all modals

### DIFF
--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -18,6 +18,9 @@ body {
   &__container {
     height: 100vh;
     max-height: 100vh;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
 
     .usa-input .usa-input__choices label {
       max-width: 62rem;


### PR DESCRIPTION
## Description
Fixes a bug where modals were appearing at the top of the screen.

## Pivotal
https://www.pivotaltracker.com/story/show/167854946

## Screenshot
<img width="1552" alt="Screen Shot 2019-08-15 at 11 03 43 AM" src="https://user-images.githubusercontent.com/43828539/63104140-684ff100-bf4c-11e9-9137-92556b98f501.png">
<img width="1552" alt="Screen Shot 2019-08-15 at 11 03 50 AM" src="https://user-images.githubusercontent.com/43828539/63104144-68e88780-bf4c-11e9-9e59-ef482e397058.png">

