### PR TITLE
Limit integration tests to only run on protected branches.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -293,6 +293,11 @@ workflows:
       - integration-tests:
           requires:
             - docker-build
+          filters:
+            branches:
+              only:
+                - staging
+                - master
       - deploy-staging:
           requires:
             - test


### PR DESCRIPTION
Because of limitations with CircleCI, we should limit Ghost Inspector
tests to only run on merge commits to our protected branches. This will
allow us to build every commit in CI without exhausting our monthly
allotment of Ghost Inspector test runs. Once that setting has been
enabled in CircleCI ("build every commit") we will not longer have to
worry about what our default branch in the Github repo is.