### PR TITLE
Render new CCPO user form in IE11

### DIFF
--- a/templates/ccpo/add_user.html
+++ b/templates/ccpo/add_user.html
@@ -1,25 +1,24 @@
 {% extends "base.html" %}
 
+{% from "components/save_button.html" import SaveButton %}
 {% from "components/text_input.html" import TextInput %}
 
 {% block content %}
-  <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_new_user') }}" method="POST">
-    {{ form.csrf_token }}
-    <h1>{{ "ccpo.form.add_user_title" | translate }}</h1>
-    <div class='form-row'>
-      <div class='form-col form-col--two-thirds'>
-        {{ TextInput(form.dod_id, validation='dodId') }}
-      </div>
-      <div class="form-col form-col--third">
-        <div class='action-group'>
-          <input
-              type='submit'
-              v-bind:disabled="invalid"
-              class='action-group__action usa-button'
-              value='{{ "common.next" | translate }}'>
-          <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">{{ "common.cancel" | translate }}</a>
+  <base-form inline-template>
+    <form id="add-ccpo-user-form" action="{{ url_for('ccpo.submit_new_user') }}" method="POST">
+      {{ form.csrf_token }}
+      <h1>{{ "ccpo.form.add_user_title" | translate }}</h1>
+      <div class='form-row'>
+        <div class='form-col form-col--two-thirds'>
+          {{ TextInput(form.dod_id, validation='dodId') }}
+        </div>
+        <div class="form-col form-col--third">
+          <div class='action-group'>
+            {{ SaveButton(text="common.next"|translate, element="input", additional_classes="action-group__action", form="add-ccpo-user-form") }}
+            <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">{{ "common.cancel" | translate }}</a>
+          </div>
         </div>
       </div>
-    </div>
-  </form>
+    </form>
+  </base-form>
 {% endblock %}


### PR DESCRIPTION
## Description
Fixes a bug where the form to add a new CCPO user was not rendering in ie11.
This was caused by a vue error that was the result of not correctly implementing a save button that is disabled until the input is valid. Fixed by actually implementing the save button functionality we had previously built out.

## Pivotal
https://www.pivotaltracker.com/story/show/167922992

## Screenshots
<img width="1552" alt="Screen Shot 2019-08-15 at 3 42 22 PM" src="https://user-images.githubusercontent.com/43828539/63121794-4cac1100-bf73-11e9-859a-525b867fba9a.png">
