### PR TITLE
coerce unipath objects to strings in app.py

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -49,8 +49,8 @@ def make_app(config):
 
     app = Flask(
         __name__,
-        template_folder=parent_dir.child("templates").absolute(),
-        static_folder=parent_dir.child("static").absolute(),
+        template_folder=str(object=parent_dir.child("templates").absolute()),
+        static_folder=str(object=parent_dir.child("static").absolute()),
     )
     app.json_encoder = CustomJSONEncoder
     make_redis(app, config)


### PR DESCRIPTION
This tiny PR will allow the VSCode debugger to work with the app.

When setting up the debugger without this change, the console would get spammed with errors that looked like:
```
Traceback (most recent call last):
  File "[Home directory].vscode/extensions/ms-python.python-2019.9.34911/pythonFiles/lib/python/ptvsd/_vendored/pydevd/_pydevd_bundle/pydevd_trace_dispatch_regular.py", line 437, in __call__
    abs_path_real_path_and_base = get_abs_path_real_path_and_base_from_frame(frame)
  File "[Home directory].vscode/extensions/ms-python.python-2019.9.34911/pythonFiles/lib/python/ptvsd/_vendored/pydevd/pydevd_file_utils.py", line 718, in get_abs_path_real_path_and_base_from_frame
    ret = get_abs_path_real_path_and_base_from_file(f)
  File "[Home directory].vscode/extensions/ms-python.python-2019.9.34911/pythonFiles/lib/python/ptvsd/_vendored/pydevd/pydevd_file_utils.py", line 698, in get_abs_path_real_path_and_base_from_file
    abs_path, real_path = _NormPaths(f)
  File "[Home directory].vscode/extensions/ms-python.python-2019.9.34911/pythonFiles/lib/python/ptvsd/_vendored/pydevd/pydevd_file_utils.py", line 326, in _NormPaths
    raise AssertionError('Paths passed to _NormPaths must be str. Found: %s (%s)' % (filename, type(filename)))
AssertionError: Paths passed to _NormPaths must be str. Found: $[Home directory]/[project folder]/templates/base.html (<class 'unipath.path.Path'>)
```

So, I just used the `str()` function on the `unipath` object to give VSCode the object type that it wanted.