### PR TITLE
Bugfix - Sticky CTA overlaps header when zoomed out

### DIFF
--- a/styles/core/_variables.scss
+++ b/styles/core/_variables.scss
@@ -6,14 +6,14 @@
 $gap: 0.8rem;
 
 // 8px at 10px $em-base
-$topbar-height: 4.8rem;
+$topbar-height: 48px;
 $icon-bar-width: 4rem;
 $icon-size-small: 2.4rem;
 $hover-transition-time: 0.2s;
 $search-input-height: 4.4rem;
 $search-button-width: 5rem;
 $footer-height: 5rem;
-$usa-banner-height: 2.8rem;
+$usa-banner-height: 28px;
 $sidenav-expanded-width: 25rem;
 $sidenav-collapsed-width: 10rem;
 

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -56,7 +56,7 @@
         padding-bottom: $gap;
         position: fixed;
         overflow-y: scroll;
-        top: $topbar-height + $usa-banner-height + 4rem;
+        top: $topbar-height + $usa-banner-height + 40px;
         bottom: 0;
         left: 0;
         width: $sidenav-expanded-width;


### PR DESCRIPTION
## Description
Stickybits uses px to set the the position of a sticky element, so we need to use px to set the height of the elements that the sticky cta is supposed to stick underneath. However, this causes some issues when you zoom out more than 50%, the text starts to not have enough room around it to be legible. 
Stickybits does not allow you to specify the units for the offset, so unfortunately this may be the best solution (besides not using Stickybits).

## Pivotal
https://www.pivotaltracker.com/story/show/168598430

## Screenshot
At 50% zoom:
<img width="955" alt="Screen Shot 2019-10-01 at 3 06 28 PM" src="https://user-images.githubusercontent.com/43828539/65992560-6fc84c80-e45d-11e9-8045-817ab5293f9c.png">