### PR TITLE
Add styling for a and button elements on focus

### DIFF
--- a/styles/atat.scss
+++ b/styles/atat.scss
@@ -45,11 +45,3 @@
 @import "sections/application_edit";
 @import "sections/reports";
 @import "sections/task_order";
-
-//
-// IE likes to display an outline when focusing on an element. This
-// fix removes that unwanted outline on focus.
-//
-*:focus {
-  outline: 0;
-}


### PR DESCRIPTION
## Description
A long time ago, [this PR](http://github.com/dod-ccpo/atst/pull/655) was made to fix a bug where outlines were showing on any focused item in IE. However, that fix removed the focus styling from button elements as well. 
I fixed the bug where the cancel TO modal was not tab navigable by adding on focus styling to button elements, the issue was that there was not focus styling on button elements, so I reverted the change that introduced this bug.

## Pivotal
https://www.pivotaltracker.com/story/show/168600807
https://www.pivotaltracker.com/story/show/168704257
https://www.pivotaltracker.com/story/show/168675325
https://www.pivotaltracker.com/story/show/168705044
https://www.pivotaltracker.com/story/show/168667801