### PR TITLE
Fix invite bug

### DIFF
--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -143,10 +143,3 @@ class PortfolioInvitations(BaseInvitations):
 class ApplicationInvitations(BaseInvitations):
     model = ApplicationInvitation
     role_domain_class = ApplicationRoles
-
-    @classmethod
-    def _update_status(cls, invite, new_status):
-        invite = super()._update_status(invite, new_status)
-        ApplicationRoles.disable(invite.role)
-
-        return invite

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -566,7 +566,6 @@ def test_revoke_invite(client, user_session):
     )
 
     assert invite.is_revoked
-    assert app_role.status == ApplicationRoleStatus.DISABLED
 
 
 def test_filter_environment_roles():


### PR DESCRIPTION
## Description
Fixes a bug where when a user accepted an app invite, they were removed from the app. We were previously overwriting `_update_status()` in ApplicationInvitations and disabling the app role, so every time an app invite status changed, the role was disabled! Since we shouldn't be disabling app roles when an invite is revoked, I got rid of this and updated tests to check the role status when an invite status changes.

## Pivotal
https://www.pivotaltracker.com/story/show/168931663