### PR TITLE
Styling error page

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$",
     "lines": null
   },
-  "generated_at": "2019-09-30T13:51:34Z",
+  "generated_at": "2019-10-02T14:52:59Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -199,5 +199,5 @@
       }
     ]
   },
-  "version": "0.12.5"
+  "version": "0.12.6"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -194,7 +194,7 @@
         "hashed_secret": "e4f14805dfd1e6af030359090c535e149e6b4207",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 543,
+        "line_number": 638,
         "type": "Hex High Entropy String"
       }
     ]

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -26,25 +26,10 @@ def notify(e, message, code):
         current_app.notification_sender.send(message)
 
 
-def handle_error(
-    e,
-    message=translate("errors.not_found"),
-    code=404,
-    submessage=translate("errors.not_found_sub"),
-    more_info=translate("common.lorem"),
-):
+def handle_error(e, message=translate("errors.not_found"), code=404):
     log_error(e)
     notify(e, message, code)
-    return (
-        render_template(
-            "error.html",
-            message=message,
-            code=code,
-            submessage=submessage,
-            more_info=more_info,
-        ),
-        code,
-    )
+    return (render_template("error.html", message=message, code=code), code)
 
 
 def make_error_pages(app):

--- a/atst/routes/errors.py
+++ b/atst/routes/errors.py
@@ -11,6 +11,7 @@ from atst.domain.invitations import (
 from atst.domain.authnid.crl import CRLInvalidException
 from atst.domain.portfolios import PortfolioError
 from atst.utils.flash import formatted_flash as flash
+from atst.utils.localization import translate
 
 NO_NOTIFY_STATUS_CODES = set([404, 401])
 
@@ -25,10 +26,25 @@ def notify(e, message, code):
         current_app.notification_sender.send(message)
 
 
-def handle_error(e, message="Not Found", code=404):
+def handle_error(
+    e,
+    message=translate("errors.not_found"),
+    code=404,
+    submessage=translate("errors.not_found_sub"),
+    more_info=translate("common.lorem"),
+):
     log_error(e)
     notify(e, message, code)
-    return render_template("error.html", message=message), code
+    return (
+        render_template(
+            "error.html",
+            message=message,
+            code=code,
+            submessage=submessage,
+            more_info=more_info,
+        ),
+        code,
+    )
 
 
 def make_error_pages(app):

--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -38,6 +38,7 @@
 @import "components/usa_banner";
 @import "components/dod_login_notice.scss";
 @import "components/sticky_cta.scss";
+@import "components/error_page.scss";
 
 @import "sections/login";
 @import "sections/home";

--- a/styles/components/_error_page.scss
+++ b/styles/components/_error_page.scss
@@ -2,23 +2,25 @@
   max-width: 475px;
   margin: auto;
 
-  .panel__heading {
-    text-align: center;
-    padding: $gap 0;
+  .panel {
+    &__heading {
+      text-align: center;
+      padding: $gap 0;
 
-    hr {
-      width: 100%;
-      border: 1px solid $color-red;
+      hr {
+        width: 100%;
+        border: 1px solid $color-red;
+      }
+
+      h1 {
+        margin-bottom: $gap;
+      }
     }
 
-    h1 {
-      margin-bottom: $gap;
+    &__body {
+      padding: $gap * 2;
+      margin: 0;
     }
-  }
-
-  .panel__body {
-    padding: $gap * 2;
-    margin: 0;
   }
 
   .icon {

--- a/styles/components/_error_page.scss
+++ b/styles/components/_error_page.scss
@@ -1,0 +1,33 @@
+.error-page {
+  max-width: 475px;
+  margin: auto;
+
+  .panel__heading {
+    text-align: center;
+    padding: $gap 0;
+
+    hr {
+      width: 100%;
+      border: 1px solid $color-red;
+    }
+
+    h1 {
+      margin-bottom: $gap;
+    }
+  }
+
+  .panel__body {
+    padding: $gap * 2;
+    margin: 0;
+  }
+
+  .icon {
+    @include icon-size(60);
+  }
+
+  hr {
+    margin-bottom: $gap * 4;
+    width: 80%;
+    border: 0.5px solid $color-gray-light;
+  }
+}

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,19 +1,25 @@
 {% extends "error_base.html" %}
 
+{% from "components/icon.html" import Icon %}
+
 {% block content %}
 
-<main class="usa-section usa-content">
-
-{% if message %}
-    <h1>{{ message }}</h1>
-{% else %}
-    <h1>An error occurred.</h1>
-{% endif %}
-
-{% if g.current_user %}
-  <p>Return <a href="{{ url_for("atst.home") }}">home</a>.</p>
-{% endif %}
-
+<main class="usa-section usa-content error-page">
+    <div class="panel__heading">
+      {{ Icon('cloud', classes="icon--red icon--large")}}
+      <hr>
+      <h1>{{ code }} - {{ message }}</h1>
+      <p>{{ submessage }}</p>
+    </div>
+    <hr>
+    <div class="panel__body">
+      <p>
+        {{ more_info }}
+      </p>
+      <p>
+        <a href="#">More lorem</a>
+      </p>
+    </div>
 </main>
 
 {% endblock %}

--- a/templates/error.html
+++ b/templates/error.html
@@ -9,12 +9,12 @@
       {{ Icon('cloud', classes="icon--red icon--large")}}
       <hr>
       <h1>{{ code }} - {{ message }}</h1>
-      <p>{{ submessage }}</p>
+      <p>{{ "errors.not_found_sub" | translate }}</p>
     </div>
     <hr>
     <div class="panel__body">
       <p>
-        {{ more_info }}
+        {{ "common.lorem" | translate }}
       </p>
       <p>
         <a href="#">More lorem</a>

--- a/templates/error.html
+++ b/templates/error.html
@@ -9,7 +9,13 @@
       {{ Icon('cloud', classes="icon--red icon--large")}}
       <hr>
       <h1>{{ code }} - {{ message }}</h1>
-      <p>{{ "errors.not_found_sub" | translate }}</p>
+      <p>
+        {% if code == 404 -%}
+          {{ "errors.not_found_sub" | translate }}
+        {% else %}
+          {{ "errors.default_sub" | translate }}
+        {%- endif %}
+      </p>
     </div>
     <hr>
     <div class="panel__body">

--- a/templates/error_base.html
+++ b/templates/error_base.html
@@ -13,6 +13,10 @@
 
   {% block template_vars %}{% endblock %}
 
+  {% include 'components/usa_header.html' %}
+
+  {% include 'navigation/topbar.html' %}
+
   <div class='global-layout'>
 
     <div class='global-panel-container'>

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -74,6 +74,11 @@ def test_all_protected_routes_have_access_control(
     )
     monkeypatch.setattr("atst.app.assign_resources", lambda *a: None)
 
+    # monkeypatch the error handler
+    monkeypatch.setattr(
+        "atst.routes.errors.handle_error", lambda *a, **k: ("error", 500)
+    )
+
     # patch the internal function the access decorator uses so that
     # we can check that it was called
     mocker.patch("atst.domain.authz.decorator.check_access")

--- a/translations.yaml
+++ b/translations.yaml
@@ -98,6 +98,7 @@ components:
         </p>
       title: Here’s how you know
 errors:
+  default_sub: An error has occured!
   not_found: Page Not Found
   not_found_sub: Looks like that page does not exist!
 email:

--- a/translations.yaml
+++ b/translations.yaml
@@ -55,6 +55,7 @@ common:
   disable: Disable
   edit: Edit
   email: Email
+  lorem: Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.
   members: Members
   name: Name
   next: Next
@@ -96,6 +97,9 @@ components:
           The <strong>https://</strong> ensures that you are connecting to the official website and that any information you provide is encrypted and transmitted securely.
         </p>
       title: Here’s how you know
+errors:
+  not_found: Page Not Found
+  not_found_sub: Looks like that page does not exist!
 email:
   application_invite: "{inviter_name} has invited you to a JEDI cloud application"
   portfolio_invite: "{inviter_name} has invited you to a JEDI cloud portfolio"


### PR DESCRIPTION
## Description
Update the styling of the error page. I was unable to find an icon on Font Awesome similar to the designs, so I used the existing cloud icon for now.

## Pivotal
https://www.pivotaltracker.com/story/show/168545107

## Screenshots
<img width="1920" alt="Screen Shot 2019-09-30 at 11 29 45 AM" src="https://user-images.githubusercontent.com/43828539/65893251-a4f96f80-e375-11e9-97cd-9a0a15d221c2.png">