### PR TITLE
Catch CSP exceptions and display a flash message with the error

### DIFF
--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -6,6 +6,7 @@ from atst.domain.environments import Environments
 from atst.domain.applications import Applications
 from atst.domain.application_roles import ApplicationRoles
 from atst.domain.audit_log import AuditLog
+from atst.domain.csp.cloud import GeneralCSPException
 from atst.domain.common import Paginator
 from atst.domain.environment_roles import EnvironmentRoles
 from atst.domain.invitations import ApplicationInvitations
@@ -221,14 +222,22 @@ def handle_update_member(application_id, application_role_id, form_data):
     )
 
     if form.validate():
-        ApplicationRoles.update_permission_sets(app_role, form.data["permission_sets"])
+        try:
+            ApplicationRoles.update_permission_sets(
+                app_role, form.data["permission_sets"]
+            )
 
-        for env_role in form.environment_roles:
-            environment = Environments.get(env_role.environment_id.data)
-            new_role = None if env_role.disabled.data else env_role.data["role"]
-            Environments.update_env_role(environment, app_role, new_role)
+            for env_role in form.environment_roles:
+                environment = Environments.get(env_role.environment_id.data)
+                new_role = None if env_role.disabled.data else env_role.data["role"]
+                Environments.update_env_role(environment, app_role, new_role)
 
-        flash("application_member_updated", user_name=app_role.user_name)
+            flash("application_member_updated", user_name=app_role.user_name)
+
+        except GeneralCSPException:
+            flash(
+                "application_member_update_error", user_name=app_role.user_name,
+            )
     else:
         pass
         # TODO: flash error message

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -54,6 +54,11 @@ MESSAGES = {
         "message_template": "You have successfully deleted {{ user_name }} from {{ application_name }}",
         "category": "success",
     },
+    "application_member_update_error": {
+        "title_template": "{{ user_name }} could not be updated",
+        "message_template": "An unexpected problem occurred with your request, please try again. If the problem persists, contact an administrator.",
+        "category": "error",
+    },
     "application_member_updated": {
         "title_template": "Team member updated",
         "message_template": "You have successfully updated the permissions for {{ user_name }}",


### PR DESCRIPTION
## Description
Catches errors when revoking an env role fails and displays a flash message to the user. Until we get copy for this, I am using the message property on the error for the flash message.

## Pivotal
https://www.pivotaltracker.com/story/show/169852180

## Screenshot
<img width="1677" alt="Screen Shot 2019-11-19 at 4 38 49 PM" src="https://user-images.githubusercontent.com/43828539/69188812-3ae68680-0aeb-11ea-8565-d636baff4dc5.png">