### PR TITLE
Better incorporate fixture data into reporting

### DIFF
--- a/templates/portfolios/reports/application_and_env_spending.html
+++ b/templates/portfolios/reports/application_and_env_spending.html
@@ -49,7 +49,7 @@
                   <span v-html='formatDollars(application.last_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(application.total)'></span>
+                  <span v-html='formatDollars(application.total || 0)'></span>
                 </td>
               </tr>
               <tr 
@@ -67,7 +67,7 @@
                   <span v-html='formatDollars(environment.last_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(environment.total)'></span>
+                  <span v-html='formatDollars(environment.total || 0)'></span>
                 </td>
               </tr>
             </template>

--- a/tests/domain/cloud/reports/test_reports.py
+++ b/tests/domain/cloud/reports/test_reports.py
@@ -1,4 +1,5 @@
 from atst.domain.csp.reports import MockReportingProvider
+from tests.factories import PortfolioFactory
 
 
 def test_get_environment_monthly_totals():
@@ -20,6 +21,11 @@ def test_get_environment_monthly_totals():
 
 
 def test_get_application_monthly_totals():
+    portfolio = PortfolioFactory.create(
+        applications=[
+            {"name": "Test Application", "environments": [{"name": "Z"}, {"name": "A"}]}
+        ],
+    )
     application = {
         "name": "Test Application",
         "environments": [
@@ -42,7 +48,9 @@ def test_get_application_monthly_totals():
         ],
     }
 
-    totals = MockReportingProvider._get_application_monthly_totals(application)
+    totals = MockReportingProvider._get_application_monthly_totals(
+        portfolio, application
+    )
     assert totals["name"] == "Test Application"
     assert totals["this_month"] == 300
     assert totals["last_month"] == 700


### PR DESCRIPTION
<img width="1157" alt="image" src="https://user-images.githubusercontent.com/54586407/71524079-e5478b80-2899-11ea-81e2-fbe420dee07c.png">

Before this commit, if a portfolio wasn't present in the spending fixture data, the reporting screen would be empty -- even if the portfolio had applications and environments associated with it on the database. Now, 0s appear if an application and / or environment isn't present in the fixture data.

Addresses: https://www.pivotaltracker.com/story/show/170325621