### PR TITLE
App invitation modal step 2 changes

### DIFF
--- a/templates/applications/fragments/member_form_fields.html
+++ b/templates/applications/fragments/member_form_fields.html
@@ -3,7 +3,8 @@
 {% from "components/phone_input.html" import PhoneInput %}
 
 {% macro PermsFields(form, new=False, member_role_id=None) %}
-  <h4>{{ "portfolios.applications.members.form.project_perms" | translate }}</h4>
+  <h2>{{ "portfolios.applications.members.form.app_perms.title" | translate }}</h2>
+  <p class='usa-input__help subtitle'>{{ "portfolios.applications.members.form.app_perms.description" | translate | safe}}</p>
   <div class="application-perms">
     {% if new %}
       {% set team_mgmt = form.perms_team_mgmt.name %}
@@ -19,8 +20,10 @@
     {{ CheckboxInput(form.perms_env_mgmt, classes="input__inline-fields", key=env_mgmt, id=env_mgmt, optional=True) }}
     {{ CheckboxInput(form.perms_del_env, classes="input__inline-fields", key=del_env, id=del_env, optional=True) }}
   </div>
+  <hr>
   <div class="environment_roles environment-roles-new">
-    <h4>{{ "portfolios.applications.members.form.env_access" | translate }}</h4>
+    <h2>{{ "portfolios.applications.members.form.env_access.title" | translate }}</h2>
+    <p class='usa-input__help subtitle'>{{ "portfolios.applications.members.form.env_access.description" | translate | safe }}</p>
     <hr>
     {% for environment_data in form.environment_roles %}
       <optionsinput inline-template

--- a/templates/applications/fragments/new_member_modal_content.html
+++ b/templates/applications/fragments/new_member_modal_content.html
@@ -1,9 +1,9 @@
 {% from "components/icon.html" import Icon %}
 {% import "applications/fragments/member_form_fields.html" as member_fields %}
 
-{% macro MemberFormTemplate(title, next_button, previous=True) %}
+{% macro MemberFormTemplate(title=None, next_button=None, previous=True) %}
   <hr>
-  <h1>{{ Icon('avatar') }} {{ title }}</h1>
+  {% if title %} <h1>{{ title }}</h1> {% endif %}
 
   {{ caller() }}
 
@@ -43,7 +43,7 @@
       value='{{ "portfolios.applications.members.form.add_member" | translate}}'>
   {% endset %}
 
-  {% call MemberFormTemplate(title="portfolios.applications.members.form.step_2_title"|translate, next_button=next_button) %}
+  {% call MemberFormTemplate(next_button=next_button) %}
     {{ member_fields.PermsFields(form=member_form) }}
   {% endcall %}
 {% endmacro %}

--- a/translations.yaml
+++ b/translations.yaml
@@ -393,18 +393,21 @@ portfolios:
       blank_slate: This Application has no members
       form:
         env_mgmt:
-          label: Manage Environments
-          description: Add and rename project environments, assign environment access roles to team members.
+          label: Manage Application Environments
+          description: Add and rename Environments, assign Environment access roles to team members.
         team_mgmt:
-          label: Edit Team
+          label: Edit Application Team
           description: Add and remove team members.
         del_env:
           label: Delete Application
           description: Delete this application.
-        env_access: Environment Access
+        env_access: 
+          title: Environment Roles
+          description: Additional role controls are available in the CSP console. <a href="#"> Learn More </a>
         next_button: "Next: Permissions"
-        project_perms: Project Permissions
-        step_2_title: Set Permissions and Roles
+        app_perms:
+          title: Application Permissions
+          description: Application permissions allow users to provision and modify applications and teams. <a href="#"> Learn More </a>
         add_member: Add Member
       new:
         assign_roles: Assign Member Environments and Roles


### PR DESCRIPTION
Updates some text in step 2 of inviting a member to an application.
Addresses https://www.pivotaltracker.com/story/show/169343220

| Before | After |
|--------|-------|
| ![](https://user-images.githubusercontent.com/54586407/67591763-23a2bc00-f72c-11e9-83ee-d64413ed936d.png)| ![](https://user-images.githubusercontent.com/54586407/67591710-0837b100-f72c-11e9-8090-b72b3df3f550.png)|

Note: The text in the dropdowns still says `"no access"` by default, even though the mockups have the default value as `"Select Access Level"`. I talked with JT on Slack, and he said that we could keep the default option as is.
