### PR TITLE
URL changed for the entr tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ locally:
   running on the default port of 6379. You can ensure that Redis is running by
   executing `redis-cli` with no options and ensuring a connection is succesfully made.
 
-* [`entr`](http://www.entrproject.org/)
+* [`entr`](http://eradman.com/entrproject/)
   This dependency is optional. If present, the queue worker process will hot
   reload in development.
 


### PR DESCRIPTION
As I ran through the setup steps for the Catalina Beta testing, I found that the entr project homepage has moved. This PR updates the README accordingly.

Pivotal Tracker card: https://www.pivotaltracker.com/story/show/167950792