### PR TITLE
Total and Obligated Funding % Bug

### DIFF
--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -243,6 +243,8 @@ export default {
           return '<1%'
         } else if (percentage > 99 && percentage < 100) {
           return '>99%'
+        } else if (percentage > 100) {
+          return '>100%'
         } else {
           return `${percentage.toFixed(0)}%`
         }


### PR DESCRIPTION
## Description
Fixes a bug were if the obligated amount was more that the total amount, the percentage obligated would show as `infinity%`. Updated to now show `>100%` when the obligated amount is more than the total.

## Pivotal
https://www.pivotaltracker.com/story/show/168516197

## Screenshot
<img width="1552" alt="Screen Shot 2019-09-20 at 1 14 21 PM" src="https://user-images.githubusercontent.com/43828539/65345576-9a3a2000-dba8-11e9-9fb1-7895b667b46b.png">