### PR TITLE
Add more restrictions to K8s CRL CronJob.

### DIFF
--- a/deploy/azure/crls-sync.yaml
+++ b/deploy/azure/crls-sync.yaml
@@ -5,6 +5,8 @@ metadata:
   namespace: atat
 spec:
   schedule: "0 * * * *"
+  concurrencyPolicy: Replace
+  successfulJobsHistoryLimit: 1
   jobTemplate:
     spec:
       template:


### PR DESCRIPTION
The K8s CronJob that manages CRL syncing often leaves pods hanging
around for days at a time. This appears to happen when the download of a
particular CRL from DISA hangs for whatever reason. This updates the
configuration so that a running cronjob is automatically replaced by its
successor, rather than the two running concurrently. (The CRL CronJob
runs every hour, and it one has taken that long then it's hanging and
needs to be replace.) Similarly, this updates the config to only retain
one successful CRL pod, rather than the default of three.