### PR TITLE
Revoke env access before env role has been provisioned

### DIFF
--- a/atst/domain/environment_roles.py
+++ b/atst/domain/environment_roles.py
@@ -105,8 +105,9 @@ class EnvironmentRoles(object):
     def disable(cls, environment_role_id):
         environment_role = EnvironmentRoles.get_by_id(environment_role_id)
 
-        credentials = environment_role.environment.csp_credentials
-        app.csp.cloud.disable_user(credentials, environment_role.csp_user_id)
+        if not environment_role.environment.is_pending:
+            credentials = environment_role.environment.csp_credentials
+            app.csp.cloud.disable_user(credentials, environment_role.csp_user_id)
 
         environment_role.status = EnvironmentRole.Status.DISABLED
         db.session.add(environment_role)

--- a/atst/domain/environment_roles.py
+++ b/atst/domain/environment_roles.py
@@ -105,7 +105,7 @@ class EnvironmentRoles(object):
     def disable(cls, environment_role_id):
         environment_role = EnvironmentRoles.get_by_id(environment_role_id)
 
-        if not environment_role.environment.is_pending:
+        if environment_role.csp_user_id and not environment_role.environment.is_pending:
             credentials = environment_role.environment.csp_credentials
             app.csp.cloud.disable_user(credentials, environment_role.csp_user_id)
 

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -91,6 +91,25 @@ def test_disable_completed(application_role, environment):
     assert environment_role.disabled
 
 
+def test_disable_checks_env_provisioning_status(session):
+    environment = EnvironmentFactory.create()
+    assert environment.is_pending
+    env_role1 = EnvironmentRoleFactory.create(environment=environment)
+    env_role1 = EnvironmentRoles.disable(env_role1.id)
+    assert env_role1.disabled
+
+    environment.cloud_id = "cloud-id"
+    environment.root_user_info = {"credentials": "credentials"}
+    session.add(environment)
+    session.commit()
+    session.refresh(environment)
+
+    assert not environment.is_pending
+    env_role2 = EnvironmentRoleFactory.create(environment=environment)
+    env_role2 = EnvironmentRoles.disable(env_role2.id)
+    assert env_role2.disabled
+
+
 def test_get_for_update(application_role, environment):
     EnvironmentRoleFactory.create(
         application_role=application_role, environment=environment, deleted=True

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -110,6 +110,23 @@ def test_disable_checks_env_provisioning_status(session):
     assert env_role2.disabled
 
 
+def test_disable_checks_env_role_provisioning_status():
+    environment = EnvironmentFactory.create(
+        cloud_id="cloud-id", root_user_info={"credentials": "credentials"}
+    )
+    env_role1 = EnvironmentRoleFactory.create(environment=environment)
+    assert not env_role1.csp_user_id
+    env_role1 = EnvironmentRoles.disable(env_role1.id)
+    assert env_role1.disabled
+
+    env_role2 = EnvironmentRoleFactory.create(
+        environment=environment, csp_user_id="123456"
+    )
+    assert env_role2.csp_user_id
+    env_role2 = EnvironmentRoles.disable(env_role2.id)
+    assert env_role2.disabled
+
+
 def test_get_for_update(application_role, environment):
     EnvironmentRoleFactory.create(
         application_role=application_role, environment=environment, deleted=True


### PR DESCRIPTION
## Description
Previously we were disabling an env role in the CSP every time env access was revoked, which was causing issues when suspending the role for an user that had not accepted their invite yet. I added in a check to see if the environment has been provisioned before disabling the env role in the csp.

## Pivotal
https://www.pivotaltracker.com/story/show/170004953