### PR TITLE
Specify Flask SERVER_NAME value for Celery worker.

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -193,7 +193,7 @@ def make_config(direct_config=None):
     )
     OVERRIDE_CONFIG_FILENAME = os.getenv("OVERRIDE_CONFIG_FULLPATH")
 
-    config = ConfigParser()
+    config = ConfigParser(allow_no_value=True)
     config.optionxform = str
 
     config_files = [BASE_CONFIG_FILENAME, ENV_CONFIG_FILENAME]

--- a/config/base.ini
+++ b/config/base.ini
@@ -25,6 +25,7 @@ REDIS_URI = redis://localhost:6379
 RQ_QUEUES = atat_%(ENVIRONMENT)s
 SECRET = change_me_into_something_secret
 SECRET_KEY = change_me_into_something_secret
+SERVER_NAME
 SESSION_COOKIE_NAME=atat
 SESSION_TYPE = redis
 SESSION_USE_SIGNER = True

--- a/deploy/aws/atst-worker-envvars-configmap.yml
+++ b/deploy/aws/atst-worker-envvars-configmap.yml
@@ -7,4 +7,4 @@ metadata:
 data:
   TZ: UTC
   DISABLE_CRL_CHECK: "True"
-  CRL_STORAGE_PROVIDER: CLOUDFILES
+  SERVER_NAME: aws.atat.code.mil

--- a/deploy/azure/atst-worker-envvars-configmap.yml
+++ b/deploy/azure/atst-worker-envvars-configmap.yml
@@ -7,4 +7,4 @@ metadata:
 data:
   TZ: UTC
   DISABLE_CRL_CHECK: "True"
-  CRL_STORAGE_PROVIDER: CLOUDFILES
+  SERVER_NAME: azure.atat.code.mil

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -89,16 +89,17 @@ def protected_routes(app):
 
 
 def test_protected_routes_redirect_to_login(client, app):
+    server_name = app.config.get("SERVER_NAME") or "localhost"
     for rule, protected_route in protected_routes(app):
         if "GET" in rule.methods:
             resp = client.get(protected_route)
             assert resp.status_code == 302
-            assert "http://localhost/" in resp.headers["Location"]
+            assert server_name in resp.headers["Location"]
 
         if "POST" in rule.methods:
             resp = client.post(protected_route)
             assert resp.status_code == 302
-            assert "http://localhost/" in resp.headers["Location"]
+            assert server_name in resp.headers["Location"]
 
 
 def test_get_protected_route_encodes_redirect(client):


### PR DESCRIPTION
The Celery worker cannot render URLs for the app without having a
SERVER_NAME value set. AT-AT's ability to send notifications when an
environment is ready is broken as a result.

This commit sets a null default value for SERVER_NAME in the default
config file. A setting must exist in the INI file in order to be
over-written by an environment variable, which is why we declare it as
null here. There is an additional kwarg, "allow_no_value", that must be
passed to ConfigParser to allow null values.

This also applies the correct domains as SERVER_NAME environment
variables in the Kubernetes ConfigMaps for the AWS and Azure Celery
workers.

This fixes the issue on this PR card: https://www.pivotaltracker.com/story/show/168540455

These changes have been applied to the k8s clusters.