### PR TITLE
Fix secrets baseline and type hint error.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^.*pgsslrootcert.yml$",
     "lines": null
   },
-  "generated_at": "2019-10-28T18:00:40Z",
+  "generated_at": "2019-11-01T18:50:54Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -17,6 +17,7 @@
       "name": "HexHighEntropyString"
     },
     {
+      "keyword_exclude": null,
       "name": "KeywordDetector"
     },
     {
@@ -197,7 +198,7 @@
       }
     ]
   },
-  "version": "0.12.7",
+  "version": "0.13.0",
   "word_list": {
     "file": null,
     "hash": null

--- a/atst/domain/csp/cloud.py
+++ b/atst/domain/csp/cloud.py
@@ -472,9 +472,7 @@ class AzureCloudProvider(CloudProviderInterface):
         credentials = self._get_credential_obj(root_creds)
 
         sub_client = self.sdk.subscription.SubscriptionClient(credentials)
-        subscription: self.sdk.subscription.models.Subscription = sub_client.subscriptions.get(
-            csp_environment_id
-        )
+        subscription = sub_client.subscriptions.get(csp_environment_id)
 
         managment_principal = self._get_management_service_principal()
 


### PR DESCRIPTION
- detect-secrets was previously bumped to 0.13 but the baseline file was
  not updated.
- mypy objects to the way the Azure Subscription type was defined. Since
  the module is encapsulated for dependency injection, we can either
  declare it as a generic or remove the type hint. I did the latter,
  since I don't know that we gain anything by the former.