### PR TITLE
Ie11 header bug

### DIFF
--- a/styles/components/_usa_banner.scss
+++ b/styles/components/_usa_banner.scss
@@ -27,6 +27,7 @@
 
     .icon {
       @include icon-size(12);
+      bottom: -1px;
     }
   }
 }

--- a/styles/components/_usa_banner.scss
+++ b/styles/components/_usa_banner.scss
@@ -14,6 +14,7 @@
 
   p {
     margin: 0;
+    max-width: none;
   }
 
   button.icon-tooltip {


### PR DESCRIPTION
## Description
Fixes bug were header text was splitting onto two lines in ie11. This was happening because of the max-width set on `p` elements. I also fixed an issue with the alignment of the icon for the tooltip in the header.

## Pivotal
https://www.pivotaltracker.com/story/show/168542065

## Screenshot
<img width="1552" alt="Screen Shot 2019-09-20 at 1 40 48 PM" src="https://user-images.githubusercontent.com/43828539/65347114-47fafe00-dbac-11e9-868a-77f7fbe8a939.png">