### PR TITLE
Fix Vue bug in CCPO new user confirmation.

### DIFF
--- a/templates/ccpo/confirm_user.html
+++ b/templates/ccpo/confirm_user.html
@@ -22,7 +22,6 @@
       <div class='action-group'>
         <input
             type='submit'
-            v-bind:disabled="invalid"
             class='action-group__action usa-button'
             value='{{ "ccpo.form.confirm_button" | translate }}'>
         <a class='action-group__action icon-link icon-link--default' href="{{ url_for('ccpo.users') }}">


### PR DESCRIPTION
The submit button for the page contained a Vue directive, but the button
is not nested in an appropriate Vue component. The directive and
associated behavior are unnecessary in this case, so I removed the
directive.

PT story: https://www.pivotaltracker.com/story/show/167922992
It specifically addresses this comment: https://www.pivotaltracker.com/story/show/167922992/comments/205803883