### PR TITLE
Display names for subscriptions are passed to create_subscription.

### DIFF
--- a/atst/domain/csp/cloud.py
+++ b/atst/domain/csp/cloud.py
@@ -530,7 +530,6 @@ class AzureCloudProvider(CloudProviderInterface):
     ):
         sub_client = self.sdk.subscription.SubscriptionClient(credentials)
 
-        display_name = f"{environment.application.name}_{environment.name}_{environment.id}"  # proposed format
         billing_profile_id = "?"  # where do we source this?
         sku_id = AZURE_SKU_ID
         # These 2 seem like something that might be worthwhile to allow tiebacks to


### PR DESCRIPTION
We don't need to generate the display name for a new subscription inside
the _create_subscription method.