### PR TITLE
Fix Upload Header

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -128,6 +128,7 @@ def make_flask_callbacks(app):
 
 def set_default_headers(app):  # pragma: no cover
     static_url = app.config.get("STATIC_URL")
+    blob_storage_url = app.config.get("BLOB_STORAGE_URL")
 
     @app.after_request
     def _set_security_headers(response):
@@ -146,7 +147,7 @@ def set_default_headers(app):  # pragma: no cover
         else:
             response.headers[
                 "Content-Security-Policy"
-            ] = f"default-src 'self' 'unsafe-eval' 'unsafe-inline' {static_url}"
+            ] = f"default-src 'self' 'unsafe-eval' 'unsafe-inline' {blob_storage_url} {static_url}"
 
         return response
 

--- a/config/base.ini
+++ b/config/base.ini
@@ -1,5 +1,6 @@
 [default]
 ASSETS_URL
+BLOB_STORAGE_URL=http://localhost:8000/
 CAC_URL = http://localhost:8000/login-redirect
 CA_CHAIN = ssl/server-certs/ca-chain.pem
 CDN_ORIGIN=http://localhost:8000

--- a/deploy/azure/atst-envvars-configmap.yml
+++ b/deploy/azure/atst-envvars-configmap.yml
@@ -6,6 +6,7 @@ metadata:
   namespace: atat
 data:
   ASSETS_URL: https://atat-cdn.azureedge.net/
+  BLOB_STORAGE_URL: https://atat.blob.core.windows.net/
   CELERY_DEFAULT_QUEUE: celery-master
   CDN_ORIGIN: https://azure.atat.code.mil
   CSP: azure


### PR DESCRIPTION
## Description

Our content security policy in non-dev environments didn't allow uploading to azure blob storage. This adds a configurable blob storage base URL to allow regions to specify which storage endpoint they expect the upload request to use.