### PR TITLE
Update NGINX config to use supplied domains.

### DIFF
--- a/deploy/azure/atst-nginx-configmap.yml
+++ b/deploy/azure/atst-nginx-configmap.yml
@@ -45,7 +45,7 @@ data:
         include /etc/nginx/snippets/ssl.conf;
 
         location /login-redirect {
-            return 301 https://auth-azure.atat.code.mil$request_uri;
+            return 301 https://${AUTH_DOMAIN}$request_uri;
         }
         location /login-dev {
             try_files $uri @appbasicauth;
@@ -82,7 +82,7 @@ data:
         include /etc/nginx/snippets/ssl.conf;
 
         location / {
-            return 301 https://azure.atat.code.mil$request_uri;
+            return 301 https://${MAIN_DOMAIN}$request_uri;
         }
         location /login-redirect {
             try_files $uri @app;


### PR DESCRIPTION
I left the domains hard-coded for the redirects in our NGINX config,
which was breaking authentication for versions of the site that don't
use that domain. This updates the config to use the domains supplied via
environment variable.