### PR TITLE
170237476 - Autoscaling fix

### DIFF
--- a/terraform/modules/k8s/main.tf
+++ b/terraform/modules/k8s/main.tf
@@ -19,7 +19,6 @@ resource "azurerm_kubernetes_cluster" "k8s" {
     vm_size               = "Standard_D1_v2"
     os_disk_size_gb       = 30
     vnet_subnet_id        = var.vnet_subnet_id
-    node_count            = 1
     enable_node_public_ip = true # Nodes need a public IP for external resources. FIXME: Switch to NAT Gateway if its available in our subscription
     enable_auto_scaling   = var.enable_auto_scaling
     max_count             = var.max_count # FIXME: if auto_scaling disabled, set to 0

--- a/terraform/providers/dev/k8s.tf
+++ b/terraform/providers/dev/k8s.tf
@@ -9,7 +9,7 @@ module "k8s" {
   vnet_subnet_id      = module.vpc.subnets #FIXME - output from module.vpc.subnets should be map
   enable_auto_scaling = true
   max_count           = 5
-  min_count           = 2
+  min_count           = 3
 }
 
 #module "main_lb" {


### PR DESCRIPTION
Specifying the node count breaks the autoscaling min/max. When this
happens, the k8s cluster needs to be manually reconfigured. Terraform
does not remove the node count even when the node count option is
removed. The k8s cluster resource needed to be destroyed and re-created
in order to resolve the issue with node count and min/max options being
specified at the same time.