### PR TITLE
Fix Save button text

### DIFF
--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -5,6 +5,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    enableSave: {
+      type: Boolean,
+      default: false,
+    },
   },
 
   mounted: function() {
@@ -52,9 +56,9 @@ export default {
     canSave: function() {
       const formValid = !this.invalid
 
-      if (formValid) {
+      if (this.changed && formValid) {
         return true
-      } else if (this.changed && formValid) {
+      } else if (this.enableSave && formValid) {
         return true
       } else {
         return false

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -57,12 +57,12 @@
               <h1>Verify Member Information</h1>
               <hr>
             </div>
-            <base-form inline-template>
+            <base-form inline-template :enable-save="true">
               <form id='{{ resend_invite_modal }}' method="POST" action="{{ url_for('applications.resend_invite', application_id=application.id, application_role_id=member.role_id) }}">
                 {{ member.update_invite_form.csrf_token }}
                 {{ member_fields.InfoFields(member.update_invite_form) }}
                 <div class="action-group">
-                {{ SaveButton(text="Resend Invite", disable_on_initial_render=False)}}
+                {{ SaveButton(text="Resend Invite")}}
                   <a class='action-group__action' v-on:click="closeModal('{{ resend_invite_modal }}')">{{ "common.cancel" | translate }}</a>
                 </div>
               </form>

--- a/templates/applications/fragments/new_member_modal_content.html
+++ b/templates/applications/fragments/new_member_modal_content.html
@@ -25,7 +25,7 @@
     <input
         type='button'
         v-on:click="next()"
-        v-bind:disabled="invalid"
+        v-bind:disabled="!canSave"
         class='action-group__action usa-button'
         value='{{ "portfolios.applications.members.form.next_button" | translate }}'>
   {% endset %}
@@ -40,6 +40,7 @@
       type="submit"
       class='action-group__action usa-button'
       form="add-app-mem"
+      v-bind:disabled="!canSave"
       value='{{ "portfolios.applications.members.form.add_member" | translate}}'>
   {% endset %}
 

--- a/templates/applications/settings.html
+++ b/templates/applications/settings.html
@@ -22,7 +22,7 @@
         {{ TextInput(application_form.name, optional=False) }}
         {{ TextInput(application_form.description, paragraph=True, optional=True, showOptional=False) }}
         <div class="action-group action-group--tight">
-          {{ SaveButton('common.save_changes'|translate) }}
+          {{ SaveButton(text='common.save_changes'|translate) }}
         </div>
       </form>
     </base-form>

--- a/templates/components/save_button.html
+++ b/templates/components/save_button.html
@@ -1,12 +1,12 @@
-{% macro SaveButton(text, element="button", additional_classes="", form=None, disable_on_initial_render=True) -%}
+{% macro SaveButton(text="common.save" | translate, element="button", additional_classes="", form=None, disable_on_initial_render=True) -%}
   {% set class = "usa-button usa-button-primary" + additional_classes %}
   {% set disabled = "!changed || invalid" if disable_on_initial_render else "invalid"%}
-  
+
   {% if element == "button" %}
     <button type="submit" class="{{ class }}" tabindex="0" v-bind:disabled='{{ disabled }}' {{ form_attr }} >
       {{ text }}
     </button>
   {% elif element == 'input' %}
-    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="invalid" value='{{ disabled }}' {% if form %}form="{{ form }}"{% endif %} />
+    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled='{{ disabled }}' value='{{ text }}' {% if form %}form="{{ form }}"{% endif %} />
   {% endif %}
 {%- endmacro %}

--- a/templates/components/save_button.html
+++ b/templates/components/save_button.html
@@ -1,12 +1,11 @@
-{% macro SaveButton(text="common.save" | translate, element="button", additional_classes="", form=None, disable_on_initial_render=True) -%}
-  {% set class = "usa-button usa-button-primary" + additional_classes %}
-  {% set disabled = "!changed || invalid" if disable_on_initial_render else "invalid"%}
+{% macro SaveButton(text="common.save" | translate, element="button", additional_classes="", form=None) -%}
+  {% set class = "usa-button usa-button-primary " + additional_classes %}
 
   {% if element == "button" %}
-    <button type="submit" class="{{ class }}" tabindex="0" v-bind:disabled='{{ disabled }}' {{ form_attr }} >
+    <button type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="!canSave" {{ form_attr }} >
       {{ text }}
     </button>
   {% elif element == 'input' %}
-    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled='{{ disabled }}' value='{{ text }}' {% if form %}form="{{ form }}"{% endif %} />
+    <input type="submit" class="{{ class }}" tabindex="0" v-bind:disabled="!canSave" value='{{ text }}' {% if form %}form="{{ form }}"{% endif %} />
   {% endif %}
 {%- endmacro %}


### PR DESCRIPTION
## Description
One of the SaveButton macros was missing the kwarg 'text' so it was defaulting to something weird. To prevent this issue from happening again, I also added 'Save' as the default text for the SaveButton macro.

There was also an issue with an update to the SaveButton macro. I updated it so that the Form mixin has a prop for enabling the save button, and updated the SaveButton macro to use the form mixin's computed prop `canSave` to toggle whether or not the button is disabled. 

## Pivotal
https://www.pivotaltracker.com/story/show/169481361
https://www.pivotaltracker.com/story/show/169482695
https://www.pivotaltracker.com/story/show/169483612
https://www.pivotaltracker.com/story/show/169484262

## Screenshot
<img width="1740" alt="Screen Shot 2019-10-31 at 10 33 05 AM" src="https://user-images.githubusercontent.com/43828539/67956486-8ed80c80-fbca-11e9-9aa1-b08b7dce7342.png">