### PR TITLE
Remove edit links and menus for users with view only access

### DIFF
--- a/templates/applications/fragments/environments.html
+++ b/templates/applications/fragments/environments.html
@@ -42,14 +42,16 @@
                           classes="environment-list__item__members"
                         )
                       }}
-                      {% set edit_environment_button = "Edit" %}
-                      {{
-                      ToggleButton(
-                        open_html=edit_environment_button,
-                        close_html=edit_environment_button,
-                        section_name="edit"
-                        )
-                      }}
+                      {% if user_can(permissions.EDIT_ENVIRONMENT) -%}
+                        {% set edit_environment_button = "Edit" %}
+                        {{
+                        ToggleButton(
+                          open_html=edit_environment_button,
+                          close_html=edit_environment_button,
+                          section_name="edit"
+                          )
+                        }}
+                      {%- endif %}
                       <br>
                       {% if env['pending'] -%}
                         {{ Label('exchange', 'Changes Pending', classes='label--below')}}
@@ -72,21 +74,23 @@
                     </ul>
                   {% endcall %}
 
-                  {% call ToggleSection(section_name="edit") %}
-                    <ul>
-                      <li class="accordion-table__item-toggle-content__expanded">
-                        <form action="{{ url_for('applications.update_environment', environment_id=env['id']) }}" method="post" v-on:submit="handleSubmit">
-                          {{ edit_form.csrf_token }}
-                          {{ TextInput(edit_form.name, validation='requiredField', optional=False) }}
-                          {{
-                            SaveButton(
-                              text=("common.save" | translate)
-                            )
-                          }}
-                        </form>
-                      </li>
-                    </ul>
-                  {% endcall %}
+                  {% if user_can(permissions.EDIT_ENVIRONMENT) -%}
+                    {% call ToggleSection(section_name="edit") %}
+                      <ul>
+                        <li class="accordion-table__item-toggle-content__expanded">
+                          <form action="{{ url_for('applications.update_environment', environment_id=env['id']) }}" method="post" v-on:submit="handleSubmit">
+                            {{ edit_form.csrf_token }}
+                            {{ TextInput(edit_form.name, validation='requiredField', optional=False) }}
+                            {{
+                              SaveButton(
+                                text=("common.save" | translate)
+                              )
+                            }}
+                          </form>
+                        </li>
+                      </ul>
+                    {% endcall %}
+                  {%- endif %}
                 </li>
               </toggler>
             {% endfor %}

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -131,38 +131,38 @@
                         </span>
                       </div>
                     {% endfor %}
-                    <div class="app-member-menu">
-                      {% set toggle_button -%}
-                        {{ Icon('ellipsis')}}
-                      {%- endset %}
-                      {% set section = "app_member_edit-{}".format(member.role_id) %}
+                    {% if user_can(permissions.EDIT_APPLICATION_MEMBER) -%}
+                      <div class="app-member-menu">
+                        {% set toggle_button -%}
+                          {{ Icon('ellipsis')}}
+                        {%- endset %}
+                        {% set section = "app_member_edit-{}".format(member.role_id) %}
 
-                      {{
-                        ToggleButton(
-                          open_html=toggle_button,
-                          close_html=toggle_button,
-                          section_name=section,
-                          active_style=True
-                        )
-                      }}
-                      {% call ToggleSection(section_name=section, classes="app-member-menu__toggle") %}
-                        {% if user_can(permissions.EDIT_APPLICATION_MEMBER) -%}
-                          <a v-on:click="openModal('{{ perms_modal }}')">
-                            {{ "portfolios.applications.members.menu.edit" | translate }}
-                          </a>
-                        {%- endif %}
-                        {% if member.role_status == 'pending' -%}
-                          {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
-                          {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
-                          <a v-on:click='openModal("{{ resend_invite_modal }}")'>
-                            {{ "portfolios.applications.members.menu.resend" | translate }}
-                          </a>
-                          {% if user_can(permissions.DELETE_APPLICATION_MEMBER) -%}
-                            <a v-on:click='openModal("{{ revoke_invite_modal }}")'>{{ 'invites.revoke' | translate }}</a>
+                        {{
+                          ToggleButton(
+                            open_html=toggle_button,
+                            close_html=toggle_button,
+                            section_name=section,
+                            active_style=True
+                          )
+                        }}
+                        {% call ToggleSection(section_name=section, classes="app-member-menu__toggle") %}
+                            <a v-on:click="openModal('{{ perms_modal }}')">
+                              {{ "portfolios.applications.members.menu.edit" | translate }}
+                            </a>
+                          {% if member.role_status == 'pending' -%}
+                            {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
+                            {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
+                            <a v-on:click='openModal("{{ resend_invite_modal }}")'>
+                              {{ "portfolios.applications.members.menu.resend" | translate }}
+                            </a>
+                            {% if user_can(permissions.DELETE_APPLICATION_MEMBER) -%}
+                              <a v-on:click='openModal("{{ revoke_invite_modal }}")'>{{ 'invites.revoke' | translate }}</a>
+                            {%- endif %}
                           {%- endif %}
-                        {%- endif %}
-                      {% endcall %}
-                    </div>
+                        {% endcall %}
+                      </div>
+                    {%- endif %}
                   </td>
                 </tr>
               {% endfor %}


### PR DESCRIPTION
## Description
App members with view only access should not see the app member edit menu or the link to edit an environment name.

## Pivotal
https://www.pivotaltracker.com/story/show/169603273

## Screenshot
<img width="1696" alt="Screen Shot 2019-11-15 at 3 48 28 PM" src="https://user-images.githubusercontent.com/43828539/68974780-8df4cc80-07bf-11ea-81ea-5816b863b40a.png">