### PR TITLE
Enable debug mode in tests.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2019-08-28T19:50:39Z",
+  "generated_at": "2019-08-29T17:03:11Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -194,11 +194,10 @@
         "hashed_secret": "e4f14805dfd1e6af030359090c535e149e6b4207",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 523,
+        "line_number": 544,
         "type": "Hex High Entropy String"
       }
     ]
   },
   "version": "0.12.5"
 }
-

--- a/config/test.ini
+++ b/config/test.ini
@@ -1,7 +1,8 @@
 [default]
-DEBUG = false
+DEBUG = true
 ENVIRONMENT = test
 PGDATABASE = atat_test
 CRL_STORAGE_CONTAINER = tests/fixtures/crl
 WTF_CSRF_ENABLED = false
 STORAGE_PROVIDER=LOCAL
+PRESERVE_CONTEXT_ON_EXCEPTION = false

--- a/tests/routes/portfolios/test_admin.py
+++ b/tests/routes/portfolios/test_admin.py
@@ -1,5 +1,5 @@
 from flask import url_for
-from unittest.mock import Mock
+from unittest.mock import MagicMock
 
 from atst.domain.permission_sets import PermissionSets
 from atst.domain.portfolio_roles import PortfolioRoles
@@ -129,7 +129,7 @@ def test_rerender_admin_page_if_member_perms_form_does_not_validate(
         "members_permissions-0-perms_portfolio_mgmt": "view_portfolio_admin",
     }
 
-    mock_route = Mock()
+    mock_route = MagicMock(return_value=("", 200, {}))
     monkeypatch.setattr("atst.routes.portfolios.admin.render_admin_page", mock_route)
     client.post(
         url_for("portfolios.edit_members", portfolio_id=portfolio.id), data=form_data

--- a/tests/routes/portfolios/test_index.py
+++ b/tests/routes/portfolios/test_index.py
@@ -1,4 +1,5 @@
 from flask import url_for
+import pytest
 
 from tests.factories import (
     random_future_date,
@@ -9,7 +10,7 @@ from tests.factories import (
     UserFactory,
 )
 from atst.utils.localization import translate
-from atst.domain.portfolios import Portfolios
+from atst.domain.portfolios import Portfolios, PortfolioDeletionApplicationsExistError
 from atst.domain.portfolios.query import PortfoliosQuery
 
 
@@ -128,7 +129,7 @@ def test_delete_portfolio_success(client, user_session):
     assert len(Portfolios.for_user(user=owner)) == 0
 
 
-def test_delete_portfolio_failure(client, user_session):
+def test_delete_portfolio_failure(no_debug_client, user_session):
     portfolio = PortfolioFactory.create()
     application = ApplicationFactory.create(portfolio=portfolio)
     owner = portfolio.owner
@@ -136,7 +137,7 @@ def test_delete_portfolio_failure(client, user_session):
 
     assert len(Portfolios.for_user(user=owner)) == 1
 
-    response = client.post(
+    response = no_debug_client.post(
         url_for("portfolios.delete_portfolio", portfolio_id=portfolio.id)
     )
 

--- a/tests/utils/test_context_processors.py
+++ b/tests/utils/test_context_processors.py
@@ -1,3 +1,5 @@
+from unittest.mock import Mock
+
 import pytest
 
 from atst.domain.permission_sets import PermissionSets
@@ -33,15 +35,14 @@ def test_get_resources_from_context():
 
 
 @pytest.fixture
-def set_g(request_ctx):
+def set_g(monkeypatch):
+    _g = Mock()
+    monkeypatch.setattr("atst.utils.context_processors.g", _g)
+
     def _set_g(attr, val):
-        setattr(request_ctx.g, attr, val)
+        setattr(_g, attr, val)
 
     yield _set_g
-
-    setattr(request_ctx.g, "application", None)
-    setattr(request_ctx.g, "portfolio", None)
-    setattr(request_ctx.g, "current_user", None)
 
 
 def test_user_can_view(set_g):
@@ -77,4 +78,5 @@ def test_portfolio_no_user(set_g):
 def test_portfolio_with_user(set_g):
     user = UserFactory.create()
     set_g("current_user", user)
+    set_g("portfolio", None)
     assert portfolio_context() != {}


### PR DESCRIPTION
Debug mode allows route integration tests to raise explicit exceptions on
errors, instead of returning error pages. Some portions of the test
suite need to be able to ignore exceptions (the response is not under
test) so they use a separate pytest fixture version of the app and
client that are configured with debug disabled, as it would be in
production.