### PR TITLE
Do not try to copy crl-tmp contents if empty.

### DIFF
--- a/script/sync-crls
+++ b/script/sync-crls
@@ -5,7 +5,8 @@ set -e
 cd "$(dirname "$0")/.."
 
 mkdir -p crl-tmp crls
-# need to adjust this command
 ./.venv/bin/python ./atst/domain/authnid/crl/util.py crl-tmp crls
-cp -r crl-tmp/* crls/
+if [ "$(ls -A crl-tmp)" ]; then
+  cp -r crl-tmp/* crls/
+fi
 rm -rf crl-tmp


### PR DESCRIPTION
PT: https://www.pivotaltracker.com/story/show/168515322

The Kubernetes CronJob for syncing CRLs syncs them to a temporary folder
and then copies them to the real location once the sync is complete. If
the temporary folder is empty, the `cp` command throws an error. This
updates the bash script that manages the sync so that it will skip the
copy command if the temporary location is empty.