### PR TITLE
Do not catch errors in CI.

### DIFF
--- a/script/include/run_test
+++ b/script/include/run_test
@@ -26,28 +26,16 @@ fi
 
 ## Main
 if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
-  python_test_status=0
-  set +e
 
   output_divider "Lint Python files"
   run_python_lint "${PYTHON_FILES}"
-  ((python_test_status+=$?))
   output_divider "Perform static analysis on Python files"
   run_python_static_analysis "${PYTHON_FILES}"
-  ((python_test_status+=$?))
   output_divider "Perform type checking on Python files"
   run_python_typecheck
-  ((python_test_status+=$?))
   output_divider "Run Python unit test suite"
   run_python_unit_tests "${PYTHON_FILES}"
-  ((python_test_status+=$?))
 
-  if [ "${python_test_status}" != "0" ]; then
-    warning "Failed to pass one or more Python checks"
-    exit ${python_test_status}
-  fi
-
-  set -e
 fi
 
 if [ "${RUN_JS_TESTS}" = "true" ]; then


### PR DESCRIPTION
This removes all error-catching from the test scripts. If unit tests
fail, the script will exit immediately. The error catching functionality
was not working correctly using the sh shell in Alpine inside the
containers, and so CI was allowed to continue after test failures.