### PR TITLE
Docker multi tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
-    aws-ecr: circleci/aws-ecr@4.0.1
+    aws-ecr: circleci/aws-ecr@6.3.0
     aws-eks: circleci/aws-eks@0.1.0
-    azure-acr: circleci/azure-acr@0.1.1
+    azure-acr: circleci/azure-acr@0.1.2
     azure-aks: circleci/azure-aks@0.2.0
     kubernetes: circleci/kubernetes@0.3.0
 
@@ -120,6 +120,21 @@ jobs:
           resource-group: atat
       - migration_apply
 
+  # the azure-acr orb doesn't allow for multiple tags in the
+  # build-and-push-image step, so instead we wrap our own job around it and run
+  # some additional Docker commands
+  azure-build-and-push-image:
+    executor: azure-acr/default
+    steps:
+      - azure-acr/build-and-push-image:
+          extra-build-args: "--build-arg CSP=azure"
+          login-server-name: "${AZURE_SERVER_NAME}"
+          registry-name: pwatat
+          repo: atat
+          tag: "${CIRCLE_SHA1}"
+      - run: "docker tag ${AZURE_SERVER_NAME}/atat:${CIRCLE_SHA1}  ${AZURE_SERVER_NAME}/atat:latest"
+      - run: "docker push ${AZURE_SERVER_NAME}/atat:latest"
+
 workflows:
   version: 2
   run-tests:
@@ -128,12 +143,7 @@ workflows:
       - test:
           requires:
             - app_setup
-      - azure-acr/build_and_push_image:
-          extra-build-args: "--build-arg CSP=azure"
-          login-server-name: "${AZURE_SERVER_NAME}"
-          registry-name: pwatat
-          repo: atat
-          tag: "${CIRCLE_SHA1}"
+      - azure-build-and-push-image:
           requires:
             - test
           filters:
@@ -142,7 +152,7 @@ workflows:
                 - master
       - azure-migration:
           requires:
-            - azure-acr/build_and_push_image
+            - azure-build-and-push-image
           filters:
             branches:
               only:
@@ -175,10 +185,10 @@ workflows:
             branches:
               only:
                 - master
-      - aws-ecr/build_and_push_image:
+      - aws-ecr/build-and-push-image:
           extra-build-args: "--build-arg CSP=aws"
           repo: atat
-          tag: "${CIRCLE_SHA1}"
+          tag: "${CIRCLE_SHA1},latest"
           requires:
             - test
           filters:
@@ -187,7 +197,7 @@ workflows:
                 - master
       - aws-migration:
           requires:
-            - aws-ecr/build_and_push_image
+            - aws-ecr/build-and-push-image
           filters:
             branches:
               only:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -102,7 +102,7 @@ jobs:
     executor: aws-eks/python3
     steps:
       - migration_setup:
-          container_image: "$AWS_ECR_ACCOUNT_URL/atat:$CIRCLE_SHA1"
+          container_image: "$AWS_ECR_ACCOUNT_URL/atat:atat-$CIRCLE_SHA1"
       - aws-eks/update-kubeconfig-with-authenticator:
           cluster-name: atat
           aws-region: "${AWS_REGION}"
@@ -112,7 +112,7 @@ jobs:
     executor: azure-aks/default
     steps:
       - migration_setup:
-          container_image: "$AZURE_SERVER_NAME/atat:$CIRCLE_SHA1"
+          container_image: "$AZURE_SERVER_NAME/atat:atat-$CIRCLE_SHA1"
       - azure-aks/update-kubeconfig-with-credentials:
           cluster-name: atat-cluster
           install-kubectl: true
@@ -131,8 +131,8 @@ jobs:
           login-server-name: "${AZURE_SERVER_NAME}"
           registry-name: pwatat
           repo: atat
-          tag: "${CIRCLE_SHA1}"
-      - run: "docker tag ${AZURE_SERVER_NAME}/atat:${CIRCLE_SHA1}  ${AZURE_SERVER_NAME}/atat:latest"
+          tag: "atat-${CIRCLE_SHA1}"
+      - run: "docker tag ${AZURE_SERVER_NAME}/atat:atat-${CIRCLE_SHA1}  ${AZURE_SERVER_NAME}/atat:latest"
       - run: "docker push ${AZURE_SERVER_NAME}/atat:latest"
 
 workflows:
@@ -159,7 +159,7 @@ workflows:
                 - master
       - azure-aks/update-container-image:
           cluster-name: atat-cluster
