### PR TITLE
TO Builder Step 4 bugfixes

### DIFF
--- a/atst/models/task_order.py
+++ b/atst/models/task_order.py
@@ -140,7 +140,10 @@ class TaskOrder(Base, mixins.TimestampsMixin):
     @property
     def invoiced_funds(self):
         # TODO: implement this using reporting data from the CSP
-        return self.total_obligated_funds * Decimal(0.75)
+        if self.is_active:
+            return self.total_obligated_funds * Decimal(0.75)
+        else:
+            return 0
 
     @property
     def display_status(self):

--- a/templates/task_orders/form_header.html
+++ b/templates/task_orders/form_header.html
@@ -1,4 +1,4 @@
-{% macro TOFormStepHeader(description, title=None, to_number=None) %}
+{% macro TOFormStepHeader(description=None, title=None, to_number=None) %}
   <div class="task-order__header">
     {% if title -%}
       <div class="h2">
@@ -10,8 +10,10 @@
         <strong>Task Order Number:</strong> {{ to_number }}
       </p>
     {% endif %}
-    <p>
-      {{ description }}
-    </p>
+    {% if description %}
+      <p>
+        {{ description }}
+      </p>
+    {% endif %}
   </div>
 {% endmacro %}

--- a/templates/task_orders/fragments/task_order_view.html
+++ b/templates/task_orders/fragments/task_order_view.html
@@ -23,14 +23,9 @@
           <span class="summary-item__header-text">Total Task Order value</span>
           {{ Tooltip(("task_orders.review.tooltip.total_value" | translate), title="", classes="summary-item__header-icon") }}
         </h4>
-        {% set earliest_pop_start_date, latest_pop_end_date = portfolio.funding_duration %}
-        {% if earliest_pop_start_date and latest_pop_end_date  %}
-          <p class="summary-item__value--large">
-            {{ contract_amount | dollars }}
-          </p>
-        {% else %}
-          <p class="summary-item__value--large"> - </p>
-        {% endif %}
+        <p class="summary-item__value--large">
+          {{ contract_amount | dollars }}
+        </p>
       </div>
       <div class='col col--grow summary-item'>
         <h4 class="summary-item__header">

--- a/templates/task_orders/step_4.html
+++ b/templates/task_orders/step_4.html
@@ -1,6 +1,7 @@
 {% extends "task_orders/builder_base.html" %}
 
 {% from "task_orders/fragments/task_order_view.html" import TaskOrderView %}
+{% from 'task_orders/form_header.html' import TOFormStepHeader %}
 
 {% set action = url_for('task_orders.form_step_five_confirm_signature', task_order_id=task_order_id) %}
 {% set previous_button_link = url_for("task_orders.form_step_three_add_clins", task_order_id=task_order_id) %}
@@ -16,5 +17,6 @@
 {% endblock %}
 
 {% block to_builder_form_field %}
+  {{ TOFormStepHeader(to_number=task_order.number) }}
   {{ TaskOrderView(task_order, portfolio, builder_mode=True) }}
 {% endblock %}


### PR DESCRIPTION
## Description
Fixes several bugs on the Step 4 page of the TO builder:
- Correctly displays the TO total value in the summary header.
- Fixes faked expended data so that TOs that are pending show $0 funds expended.
- Adds missing TO number to the page.

## Pivotal
https://www.pivotaltracker.com/story/show/170552562
https://www.pivotaltracker.com/story/show/170552678
https://www.pivotaltracker.com/story/show/170579969

## Screenshot
<img width="1488" alt="Screen Shot 2020-01-09 at 10 53 37 AM" src="https://user-images.githubusercontent.com/43828539/72082537-52154980-32ce-11ea-9c97-e49aa3b2d3f4.png">