### PR TITLE
Seed roles in the container used for integration tests.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -184,6 +184,9 @@ jobs:
         name: Apply migrations
         command: docker exec test-atat .venv/bin/python .venv/bin/alembic upgrade head
     - run:
+        name: Apply the default permission sets
+        command: docker exec test-atat .venv/bin/python script/seed_roles.py
+    - run:
         name: Execute Ghost Inspector test suite
         command: |
           docker pull ghostinspector/test-runner-standalone:latest


### PR DESCRIPTION
Forgot this in the initial setup. We need this, or else no one can have roles in the Ghost Inspector tests.