### PR TITLE
To index page redesign part 3

### DIFF
--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -17,7 +17,7 @@ class Status(Enum):
     ACTIVE = "Active"
     UPCOMING = "Upcoming"
     EXPIRED = "Expired"
-    UNSIGNED = "Not signed"
+    UNSIGNED = "Unsigned"
 
 
 SORT_ORDERING = [

--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from decimal import Decimal
 
 from sqlalchemy import Column, DateTime, ForeignKey, String
 from sqlalchemy.ext.hybrid import hybrid_property
@@ -172,7 +173,7 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     @property
     def invoiced_funds(self):
         # TODO: implement this using reporting data from the CSP
-        return self.total_obligated_funds * 75 / 100
+        return self.total_obligated_funds * Decimal(0.75)
 
     @property
     def display_status(self):

--- a/atst/routes/task_orders/index.py
+++ b/atst/routes/task_orders/index.py
@@ -28,5 +28,8 @@ def review_task_order(task_order_id):
 def portfolio_funding(portfolio_id):
     portfolio = Portfolios.get(g.current_user, portfolio_id)
     task_orders = TaskOrders.sort_by_status(portfolio.task_orders)
+    to_count = len(portfolio.task_orders)
     # TODO: Get expended amount from the CSP
-    return render_template("task_orders/index.html", task_orders=task_orders)
+    return render_template(
+        "task_orders/index.html", task_orders=task_orders, to_count=to_count
+    )

--- a/styles/elements/_accordions.scss
+++ b/styles/elements/_accordions.scss
@@ -46,6 +46,13 @@
         margin: 0;
       }
     }
+
+    &--empty {
+      font-weight: $font-bold;
+      color: $color-gray-dark;
+      padding: $gap * 8;
+      text-align: center;
+    }
   }
 
   &-list {

--- a/templates/task_orders/index.html
+++ b/templates/task_orders/index.html
@@ -56,7 +56,9 @@
           </div>
         {% endfor %}
       {% else %}
-        {{ "task_orders.status_empty_state" | translate({ 'status': status }) }}
+        <div class="accordion__content--empty">
+          {{ "task_orders.status_empty_state" | translate({ 'status': status }) }}
+        </div>
       {% endif %}
     {% endcall %}
   </div>

--- a/templates/task_orders/index.html
+++ b/templates/task_orders/index.html
@@ -15,45 +15,49 @@
 
 {% macro TaskOrderList(task_orders, status) %}
   <div class="accordion">
-    {% call Accordion(title=status, id=status, heading_tag="h4") %}
-      {% for task_order in task_orders %}
-        {% set to_number %}
-          {% if task_order.number != "" %}
-            Task Order #{{ task_order.number }}
-          {% else %}
-            New Task Order
-          {% endif %}
-        {% endset %}
-        <div class="accordion__content--list-item">
-          <h4><a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id) }}">{{ to_number }} {{ Icon("caret_right", classes="icon--tiny icon--primary" ) }}</a></h4>
-          {% if status != 'Expired' -%}
-            <div class="row">
-              <div class="col col--grow">
-                <h5>
-                  Current Period of Performance
-                </h5>
-                <p>
-                  {{ task_order.start_date | formattedDate(formatter="%b %d, %Y") }}
-                  -
-                  {{ task_order.end_date | formattedDate(formatter="%b %d, %Y") }}
-                </p>
+    {% call Accordion(title=("task_orders.status_list_title"|translate({'status': status})), id=status, heading_tag="h4") %}
+      {% if task_orders|length > 0 %}
+        {% for task_order in task_orders %}
+          {% set to_number %}
+            {% if task_order.number != "" %}
+              Task Order #{{ task_order.number }}
+            {% else %}
+              New Task Order
+            {% endif %}
+          {% endset %}
+          <div class="accordion__content--list-item">
+            <h4><a href="{{ url_for('task_orders.review_task_order', task_order_id=task_order.id) }}">{{ to_number }} {{ Icon("caret_right", classes="icon--tiny icon--primary" ) }}</a></h4>
+            {% if status != 'Expired' -%}
+              <div class="row">
+                <div class="col col--grow">
+                  <h5>
+                    Current Period of Performance
+                  </h5>
+                  <p>
+                    {{ task_order.start_date | formattedDate(formatter="%b %d, %Y") }}
+                    -
+                    {{ task_order.end_date | formattedDate(formatter="%b %d, %Y") }}
+                  </p>
+                </div>
+                <div class="col col--grow">
+                  <h5>Total Value</h5>
+                  <p>{{ task_order.total_contract_amount | dollars }}</p>
+                </div>
+                <div class="col col--grow">
+                  <h5>Total Obligated</h5>
+                  <p>{{ task_order.total_obligated_funds | dollars }}</p>
+                </div>
+                <div class="col col--grow">
+                  <h5>Total Expended</h5>
+                  <p>{{ task_order.invoiced_funds | dollars }}</p>
+                </div>
               </div>
