### PR TITLE
Add optional label to inputs

### DIFF
--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -86,7 +86,6 @@
   }
 
   &__title {
-    display: flex;
     align-items: center;
 
     &-inline {

--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -378,8 +378,7 @@ select {
     margin-left: $gap * 4;
 
     .usa-input {
-      input,
-      label {
+      input {
         max-width: 12rem;
       }
 

--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -1,7 +1,7 @@
 {% from "components/icon.html" import Icon %}
 {% from "components/tooltip.html" import Tooltip %}
 
-{% macro MultiCheckboxInput(field, other_input_field=None, tooltip=None, inline=False) -%}
+{% macro MultiCheckboxInput(field, other_input_field=None, tooltip=None, inline=False, optional=True) -%}
   <multicheckboxinput
     v-cloak
     name='{{ field.name }}'
@@ -24,6 +24,10 @@
         <legend>
           <div class="usa-input__title">
             {{ field.label | striptags}}
+            {% if optional %}
+              &nbsp;
+              <span class="usa-input-label-helper">(optional)</span>
+            {% endif %}
             {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
             {% if not field.description %}
               {{ validation_icons }}

--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -23,9 +23,8 @@
       <fieldset data-ally-disabled="true" v-on:change="onInput" class="usa-input__choices {% if inline %}usa-input__choices--inline{% endif %}">
         <legend>
           <div class="usa-input__title">
-            {{ field.label | striptags}}
+            {{ field.label | striptags }}
             {% if optional %}
-              &nbsp;
               <span class="usa-input-label-helper">(optional)</span>
             {% endif %}
             {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -28,6 +28,10 @@
           <legend>
             <div class="usa-input__title{% if not field.description %}-inline{% endif %}">
               {{ field.label | striptags}}
+              {% if optional %}
+                &nbsp;
+                <span class="usa-input-label-helper">(optional)</span>
+              {% endif %}
               {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}
             </div>
 

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -29,7 +29,6 @@
             <div class="usa-input__title{% if not field.description %}-inline{% endif %}">
               {{ field.label | striptags}}
               {% if optional %}
-                &nbsp;
                 <span class="usa-input-label-helper">(optional)</span>
               {% endif %}
               {% if tooltip %}{{ Tooltip(tooltip) }}{% endif %}

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -40,6 +40,10 @@
         <label for={{field.name}}>
           <div class="usa-input__title">
             {{ label }}
+            {% if optional %}
+              &nbsp;
+              <span class="usa-input-label-helper">(optional)</span>
+            {% endif %}
             {% if tooltip and not disabled %}
               {{ Tooltip(tooltip, tooltip_title) }}
             {% endif %}

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -41,7 +41,6 @@
           <div class="usa-input__title">
             {{ label }}
             {% if optional %}
-              &nbsp;
               <span class="usa-input-label-helper">(optional)</span>
             {% endif %}
             {% if tooltip and not disabled %}

--- a/templates/fragments/edit_user_form.html
+++ b/templates/fragments/edit_user_form.html
@@ -22,9 +22,9 @@
         {{ TextInput(form.email, validation='email', optional=False) }}
         {{ PhoneInput(form.phone_number, form.phone_ext, phone_optional=False) }}
 
-        {{ OptionsInput(form.service_branch) }}
-        {{ OptionsInput(form.citizenship) }}
-        {{ OptionsInput(form.designation) }}
+        {{ OptionsInput(form.service_branch, optional=False) }}
+        {{ OptionsInput(form.citizenship, optional=False) }}
+        {{ OptionsInput(form.designation, optional=False) }}
 
 
         <div class="usa-input">

--- a/templates/portfolios/admin.html
+++ b/templates/portfolios/admin.html
@@ -17,7 +17,7 @@
               {{ portfolio_form.csrf_token }}
               <div class='form-row'>
                 <div class='form-col form-col--half'>
-                  {{ TextInput(portfolio_form.name, validation="portfolioName") }}
+                  {{ TextInput(portfolio_form.name, validation="portfolioName", optional=False) }}
                 </div>
                 <div class='edit-portfolio-name action-group'>
                   {{ SaveButton(text='Save', additional_classes='usa-button-big') }}

--- a/templates/portfolios/applications/settings.html
+++ b/templates/portfolios/applications/settings.html
@@ -25,8 +25,8 @@
             </p>
             <div class="form-row">
               <div class="form-col form-col--two-thirds">
-                {{ TextInput(application_form.name) }}
-                {{ TextInput(application_form.description, paragraph=True) }}
+                {{ TextInput(application_form.name, optional=False) }}
+                {{ TextInput(application_form.description, paragraph=True, optional=False) }}
               </div>
               <div class="form-col form-col--third">
                 {% if user_can(permissions.DELETE_APPLICATION) %}

--- a/templates/portfolios/new.html
+++ b/templates/portfolios/new.html
@@ -14,7 +14,7 @@
     <form id="portfolio-create" action="{{ url_for('portfolios.create_portfolio') }}" method="POST">
       {{ form.csrf_token }}
 
-      {{ TextInput(form.name) }}
+      {{ TextInput(form.name, optional=False) }}
       {{ OptionsInput(form.defense_component, optional=False) }}
       {{ TextInput(form.description, paragraph=True) }}
 

--- a/translations.yaml
+++ b/translations.yaml
@@ -143,7 +143,7 @@ forms:
     first_name_label: First name
     funding: Funding
     last_name_label: Last name
-    phone_number_label: Phone number (optional)
+    phone_number_label: Phone number
     portfolio_mgmt: Portfolio management
     reporting: Reporting
   portfolio:


### PR DESCRIPTION
## Description
Uses the `optional` attribute in input macros to conditionally display the optional tag in form field labels. 
Let me know if any of the fields are incorrectly labeled optional or vice versa. I was going by what was required in our WTForms classes.

## Pivotal
https://www.pivotaltracker.com/story/show/168199417

## Screenshots
<img width="1182" alt="Screen Shot 2019-08-29 at 1 37 47 PM" src="https://user-images.githubusercontent.com/43828539/63963242-9a8c4300-ca62-11e9-9a08-13a664ad32e9.png">
<img width="1182" alt="Screen Shot 2019-08-29 at 1 37 51 PM" src="https://user-images.githubusercontent.com/43828539/63963250-9e1fca00-ca62-11e9-95ae-dab8ec0867cf.png">
<img width="1182" alt="Screen Shot 2019-08-29 at 1 37 54 PM" src="https://user-images.githubusercontent.com/43828539/63963254-a11aba80-ca62-11e9-8350-d3dd8a6b64a8.png">
<img width="1242" alt="Screen Shot 2019-08-29 at 1 40 00 PM" src="https://user-images.githubusercontent.com/43828539/63963258-a546d800-ca62-11e9-91ee-73a910891080.png">
<img width="1242" alt="Screen Shot 2019-08-29 at 1 41 26 PM" src="https://user-images.githubusercontent.com/43828539/63963311-bf80b600-ca62-11e9-8b27-c8df369737ab.png">

