### PR TITLE
Bugfix: use correct route for create member macro

### DIFF
--- a/templates/applications/settings.html
+++ b/templates/applications/settings.html
@@ -78,7 +78,7 @@
     application, 
     members, 
     new_member_form,
-    "applications.settings",
+    "applications.create_member",
     user_can(permissions.CREATE_APPLICATION_MEMBER)) }}
 
   <div class='subheading'>

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -87,6 +87,13 @@ def test_application_settings(client, user_session):
         url_for("applications.settings", application_id=application.id)
     )
     assert response.status_code == 200
+    # the assertion below is a quick check to prevent regressions -- this ensures that
+    # the correct URL for creating a member for an application is _somewhere_ in
+    # the settings page.
+    assert (
+        url_for("applications.create_member", application_id=application.id)
+        in response.data.decode()
+    )
 
 
 def test_edit_application_environments_obj(app, client, user_session):


### PR DESCRIPTION
In my last PR, I included the wrong route in the new macro that encapsulates the "add member to application" macro on the `<application_id>/settings`.

This fixes the bug, but if anyone has ideas about how to include a test that prevents this sort of thing in the future, I'm all ears.