### PR TITLE
Bug fixes

### DIFF
--- a/templates/components/sidenav_item.html
+++ b/templates/components/sidenav_item.html
@@ -1,5 +1,3 @@
-{% from "components/icon.html" import Icon %}
-
 {% macro SidenavItem(label, href, active=False) -%}
   <li>
     <a class="sidenav__link {% if active %}sidenav__link--active{% endif %}" href="{{href}}" title="{{label}}">

--- a/templates/portfolios/new/step_1.html
+++ b/templates/portfolios/new/step_1.html
@@ -41,7 +41,7 @@
         {% block next_button %}
           {{ SaveButton(text=('common.save' | translate), form="portfolio-create", element="input") }}
         {% endblock %}
-        <a href="{{ url_for('applications.portfolio_applications', portfolio_id=portfolio.id) }}">
+        <a href="{{ url_for('atst.home') }}">
           Cancel
         </a>
       </form>

--- a/templates/task_orders/step_1.html
+++ b/templates/task_orders/step_1.html
@@ -14,6 +14,9 @@
 {% set step = "1" %}
 
 {% block to_builder_form_field %}
-  {{ TOFormStepHeader('task_orders.form.supporting_docs_header' | translate, 'task_orders.form.supporting_docs_text' | translate) }}
+  {{ TOFormStepHeader(
+    title='task_orders.form.supporting_docs_header' | translate,
+    description='task_orders.form.supporting_docs_text' | translate,
+  ) }}
   {{ UploadInput(form.pdf, portfolio.id) }}
 {% endblock %}

--- a/templates/task_orders/step_2.html
+++ b/templates/task_orders/step_2.html
@@ -9,6 +9,9 @@
 {% set step = "2" %}
 
 {% block to_builder_form_field %}
-  {{ TOFormStepHeader('task_orders.form.add_to_header' | translate, 'task_orders.form.add_to_description' | translate)}}
+  {{ TOFormStepHeader(
+    title='task_orders.form.add_to_header' | translate,
+    description='task_orders.form.add_to_description' | translate,
+  ) }}
   {{ TextInput(form.number, validation='taskOrderNumber', optional=False) }}
 {% endblock %}

--- a/templates/task_orders/step_3.html
+++ b/templates/task_orders/step_3.html
@@ -12,7 +12,11 @@
 
 {% block to_builder_form_field %}
   <div>
-    {{ TOFormStepHeader('task_orders.form.clin_title' | translate, 'task_orders.form.clin_description' | translate, task_order.number) }}
+    {{ TOFormStepHeader(
+      title='task_orders.form.clin_title' | translate,
+      description='task_orders.form.clin_description' | translate,
+      to_number=task_order.number,
+    ) }}
 
     {% for clin in form.clins %}
       {{ CLINFields(contract_start, contract_end, clin, index=loop.index - 1) }}

--- a/templates/task_orders/step_5.html
+++ b/templates/task_orders/step_5.html
@@ -10,7 +10,10 @@
 {% set step = "5" %}
 
 {% block to_builder_form_field %}
-  {{ TOFormStepHeader('task_orders.form.step_5.description' | translate, to_number=task_order.number) }}
+  {{ TOFormStepHeader(
+    description='task_orders.form.step_5.description' | translate,
+    to_number=task_order.number
+  ) }}
   <div class="task-order__confirmation">
     {{ CheckboxInput(form.signature) }}
     {{ CheckboxInput(form.confirm) }}


### PR DESCRIPTION
## Description
- Fixes bug where canceling out of the Portfolio builder would give a 404 or 500 error. Fixed by redirecting to home page when user cancels from the Portfolio builder.
- Fixes swapped titles and descriptions in the TO builder.

## Pivotal
https://www.pivotaltracker.com/story/show/170363548
https://www.pivotaltracker.com/story/show/170385396