### PR TITLE
Remove the Celery schedule for the environment baseline task.

### DIFF
--- a/atst/queue.py
+++ b/atst/queue.py
@@ -14,10 +14,6 @@ def update_celery(celery, app):
             "task": "atst.jobs.dispatch_create_atat_admin_user",
             "schedule": 60,
         },
-        "beat-dispatch_create_environment_baseline": {
-            "task": "atst.jobs.dispatch_create_environment_baseline",
-            "schedule": 60,
-        },
         "beat-dispatch_provision_user": {
             "task": "atst.jobs.dispatch_provision_user",
             "schedule": 60,


### PR DESCRIPTION
This was still hanging around. The worker throws errors about it being unregistered.