### PR TITLE
Compose REDIS_URI from component parts.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ commands:
         default: atat_test
       container_env:
         type: string
-        default: -e PGHOST=postgres -e REDIS_URI=redis://redis:6379
+        default: -e PGHOST=postgres -e REDIS_HOST=redis:6379
     steps:
       - run:
           name: Set up temporary docker network
@@ -172,7 +172,7 @@ jobs:
           command: |
             docker run \
               -e PGHOST=postgres \
-              -e REDIS_URI=redis://redis:6379 \
+              -e REDIS_HOST=redis:6379 \
               --network atat \
               atat:builder \
               /bin/sh -c "pipenv install --dev && /bin/sh script/cibuild"

--- a/atst/app.py
+++ b/atst/app.py
@@ -223,19 +223,23 @@ def make_config(direct_config=None):
         config.read_dict({"default": direct_config})
 
     # Assemble DATABASE_URI value
-    database_uri = (
-        "postgres://"
-        + config.get("default", "PGUSER")
-        + ":"
-        + config.get("default", "PGPASSWORD")
-        + "@"
-        + config.get("default", "PGHOST")
-        + ":"
-        + config.get("default", "PGPORT")
-        + "/"
-        + config.get("default", "PGDATABASE")
+    database_uri = "postgres://{}:{}@{}:{}/{}".format(  # pragma: allowlist secret
+        config.get("default", "PGUSER"),
+        config.get("default", "PGPASSWORD"),
+        config.get("default", "PGHOST"),
+        config.get("default", "PGPORT"),
+        config.get("default", "PGDATABASE"),
     )
     config.set("default", "DATABASE_URI", database_uri)
+
+    # Assemble REDIS_URI value
+    redis_uri = "redis{}://{}:{}@{}".format(  # pragma: allowlist secret
+        ("s" if config["default"].getboolean("REDIS_TLS") else ""),
+        (config.get("default", "REDIS_USER") or ""),
+        (config.get("default", "REDIS_PASSWORD") or ""),
+        config.get("default", "REDIS_HOST"),
+    )
+    config.set("default", "REDIS_URI", redis_uri)
 
     return map_config(config)
 

--- a/config/base.ini
+++ b/config/base.ini
@@ -24,7 +24,10 @@ PGSSLMODE = prefer
 PGSSLROOTCERT
 PGUSER = postgres
 PORT=8000
-REDIS_URI = redis://localhost:6379
+REDIS_HOST=localhost:6379
+REDIS_PASSWORD
+REDIS_TLS=False
+REDIS_USER
 SECRET_KEY = change_me_into_something_secret
 SERVER_NAME
 SESSION_COOKIE_NAME=atat

--- a/config/ci.ini
+++ b/config/ci.ini
@@ -1,8 +1,6 @@
 [default]
-DEBUG = true
-PGHOST = postgreshost
-PGDATABASE = atat_test
-REDIS_URI = redis://redishost:6379
 CRL_STORAGE_CONTAINER = tests/fixtures/crl
-WTF_CSRF_ENABLED = false
 CSP=mock-test
+DEBUG = true
+PGDATABASE = atat_test
+WTF_CSRF_ENABLED = false

--- a/deploy/azure/atst-envvars-configmap.yml
+++ b/deploy/azure/atst-envvars-configmap.yml
@@ -7,14 +7,16 @@ metadata:
 data:
   ASSETS_URL: https://atat-cdn.azureedge.net/
   BLOB_STORAGE_URL: https://atat.blob.core.windows.net/
-  CELERY_DEFAULT_QUEUE: celery-master
   CDN_ORIGIN: https://azure.atat.code.mil
+  CELERY_DEFAULT_QUEUE: celery-master
   CSP: azure
   FLASK_ENV: master
   LOG_JSON: "true"
   OVERRIDE_CONFIG_FULLPATH: /opt/atat/atst/atst-overrides.ini
   PGSSLMODE: verify-full
   PGSSLROOTCERT: /opt/atat/atst/ssl/pgsslrootcert.crt
+  REDIS_HOST: atat.redis.cache.windows.net:6380
+  REDIS_TLS: "true"
   STATIC_URL: https://atat-cdn.azureedge.net/static/
   TZ: UTC
   UWSGI_CONFIG_FULLPATH: /opt/atat/atst/uwsgi.ini


### PR DESCRIPTION
This updates the configuration handling for the Redis connection string.
The motivation is so that the Redis password can be managed separately
via Azure Key Vault and eventually be rotated independently of the rest
of the connection URI.

This also tweaks the method we use to build the DATABASE_URI and removes
some stale config from the CI config file.