### PR TITLE
Styling Bugs

### DIFF
--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -49,6 +49,7 @@
       font-weight: $font-bold;
       border-bottom: 1px solid $color-gray-lightest;
       margin: 0;
+      list-style-type: none;
 
       .icon-link--large {
         padding-top: $gap * 0.5;

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -119,10 +119,6 @@
         float: none;
       }
 
-      > *:first-child {
-        padding-left: 0;
-      }
-
       > *:last-child {
         float: right;
       }

--- a/styles/components/_accordion_table.scss
+++ b/styles/components/_accordion_table.scss
@@ -107,6 +107,7 @@
     &__action-group {
       padding: 1rem 3.2rem;
       background-color: $color-gray-lightest;
+      text-align: right;
 
       button,
       a {
@@ -117,10 +118,6 @@
       .icon-link {
         padding-top: 0.5rem;
         float: none;
-      }
-
-      > *:last-child {
-        float: right;
       }
     }
 

--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -98,6 +98,10 @@
       cursor: default;
       margin: 0 0 0 ($gap / 2);
     }
+
+    &__view-only {
+      margin: 0;
+    }
   }
 
   &__help {

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -56,18 +56,18 @@
         </p>
         <div class="form-row">
           <div class="form-col">
-            <div class="usa-input usa-input__title">
+            <div class="usa-input usa-input__title__view-only">
               {{ application_form.name.label() }}
-              {{ application_form.name.data }}
             </div>
+            {{ application_form.name.data }}
           </div>
         </div>
         <div class="form-row">
           <div class="form-col">
-            <div class="usa-input usa-input__title">
+            <div class="usa-input usa-input__title__view-only">
               {{ application_form.description.label() }}
-              {{ application_form.description.data }}
             </div>
+            {{ application_form.description.data }}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Description
Fixes `Remove Member` button in the team settings table.
Fixes the formatting of the name and description of an app when the user has view only perms.
Removes bullet points that were showing up in the app settings and team settings tables.

## Pivotal
https://www.pivotaltracker.com/story/show/167731572
https://www.pivotaltracker.com/story/show/167745600
https://www.pivotaltracker.com/story/show/167874574

## Screenshots
<img width="1552" alt="Screen Shot 2019-08-15 at 2 26 03 PM" src="https://user-images.githubusercontent.com/43828539/63117015-ecb06d00-bf68-11e9-8a68-f6e69e794ba2.png">
<img width="1552" alt="Screen Shot 2019-08-15 at 2 26 58 PM" src="https://user-images.githubusercontent.com/43828539/63117017-ede19a00-bf68-11e9-9890-8ad97ba01772.png">
<img width="1552" alt="Screen Shot 2019-08-15 at 2 27 55 PM" src="https://user-images.githubusercontent.com/43828539/63117022-f043f400-bf68-11e9-900d-2fc9d5993f5a.png">