### PR TITLE
Status labels on app members table

### DIFF
--- a/atst/models/application_role.py
+++ b/atst/models/application_role.py
@@ -110,6 +110,29 @@ class ApplicationRole(
     def is_active(self):
         return self.status == Status.ACTIVE
 
+    @property
+    def display_status(self):
+        if (
+            self.is_pending
+            and self.latest_invitation
+            and self.latest_invitation.is_pending
+        ):
+            return "invite_pending"
+
+        elif (
+            self.is_pending
+            and self.latest_invitation
+            and self.latest_invitation.is_expired
+        ):
+            return "invite_expired"
+
+        elif self.is_active and any(
+            env_role.is_pending for env_role in self.environment_roles
+        ):
+            return "changes_pending"
+
+        return None
+
 
 Index(
     "application_role_user_application",

--- a/atst/models/application_role.py
+++ b/atst/models/application_role.py
@@ -102,6 +102,14 @@ class ApplicationRole(
             "portfolio": self.application.portfolio.name,
         }
 
+    @property
+    def is_pending(self):
+        return self.status == Status.PENDING
+
+    @property
+    def is_active(self):
+        return self.status == Status.ACTIVE
+
 
 Index(
     "application_role_user_application",

--- a/atst/models/environment_role.py
+++ b/atst/models/environment_role.py
@@ -71,6 +71,10 @@ class EnvironmentRole(
         return self.status == EnvironmentRole.Status.DISABLED
 
     @property
+    def is_pending(self):
+        return self.status == EnvironmentRole.Status.PENDING
+
+    @property
     def event_details(self):
         return {
             "updated_user_name": self.application_role.user_name,

--- a/atst/routes/applications/new.py
+++ b/atst/routes/applications/new.py
@@ -153,7 +153,6 @@ def view_new_application_step_3(application_id):
         application=application,
         members=members,
         new_member_form=new_member_form,
-        label_info=LABEL_INFO,
     )
 
 

--- a/atst/routes/applications/new.py
+++ b/atst/routes/applications/new.py
@@ -153,6 +153,7 @@ def view_new_application_step_3(application_id):
         application=application,
         members=members,
         new_member_form=new_member_form,
+        label_info=LABEL_INFO,
     )
 
 

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -111,20 +111,6 @@ def filter_env_roles_form_data(member, environments):
     return env_roles_form_data
 
 
-def get_app_role_status(app_role):
-    status = app_role.status.value
-
-    if app_role.is_pending and app_role.latest_invitation.is_expired:
-        status = "expired"
-
-    if app_role.is_active and any(
-        env_role.is_pending for env_role in app_role.environment_roles
-    ):
-        status = "env_changes_pending"
-
-    return status
-
-
 def get_members_data(application):
     members_data = []
     for member in application.members:
@@ -149,7 +135,7 @@ def get_members_data(application):
                 "user_name": member.user_name,
                 "permission_sets": permission_sets,
                 "environment_roles": environment_roles,
-                "role_status": get_app_role_status(member),
+                "role_status": member.display_status,
                 "form": form,
                 "update_invite_form": update_invite_form,
             }

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -21,6 +21,19 @@ from atst.utils.localization import translate
 from atst.jobs import send_mail
 
 
+LABEL_INFO = {
+    "pending": {"icon": "envelope", "text": "invite pending", "type": "success",},
+    "expired": {"icon": "envelope", "text": "invite expired", "type": "error",},
+    "env_changes_pending": {
+        "icon": "exchange",
+        "text": "changes pending",
+        "type": "default",
+    },
+    "active": None,
+    "disabled": None,
+}
+
+
 def get_environments_obj_for_app(application):
     return sorted(
         [
@@ -98,6 +111,20 @@ def filter_env_roles_form_data(member, environments):
     return env_roles_form_data
 
 
+def get_app_role_status(app_role):
+    status = app_role.status.value
+
+    if app_role.is_pending and app_role.latest_invitation.is_expired:
+        status = "expired"
+
+    if app_role.is_active and any(
+        env_role.is_pending for env_role in app_role.environment_roles
+    ):
+        status = "env_changes_pending"
+
+    return status
+
+
 def get_members_data(application):
     members_data = []
     for member in application.members:
@@ -122,7 +149,7 @@ def get_members_data(application):
                 "user_name": member.user_name,
                 "permission_sets": permission_sets,
                 "environment_roles": environment_roles,
-                "role_status": member.status.value,
+                "role_status": get_app_role_status(member),
                 "form": form,
                 "update_invite_form": update_invite_form,
             }
@@ -164,6 +191,7 @@ def render_settings_page(application, **kwargs):
         audit_events=audit_events,
         new_member_form=new_member_form,
         members=members,
+        label_info=LABEL_INFO,
         **kwargs,
     )
 

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -21,19 +21,6 @@ from atst.utils.localization import translate
 from atst.jobs import send_mail
 
 
-LABEL_INFO = {
-    "pending": {"icon": "envelope", "text": "invite pending", "type": "success",},
-    "expired": {"icon": "envelope", "text": "invite expired", "type": "error",},
-    "env_changes_pending": {
-        "icon": "exchange",
-        "text": "changes pending",
-        "type": "default",
-    },
-    "active": None,
-    "disabled": None,
-}
-
-
 def get_environments_obj_for_app(application):
     return sorted(
         [
@@ -177,7 +164,6 @@ def render_settings_page(application, **kwargs):
         audit_events=audit_events,
         new_member_form=new_member_form,
         members=members,
-        label_info=LABEL_INFO,
         **kwargs,
     )
 

--- a/styles/elements/_labels.scss
+++ b/styles/elements/_labels.scss
@@ -20,6 +20,10 @@
   white-space: nowrap;
   text-transform: uppercase;
 
+  &--default {
+    background-color: $color-gray-dark;
+  }
+
   &--info {
     background-color: $color-primary;
   }

--- a/templates/applications/fragments/environments.html
+++ b/templates/applications/fragments/environments.html
@@ -54,7 +54,7 @@
                       {%- endif %}
                       <br>
                       {% if env['pending'] -%}
-                        {{ Label('exchange', 'Changes Pending', classes='label--below')}}
+                        {{ Label(type="changes_pending", classes='label--below')}}
                       {% else %}
                         <a href='{{ url_for("applications.access_environment", environment_id=env.id)}}' target='_blank' rel='noopener noreferrer' class='application-list-item__environment__csp_link'>
                           <span>{{ "portfolios.applications.csp_link" | translate }} {{ Icon('link', classes="icon--tiny") }}</span>

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -33,6 +33,8 @@
   {% else %}
 
     {% for member in members %}
+      {% set invite_pending = member.role_status == 'invite_pending' %}
+      {% set invite_expired = member.role_status == 'invite_expired' %}
       {%- if user_can(permissions.EDIT_APPLICATION_MEMBER) %}
         {% set modal_name = "edit_member-{}".format(loop.index) %}
         {% call Modal(modal_name, classes="form-content--app-mem") %}
@@ -52,7 +54,7 @@
           </base-form>
         {% endcall %}
 
-        {%- if member.role_status == 'pending' or member.role_status == 'expired' %}
+        {%- if invite_pending or invite_expired %}
           {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
           {% call Modal(resend_invite_modal, classes="form-content--app-mem") %}
             <div class="modal__form--header">
@@ -73,7 +75,7 @@
         {% endif -%}
       {% endif -%}
 
-      {% if user_can(permissions.DELETE_APPLICATION_MEMBER) and (member.role_status == 'pending' or member.role_status == 'expired') -%}
+      {% if user_can(permissions.DELETE_APPLICATION_MEMBER) and (invite_pending or invite_expired) -%}
         {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
         {% call Modal(name=revoke_invite_modal) %}
           <form method="post" action="{{ url_for('applications.revoke_invite', application_id=application.id, application_role_id=member.role_id) }}">
@@ -104,13 +106,13 @@
             <tbody>
               {% for member in members %}
                 {% set perms_modal = "edit_member-{}".format(loop.index) %}
+                {% set invite_pending = member.role_status == 'invite_pending' %}
+                {% set invite_expired = member.role_status == 'invite_expired' %}
                 <tr>
                   <td>
                     <strong>{{ member.user_name }}</strong>
                     <br>
-                    {% if label_info[member.role_status] -%}
-                      {{ Label(classes='label--below', **label_info[member.role_status]) }}
-                    {%- endif %}
+                    {{ Label(type=member.role_status, classes='label--below') }}
                   </td>
 
                   <td>
@@ -150,7 +152,7 @@
                           <a v-on:click="openModal('{{ perms_modal }}')">
                             {{ "portfolios.applications.members.menu.edit" | translate }}
                           </a>
-                          {% if member.role_status == 'pending' or member.role_status == 'expired' -%}
+                          {% if invite_pending or invite_expired -%}
                             {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
                             {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
                             <a v-on:click='openModal("{{ resend_invite_modal }}")'>

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -52,7 +52,7 @@
           </base-form>
         {% endcall %}
 
-        {%- if member.role_status == 'pending' %}
+        {%- if member.role_status == 'pending' or member.role_status == 'expired' %}
           {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
           {% call Modal(resend_invite_modal, classes="form-content--app-mem") %}
             <div class="modal__form--header">
@@ -73,7 +73,7 @@
         {% endif -%}
       {% endif -%}
 
-      {% if user_can(permissions.DELETE_APPLICATION_MEMBER) and member.role_status == 'pending' -%}
+      {% if user_can(permissions.DELETE_APPLICATION_MEMBER) and (member.role_status == 'pending' or member.role_status == 'expired') -%}
         {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
         {% call Modal(name=revoke_invite_modal) %}
           <form method="post" action="{{ url_for('applications.revoke_invite', application_id=application.id, application_role_id=member.role_id) }}">
@@ -107,11 +107,10 @@
                 <tr>
                   <td>
                     <strong>{{ member.user_name }}</strong>
-                    {% if member.role_status == 'pending' %}
-                      <br>
-                      {{ Label('envelope', 'invite pending', 'success', classes='label--below') }}
-                    {% endif %}
-
+                    <br>
+                    {% if label_info[member.role_status] -%}
+                      {{ Label(classes='label--below', **label_info[member.role_status]) }}
+                    {%- endif %}
                   </td>
 
                   <td>
@@ -148,10 +147,10 @@
                           )
                         }}
                         {% call ToggleSection(section_name=section, classes="app-member-menu__toggle") %}
-                            <a v-on:click="openModal('{{ perms_modal }}')">
-                              {{ "portfolios.applications.members.menu.edit" | translate }}
-                            </a>
-                          {% if member.role_status == 'pending' -%}
+                          <a v-on:click="openModal('{{ perms_modal }}')">
+                            {{ "portfolios.applications.members.menu.edit" | translate }}
+                          </a>
+                          {% if member.role_status == 'pending' or member.role_status == 'expired' -%}
                             {% set revoke_invite_modal = "revoke_invite_{}".format(member.role_id) %}
                             {% set resend_invite_modal = "resend_invite-{}".format(member.role_id) %}
                             <a v-on:click='openModal("{{ resend_invite_modal }}")'>

--- a/templates/components/label.html
+++ b/templates/components/label.html
@@ -1,8 +1,19 @@
 {% from "components/icon.html" import Icon %}
 
-{% macro Label(icon, text, type=None, classes="") -%}
+{% macro Label(type=None, classes="") -%}
+  {% set label_info = {
+      "invite_pending": {"icon": "envelope", "text": "invite pending", "color": "success",},
+      "invite_expired": {"icon": "envelope", "text": "invite expired", "color": "error",},
+      "changes_pending": {
+          "icon": "exchange",
+          "text": "changes pending",
+          "color": "default",
+      },
+  } %}
 
-  <span class='label {% if type %}label--{{ type }}{% endif %} {{ classes }}'>
-    {{ Icon(icon) }} {{ text }}
-  </span>
+  {% if type -%}
+    <span class='label label--{{ label_info[type]["color"] }} {{ classes }}'>
+      {{ Icon(label_info[type]["icon"]) }} {{ label_info[type]["text"] }}
+    </span>
+  {%- endif %}
 {%- endmacro %}

--- a/templates/components/label.html
+++ b/templates/components/label.html
@@ -1,8 +1,8 @@
 {% from "components/icon.html" import Icon %}
 
-{% macro Label(icon_name, text, type=None, classes="") -%}
+{% macro Label(icon, text, type=None, classes="") -%}
 
   <span class='label {% if type %}label--{{ type }}{% endif %} {{ classes }}'>
-    {{ Icon(icon_name) }} {{ text }}
+    {{ Icon(icon) }} {{ text }}
   </span>
 {%- endmacro %}

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -202,7 +202,7 @@ class EnvironmentFactory(Base):
         for member in with_members:
             user = member.get("user", UserFactory.create())
             application_role = ApplicationRoleFactory.create(
-                application=environment.application, user=user
+                application=environment.application, user=user, invite=True
             )
             role_name = member["role_name"]
             EnvironmentRoleFactory.create(
@@ -232,6 +232,16 @@ class ApplicationRoleFactory(Base):
     user = factory.SubFactory(UserFactory)
     status = ApplicationRoleStatus.PENDING
     permission_sets = factory.LazyFunction(base_application_permission_sets)
+
+    @classmethod
+    def _create(cls, model_class, *args, **kwargs):
+        with_invite = kwargs.pop("invite", False)
+        app_role = super()._create(model_class, *args, **kwargs)
+
+        if with_invite:
+            ApplicationInvitationFactory.create(role=app_role)
+
+        return app_role
 
 
 class EnvironmentRoleFactory(Base):

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -202,7 +202,7 @@ class EnvironmentFactory(Base):
         for member in with_members:
             user = member.get("user", UserFactory.create())
             application_role = ApplicationRoleFactory.create(
-                application=environment.application, user=user, invite=True
+                application=environment.application, user=user
             )
             role_name = member["role_name"]
             EnvironmentRoleFactory.create(
@@ -235,7 +235,7 @@ class ApplicationRoleFactory(Base):
 
     @classmethod
     def _create(cls, model_class, *args, **kwargs):
-        with_invite = kwargs.pop("invite", False)
+        with_invite = kwargs.pop("invite", True)
         app_role = super()._create(model_class, *args, **kwargs)
 
         if with_invite:
@@ -269,7 +269,7 @@ class ApplicationInvitationFactory(Base):
     email = factory.Faker("email")
     status = InvitationStatus.PENDING
     expiration_time = PortfolioInvitations.current_expiration_time()
-    role = factory.SubFactory(ApplicationRoleFactory)
+    role = factory.SubFactory(ApplicationRoleFactory, invite=False)
 
 
 class AttachmentFactory(Base):

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -61,21 +61,18 @@ def test_environment_roles():
 
 
 def test_display_status():
-    app_role_expired_invite = ApplicationRoleFactory.create()
     yesterday = datetime.date.today() - datetime.timedelta(days=1)
-    ApplicationInvitationFactory.create(
-        role=app_role_expired_invite, expiration_time=yesterday
-    )
-    assert app_role_expired_invite.display_status == "expired"
+    expired_invite = ApplicationInvitationFactory.create(expiration_time=yesterday)
+    assert expired_invite.role.display_status == "invite_expired"
 
     app_role_pending = ApplicationRoleFactory.create()
     invite = ApplicationInvitationFactory.create(
         role=app_role_pending, user=app_role_pending.user
     )
-    assert app_role_pending.display_status == "pending"
+    assert app_role_pending.display_status == "invite_pending"
 
     app_role_active = ApplicationRoleFactory.create(status=ApplicationRoleStatus.ACTIVE)
-    assert app_role_active.display_status == "active"
+    assert app_role_active.display_status == None
 
     env_role_pending = EnvironmentRoleFactory.create(application_role=app_role_active)
-    assert env_role_pending.application_role.display_status == "env_changes_pending"
+    assert env_role_pending.application_role.display_status == "changes_pending"

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -58,3 +58,24 @@ def test_environment_roles():
     )
 
     assert not EnvironmentRoles.get_by_user_and_environment(user.id, environment2.id)
+
+
+def test_display_status():
+    app_role_expired_invite = ApplicationRoleFactory.create()
+    yesterday = datetime.date.today() - datetime.timedelta(days=1)
+    ApplicationInvitationFactory.create(
+        role=app_role_expired_invite, expiration_time=yesterday
+    )
+    assert app_role_expired_invite.display_status == "expired"
+
+    app_role_pending = ApplicationRoleFactory.create()
+    invite = ApplicationInvitationFactory.create(
+        role=app_role_pending, user=app_role_pending.user
+    )
+    assert app_role_pending.display_status == "pending"
+
+    app_role_active = ApplicationRoleFactory.create(status=ApplicationRoleStatus.ACTIVE)
+    assert app_role_active.display_status == "active"
+
+    env_role_pending = EnvironmentRoleFactory.create(application_role=app_role_active)
+    assert env_role_pending.application_role.display_status == "env_changes_pending"

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -10,10 +10,11 @@ from tests.factories import *
 from atst.domain.applications import Applications
 from atst.domain.application_roles import ApplicationRoles
 from atst.domain.environment_roles import EnvironmentRoles
+from atst.domain.invitations import ApplicationInvitations
 from atst.domain.common import Paginator
 from atst.domain.permission_sets import PermissionSets
 from atst.models.application_role import Status as ApplicationRoleStatus
-from atst.models.environment_role import CSPRole
+from atst.models.environment_role import CSPRole, EnvironmentRole
 from atst.models.permissions import Permissions
 from atst.forms.application import EditEnvironmentForm
 from atst.forms.application_member import UpdateMemberForm
@@ -109,12 +110,13 @@ def test_edit_application_environments_obj(app, client, user_session):
         {"env"},
     )
     env = application.environments[0]
-    app_role1 = ApplicationRoleFactory.create(application=application)
+    app_role1 = ApplicationRoleFactory.create(application=application, invite=True)
     env_role1 = EnvironmentRoleFactory.create(
         application_role=app_role1, environment=env, role=CSPRole.BASIC_ACCESS.value
     )
-    app_role2 = ApplicationRoleFactory.create(application=application, user=None)
-    invite = ApplicationInvitationFactory.create(role=app_role2)
+    app_role2 = ApplicationRoleFactory.create(
+        application=application, user=None, invite=True
+    )
     env_role2 = EnvironmentRoleFactory.create(
         application_role=app_role2, environment=env, role=CSPRole.NETWORK_ADMIN.value
     )
@@ -165,7 +167,7 @@ def test_get_members_data(app, client, user_session):
                 "name": "testing",
                 "members": [{"user": user, "role_name": CSPRole.BASIC_ACCESS.value}],
             }
-        ]
+        ],
     )
     environment = application.environments[0]
     app_role = ApplicationRoles.get(user_id=user.id, application_id=application.id)

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -23,8 +23,11 @@ from atst.routes.applications.settings import (
     filter_env_roles_form_data,
     filter_env_roles_data,
     get_environments_obj_for_app,
+<<<<<<< HEAD
     handle_create_member,
     handle_update_member,
+=======
+>>>>>>> Move display status logic to be a property of an ApplicationRole
 )
 
 from tests.utils import captured_templates

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -23,11 +23,8 @@ from atst.routes.applications.settings import (
     filter_env_roles_form_data,
     filter_env_roles_data,
     get_environments_obj_for_app,
-<<<<<<< HEAD
     handle_create_member,
     handle_update_member,
-=======
->>>>>>> Move display status logic to be a property of an ApplicationRole
 )
 
 from tests.utils import captured_templates

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -110,13 +110,11 @@ def test_edit_application_environments_obj(app, client, user_session):
         {"env"},
     )
     env = application.environments[0]
-    app_role1 = ApplicationRoleFactory.create(application=application, invite=True)
+    app_role1 = ApplicationRoleFactory.create(application=application)
     env_role1 = EnvironmentRoleFactory.create(
         application_role=app_role1, environment=env, role=CSPRole.BASIC_ACCESS.value
     )
-    app_role2 = ApplicationRoleFactory.create(
-        application=application, user=None, invite=True
-    )
+    app_role2 = ApplicationRoleFactory.create(application=application, user=None)
     env_role2 = EnvironmentRoleFactory.create(
         application_role=app_role2, environment=env, role=CSPRole.NETWORK_ADMIN.value
     )


### PR DESCRIPTION
## Description
Update the status labels on the app members table to accurately reflect the member's status: `invite pending`, `invite expired`, and `changes pending`.

## Pivotal
https://www.pivotaltracker.com/story/show/169273556

## Screenshot
<img width="1460" alt="Screen Shot 2019-11-18 at 4 45 01 PM" src="https://user-images.githubusercontent.com/43828539/69096654-d9f37b80-0a22-11ea-873b-4fcb2732c234.png">
<img width="1677" alt="Screen Shot 2019-11-19 at 3 17 07 PM" src="https://user-images.githubusercontent.com/43828539/69182771-afb3c380-0adf-11ea-9463-80fd95dec412.png">