### PR TITLE
Fix ConfigMap to directory mapping.

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -47,7 +47,8 @@ spec:
               mountPath: "/opt/atat/atst/ssl/pgsslrootcert.crt"
               subPath: pgsslrootcert.crt
             - name: uwsgi-config
-              mountPath: "/opt/atat/atst/"
+              mountPath: "/opt/atat/atst/uwsgi.ini"
+              subPath: uwsgi.ini
         - name: nginx
           image: nginx:alpine
           ports:
@@ -130,6 +131,10 @@ spec:
           configMap:
             name: uwsgi-config
             defaultMode: 0666
+            items:
+            - key: uwsgi.ini
+              path: uwsgi.ini
+              mode: 0644
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment


### PR DESCRIPTION
Turns out you can't map multiple K8s resources over the same directory.
The K8s secret for the INI file and the ConfigMap for the uWSGI config
both map into /opt/atat/atst in the container. This caused errors when
the container tried to launch. Instead, we need to specify the full file
path for every file we're mapping into that directory to avoid
conflicts.