### PR TITLE
Allow submit buttons to be valid on initial render

### DIFF
--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -62,7 +62,7 @@
                 {{ member.update_invite_form.csrf_token }}
                 {{ member_fields.InfoFields(member.update_invite_form) }}
                 <div class="action-group">
-                  <input type="submit" class="usa-button usa-button-primary action-group__action" tabindex="0" value="Resend Invite" />
+                {{ SaveButton(text="Resend Invite", disable_on_initial_render=False)}}
                   <a class='action-group__action' v-on:click="closeModal('{{ resend_invite_modal }}')">{{ "common.cancel" | translate }}</a>
                 </div>
               </form>

--- a/templates/components/save_button.html
+++ b/templates/components/save_button.html
@@ -1,10 +1,12 @@
-{% macro SaveButton(text, element="button", additional_classes="", form=None) -%}
+{% macro SaveButton(text, element="button", additional_classes="", form=None, disable_on_initial_render=True) -%}
   {% set class = "usa-button usa-button-primary" + additional_classes %}
+  {% set disabled = "!changed || invalid" if disable_on_initial_render else "invalid"%}
+  
   {% if element == "button" %}
-    <button type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="!changed || invalid" {{ form_attr }} >
+    <button type="submit" class="{{ class }}" tabindex="0" v-bind:disabled='{{ disabled }}' {{ form_attr }} >
       {{ text }}
     </button>
   {% elif element == 'input' %}
-    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="!changed || invalid" value="{{ text }}" {% if form %}form="{{ form }}"{% endif %} />
+    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="invalid" value='{{ disabled }}' {% if form %}form="{{ form }}"{% endif %} />
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
In the resend invite modal, an input was written that could never be disabled. This allowed users to submit potentially invalid data. This PR fixes that [bug](https://www.pivotaltracker.com/story/show/169164861) by replacing that input with a `SaveButton()` component and adding an option to control whether or not the submit button will be disabled when initially rendered.