### PR TITLE
Center modals in ie11

### DIFF
--- a/styles/components/_modal.scss
+++ b/styles/components/_modal.scss
@@ -21,6 +21,7 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: center;
+    align-items: center;
 
     .usa-input .usa-input__choices label {
       max-width: 62rem;


### PR DESCRIPTION
## Description
Fix bug in IE11 where modals were not centered horizontally on the screen.

## Pivotal
https://www.pivotaltracker.com/story/show/167854946

## Screenshot
<img width="1532" alt="Screen Shot 2019-08-19 at 11 20 57 AM" src="https://user-images.githubusercontent.com/43828539/63277504-7450f100-c273-11e9-96e8-1a64be03ace5.png">
