### PR TITLE
Seed sample perms

### DIFF
--- a/atst/models/user.py
+++ b/atst/models/user.py
@@ -4,7 +4,6 @@ from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.event import listen
 
 from atst.models import Base, ApplicationRole, types, mixins
-from atst.models.permissions import Permissions
 from atst.models.portfolio_invitation import PortfolioInvitation
 from atst.models.application_invitation import ApplicationInvitation
 from atst.models.mixins.auditable import (
@@ -98,10 +97,6 @@ class User(
         return "{} {}".format(self.first_name, self.last_name)
 
     @property
-    def has_portfolios(self):
-        return (Permissions.VIEW_PORTFOLIO in self.permissions) or self.portfolio_roles
-
-    @property
     def displayname(self):
         return self.full_name
 
@@ -114,8 +109,8 @@ class User(
         return None
 
     def __repr__(self):
-        return "<User(name='{}', dod_id='{}', email='{}', has_portfolios='{}', id='{}')>".format(
-            self.full_name, self.dod_id, self.email, self.has_portfolios, self.id
+        return "<User(name='{}', dod_id='{}', email='{}', id='{}')>".format(
+            self.full_name, self.dod_id, self.email, self.id
         )
 
     def to_dictionary(self):

--- a/script/seed_sample.py
+++ b/script/seed_sample.py
@@ -156,7 +156,9 @@ def get_users():
 def add_members_to_portfolio(portfolio):
     for user_data in PORTFOLIO_USERS:
         invite = Portfolios.invite(portfolio, portfolio.owner, user_data)
-        profile = {k: user_data[k] for k in user_data if k != "dod_id"}
+        profile = {
+            k: user_data[k] for k in user_data if k not in ["dod_id", "permission_sets"]
+        }
         user = Users.get_or_create_by_dod_id(user_data["dod_id"], **profile)
         PortfolioRoles.enable(invite.role, user)
 


### PR DESCRIPTION
Fixes this bug: https://www.pivotaltracker.com/story/show/167926545

This PR does two things:
- Fixes where the sample script was adding CCPO-level perms to sample portfolio users
- Simplifies the `User` model string serialization and removes an unused method (I was testing the previous point and the string representation really bugged me so I changed it)