### PR TITLE
Use Disabled save button functionality across the site

### DIFF
--- a/templates/fragments/admin/add_new_portfolio_member.html
+++ b/templates/fragments/admin/add_new_portfolio_member.html
@@ -21,23 +21,23 @@
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.first_name, validation='requiredField') }}
+      {{ TextInput(member_form.user_data.first_name, validation='requiredField', optional=False) }}
     </div>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.last_name, validation='requiredField') }}
-    </div>
-  </div>
-  <div class='form-row'>
-    <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.email, validation='email') }}
-    </div>
-    <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.phone_number, validation='usPhone', optional=True) }}
+      {{ TextInput(member_form.user_data.last_name, validation='requiredField', optional=False) }}
     </div>
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(member_form.user_data.dod_id, validation='dodId') }}
+      {{ TextInput(member_form.user_data.email, validation='email', optional=False) }}
+    </div>
+    <div class='form-col form-col--half'>
+      {{ TextInput(member_form.user_data.phone_number, validation='usPhone') }}
+    </div>
+  </div>
+  <div class='form-row'>
+    <div class='form-col form-col--half'>
+      {{ TextInput(member_form.user_data.dod_id, validation='dodId', optional=False) }}
     </div>
     <div class='form-col form-col--half'>
     </div>

--- a/templates/fragments/applications/edit_environment_team_form.html
+++ b/templates/fragments/applications/edit_environment_team_form.html
@@ -81,7 +81,7 @@
           <div class='action-group'>
             {{
               SaveButton(
-                text=("portfolios.applications.update_button_text" | translate)
+                text=("common.save" | translate)
               )
             }}
           </div>

--- a/templates/fragments/applications/edit_environments.html
+++ b/templates/fragments/applications/edit_environments.html
@@ -90,7 +90,7 @@
                     {{ TextInput(edit_form.name, validation='requiredField') }}
                     {{
                       SaveButton(
-                        text=("portfolios.applications.update_button_text" | translate)
+                        text=("common.save" | translate)
                       )
                     }}
                   </form>

--- a/templates/fragments/applications/new_member_modal_content.html
+++ b/templates/fragments/applications/new_member_modal_content.html
@@ -8,15 +8,15 @@
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(new_member_form.user_data.first_name, validation='requiredField') }}
+      {{ TextInput(new_member_form.user_data.first_name, validation='requiredField', optional=False) }}
     </div>
     <div class='form-col form-col--half'>
-      {{ TextInput(new_member_form.user_data.last_name, validation='requiredField') }}
+      {{ TextInput(new_member_form.user_data.last_name, validation='requiredField', optional=False) }}
     </div>
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(new_member_form.user_data.email, validation='email') }}
+      {{ TextInput(new_member_form.user_data.email, validation='email', optional=False) }}
     </div>
     <div class='form-col form-col--half'>
       {{ TextInput(new_member_form.user_data.phone_number, validation='usPhone', optional=True) }}
@@ -24,7 +24,7 @@
   </div>
   <div class='form-row'>
     <div class='form-col form-col--half'>
-      {{ TextInput(new_member_form.user_data.dod_id, validation='dodId') }}
+      {{ TextInput(new_member_form.user_data.dod_id, validation='dodId', optional=False) }}
     </div>
     <div class='form-col form-col--half'>
     </div>

--- a/templates/portfolios/applications/new.html
+++ b/templates/portfolios/applications/new.html
@@ -43,7 +43,7 @@
           </p>
           <div class="form-row">
             <div class="form-col form-col--two-thirds">
-              {{ TextInput(form.name) }}
+              {{ TextInput(form.name, optional=False) }}
             </div>
             <div class="form-col form-col--third">
               &nbsp;
@@ -51,7 +51,7 @@
           </div>
           <div class="form-row">
             <div class="form-col form-col--two-thirds">