-              <div class="col col--grow">
-                <h5>Total Value</h5>
-                <p>{{ task_order.total_contract_amount | dollars }}</p>
-              </div>
-              <div class="col col--grow">
-                <h5>Total Obligated</h5>
-                <p>{{ task_order.total_obligated_funds | dollars }}</p>
-              </div>
-              <div class="col col--grow">
-                <h5>Total Expended</h5>
-                <p>{{ task_order.invoiced_funds | dollars }}</p>
-              </div>
-            </div>
-          {%- endif %}
-        </div>
-      {% endfor %}
+            {%- endif %}
+          </div>
+        {% endfor %}
+      {% else %}
+        {{ "task_orders.status_empty_state" | translate({ 'status': status }) }}
+      {% endif %}
     {% endcall %}
   </div>
 {% endmacro %}
@@ -71,7 +75,7 @@
 
 <div class="portfolio-funding">
 
-  {% if task_orders  %}
+  {% if to_count > 0 %}
     {% call AccordionList() %}
       {% for status, to_list in task_orders.items() %}
         {{ TaskOrderList(to_list, status) }}

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -152,5 +152,5 @@ def test_task_order_sort_by_status():
     assert len(sorted_by_status["Active"]) == 1
     assert len(sorted_by_status["Upcoming"]) == 1
     assert len(sorted_by_status["Expired"]) == 2
-    assert len(sorted_by_status["Not signed"]) == 1
+    assert len(sorted_by_status["Unsigned"]) == 1
     assert list(sorted_by_status.keys()) == [status.value for status in SORT_ORDERING]

--- a/translations.yaml
+++ b/translations.yaml
@@ -529,6 +529,8 @@ task_orders:
       team_title: Your team
   sign:
     digital_signature_description: I acknowledge that the uploaded task order contains the required KO signature.
+  status_empty_state: 'This Portfolio has no {status} Task Orders.'
+  status_list_title: '{status} Task Orders'
 JEDICLINType:
   JEDI_CLIN_1: 'IDIQ CLIN 0001 Unclassified IaaS/PaaS'
   JEDI_CLIN_2: 'IDIQ CLIN 0002 Classified IaaS/PaaS'


### PR DESCRIPTION
## Description
Fixes issues that were causing ghost tests to fail, also updates the blank state for an individual TO statuses. 
- The TOs are now passed to the template in a dict instead of a list, so it wasn't properly evaluating when to show the blank slate screen. Fixed by passing a portfolios TO count to the template.
- The issue of trying to multiply a decimal and float was not properly fixed in the previous PR. I explicitly convert the float into a decimal, so this should no longer be an issue.

## Pivotal
https://www.pivotaltracker.com/story/show/168907682

## Screenshot
<img width="1592" alt="Screen Shot 2019-12-13 at 11 39 50 AM" src="https://user-images.githubusercontent.com/43828539/70816847-5b2dfc00-1d9e-11ea-9425-cd60f8275705.png">