### PR TITLE
Configure K8s deployment for easy LetsEncrypt verification.

### DIFF
--- a/deploy/azure/acme-challenges.yml
+++ b/deploy/azure/acme-challenges.yml
@@ -1,0 +1,8 @@
+apiVersion: v1
+data:
+  foo: |
+    bar
+kind: ConfigMap
+metadata:
+  name: acme-challenges
+  namespace: atat

--- a/deploy/azure/atst-nginx-configmap.yml
+++ b/deploy/azure/atst-nginx-configmap.yml
@@ -9,12 +9,24 @@ data:
     server {
         listen ${PORT_PREFIX}342;
         server_name ${MAIN_DOMAIN};
-        return 301 https://$host$request_uri;
+        root /usr/share/nginx/html;
+        location /.well-known/acme-challenge/ {
+          try_files $uri =404;
+        }
+        location / {
+          return 301 https://$host$request_uri;
+        }
     }
     server {
         listen ${PORT_PREFIX}343;
         server_name ${AUTH_DOMAIN};
-        return 301 https://$host$request_uri;
+        root /usr/share/nginx/html;
+        location /.well-known/acme-challenge/ {
+          try_files $uri =404;
+        }
+        location / {
+          return 301 https://$host$request_uri;
+        }
     }
     server {
         server_name ${MAIN_DOMAIN};

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -70,6 +70,8 @@ spec:
               mountPath: "/etc/ssl/private"
             - name: nginx-client-ca-bundle
               mountPath: "/etc/ssl/"
+            - name: acme
+              mountPath: "/usr/share/nginx/html/.well-known/acme-challenge/"
       volumes:
         - name: atst-config
           secret:
@@ -118,6 +120,10 @@ spec:
             - key: cert
               path: pgsslrootcert.crt
               mode: 0666
+        - name: acme
+          configMap:
+            name: acme-challenges
+            defaultMode: 0666
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/deploy/azure/kustomization.yaml
+++ b/deploy/azure/kustomization.yaml
@@ -9,3 +9,4 @@ resources:
   - pgsslrootcert.yml
   - volume-claim.yml
   - nginx-client-ca-bundle.yml
+  - acme-challenges.yml


### PR DESCRIPTION
This is not the certificate setup we will use in production. I'd like to
merge this configuration as a reference point because this is the
easiest way to handle manual LetsEncrypt verification within the
cluster.

This allows NGINX to serve static files over HTTP from the
".well-known/acme-challenge" directory, which is necessary for certbot
validation of domain ownership.