### PR TITLE
Fix PoP error bug

### DIFF
--- a/js/components/__tests__/pop_date_range.test.js
+++ b/js/components/__tests__/pop_date_range.test.js
@@ -20,13 +20,13 @@ describe('PopDateRange Test', () => {
   const component = new Vue(PopDateRange)
 
   it('should calculate the max start date', () => {
-    component.maxStartDate = new Date('2020-01-01')
+    component.contractEnd = new Date('2020-01-01')
     const date = new Date('2019-12-31')
     expect(component.calcMaxStartDate(date)).toEqual(date)
   })
 
   it('should calculate the min end date', () => {
-    component.minEndDate = new Date('2020-01-01')
+    component.contractStart = new Date('2020-01-01')
     const date = new Date('2020-02-02')
     expect(component.calcMinEndDate(date)).toEqual(date)
   })

--- a/js/components/pop_date_range.js
+++ b/js/components/pop_date_range.js
@@ -45,6 +45,8 @@ export default {
     return {
       maxStartDate: maxStartDate,
       minEndDate: minEndDate,
+      contractStart: contractStart,
+      contractEnd: contractEnd,
     }
   },
 
@@ -60,7 +62,7 @@ export default {
     },
 
     calcMaxStartDate: function(date) {
-      if (!!date && date < this.maxStartDate) {
+      if (!!date && date < this.contractEnd) {
         return date
       } else {
         return this.maxStartDate
@@ -68,7 +70,7 @@ export default {
     },
 
     calcMinEndDate: function(date) {
-      if (!!date && date > this.minEndDate) {
+      if (!!date && date > this.contractStart) {
         return date
       } else {
         return this.minEndDate


### PR DESCRIPTION
## Description
Fixes bug where if a user got an error on the end date, then went to the start date to fix the date range, the error would not go away on the end date. 
This was fixed by calculating the maxStart and minEnd dates by comparing them to the contract dates and not the current values of maxStart and minEnd. Previously we were calculating them based on the current value, which means that if a user updated the start date to be earlier than the start date they had previously put in, the minEnd would not update to reflect the change.

## Pivotal
https://www.pivotaltracker.com/story/show/168408495