### PR TITLE
Fix "disabled environment role status" migration

### DIFF
--- a/alembic/versions/f328f1ea400c_add_disabled_enviornment_role_status.py
+++ b/alembic/versions/f328f1ea400c_add_disabled_enviornment_role_status.py
@@ -17,6 +17,14 @@ depends_on = None
 
 
 def upgrade():
+    conn = op.get_bind()
+    conn.execute(
+        """
+        UPDATE environment_roles
+        SET status = (CASE WHEN status = 'PENDING_DELETE' THEN 'COMPLETED' ELSE status END)
+        """
+    )
+
     op.alter_column(
         "environment_roles",
         "status",


### PR DESCRIPTION
Fix for our latest migration.

Environment roles with status `PENDING_DELETE` were no longer valid because alembic updated the `status` column to a `VARCHAR(9)` from a `VARCHAR(14)` which meant that the value couldn't fit in the column.

Updating sqlalchemy enums in alembic is a pain. It makes me wonder if we're doing something wrong.