### PR TITLE
Minor ui tweaks

### DIFF
--- a/styles/components/_footer.scss
+++ b/styles/components/_footer.scss
@@ -3,8 +3,7 @@
   background-color: $color-white;
   border-top: 1px solid $color-gray-lightest;
   display: flex;
-  flex-direction: row;
-  justify-content: space-between;
+  flex-direction: row-reverse;
   align-items: center;
   padding: $gap * 1.5;
   position: fixed;
@@ -15,19 +14,7 @@
   color: $color-gray-dark;
   font-size: 1.5rem;
 
-  &__info {
-    flex-grow: 1;
+  &__login {
     padding-left: 0.8rem;
-
-    &__link {
-      margin: (-$gap * 2) (-$gap);
-      font-weight: normal;
-
-      .icon--footer {
-        @include icon-size(16);
-
-        margin: 0rem 0.8rem 0rem 0rem;
-      }
-    }
   }
 }

--- a/templates/footer.html
+++ b/templates/footer.html
@@ -1,14 +1,8 @@
 {% from "components/icon.html" import Icon %}
 
 <footer class='app-footer'>
-  <div class='app-footer__info'>
-    <a href="#" class='icon-link app-footer__info__link' target='_blank' rel='noopener noreferrer'>
-      {{ Icon('help', classes='icon--footer') }}
-      <span>{{ "footer.jedi_help_link_text" | translate }}</span>
-    </a>
-  </div>
   {% if g.last_login %}
-    <div class="">
+    <div class="app-footer__login">
       {{ "footer.login" | translate }} <local-datetime timestamp='{{ g.last_login }}' format='MMM D YYYY H:mm Z'></local-datetime>
     </div>
   {% endif %}

--- a/templates/navigation/topbar.html
+++ b/templates/navigation/topbar.html
@@ -12,8 +12,12 @@
     <div class="topbar__context">
       {% if g.current_user %}
         <a href="{{ url_for('users.user') }}" class="topbar__link">
-          <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>
           {{ Icon('avatar', classes='topbar__link-icon') }}
+          <span class="topbar__link-label">{{ g.current_user.first_name + " " + g.current_user.last_name }}</span>
+        </a>
+        <a href="{{ url_for('atst.helpdocs') }}" class="topbar__link">
+          {{ Icon('question', classes='topbar__link-icon') }}
+          <span class="topbar__link-label">Support</span>
         </a>
 
         <a href="{{ url_for('atst.logout') }}" class="topbar__link" title='{{ "navigation.topbar.logout_link_title" | translate }}'>

--- a/translations.yaml
+++ b/translations.yaml
@@ -135,7 +135,6 @@ flash:
   updated_application_team_settings: 'You have updated the {application_name} team settings.'
   logged_out: Logged out
 footer:
-  jedi_help_link_text: Need help?  Click here!
   login: 'Last login:'
 forms:
   application:


### PR DESCRIPTION
<img width="1459" alt="Screen Shot 2019-12-26 at 10 52 12 AM" src="https://user-images.githubusercontent.com/54586407/71481931-f6c36180-27cd-11ea-9a34-84888c136c0b.png">

Minor UI edits to the [top](https://www.pivotaltracker.com/story/show/168907375) and [bottom](https://www.pivotaltracker.com/story/show/168907375) bars.

This PR _was_ going to include making the grey banner with "Here's how you know" not fixed, but this proved to be a bit of a time sink. I put this requirement in [another Pivotal Card](https://www.pivotaltracker.com/story/show/170447955)