### PR TITLE
Edit member perms in new app form bugfix

### DIFF
--- a/atst/routes/applications/new.py
+++ b/atst/routes/applications/new.py
@@ -157,6 +157,10 @@ def view_new_application_step_3(application_id):
 
 
 @applications_bp.route("/applications/<application_id>/new/step_3", methods=["POST"])
+@applications_bp.route(
+    "/applications/<application_id>/new/step_3/member/<application_role_id>",
+    methods=["POST"],
+)
 @user_can(Permissions.CREATE_APPLICATION, message="view create new application form")
 def update_new_application_step_3(application_id, application_role_id=None):
     if application_role_id:

--- a/atst/routes/applications/new.py
+++ b/atst/routes/applications/new.py
@@ -11,6 +11,7 @@ from atst.routes.applications.settings import (
     get_members_data,
     get_new_member_form,
     handle_create_member,
+    handle_update_member,
 )
 
 
@@ -157,9 +158,11 @@ def view_new_application_step_3(application_id):
 
 @applications_bp.route("/applications/<application_id>/new/step_3", methods=["POST"])
 @user_can(Permissions.CREATE_APPLICATION, message="view create new application form")
-def update_new_application_step_3(application_id):
-
-    handle_create_member(application_id, http_request.form)
+def update_new_application_step_3(application_id, application_role_id=None):
+    if application_role_id:
+        handle_update_member(application_id, application_role_id, http_request.form)
+    else:
+        handle_create_member(application_id, http_request.form)
 
     return redirect(
         url_for(

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -210,6 +210,30 @@ def handle_create_member(application_id, form_data):
         # TODO: flash error message
 
 
+def handle_update_member(application_id, application_role_id, form_data):
+    app_role = ApplicationRoles.get_by_id(application_role_id)
+    application = Applications.get(application_id)
+    existing_env_roles_data = filter_env_roles_form_data(
+        app_role, application.environments
+    )
+    form = UpdateMemberForm(
+        formdata=form_data, environment_roles=existing_env_roles_data
+    )
+
+    if form.validate():
+        ApplicationRoles.update_permission_sets(app_role, form.data["permission_sets"])
+
+        for env_role in form.environment_roles:
+            environment = Environments.get(env_role.environment_id.data)
+            new_role = None if env_role.disabled.data else env_role.data["role"]
+            Environments.update_env_role(environment, app_role, new_role)
+
+        flash("application_member_updated", user_name=app_role.user_name)
+    else:
+        pass
+        # TODO: flash error message
+
+
 @applications_bp.route("/applications/<application_id>/settings")
 @user_can(Permissions.VIEW_APPLICATION, message="view application edit form")
 def settings(application_id):
@@ -382,27 +406,8 @@ def remove_member(application_id, application_role_id):
 )
 @user_can(Permissions.EDIT_APPLICATION_MEMBER, message="update application member")
 def update_member(application_id, application_role_id):
-    app_role = ApplicationRoles.get_by_id(application_role_id)
-    application = Applications.get(application_id)
-    existing_env_roles_data = filter_env_roles_form_data(
-        app_role, application.environments
-    )
-    form = UpdateMemberForm(
-        formdata=http_request.form, environment_roles=existing_env_roles_data
-    )
 
-    if form.validate():
-        ApplicationRoles.update_permission_sets(app_role, form.data["permission_sets"])
-
-        for env_role in form.environment_roles:
-            environment = Environments.get(env_role.environment_id.data)
-            new_role = None if env_role.disabled.data else env_role.data["role"]
-            Environments.update_env_role(environment, app_role, new_role)
-
-        flash("application_member_updated", user_name=app_role.user_name)
-    else:
-        pass
-        # TODO: flash error message
+    handle_update_member(application_id, application_role_id, http_request.form)
 
     return redirect(
         url_for(

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -12,7 +12,8 @@
   application,
   members,
   new_member_form,
-  action) %}
+  action_new,
+  action_update) %}
 
   <h3  id="application-members">
     {{ 'portfolios.applications.settings.team_members' | translate }}
@@ -40,7 +41,7 @@
             <hr>
           </div>
           <base-form inline-template>
-            <form id='{{ modal_name }}' method="POST" action="{{ url_for('applications.update_member', application_id=application.id, application_role_id=member.role_id) }}">
+            <form id='{{ modal_name }}' method="POST" action="{{ url_for(action_update, application_id=application.id, application_role_id=member.role_id,) }}">
               {{ member.form.csrf_token }}
               {{ member_fields.PermsFields(form=member.form, member_role_id=member.role_id) }}
               <div class="action-group">
@@ -181,7 +182,7 @@
     {{ MultiStepModalForm(
         name=new_member_modal_name,
         form=new_member_form,
-        form_action=url_for(action, application_id=application.id),
+        form_action=url_for(action_new, application_id=application.id),
         steps=[
           member_steps.MemberStepOne(new_member_form),
           member_steps.MemberStepTwo(new_member_form, application)

--- a/templates/applications/new/step_3.html
+++ b/templates/applications/new/step_3.html
@@ -21,7 +21,8 @@
     application,
     members,
     new_member_form,
-    "applications.update_new_application_step_3") }}
+    action_new="applications.update_new_application_step_3",
+    action_update="applications.update_new_application_step_3") }}
 
 
   <span class="action-group-footer">

--- a/templates/applications/settings.html
+++ b/templates/applications/settings.html
@@ -51,7 +51,8 @@
     application,
     members,
     new_member_form,
-    "applications.create_member") }}
+    action_new="applications.create_member",
+    action_update="applications.update_member") }}
 
   {{ EnvironmentManagementTemplate(
     application,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import alembic.command
 from logging.config import dictConfig
 from werkzeug.datastructures import FileStorage
 from collections import OrderedDict
+from unittest.mock import Mock
 
 from atst.app import make_app, make_config
 from atst.database import db as _db


### PR DESCRIPTION
## Description
Previously when updating an app members perms through the new app form, it was submitting to the same route as updating an app member through the settings page, which was causing it to redirect to the wrong page after update. This was fixed by posting to the update route for step_3 of the new app form instead.

## Pivotal
https://www.pivotaltracker.com/story/show/169682731