### PR TITLE
Update home page

### DIFF
--- a/styles/core/_util.scss
+++ b/styles/core/_util.scss
@@ -88,5 +88,9 @@ p {
 hr {
   border: 0;
   border-bottom: 1px solid $color-gray-light;
-  margin: ($gap * 3) ($site-margins * -4);
+  margin: ($gap * 3) 0;
+
+  &.full-width {
+    margin: ($gap * 3) ($site-margins * -4);
+  }
 }

--- a/styles/core/_variables.scss
+++ b/styles/core/_variables.scss
@@ -17,6 +17,7 @@ $usa-banner-height: 2.8rem;
 $sidenav-expanded-width: 25rem;
 $sidenav-collapsed-width: 10rem;
 $max-panel-width: 80rem;
+$home-pg-icon-width: 6rem;
 
 /*
  * USWDS Variables

--- a/styles/elements/_icons.scss
+++ b/styles/elements/_icons.scss
@@ -94,4 +94,19 @@
   &--primary {
     @include icon-color($color-primary);
   }
+
+  &--home-pg-badge {
+    @include icon-size(27);
+    @include icon-color($color-white);
+
+    background-color: $color-primary;
+    height: $home-pg-icon-width;
+    width: $home-pg-icon-width;
+    border-radius: 100%;
+    display: inline-flex;
+
+    svg {
+      margin: auto;
+    }
+  }
 }

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -72,7 +72,7 @@
       &.sidenav__list--padded {
         margin-top: 3 * $gap;
         margin-bottom: $footer-height;
-        padding:  0 $gap ($gap * 2);
+        padding-bottom: ($gap * 2);
         position: fixed;
         overflow-y: scroll;
         top: $topbar-height + $usa-banner-height + 4rem;
@@ -109,100 +109,19 @@
     &__link {
       display: block;
       padding: $gap ($gap * 2);
-      color: $color-black;
-      text-decoration: none;
       white-space: nowrap;
       overflow: hidden;
+      color: $color-black-light;
+      text-decoration: none;
       text-overflow: ellipsis;
-
-      &-icon {
-        margin-left: -($gap * 0.5);
-      }
-
-      &--disabled {
-        color: $color-shadow;
-        pointer-events: none;
-      }
-
-      &--add {
-        color: $color-blue;
-        font-size: $small-font-size;
-
-        .icon {
-          @include icon-color($color-blue);
-          @include icon-size(14);
-        }
-      }
 
       &--active {
         @include h4;
 
-        color: $color-primary;
         background-color: $color-aqua-lightest;
-        box-shadow: inset ($gap / 2) 0 0 0 $color-primary;
-
-        .sidenav__link-icon {
-          @include icon-style-active;
-        }
-
+        box-shadow: inset ($gap / 2) 0 0 0 $color-primary-darker;
         position: relative;
-
-        &_indicator .icon {
-          @include icon-color($color-primary);
-
-          position: absolute;
-          right: 0;
-        }
-
-        + ul {
-          background-color: $color-primary;
-
-          .sidenav__link {
-            color: $color-white;
-            background-color: $color-primary;
-
-            &:hover {
-              background-color: $color-blue-darker;
-            }
-
-            &--active {
-              @include h5;
-
-              color: $color-white;
-              background-color: $color-primary;
-              box-shadow: none;
-            }
-
-            .icon {
-              @include icon-color($color-white);
-            }
-          }
-        }
-      }
-
-      + ul {
-        li {
-          .sidenav__link {
-            @include h5;
-
-            padding: $gap * 0.75;
-            padding-left: 4.5rem;
-            border: 0;
-            font-weight: normal;
-
-            .sidenav__link-icon {
-              @include icon-size(12);
-
-              flex-shrink: 0;
-              margin-right: 1.5rem;
-              margin-left: -3rem;
-            }
-
-            .sidenav__link-label {
-              padding-left: 0;
-            }
-          }
-        }
+        color: $color-primary-darker;
       }
 
       &:hover {

--- a/styles/elements/_sidenav.scss
+++ b/styles/elements/_sidenav.scss
@@ -1,8 +1,3 @@
-@mixin sidenav__header {
-  padding: $gap ($gap * 2);
-  font-weight: bold;
-}
-
 .sidenav-container {
   box-shadow: $box-shadow;
   overflow: hidden;
@@ -26,34 +21,58 @@
       margin: 0px;
     }
 
-    &__title {
-      @include sidenav__header;
+    &__header {
+      padding: $gap ($gap * 2);
+      font-weight: bold;
+      border-bottom: 1px solid $color-gray-lighter;
 
-      font-size: $h3-font-size;
+      &--minimized {
+        @extend .sidenav__header;
+
+        padding: $gap;
+        width: $sidenav-collapsed-width;
+      }
+    }
+
+    &__title {
+      font-size: $h6-font-size;
       text-transform: uppercase;
       width: 50%;
       color: $color-gray-dark;
       opacity: 0.54;
+      white-space: nowrap;
+      padding: $gap;
+      display: inline-flex;
+      align-items: center;
     }
 
     &__toggle {
-      @include sidenav__header;
-
       font-size: $small-font-size;
-      line-height: 2.8rem;
-      float: right;
-      color: $color-blue-darker;
+      color: $color-blue;
+      text-decoration: none;
+      padding: $gap;
+      display: inline-flex;
+      align-items: center;
 
       .toggle-arrows {
         vertical-align: middle;
+        @include icon-size(20);
+
+        &:first-child {
+          margin-left: 0;
+        }
+
+        &:last-child {
+          margin-right: 0;
+        }
       }
     }
 
     ul {
       &.sidenav__list--padded {
-        margin-top: 4 * $gap;
+        margin-top: 3 * $gap;
         margin-bottom: $footer-height;
-        padding-bottom: $gap;
+        padding:  0 $gap ($gap * 2);
         position: fixed;
         overflow-y: scroll;
         top: $topbar-height + $usa-banner-height + 4rem;
@@ -69,6 +88,7 @@
       li {
         margin: 0;
         display: block;
+        color: $color-black-light;
       }
     }
 
@@ -90,7 +110,7 @@
       display: block;
       padding: $gap ($gap * 2);
       color: $color-black;
-      text-decoration: underline;
+      text-decoration: none;
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;

--- a/styles/sections/_home.scss
+++ b/styles/sections/_home.scss
@@ -1,4 +1,5 @@
 .home {
+  margin: $gap * 3;
   .sticky-cta {
     margin: -1.6rem -1.6rem 0 -1.6rem;
   }

--- a/styles/sections/_home.scss
+++ b/styles/sections/_home.scss
@@ -2,47 +2,22 @@
   .sticky-cta {
     margin: -1.6rem -1.6rem 0 -1.6rem;
   }
-}
 
-.about-cloud {
-  margin: 4rem auto;
-  max-width: 900px;
-}
+  &__content {
+    margin: 4rem auto;
+    max-width: 900px;
 
-.your-project {
-  margin-top: 3rem;
-  padding: 3rem;
-  background-color: $color-gray-lightest;
+    &--descriptions {
+      .col {
+        margin-left: $home-pg-icon-width;
+        padding: ($gap * 2) ($gap * 4);
+        position: relative;
 
-  h2 {
-    margin-top: 0;
-  }
-
-  .links {
-    justify-content: flex-start;
-
-    .icon-link {
-      padding: $gap ($gap * 4);
-
-      &:first-child {
-        padding-left: 0;
-      }
-
-      &:last-child {
-        padding-right: 0;
-      }
-
-      &:hover {
-        background-color: transparent;
-        color: $color-gray-dark;
-
-        .svg * {
-          fill: $color-gray-dark;
+        .icon--home-pg-badge {
+          position: absolute;
+          left: -$home-pg-icon-width;
+          top: $gap * 3;
         }
-      }
-
-      &.active:hover {
-        color: $color-blue;
       }
     }
   }
@@ -111,9 +86,4 @@
       }
     }
   }
-}
-
-#jedi-heirarchy {
-  max-width: 65rem;
-  margin-top: $gap * 8;
 }

--- a/styles/sections/_home.scss
+++ b/styles/sections/_home.scss
@@ -5,7 +5,7 @@
   }
 
   &__content {
-    margin: 4rem auto;
+    margin: 4rem;
     max-width: 900px;
 
     &--descriptions {

--- a/templates/applications/fragments/member_form_fields.html
+++ b/templates/applications/fragments/member_form_fields.html
@@ -100,7 +100,7 @@
     {{ CheckboxInput(form.perms_env_mgmt, classes="input__inline-fields", key=env_mgmt, id=env_mgmt, optional=True) }}
     {{ CheckboxInput(form.perms_del_env, classes="input__inline-fields", key=del_env, id=del_env, optional=True) }}
   </div>
-  <hr>
+  <hr class="full-width">
   <div class="environment_roles environment-roles-new">
     <h2>{{ "portfolios.applications.members.form.env_access.title" | translate }}</h2>
     <p class='usa-input__help subtitle'>

--- a/templates/applications/fragments/members.html
+++ b/templates/applications/fragments/members.html
@@ -40,7 +40,7 @@
         {% call Modal(modal_name, classes="form-content--app-mem") %}
           <div class="modal__form--header">
             <h1>{{ Icon('avatar') }} {{ "portfolios.applications.members.form.edit_access_header" | translate({ "user": member.user_name }) }}</h1>
-            <hr>
+            <hr class="full-width">
           </div>
           <base-form inline-template>
             <form id='{{ modal_name }}' method="POST" action="{{ url_for(action_update, application_id=application.id, application_role_id=member.role_id,) }}">
@@ -59,7 +59,7 @@
           {% call Modal(resend_invite_modal, classes="form-content--app-mem") %}
             <div class="modal__form--header">
               <h1>{{ "portfolios.applications.members.new.verify" | translate }}</h1>
-              <hr>
+              <hr class="full-width">
             </div>
             <base-form inline-template :enable-save="true">
               <form id='{{ resend_invite_modal }}' method="POST" action="{{ url_for('applications.resend_invite', application_id=application.id, application_role_id=member.role_id) }}">

--- a/templates/applications/fragments/new_member_modal_content.html
+++ b/templates/applications/fragments/new_member_modal_content.html
@@ -2,7 +2,7 @@
 {% import "applications/fragments/member_form_fields.html" as member_fields %}
 
 {% macro MemberFormTemplate(title=None, next_button=None, previous=True) %}
-  <hr>
+  <hr class="full-width">
   {% if title %} <h1>{{ title }}</h1> {% endif %}
 
   {{ caller() }}

--- a/templates/applications/new/step_1.html
+++ b/templates/applications/new/step_1.html
@@ -30,7 +30,7 @@
           {{ ('portfolios.applications.new.step_1_form_help_text.name' | translate | safe) }}
         </div>
       </div>
-      <hr class="panel__break">
+      <hr>
       <div class="form-row">
         <div class="form-col form-col--two-thirds">
           {{ TextInput(form.description, paragraph=True, optional=True) }}

--- a/templates/applications/new/step_2.html
+++ b/templates/applications/new/step_2.html
@@ -19,7 +19,7 @@
   <p>
     {{ 'portfolios.applications.new.step_2_description' | translate }}
   </p>
-  <hr class="panel__break"> 
+  <hr>
   <application-environments inline-template v-bind:initial-data='{{ form.data|tojson }}'>
     <form method="POST" action="{{ url_for('applications.update_new_application_step_2', portfolio_id=portfolio.id, application_id=application.id) }}" v-on:submit="handleSubmit">
       <div class="subheading">{{ 'portfolios.applications.environments_heading' | translate }}</div>

--- a/templates/applications/new/step_2.html
+++ b/templates/applications/new/step_2.html
@@ -58,9 +58,9 @@
                 {{ Icon("plus") }}
               </button>
             </div>
-        </div>    
+        </div>
       </div>
-    </div>    
+    </div>
       <span class="action-group-footer">
         {% block next_button %}
           {{ SaveButton(text=('portfolios.applications.new.step_2_button_text' | translate)) }}

--- a/templates/applications/new/step_3.html
+++ b/templates/applications/new/step_3.html
@@ -15,7 +15,7 @@
   <p>
     {{ ('portfolios.applications.new.step_3_description' | translate) }}
   </p>
-  <hr class="panel__break">
+  <hr>
 
   {{ MemberManagementTemplate(
     application,

--- a/templates/base.html
+++ b/templates/base.html
@@ -21,9 +21,7 @@
     {% include 'navigation/topbar.html' %}
 
     <div class='global-layout'>
-      {% if portfolios %}
-        {% include 'navigation/global_sidenav.html' %}
-      {% endif %}
+      {% include 'navigation/global_sidenav.html' %}
 
       <div class='global-panel-container'>
         {% block sidenav %}{% endblock %}

--- a/templates/components/sidenav_item.html
+++ b/templates/components/sidenav_item.html
@@ -1,35 +1,11 @@
 {% from "components/icon.html" import Icon %}
 
-{% macro SidenavItem(label, href, active=False, icon=None, subnav=None) -%}
+{% macro SidenavItem(label, href, active=False) -%}
   <li>
-  <a class="sidenav__link {% if active %}sidenav__link--active{% endif %}" href="{{href}}" title="{{label}}">
-    {% if icon %}
-      {{ Icon(icon, classes="sidenav__link-icon") }}
-    {% endif %}
-
-    <span class="sidenav__link-label">
-      {{label}}
-    </span>
-    {% if active %}
-      <span class="sidenav__link-active_indicator">
-        {{ Icon("caret_right") }}
+    <a class="sidenav__link {% if active %}sidenav__link--active{% endif %}" href="{{href}}" title="{{label}}">
+      <span class="sidenav__link-label">
+        {{label}}
       </span>
-      {% endif %}
-  </a>
-
-  {% if subnav and active %}
-      <ul>
-      {% for item in subnav %}
-      <li>
-          <a class="sidenav__link {% if item["active"] %}sidenav__link--active{% endif %}" href="{{item["href"]}}" title="{{item["label"]}}">
-          {% if "icon" in item %}
-              {{ Icon(item["icon"], classes="sidenav__link-icon") }}
-          {% endif %}
-          <span class="sidenav__link-label">{{item["label"]}}</span>
-          </a>
-      </li>
-      {% endfor %}
-      </ul>
-  {% endif %}
+    </a>
   </li>
 {%- endmacro %}

--- a/templates/home.html
+++ b/templates/home.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 
-{% from "components/sticky_cta.html" import StickyCTA %}
 {% from "components/icon.html" import Icon %}
-{% from "components/semi_collapsible_text.html" import SemiCollapsibleText %}
+{% from "components/sticky_cta.html" import StickyCTA %}
 
 {% block content %}
 
@@ -13,80 +12,50 @@
      {% set sticky_header = "home.get_started" | translate  %}
   {% endif %}
 
-  <div class="about-cloud">
+  <div class="home__content">
     {% include "fragments/flash.html" %}
 
     <h1>{{ "home.head" | translate }}</h1>
+    <h3>Set up a Portfolio</h3>
+    <h4>New Portfolios will be visible in the left side bar of this page. </h4>
+    <p>All TOs associated to a specific Application or set of related Applications will be entered at the Portfolio level. Funding is applied and managed at the Portfolio level as well.</p>
+    <hr>
 
-    {{ SemiCollapsibleText(first_half=("home.about_cloud.part1"|translate), second_half=("home.about_cloud.part2"|translate)) }}
-
-    <div class="your-project">
-      <h2 class="h3">{{ "home.your_project" | translate }}</h2>
-      <p>{{ "home.your_project_descrip" | translate }}</p>
-
-      <hr>
-
-      {% macro Link(icon, text, section, default=False) %}
-      {% if default %}
-        <div v-bind:class='{"icon-link": true, active: selectedSection === "{{ section }}" || selectedSection === null}' v-on:click="toggleSection('{{ section }}')">
-      {% else %}
-        <div v-bind:class='{"icon-link": true, active: selectedSection === "{{ section }}"}' v-on:click="toggleSection('{{ section }}')">
-      {% endif %}
-          <div class="col">
-            <div class='icon-link--icon'>{{ Icon(icon) }}</div>
-            <div class='icon-link--name'>{{ text }}</div>
-          </div>
+    <div class="home__content--descriptions">
+      <div class="row">
+        <div class="col col--half col--pad">
+          {{ Icon('funding', classes="icon--home-pg-badge") }}
+          <h4>{{ "navigation.portfolio_navigation.breadcrumbs.funding" | translate }}</h4>
+          <p>
+            {{ "home.funding_descrip" | translate }}
+          </p>
         </div>
-      {% endmacro %}
-
-      <toggler inline-template v-bind:initial-selected-section="'funding'">
-        <div>
-          <div class="portfolio-header">
-            <div class="links row">
-              {{ Link(
-              icon='funding',
-              section='funding',
-              text='navigation.portfolio_navigation.breadcrumbs.funding' | translate,
-              default=True
-              ) }}
-              {{ Link(
-              icon='applications',
-              section='applications',
-              text='navigation.portfolio_navigation.breadcrumbs.applications' | translate,
-              ) }}
-              {{ Link(
-              icon='chart-pie',
-              section='reports',
-              text='navigation.portfolio_navigation.breadcrumbs.reports' | translate,
-              ) }}
-              {{ Link(
-              icon='cog',
-              section='admin',
-              text='navigation.portfolio_navigation.breadcrumbs.admin' | translate,
-              ) }}
-            </div>
-          </div>
-          {% macro Description(section, default=False) %}
-          {% if default %}
-            <p v-show="selectedSection === '{{ section }}' || selectedSection === null">
-          {% else %}
-            <p v-show="selectedSection === '{{ section }}'">
-          {% endif %}
-              <strong>
-                {{ "navigation.portfolio_navigation.breadcrumbs.%s" | format(section) | translate }}
-              </strong>
-              {{ "home.%s_descrip" | format(section) | translate }}
-            </p>
-          {% endmacro %}
-          <div class="project-section-descriptions">
-            {{ Description('funding', default=True) }}
-            {{ Description('applications') }}
-            {{ Description('reports') }}
-            {{ Description('admin') }}
-          </div>
+        <div class="col col--half col--pad">
+          {{ Icon('chart-pie', classes="icon--home-pg-badge") }}
+          <h4>{{ "navigation.portfolio_navigation.breadcrumbs.reports" | translate }}</h4>
+          <p>
+            {{ "home.reports_descrip" | translate }}
+          </p>
         </div>
-      </toggler>
+      </div>
+      <div class="row">
+        <div class="col col--half col--pad">
+          {{ Icon('applications', classes="icon--home-pg-badge") }}
+          <h4>{{ "navigation.portfolio_navigation.breadcrumbs.applications" | translate }}</h4>
+          <p>
+            {{ "home.applications_descrip" | translate }}
+          </p>
+        </div>
+        <div class="col col--half col--pad">
+          {{ Icon('cog', classes="icon--home-pg-badge") }}
+          <h4>{{ "navigation.portfolio_navigation.breadcrumbs.admin" | translate }}</h4>
+          <p>
+            {{ "home.admin_descrip" | translate }}
+          </p>
+        </div>
+      </div>
     </div>
+
     <a href="{{ url_for("portfolios.new_portfolio_step_1") }}" class="usa-button-primary">
       {{ "home.add_portfolio_button_text" | translate }}
     </a>

--- a/templates/home.html
+++ b/templates/home.html
@@ -55,10 +55,13 @@
         </div>
       </div>
     </div>
-
-    <a href="{{ url_for("portfolios.new_portfolio_step_1") }}" class="usa-button-primary">
-      {{ "home.add_portfolio_button_text" | translate }}
-    </a>
+    <div class="empty-state">
+      <div class="empty-state__footer">
+        <a href="{{ url_for("portfolios.new_portfolio_step_1") }}" class="usa-button usa-button-primary">
+          {{ "home.add_portfolio_button_text" | translate }}
+        </a>
+      </div>
+    </div>
   </div>
 </main>
 

--- a/templates/navigation/global_sidenav.html
+++ b/templates/navigation/global_sidenav.html
@@ -7,29 +7,29 @@
     <div v-bind:class="{'sidenav-container': props.isVisible, 'sidenav-container--minimized': !props.isVisible}">
       <div class="sidenav-container__fixed">
         <div v-bind:class="{'sidenav': props.isVisible, 'sidenav--minimized': !props.isVisible}">
-          <a href="#" v-on:click="props.toggle" class="sidenav__toggle">
+          <div v-bind:class="{'sidenav__header': props.isVisible, 'sidenav__header--minimized': !props.isVisible}" class="row">
             <template v-if="props.isVisible">
-              {{ Icon('angle-double-left-solid', classes="toggle-arrows icon--blue") }}
-              Hide
+              <span class="sidenav__title col col--grow">My Portfolios</span>
+              <a href="#" v-on:click="props.toggle" class="sidenav__toggle col">
+                {{ Icon('angle-double-left-solid', classes="toggle-arrows icon--primary") }}
+                <span>Hide</span>
+              </a>
             </template>
             <template v-else>
-              Show
-              {{ Icon('angle-double-right-solid', classes="toggle-arrows icon--blue") }}
+              <a href="#" v-on:click="props.toggle" class="sidenav__toggle col">
+                <span>Show</span>
+                {{ Icon('angle-double-right-solid', classes="toggle-arrows icon--primary") }}
+              </a>
             </template>
-          </a>
+          </div>
           <div v-if="props.isVisible">
-            <div class="sidenav__title">Portfolios</div>
             <ul class="sidenav__list--padded">
-              {% if portfolios %}
-                {% for other_portfolio in portfolios|sort(attribute='name') %}
-                  {{ SidenavItem(other_portfolio.name,
-                    href=url_for("applications.portfolio_applications", portfolio_id=other_portfolio.id),
-                    active=(other_portfolio.id | string) == request.view_args.get('portfolio_id')
-                    ) }}
-                {% endfor %}
-              {% else %}
-                <li><span class="sidenav__text">You have no portfolios yet</span></li>
-              {% endif %}
+              {% for other_portfolio in portfolios|sort(attribute='name') %}
+                {{ SidenavItem(other_portfolio.name,
+                  href=url_for("applications.portfolio_applications", portfolio_id=other_portfolio.id),
+                  active=(other_portfolio.id | string) == request.view_args.get('portfolio_id')
+                  ) }}
+              {% endfor %}
             </ul>
           </div>
         </div>

--- a/templates/portfolios/fragments/add_new_portfolio_member.html
+++ b/templates/portfolios/fragments/add_new_portfolio_member.html
@@ -16,7 +16,7 @@
 {% endmacro %}
 
 {% set step_one %}
-  <hr>
+  <hr class="full-width">
   <h1>Invite new portfolio member</h1>
   <div class='form-row'>
     <div class='form-col form-col--half'>
@@ -52,7 +52,7 @@
   </div>
 {% endset %}
 {% set step_two %}
-  <hr>
+  <hr class="full-width">
   <h1>Assign member permissions</h1>
   <a class='icon-link'>
     {{ Icon('info') }}

--- a/templates/portfolios/fragments/change_ppoc.html
+++ b/templates/portfolios/fragments/change_ppoc.html
@@ -5,7 +5,7 @@
 {% from "components/options_input.html" import OptionsInput %}
 
 {% set step_one %}
-  <hr>
+  <hr class="full-width">
   <h1>{{ "fragments.ppoc.update_ppoc_title" | translate }}</h1>
 
   {{
@@ -42,7 +42,7 @@
 {% endset %}
 
 {% set step_two %}
-  <hr>
+  <hr class="full-width">
   <h1>{{ "fragments.ppoc.update_ppoc_confirmation_title" | translate }}</h1>
 
   {{

--- a/translations.yaml
+++ b/translations.yaml
@@ -22,13 +22,13 @@ home:
   add_portfolio_button_text: Add New Portfolio
   new_portfolio: New Portfolio
   get_started: Get Started
-  head: About Cloud Services
+  head: JEDI Cloud Services
   your_project: Your Project
   your_project_descrip: Your portfolio is where all task orders pertaining to a specific project or set of related projects live. In JEDI, every task order in your portfolio has four components.
-  funding_descrip: is information about all approved task orders associated to your portfolio.
-  applications_descrip: ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
-  reports_descrip: enim ad minim veniam, quis nostrud exercitation ullamco
-  admin_descrip: aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+  funding_descrip: The Task Orders section allows you to enter, manage, and edit awarded TOs associated to a specific Portfolio.
+  applications_descrip: The Applications section allows you to easily create and define new Applications within a Portfolio, as well as manage user permissions and Environments.
+  reports_descrip: The Reports section allows you to view and monitor funding usage within a specific Portfolio.
+  admin_descrip: Within the Settings section, you can manage your Portfolio name and description, as well as add, edit, and delete Portfolio managers.
 ccpo:
   users_title: CCPO Users
   add_user: Add new CCPO user


### PR DESCRIPTION
## Description
Update styling and copy on home page and side nav.
Some global changes were made to the `hr` element:
- Previously `hr`s were globally styled to extend into the margin of their containing element. Since this is only necessary in a few places, I changed the default to have the `hr` fill the element and not extend into the margin, and added a util class `.full-width` for the few cases were a `hr` needs to extend into the margins of its container.
- Deleted unused class `panel__break` from `hr` elements.

## Pivotal
https://www.pivotaltracker.com/story/show/168907390
https://www.pivotaltracker.com/story/show/168907361

## Screenshots
<img width="1416" alt="Screen Shot 2019-12-18 at 4 57 35 PM" src="https://user-images.githubusercontent.com/43828539/71126829-cc631a00-21b7-11ea-8dcb-12c8a7195d86.png">
<img width="1416" alt="Screen Shot 2019-12-18 at 4 57 38 PM" src="https://user-images.githubusercontent.com/43828539/71126832-ce2cdd80-21b7-11ea-89b4-9bfcfa660d22.png">
<img width="1416" alt="Screen Shot 2019-12-18 at 4 58 38 PM" src="https://user-images.githubusercontent.com/43828539/71126837-cff6a100-21b7-11ea-82d5-c1a0ba2562a0.png">