### PR TITLE
Fix bug in kubectl command in script/cluster_migration

### DIFF
--- a/deploy/shared/migration.yaml
+++ b/deploy/shared/migration.yaml
@@ -31,6 +31,9 @@ spec:
           - name: atst-config
             mountPath: "/opt/atat/atst/atst-overrides.ini"
             subPath: atst-overrides.ini
+          - name: pgsslrootcert
+            mountPath: "/opt/atat/atst/ssl/pgsslrootcert.crt"
+            subPath: pgsslrootcert.crt
       volumes:
         - name: atst-config
           secret:
@@ -39,4 +42,11 @@ spec:
             - key: override.ini
               path: atst-overrides.ini
               mode: 0644
+        - name: pgsslrootcert
+          configMap:
+            name: pgsslrootcert
+            items:
+            - key: cert
+              path: pgsslrootcert.crt
+              mode: 0666
       restartPolicy: Never

--- a/script/cluster_migration
+++ b/script/cluster_migration
@@ -28,7 +28,7 @@ if echo "$JOB_SUCCESS" | grep -q "condition met"; then
 else
   POD_NAME=$(${K8S_CMD} -n atat get pods -l job-name=migration -o=jsonpath='{.items[0].metadata.name}')
   echo "Job failed:"
-  $K8S_CMD -n atat log $POD_NAME
+  $K8S_CMD -n atat logs $POD_NAME
   delete_job
   exit 1
 fi


### PR DESCRIPTION
`logs` not `log`. It works on some versions of kubectl (it did for me locally when I wrote the script) but I guess the singular form is deprecated.

Fixes the error you can see here: https://circleci.com/gh/dod-ccpo/atst/13648?utm_campaign=workflow-failed&utm_medium=email&utm_source=notification