### PR TITLE
169163334 - Adds Virtual Network Gateway for VPN

### DIFF
--- a/terraform/modules/vpc/variables.tf
+++ b/terraform/modules/vpc/variables.tf
@@ -41,3 +41,8 @@ variable "route_tables" {
   type        = map
   description = "A map with the route tables to create"
 }
+
+variable "gateway_subnet" {
+  type        = string
+  description = "The Subnet CIDR that we'll use for the virtual_network_gateway 'GatewaySubnet'"
+}

--- a/terraform/providers/dev/variables.tf
+++ b/terraform/providers/dev/variables.tf
@@ -31,6 +31,12 @@ variable "networks" {
   }
 }
 
+variable "gateway_subnet" {
+  type    = string
+  default = "10.1.20.0/24"
+}
+
+
 variable "route_tables" {
   description = "Route tables and their default routes"
   type        = map

--- a/terraform/providers/dev/vpc.tf
+++ b/terraform/providers/dev/vpc.tf
@@ -4,6 +4,7 @@ module "vpc" {
   region          = var.region
   virtual_network = var.virtual_network
   networks        = var.networks
+  gateway_subnet  = var.gateway_subnet
   route_tables    = var.route_tables
   owner           = var.owner
   name            = var.name


### PR DESCRIPTION
The Virtual Network Gateway is required for OpenVPN connectivity. The
change to the VPC module also adds a subnet which is exclusively used
for the Gateway.