### PR TITLE
CI script should fail hard.

### DIFF
--- a/script/cibuild
+++ b/script/cibuild
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # script/cibuild: Run CI related checks and tests
 


### PR DESCRIPTION
Right now, unit test failures in script/cibuild are not being emitted
correctly. Instead, we'll just `set -e` at the top of the CI script so
that failures are fast and obvious.