### PR TITLE
Standardize member and env name ordering

### DIFF
--- a/atst/models/application.py
+++ b/atst/models/application.py
@@ -25,6 +25,7 @@ class Application(
         primaryjoin=and_(
             Environment.application_id == id, Environment.deleted == False
         ),
+        order_by="Environment.name",
     )
     roles = relationship(
         "ApplicationRole",

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -30,9 +30,9 @@ def get_environments_obj_for_app(application):
                 "pending": env.is_pending,
                 "edit_form": EditEnvironmentForm(obj=env),
                 "member_count": len(env.roles),
-                "members": [
-                    env_role.application_role.user_name for env_role in env.roles
-                ],
+                "members": sorted(
+                    [env_role.application_role.user_name for env_role in env.roles]
+                ),
             }
             for env in application.environments
         ],
@@ -100,12 +100,11 @@ def get_members_data(application):
         form = UpdateMemberForm(
             environment_roles=env_roles_form_data, **permission_sets
         )
-        update_invite_form = None
-
-        if member.latest_invitation and member.latest_invitation.can_resend:
-            update_invite_form = MemberForm(obj=member.latest_invitation)
-        else:
-            update_invite_form = MemberForm()
+        update_invite_form = (
+            MemberForm(obj=member.latest_invitation)
+            if member.latest_invitation and member.latest_invitation.can_resend
+            else MemberForm()
+        )
 
         members_data.append(
             {
@@ -119,14 +118,17 @@ def get_members_data(application):
             }
         )
 
-    return members_data
+    return sorted(members_data, key=lambda member: member["user_name"])
 
 
 def get_new_member_form(application):
-    env_roles = [
-        {"environment_id": e.id, "environment_name": e.name}
-        for e in application.environments
-    ]
+    env_roles = sorted(
+        [
+            {"environment_id": e.id, "environment_name": e.name}
+            for e in application.environments
+        ],
+        key=lambda role: role["environment_name"],
+    )
 
     return NewMemberForm(data={"environment_roles": env_roles})
 

--- a/atst/routes/portfolios/admin.py
+++ b/atst/routes/portfolios/admin.py
@@ -52,7 +52,10 @@ def serialize_member_form_data(member):
 
 
 def get_members_data(portfolio):
-    members = [serialize_member_form_data(member) for member in portfolio.members]
+    members = sorted(
+        [serialize_member_form_data(member) for member in portfolio.members],
+        key=lambda member: member["member_name"],
+    )
     for member in members:
         if member["member_id"] == portfolio.owner_role.id:
             ppoc = member

--- a/translations.yaml
+++ b/translations.yaml
@@ -342,7 +342,7 @@ portfolios:
             </p>
           </div>
       step_2_header: Add Environments to {application_name}
-      step_2_description: "Production, Staging, Testing, and Development environments are included by default. However, you can add, edit, and delete environments based on the needs of your Application."
+      step_2_description: Development, Testing, Staging, and Production environments are included by default. However, you can add, edit, and delete environments based on the needs of your Application. 
       step_2_button_text: "Next: Add Members"
       step_3_header: Add Members to {application_name}
       step_3_description: "To proceed, you will need each member's email address and DOD ID. Within this section, you will also assign Application-level permissions and environment-level roles for each member."


### PR DESCRIPTION
There were a few bugs that pointed out inconsistencies / lack of ordering. This PR fixes those.


| Story  | Screenshot |
| ------------- | ------------- |
| [Portfolio applications- Environments dropdown](https://www.pivotaltracker.com/story/show/169607538)  | ![](https://user-images.githubusercontent.com/54586407/68507532-1f04fa00-023a-11ea-82bf-28446e2997e9.png)  |
| [App settings -> Application Team](https://www.pivotaltracker.com/story/show/169605561)  | ![](https://user-images.githubusercontent.com/54586407/68507580-45c33080-023a-11ea-9ce1-3cb948a400fc.png)  |
| [App Settings -> Environment members ](https://www.pivotaltracker.com/story/show/169607374)  | ![](https://user-images.githubusercontent.com/54586407/68507614-5d021e00-023a-11ea-82b4-1decfd67c410.png)  |
| [Portfolio members](https://www.pivotaltracker.com/story/show/169607752) -- note: for this one, the ordering is PPOC, then other portfolio members in alphabetical order.  | ![](https://user-images.githubusercontent.com/54586407/68507672-786d2900-023a-11ea-8595-3f3e0e268d21.png)  |
| Application Members: [New](https://www.pivotaltracker.com/story/show/169607265) / [Edit](https://www.pivotaltracker.com/story/show/169607235) member modal | ![](https://user-images.githubusercontent.com/54586407/68507748-a2bee680-023a-11ea-94ba-540d951edd6e.png)  |
| [New Application - Step 2](https://www.pivotaltracker.com/story/show/169606042) | ![](https://user-images.githubusercontent.com/54586407/68602626-b35aa100-0474-11ea-9bd7-368d10482dee.png) |
| [New Application - Step 3](https://www.pivotaltracker.com/story/show/169503971) | ![](https://user-images.githubusercontent.com/54586407/68602592-a0e06780-0474-11ea-887b-25916b7fa296.png) |