### PR TITLE
Make log-level INFO for Celery workers in kubernetes cluster.

### DIFF
--- a/deploy/aws/aws.yml
+++ b/deploy/aws/aws.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:884d95ada21a5097f5c07f305d8e4e24d0f2a03f
+          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
           resources:
             requests:
                memory: "500Mi"
@@ -139,13 +139,14 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:884d95ada21a5097f5c07f305d8e4e24d0f2a03f
+          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
           args: [
             "/opt/atat/atst/.venv/bin/python",
             "/opt/atat/atst/.venv/bin/celery",
             "-A",
             "celery_worker.celery",
             "worker",
+            "--loglevel=info"
           ]
           resources:
             requests:

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: pwatat.azurecr.io/atat:884d95ada21a5097f5c07f305d8e4e24d0f2a03f
+          image: pwatat.azurecr.io/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
           resources:
             requests:
                memory: "500Mi"
@@ -140,13 +140,14 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: pwatat.azurecr.io/atat:884d95ada21a5097f5c07f305d8e4e24d0f2a03f
+          image: pwatat.azurecr.io/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
           args: [
             "/opt/atat/atst/.venv/bin/python",
             "/opt/atat/atst/.venv/bin/celery",
             "-A",
             "celery_worker.celery",
             "worker",
+            "--loglevel=info"
           ]
           resources:
             requests:


### PR DESCRIPTION
This is useful for testing and development purposes. Otherwise there's
not much log output.

This change has already been applied to the clusters. You can tail the logs for one of the worker pods.