### PR TITLE
PPoC bug fixes

### DIFF
--- a/styles/elements/_buttons.scss
+++ b/styles/elements/_buttons.scss
@@ -7,7 +7,6 @@
 button,
 [type="button"] {
   &:disabled {
-    background-color: unset;
     opacity: 0.75;
   }
 }

--- a/templates/portfolios/fragments/change_ppoc.html
+++ b/templates/portfolios/fragments/change_ppoc.html
@@ -21,7 +21,8 @@
     <div class='form-col form-col--half'>
       {{
         OptionsInput(
-          assign_ppoc_form.role_id
+          assign_ppoc_form.role_id,
+          optional=False
         )
       }}
     </div>
@@ -65,9 +66,10 @@
 {% endset %}
 
 <div class="flex-reverse-row">
-  <a class="usa-button-primary" v-on:click="openModal('change-ppoc-form')">
+  {% set disable_ppoc_button = 1 == portfolio.members |length %}
+  <button type="button" class="usa-button usa-button-primary" v-on:click="openModal('change-ppoc-form')" {% if disable_ppoc_button %}disabled{% endif %}>
     {{ "fragments.ppoc.update_btn" | translate }}
-  </a>
+  </button>
   {{
     MultiStepModalForm(
       'change-ppoc-form',


### PR DESCRIPTION
## Description
Fixes two bugs related to the portfolio PPoC:
1. Removes the optional tag from the update PPoC form
2. Disables the button to update the PPoC when there is only one portfolio member

## Pivotal
https://www.pivotaltracker.com/story/show/169047524
https://www.pivotaltracker.com/story/show/169047431

## Screenshots
<img width="1541" alt="Screen Shot 2019-10-16 at 12 12 24 PM" src="https://user-images.githubusercontent.com/43828539/66938030-7387d180-f00e-11e9-96e0-7bb62343ec93.png">
<img width="1541" alt="Screen Shot 2019-10-16 at 12 12 13 PM" src="https://user-images.githubusercontent.com/43828539/66938033-74206800-f00e-11e9-9ae3-7220242f1073.png">