-              {{ TextInput(form.description, paragraph=True) }}
+              {{ TextInput(form.description, paragraph=True, optional=False) }}
             </div>
             <div class="form-col form-col--third">
               &nbsp;

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -5,6 +5,7 @@
 {% from "components/icon.html" import Icon %}
 {% from "components/modal.html" import Modal %}
 {% from "components/pagination.html" import Pagination %}
+{% from "components/save_button.html" import SaveButton %}
 {% from "components/text_input.html" import TextInput %}
 
 {% set secondary_breadcrumb = 'portfolios.applications.existing_application_title' | translate({ "application_name": application.name }) %}
@@ -14,40 +15,42 @@
   <div class='subheading'>{{ 'portfolios.applications.settings_heading' | translate }}</div>
 
   {% if user_can(permissions.EDIT_APPLICATION) %}
-    <form method="POST" action="{{ url_for('applications.update', application_id=application.id) }}">
-      <div class="panel">
-        <div class="panel__content">
-          {{ application_form.csrf_token }}
-          <p>
-            {{ "fragments.edit_application_form.explain" | translate }}
-          </p>
-          <div class="form-row">
-            <div class="form-col form-col--two-thirds">
-              {{ TextInput(application_form.name) }}
-              {{ TextInput(application_form.description, paragraph=True) }}
+    <base-form inline-template>
+      <form method="POST" action="{{ url_for('applications.update', application_id=application.id) }}">
+        <div class="panel">
+          <div class="panel__content">
+            {{ application_form.csrf_token }}
+            <p>
+              {{ "fragments.edit_application_form.explain" | translate }}
+            </p>
+            <div class="form-row">
+              <div class="form-col form-col--two-thirds">
+                {{ TextInput(application_form.name) }}
+                {{ TextInput(application_form.description, paragraph=True) }}
+              </div>
+              <div class="form-col form-col--third">
+                {% if user_can(permissions.DELETE_APPLICATION) %}
+                  <div class="usa-input">
+                    <input
+                      id="delete-application"
+                      type="button"
+                      v-on:click="openModal('delete-application')"
+                      class='usa-button button-danger-outline'
+                      value="{{ 'portfolios.applications.delete.button' | translate }}"
+                      >
+                  </div>
+                {% endif %}
+              </div>
             </div>
-            <div class="form-col form-col--third">
-              {% if user_can(permissions.DELETE_APPLICATION) %}
-                <div class="usa-input">
-                  <input
-                    id="delete-application"
-                    type="button"
-                    v-on:click="openModal('delete-application')"
-                    class='usa-button button-danger-outline'
-                    value="{{ 'portfolios.applications.delete.button' | translate }}"
-                    >
-                </div>
-              {% endif %}
+          </div>
+          <div class="panel__footer">
+            <div class="action-group">
+              {{ SaveButton('common.save'|translate) }}
             </div>
           </div>
         </div>
-        <div class="panel__footer">
-          <div class="action-group">
-            <button class="usa-button usa-button-primary" tabindex="0" type="submit">{{ 'portfolios.applications.update_button_text' | translate }}</button>
-          </div>
-        </div>
-      </div>
-    </form>
+      </form>
+    </base-form>
   {% else %}
     <div class="panel">
       <div class="panel__content">

--- a/translations.yaml
+++ b/translations.yaml
@@ -325,7 +325,6 @@ portfolios:
       title: '{application_name} Team Settings'
       add_to_environment: Add to existing environment
     team_text: Team
-    update_button_text: Save
     members:
       new:
         assign_roles: Assign Member Environments and Roles


### PR DESCRIPTION
## Description
This PR makes the functionality of the save buttons consistent across the site. Now all save/next/continue buttons in forms remain disabled until the form is valid or, in the case of editing something, a change is made. Adding this functionality to the new ccpo user form is covered in #1027.
Let me know if I missed any save/next/continue buttons!

## Pivotal
https://www.pivotaltracker.com/story/show/167929699