### PR TITLE
Environment bugfixes

### DIFF
--- a/atst/models/environment.py
+++ b/atst/models/environment.py
@@ -32,6 +32,12 @@ class Environment(
 
     job_failures = relationship("EnvironmentJobFailure")
 
+    roles = relationship(
+        "EnvironmentRole",
+        back_populates="environment",
+        primaryjoin="and_(EnvironmentRole.environment_id == Environment.id, EnvironmentRole.deleted == False)",
+    )
+
     class ProvisioningStatus(Enum):
         PENDING = "pending"
         COMPLETED = "completed"

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -24,7 +24,7 @@ class EnvironmentRole(
     environment_id = Column(
         UUID(as_uuid=True), ForeignKey("environments.id"), nullable=False
     )
-    environment = relationship("Environment", backref="roles")
+    environment = relationship("Environment")
 
     role = Column(String())
 

--- a/templates/applications/fragments/environments.html
+++ b/templates/applications/fragments/environments.html
@@ -76,7 +76,7 @@
                       <li class="accordion-table__item-toggle-content__expanded">
                         <form action="{{ url_for('applications.update_environment', environment_id=env['id']) }}" method="post" v-on:submit="handleSubmit">
                           {{ edit_form.csrf_token }}
-                          {{ TextInput(edit_form.name, validation='requiredField') }}
+                          {{ TextInput(edit_form.name, validation='requiredField', optional=False) }}
                           {{
                             SaveButton(
                               text=("common.save" | translate)

--- a/tests/models/test_environments.py
+++ b/tests/models/test_environments.py
@@ -3,6 +3,7 @@ import pytest
 from atst.models import AuditEvent
 from atst.models.environment_role import CSPRole
 from atst.domain.applications import Applications
+from atst.domain.environment_roles import EnvironmentRoles
 
 from tests.factories import *
 
@@ -70,3 +71,19 @@ def test_audit_event_for_environment_deletion(session):
 def test_environment_provisioning_status(env_data, expected_status):
     environment = EnvironmentFactory.create(**env_data)
     assert environment.provisioning_status == expected_status
+
+
+def test_environment_roles_do_not_include_deleted():
+    member_list = [
+        {"role_name": CSPRole.BASIC_ACCESS.value},
+        {"role_name": CSPRole.BASIC_ACCESS.value},
+        {"role_name": CSPRole.BASIC_ACCESS.value},
+    ]
+    env = EnvironmentFactory.create(members=member_list)
+    role_1 = env.roles[0]
+    role_2 = env.roles[1]
+
+    EnvironmentRoles.delete(role_1.application_role_id, env.id)
+    EnvironmentRoles.disable(role_2.id)
+
+    assert len(env.roles) == 2


### PR DESCRIPTION
## Description
Fixes two bugs:
1.) When an app invite is revoked, the user should not appear in the env members drop down list. Fixed by updating the relationship between Environment and EnvironmentRole so only environment roles that are not deleted are included.
2.) Removes the optional tag from the env name edit form.

## Pivotal
https://www.pivotaltracker.com/story/show/169183145
https://www.pivotaltracker.com/story/show/169368053