### PR TITLE
First pass at setting CPU and memory limits in Kubernetes

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -49,6 +49,13 @@ spec:
               subPath: uwsgi.ini
             - name: flask-secret
               mountPath: "/config"
+          resources:
+            requests:
+              memory: 200Mi
+              cpu: 400m
+            limits:
+              memory: 200Mi
+              cpu: 400m
         - name: nginx
           image: nginx:alpine
           ports:
@@ -77,6 +84,13 @@ spec:
               mountPath: "/etc/nginx/snippets/"
             - name: nginx-secret
               mountPath: "/etc/ssl/"
+          resources:
+            requests:
+              memory: 20Mi
+              cpu: 10m
+            limits:
+              memory: 20Mi
+              cpu: 10m
       volumes:
         - name: nginx-client-ca-bundle
           configMap:
@@ -190,6 +204,13 @@ spec:
               subPath: pgsslrootcert.crt
             - name: flask-secret
               mountPath: "/config"
+          resources:
+            requests:
+              memory: 280Mi
+              cpu: 20m
+            limits:
+              memory: 280Mi
+              cpu: 20m
       volumes:
         - name: pgsslrootcert
           configMap:
@@ -255,6 +276,13 @@ spec:
               subPath: pgsslrootcert.crt
             - name: flask-secret
               mountPath: "/config"
+          resources:
+            requests:
+              memory: 80Mi
+              cpu: 10m
+            limits:
+              memory: 80Mi
+              cpu: 10m
       volumes:
         - name: pgsslrootcert
           configMap:


### PR DESCRIPTION
The limits have been configured based off of the following max stats for each container type:

    atst:
      memory: 114mb-122mb
      cpu: 390mc (staging)
           0.8mc (production)

    nginx:
      memory: 5mb-9mb
      cpu: 6mc (staging)
           0.8mc (production)

    atst-worker:
      memory: 175mb-192mb
      cpu: 9mc-15mc

    atst-beat:
      memory: 63mb
      cpu: 0.4mc-3mc

Hopefully, the numbers configured in this PR should be more than enough. If not, it's at least a starting point for further calibration.