### PR TITLE
Tweaks to environment provisioning jobs

### DIFF
--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -104,6 +104,7 @@ class Environments(object):
             .join(CLIN)
             .filter(CLIN.start_date <= now)
             .filter(CLIN.end_date > now)
+            .filter(Environment.deleted == False)
             .filter(
                 or_(
                     Environment.claimed_until == None,

--- a/atst/jobs.py
+++ b/atst/jobs.py
@@ -108,19 +108,19 @@ def do_work(fn, task, csp, **kwargs):
         raise task.retry(exc=e)
 
 
-@celery.task(bind=True)
+@celery.task(bind=True, base=RecordEnvironmentFailure)
 def create_environment(self, environment_id=None):
     do_work(do_create_environment, self, app.csp.cloud, environment_id=environment_id)
 
 
-@celery.task(bind=True)
+@celery.task(bind=True, base=RecordEnvironmentFailure)
 def create_atat_admin_user(self, environment_id=None):
     do_work(
         do_create_atat_admin_user, self, app.csp.cloud, environment_id=environment_id
     )
 
 
-@celery.task(bind=True)
+@celery.task(bind=True, base=RecordEnvironmentFailure)
 def create_environment_baseline(self, environment_id=None):
     do_work(
         do_create_environment_baseline,


### PR DESCRIPTION
1. Filter out deleted environments in dispatch queries, reducing the amount of tasks that throw `NotFoundError`s
2. Utilize `RecordEnvironmentFailure` to log task failures in the database