-          container-image-updates: "atst=${AZURE_SERVER_NAME}/atat:${CIRCLE_SHA1}"
+          container-image-updates: "atst=${AZURE_SERVER_NAME}/atat:atat-${CIRCLE_SHA1}"
           namespace: atat
           resource-name: deployment.apps/atst
           resource-group: atat
@@ -173,7 +173,7 @@ workflows:
                 - master
       - azure-aks/update-container-image:
           cluster-name: atat-cluster
-          container-image-updates: "atst-worker=${AZURE_SERVER_NAME}/atat:${CIRCLE_SHA1}"
+          container-image-updates: "atst-worker=${AZURE_SERVER_NAME}/atat:atat-${CIRCLE_SHA1}"
           namespace: atat
           resource-name: deployment.apps/atst-worker
           resource-group: atat
@@ -188,7 +188,7 @@ workflows:
       - aws-ecr/build-and-push-image:
           extra-build-args: "--build-arg CSP=aws"
           repo: atat
-          tag: "${CIRCLE_SHA1},latest"
+          tag: "atat-${CIRCLE_SHA1},latest"
           requires:
             - test
           filters:
@@ -204,7 +204,7 @@ workflows:
                 - master
       - aws-eks/update-container-image:
           cluster-name: atat
-          container-image-updates: "atst=${AWS_ECR_ACCOUNT_URL}/atat:${CIRCLE_SHA1}"
+          container-image-updates: "atst=${AWS_ECR_ACCOUNT_URL}/atat:atat-${CIRCLE_SHA1}"
           namespace: atat
           resource-name: deployment.apps/atst
           aws-region: "${AWS_REGION}"
@@ -218,7 +218,7 @@ workflows:
                 - master
       - aws-eks/update-container-image:
           cluster-name: atat
-          container-image-updates: "atst-worker=${AWS_ECR_ACCOUNT_URL}/atat:${CIRCLE_SHA1}"
+          container-image-updates: "atst-worker=${AWS_ECR_ACCOUNT_URL}/atat:atat-${CIRCLE_SHA1}"
           namespace: atat
           resource-name: deployment.apps/atst-worker
           aws-region: "${AWS_REGION}"

--- a/deploy/aws/aws.yml
+++ b/deploy/aws/aws.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
+          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:latest
           resources:
             requests:
                memory: "500Mi"
@@ -139,7 +139,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
+          image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:latest
           args: [
             "/opt/atat/atst/.venv/bin/python",
             "/opt/atat/atst/.venv/bin/celery",

--- a/deploy/aws/crls-sync.yaml
+++ b/deploy/aws/crls-sync.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: crls
-            image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:8f1c8b5633ca70168837c885010e7d66d93562dc
+            image: 904153757533.dkr.ecr.us-east-2.amazonaws.com/atat:latest
             command: [
               "/bin/sh", "-c"
             ]

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -28,7 +28,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst
-          image: pwatat.azurecr.io/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
+          image: pwatat.azurecr.io/atat:latest
           resources:
             requests:
                memory: "500Mi"
@@ -140,7 +140,7 @@ spec:
         fsGroup: 101
       containers:
         - name: atst-worker
-          image: pwatat.azurecr.io/atat:4d14326ba77f1b3287b3c436a2d9be064bf4fba3
+          image: pwatat.azurecr.io/atat:latest
           args: [
             "/opt/atat/atst/.venv/bin/python",
             "/opt/atat/atst/.venv/bin/celery",

--- a/deploy/azure/crls-sync.yaml
+++ b/deploy/azure/crls-sync.yaml
@@ -12,7 +12,7 @@ spec:
           restartPolicy: OnFailure
           containers:
           - name: crls
-            image: pwatat.azurecr.io/atat:8f1c8b5633ca70168837c885010e7d66d93562dc
+            image: pwatat.azurecr.io/atat:latest
             command: [
               "/bin/sh", "-c"
             ]


### PR DESCRIPTION
This addresses a devops issue: https://www.pivotaltracker.com/story/show/168440887

The CRL job cannot find its image in the registry. This is because we expire old images in the registry and don't automatically update the job's spec to point at a new image. I don't think rotating the job's image in CD is a good idea. `CronJob` is not one of the resources you can set a new image for with `kubetcl image set`, so rotating it would be cumbersome and also make the build process even longer.

Instead, I've updated the CircleCI config to push two tags for every build: `latest` and `atat-[commit sha]`. This way resources like `CronJob` that we don't want to update every time with CD can point at `latest` and will always get an image when they pull that tag. It also means that we can refer to `latest` in the k8s YAML config for every other resource type as a default, and CD will swap in more specific image tags when they become available.