### PR TITLE
Force removal of existing fonts symlink in Docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,7 @@ RUN ./script/write_dotenv && \
       pip install pipenv uwsgi && \
       PIPENV_VENV_IN_PROJECT=1 pipenv sync && \
       yarn install && \
+      rm -r ./static/fonts/ &> /dev/null || true && \
       cp -rf ./node_modules/uswds/src/fonts ./static/ && \
       yarn build
 


### PR DESCRIPTION
For local development, we symlink the USWDS fonts from the npm installed
copy into our static directory. This causes problems for the Docker
build because it is not expecting to find a pre-existing "static/fonts"
directory. This forcibly removes any existing "static/fonts" directory
to fix the issue.