### PR TITLE
CRL test should skip JSON cache.

### DIFF
--- a/tests/check_crl_parse.py
+++ b/tests/check_crl_parse.py
@@ -7,7 +7,9 @@ from tests.utils import parse_for_issuer_and_next_update
 
 
 CRL_DIR = "crls"
-_CRLS = ["{}/{}".format(CRL_DIR, file_) for file_ in os.listdir(CRL_DIR)]
+_CRLS = [
+    "{}/{}".format(CRL_DIR, file_) for file_ in os.listdir(CRL_DIR) if ".crl" in file_
+]
 
 
 @pytest.mark.parametrize("crl_path", _CRLS)


### PR DESCRIPTION
Dumb bug I introduced to the `test/check_crl_parse.py` test file we run nightly. It needs to skip the generated `crl_locations.json` file, since that isn't a CRL.