### PR TITLE
Set SERVER_NAME correctly for staging Celery workers.

### DIFF
--- a/deploy/overlays/staging/envvars.yml
+++ b/deploy/overlays/staging/envvars.yml
@@ -5,6 +5,7 @@ metadata:
   name: atst-worker-envvars
 data:
   CELERY_DEFAULT_QUEUE: celery-staging
+  SERVER_NAME: staging.atat.code.mil
 ---
 apiVersion: v1
 kind: ConfigMap


### PR DESCRIPTION
It's all in the title. Forgot this when I set up the staging overlay.