### PR TITLE
Fix data['fields'] in Vue component forms

### DIFF
--- a/js/components/forms/multi_step_modal_form.js
+++ b/js/components/forms/multi_step_modal_form.js
@@ -67,8 +67,10 @@ export default {
       return valid
     },
     handleFieldMount: function(event) {
-      const { name, optional } = event
-      this.fields[name] = optional
+      if (event.parent_uid == this._uid) {
+        const { name, optional } = event
+        this.fields[name] = optional
+      }
     },
     handleModalOpen: function(_bool) {
       this.step = 0

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -1,10 +1,7 @@
 import { emitEvent } from '../lib/emitters'
-import FormMixin from '../mixins/form'
 
 export default {
   name: 'optionsinput',
-
-  mixins: [FormMixin],
 
   props: {
     name: String,

--- a/js/components/pop_date_range.js
+++ b/js/components/pop_date_range.js
@@ -1,5 +1,7 @@
 import { format } from 'date-fns'
 
+import { emitEvent } from '../lib/emitters'
+
 import DateSelector from './date_selector'
 
 const START_DATE = 'start_date'
@@ -76,6 +78,12 @@ export default {
         return this.minEndDate
       }
     },
+
+    handleFieldMount: function(event) {
+      if (event.parent_uid === this._uid) {
+        emitEvent('field-mount', this, event)
+      }
+    },
   },
 
   computed: {
@@ -86,5 +94,9 @@ export default {
     minEndProp: function() {
       return format(this.minEndDate, 'YYYY-MM-DD')
     },
+  },
+
+  created: function() {
+    this.$root.$on('field-mount', this.handleFieldMount)
   },
 }

--- a/js/mixins/form.js
+++ b/js/mixins/form.js
@@ -29,10 +29,15 @@ export default {
     },
 
     handleFieldMount: function(event) {
-      const { name, optional, valid } = event
-      this.fields[name] = optional || valid
-      const formValid = this.validateForm()
-      this.invalid = !formValid
+      if (
+        event.parent_uid === this._uid ||
+        this.$children.some(c => c._uid === event.parent_uid)
+      ) {
+        const { name, optional, valid } = event
+        this.fields[name] = optional || valid
+        const formValid = this.validateForm()
+        this.invalid = !formValid
+      }
     },
 
     validateForm: function() {

--- a/templates/portfolios/fragments/delete_portfolio.html
+++ b/templates/portfolios/fragments/delete_portfolio.html
@@ -2,7 +2,7 @@
 {% from "components/alert.html" import Alert %}
 {% from "components/modal.html" import Modal %}
 
-<section id="primary-point-of-contact" class="panel">
+<section class="panel">
   <div class="panel__content">
     <h2>{{ "fragments.delete_portfolio.title" | translate }}</h2>
     <p>{{ "fragments.delete_portfolio.subtitle" | translate }}</p>

--- a/templates/portfolios/fragments/portfolio_members.html
+++ b/templates/portfolios/fragments/portfolio_members.html
@@ -72,10 +72,6 @@
           </div>
         </div>
       </form>
-      {% if user_can(permissions.CREATE_PORTFOLIO_USERS) %}
-        {% include "portfolios/fragments/add_new_portfolio_member.html" %}
-      {% endif %}
-
       {% if user_can(permissions.EDIT_PORTFOLIO_USERS) %}
         {% for subform in member_perms_form.members_permissions %}
           {% set modal_id = "portfolio_id_{}_user_id_{}".format(portfolio.id, subform.member_id.data) %}
@@ -103,4 +99,7 @@
       {% endif %}
     </div>
   </base-form>
+  {% if user_can(permissions.CREATE_PORTFOLIO_USERS) %}
+    {% include "portfolios/fragments/add_new_portfolio_member.html" %}
+  {% endif %}
 </section>


### PR DESCRIPTION
## Description
When investigating this bug, I discovered that the issue was that when there are multiple forms on a page they capture all of the form fields on the page, so the form was never 'valid' because of the extra fields associated with the form. This issue was fixed by checking on form Vue components that the parent_id passed in the field-mount event is the forms uid or the uid of one of the forms child components.

## Pivotal
https://www.pivotaltracker.com/story/show/169327255