### PR TITLE
Disable the App Role when revoking an invite.

### DIFF
--- a/atst/domain/invitations.py
+++ b/atst/domain/invitations.py
@@ -142,3 +142,9 @@ class PortfolioInvitations(BaseInvitations):
 class ApplicationInvitations(BaseInvitations):
     model = ApplicationInvitation
     role_domain_class = ApplicationRoles
+
+    @classmethod
+    def revoke(cls, token):
+        invite = super().revoke(token)
+        ApplicationRoles.disable(invite.role)
+        return invite

--- a/tests/domain/test_application_roles.py
+++ b/tests/domain/test_application_roles.py
@@ -86,3 +86,4 @@ def test_disable(session):
     session.refresh(environment_role)
     assert member_role.status == ApplicationRoleStatus.DISABLED
     assert environment_role.status == EnvironmentRole.Status.PENDING_DELETE
+    assert member_role.deleted == True

--- a/tests/models/test_application.py
+++ b/tests/models/test_application.py
@@ -1,3 +1,5 @@
+from atst.domain.application_roles import ApplicationRoles
+from atst.models import ApplicationRoleStatus
 from atst.models import AuditEvent
 
 from tests.factories import (
@@ -14,6 +16,22 @@ def test_application_environments_excludes_deleted():
     EnvironmentFactory.create(application=app, deleted=True)
     assert len(app.environments) == 1
     assert app.environments[0].id == env.id
+
+
+def test_application_members_excludes_deleted(session):
+    app = ApplicationFactory.create()
+    member_role = ApplicationRoleFactory.create(
+        application=app, status=ApplicationRoleStatus.ACTIVE
+    )
+    disabled_role = ApplicationRoleFactory.create(
+        application=app, status=ApplicationRoleStatus.DISABLED
+    )
+    disabled_role.deleted = True
+    session.add(disabled_role)
+    session.commit()
+
+    assert len(app.members) == 1
+    assert app.members[0].id == member_role.id
 
 
 def test_audit_event_for_application_deletion(session):

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -10,6 +10,7 @@ from atst.domain.application_roles import ApplicationRoles
 from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.common import Paginator
 from atst.domain.permission_sets import PermissionSets
+from atst.models.application_role import Status as ApplicationRoleStatus
 from atst.models.environment_role import CSPRole
 from atst.models.permissions import Permissions
 from atst.forms.application import EditEnvironmentForm
@@ -553,6 +554,8 @@ def test_revoke_invite(client, user_session):
     )
 
     assert invite.is_revoked
+    assert app_role.status == ApplicationRoleStatus.DISABLED
+    assert app_role.deleted
 
 
 def test_filter_environment_roles():


### PR DESCRIPTION
## Description
Update the revoke invite function for ApplicationInvitations so that it also disabled the application role.

## Pivotal
https://www.pivotaltracker.com/story/show/168459532