### PR TITLE
Do not run test workflow for merges to main branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,7 +285,12 @@ workflows:
   version: 2
   run-tests:
     jobs:
-      - docker-build-staging
+      - docker-build-staging:
+          filters:
+            branches:
+              ignore:
+                - staging
+                - master
       - test:
           requires:
             - docker-build-staging

--- a/deploy/azure/atst-envvars-configmap.yml
+++ b/deploy/azure/atst-envvars-configmap.yml
@@ -10,7 +10,7 @@ data:
   CELERY_DEFAULT_QUEUE: celery-master
   CDN_ORIGIN: https://azure.atat.code.mil
   CSP: azure
-  FLASK_ENV: dev
+  FLASK_ENV: master
   LOG_JSON: "true"
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   PGSSLMODE: verify-full


### PR DESCRIPTION
We should not run a redundant testing workflow on merges to master or
staging.

This also includes a quick fix to configure the FLASK_ENV for the main
site.