### PR TITLE
Bugfix: Use correct path to full_name

### DIFF
--- a/atst/routes/portfolios/admin.py
+++ b/atst/routes/portfolios/admin.py
@@ -188,7 +188,7 @@ def remove_member(portfolio_id, portfolio_role_id):
     # roles they might have?
     PortfolioRoles.disable(portfolio_role=portfolio_role)
 
-    flash("portfolio_member_removed", member_name=portfolio_role.user.full_name)
+    flash("portfolio_member_removed", member_name=portfolio_role.full_name)
 
     return redirect(
         url_for(


### PR DESCRIPTION
The `full_name` property is on the `portfolio_role` object, not an intermediate `user` object

Fixes: https://www.pivotaltracker.com/story/show/167932834