### PR TITLE
File upload fixes

### DIFF
--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -64,12 +64,12 @@ export default {
   methods: {
     addAttachment: async function(e) {
       const file = e.target.files[0]
-
       const response = await this.uploader.upload(file, this.objectName)
       if (response.ok) {
         this.attachment = e.target.value
         this.$refs.attachmentFilename.value = file.name
         this.$refs.attachmentObjectName.value = this.objectName
+        this.$refs.attachmentInput.disabled = true
       } else {
         this.showErrors = true
         this.uploadError = true
@@ -89,6 +89,7 @@ export default {
       this.attachment = null
       if (this.$refs.attachmentInput) {
         this.$refs.attachmentInput.value = null
+        this.$refs.attachmentInput.disabled = false
       }
       this.showErrors = false
       this.uploadError = false

--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -110,7 +110,7 @@ export default {
     clearErrors: function() {
       this.uploadError = false
       this.sizeError = false
-    }
+    },
   },
 
   computed: {
@@ -126,7 +126,11 @@ export default {
       return this.hasInitialData && !this.changed
     },
     showErrors: function() {
-      return (!this.changed && this.initialErrors) || this.uploadError || this.sizeError
-    }
+      return (
+        (!this.changed && this.initialErrors) ||
+        this.uploadError ||
+        this.sizeError
+      )
+    },
   },
 }

--- a/js/lib/upload.js
+++ b/js/lib/upload.js
@@ -32,9 +32,9 @@ class AzureUploader {
           options,
           function(err, result) {
             if (err) {
-              resolve({ok: false})
+              resolve({ ok: false })
             } else {
-              resolve({ok: true})
+              resolve({ ok: true })
             }
           }
         )

--- a/js/lib/upload.js
+++ b/js/lib/upload.js
@@ -32,9 +32,9 @@ class AzureUploader {
           options,
           function(err, result) {
             if (err) {
-              reject(err)
+              resolve({ok: false})
             } else {
-              resolve(result)
+              resolve({ok: true})
             }
           }
         )

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -46,6 +46,9 @@
       <template v-if="uploadError">
         <span class="usa-input__message">{{ "forms.task_order.upload_error" | translate }}</span>
       </template>
+      <template v-if="sizeError">
+        <span class="usa-input__message">{{ "forms.task_order.size_error" | translate }}</span>
+      </template>
       {% for error, error_messages in field.errors.items() %}
         <span class="usa-input__message">{{error_messages[0]}}</span>
       {% endfor %}

--- a/translations.yaml
+++ b/translations.yaml
@@ -156,6 +156,7 @@ forms:
       length_error: Filename may be no longer than 100 characters.
   task_order:
     upload_error: There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.
+    size_error: The file you have selected is too large. Please choose a file no larger than 64MB.
     app_migration:
       both: 'Yes, migrating from both an on-premise data center <strong>and</strong> another cloud provider'
       cloud: 'Yes, migrating from another cloud provider'


### PR DESCRIPTION
Fixes some of the bugs in the TO upload form:

## Azure uploads resulting in error messages even when the upload is successful

## Large file uploads result in "Request Entity Too Large" from nginx even though the uploads are happening in the client

This was caused by the fact that the upload form still contains an `<input type="file">`. Though we're only using it for display purposes, the value of that field (the file) was still being sent to the server which caused nginx to choke. By disabling this form when the file is attached, the value won't be sent to the server. Then we enable it again when the file is removed so that the user can interact with the input again.

## File uploads larger than 64MB don't work on Azure

I implemented a client-side check for filesize which displays an error message and doesn't upload the file. The copy for this message hasn't been confirmed yet. 64MB seems like a large enough size that it should be acceptable for either CSP.