### PR TITLE
Remove an XSS vulnerability in CLIN title form input

### DIFF
--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -1,4 +1,5 @@
 import { emitFieldChange } from '../lib/emitters'
+import escape from '../lib/escape'
 import optionsinput from './options_input'
 import textinput from './text_input'
 import clindollaramount from './clin_dollar_amount'
@@ -99,7 +100,7 @@ export default {
   computed: {
     clinTitle: function() {
       if (!!this.clinNumber) {
-        return `CLIN ${this.clinNumber}`
+        return escape(`CLIN ${this.clinNumber}`)
       } else {
         return `CLIN`
       }

--- a/js/lib/__tests__/escape.test.js
+++ b/js/lib/__tests__/escape.test.js
@@ -1,0 +1,21 @@
+import escape from '../escape'
+describe('escape', () => {
+  const htmlEscapes = {
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#x27;',
+    '/': '&#x2F;',
+  }
+  it('should escape each character', () => {
+    for (let [char, escapedChar] of Object.entries(htmlEscapes)) {
+      expect(escape(char)).toBe(escapedChar)
+    }
+  })
+  it('should escape multiple characters', () => {
+    expect(escape('& and < and > and " and \' and /')).toBe(
+      '&amp; and &lt; and &gt; and &quot; and &#x27; and &#x2F;'
+    )
+  })
+})

--- a/js/lib/escape.js
+++ b/js/lib/escape.js
@@ -1,0 +1,20 @@
+// https://stackoverflow.com/a/6020820
+
+// List of HTML entities for escaping.
+const htmlEscapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '/': '&#x2F;',
+}
+
+const htmlEscaper = /[&<>"'\/]/g
+
+// Escape a string for HTML interpolation.
+const escape = string => {
+  return ('' + string).replace(htmlEscaper, match => htmlEscapes[match])
+}
+
+export default escape


### PR DESCRIPTION
This PR escapes the title of a CLIN (which comes from the Clin number input) so that the page is no longer vulnerable to XSS. 