### PR TITLE
Log any CSP errors that occur when disabling a user.

### DIFF
--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -20,6 +20,7 @@ from atst.domain.permission_sets import PermissionSets
 from atst.utils.flash import formatted_flash as flash
 from atst.utils.localization import translate
 from atst.jobs import send_mail
+from atst.routes.errors import log_error
 
 
 def get_environments_obj_for_app(application):
@@ -234,7 +235,8 @@ def handle_update_member(application_id, application_role_id, form_data):
 
             flash("application_member_updated", user_name=app_role.user_name)
 
-        except GeneralCSPException:
+        except GeneralCSPException as exc:
+            log_error(exc)
             flash(
                 "application_member_update_error", user_name=app_role.user_name,
             )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,6 +40,9 @@ class FakeLogger:
     def error(self, msg, *args, **kwargs):
         self._log("error", msg, *args, **kwargs)
 
+    def exception(self, msg, *args, **kwargs):
+        self._log("exception", msg, *args, **kwargs)
+
     def _log(self, _lvl, msg, *args, **kwargs):
         self.messages.append(msg)
         if "extra" in kwargs:


### PR DESCRIPTION
When one user disables another's environment role in Azure, sometimes an
exception will be raised. Since we catch the exception and display an
error message to the user, we should also log the exception so that the
error is traceable later.

PT bug: https://www.pivotaltracker.com/story/show/170004968