### PR TITLE
Use v-text instead of v-html to mitigate XSS attacks

### DIFF
--- a/js/components/clin_fields.js
+++ b/js/components/clin_fields.js
@@ -1,5 +1,4 @@
 import { emitFieldChange } from '../lib/emitters'
-import escape from '../lib/escape'
 import optionsinput from './options_input'
 import textinput from './text_input'
 import clindollaramount from './clin_dollar_amount'
@@ -100,7 +99,7 @@ export default {
   computed: {
     clinTitle: function() {
       if (!!this.clinNumber) {
-        return escape(`CLIN ${this.clinNumber}`)
+        return `CLIN ${this.clinNumber}`
       } else {
         return `CLIN`
       }

--- a/templates/components/clin_fields.html
+++ b/templates/components/clin_fields.html
@@ -23,7 +23,7 @@
     inline-template>
     <div class="clin-card" v-if="showClin">
       <div class="card__title">
-        <span class="h4" v-html='clinTitle'></span>
+        <span class="h4" v-text='clinTitle'></span>
         <button
           v-if='clinIndex > 0'
           class="icon-link icon-link__remove-clin"
@@ -119,7 +119,7 @@
         {% endif %}
 
         <div class="h5 clin-card__title">Percent Obligated</div>
-        <p id="percent-obligated" v-html='percentObligated'></p>
+        <p id="percent-obligated" v-text='percentObligated'></p>
 
         <hr>
         <div class="form-row">
@@ -140,7 +140,7 @@
             <div class='modal__dialog' role='dialog' aria-modal='true'>
               <div class='modal__body'>
                 <div class="task-order__modal-cancel">
-                  <h1 v-html='"{{ 'task_orders.form.clin_remove_text' | translate }}" + clinTitle + "?"'></h1>
+                  <h1 v-text='"{{ 'task_orders.form.clin_remove_text' | translate }}" + clinTitle + "?"'></h1>
                   <div class="task-order__modal-cancel_buttons">
                     <button
                       v-on:click='closeModal(removeModalId)'

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -15,7 +15,7 @@
   <div>
     <div v-show="valid" class="uploaded-file">
       {{ Icon("ok") }}
-      <a class="uploaded-file__name" v-html="baseName" v-bind:href="downloadLink"></a>
+      <a class="uploaded-file__name" v-text="baseName" v-bind:href="downloadLink"></a>
       <a href="#" class="uploaded-file__remove" v-on:click="removeAttachment">Remove</a>
     </div>
     <div v-show="valid === false" v-bind:class='{ "usa-input": true, "usa-input--error": showErrors }'>

--- a/templates/portfolios/reports/application_and_env_spending.html
+++ b/templates/portfolios/reports/application_and_env_spending.html
@@ -37,19 +37,19 @@
               <tr>              
                 <td>
                   <button v-on:click='toggle($event, applicationIndex)' class='icon-link icon-link--large'>
-                    <span v-html='application.name'></span>
+                    <span v-text='application.name'></span>
                     <template v-if='application.isVisible'>{{ Icon('caret_down') }}</template>
                     <template v-else>{{ Icon('caret_up') }}</template>
                   </button>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(application.this_month || 0)'></span>
+                  <span v-text='formatDollars(application.this_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(application.last_month || 0)'></span>
+                  <span v-text='formatDollars(application.last_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(application.total || 0)'></span>
+                  <span v-text='formatDollars(application.total || 0)'></span>
                 </td>
               </tr>
               <tr 
@@ -58,16 +58,16 @@
                 v-bind:class="[ index == application.environments.length -1 ? 'reporting-spend-table__env-row--last' : '']"
               >
                 <td>
-                  <span class="reporting-spend-table__env-row-label" v-html='environment.name'></span>
+                  <span class="reporting-spend-table__env-row-label" v-text='environment.name'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(environment.this_month || 0)'></span>
+                  <span v-text='formatDollars(environment.this_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(environment.last_month || 0)'></span>
+                  <span v-text='formatDollars(environment.last_month || 0)'></span>
                 </td>
                 <td class="table-cell--align-right">
-                  <span v-html='formatDollars(environment.total || 0)'></span>
+                  <span v-text='formatDollars(environment.total || 0)'></span>
                 </td>
               </tr>
             </template>


### PR DESCRIPTION
In [this PR](https://github.com/dod-ccpo/atst/pull/1296), I was surprised that using [`v-text`](https://vuejs.org/v2/api/#v-text) instead of [`v-html`](https://vuejs.org/v2/guide/syntax.html#Raw-HTML) didn't mitigate XSS attacks. Well, I gave it another go, and found that it worked?

I swapped `v-text` for `v-html` in most instances. This PR addresses:
https://www.pivotaltracker.com/story/show/170565459
<img width="594" alt="image" src="https://user-images.githubusercontent.com/54586407/72380468-76649200-36e3-11ea-8df2-92a7b917db81.png">

https://www.pivotaltracker.com/story/show/170708088
<img width="749" alt="image" src="https://user-images.githubusercontent.com/54586407/72380503-8aa88f00-36e3-11ea-8fa8-ecfc5754cdaa.png">

https://www.pivotaltracker.com/story/show/170562838 *
<img width="589" alt="image" src="https://user-images.githubusercontent.com/54586407/72380556-add33e80-36e3-11ea-8c31-cd843351cccd.png">

* even though this was already done, instead of using `esacpe()` in some places and `v-text` in others, I opted to refactor this bit to be consistent.


I left `v-html` for `validationError`s and the `title` of the `Alert()` macro. We should double check that the validation errors and alerts that we surface don't rely on user input, possibly in another story / PR.

