### PR TITLE
Exclude audit log from coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,17 @@
 [run]
-omit = atst/routes/dev.py
+omit =
+  atst/routes/dev.py
+  atst/domain/audit_log.py
+  atst/models/mixins/auditable.py
+  atst/models/audit_event.py
 branch = True
+
+[report]
+exclude_lines =
+  pragma: no cover
+  if app.config.get("USE_AUDIT_LOG", False)
+  def event_details
+  def history
+  def resource_type
+  def renderAuditEvent
+  def activity_history

--- a/tests/domain/test_audit_log.py
+++ b/tests/domain/test_audit_log.py
@@ -101,6 +101,7 @@ def test_get_portfolio_events_includes_app_and_env_events():
     assert "environment_role" in resource_types
 
 
+@pytest.mark.audit_log
 def test_get_application_events():
     # add in some portfolio level events
     portfolio = PortfolioFactory.create()


### PR DESCRIPTION
## Description
This PR is the result of a research spike into excluding audit log related functions from the pytest coverage report. I updated the `.coveragerc` config file so it now excludes the audit log files, and functions that are part of the AuditableMixin. This results in a coverage bump from 91.52% to 91.82%. I didn't have time to look into excluding the files and functions based on the `USE_AUDIT_LOG` config variable, so everything is just hard coded in for now. 
Here are the documentation on excluding code from coverage: https://coverage.readthedocs.io/en/coverage-4.3.4/excluding.html and https://coverage.readthedocs.io/en/coverage-4.4.2/config.html

## Pivotal
https://www.pivotaltracker.com/story/show/169291416