### PR TITLE
Remove the remaining uses of v-html

### DIFF
--- a/templates/components/alert.html
+++ b/templates/components/alert.html
@@ -25,7 +25,7 @@
 
     <div class='usa-alert-body'>
       {% if vue_template %}
-        <h3 class='usa-alert-heading' v-html='title'></h3>
+        <h3 class='usa-alert-heading' v-text='title'></h3>
       {% elif title %}
         <h3 class='usa-alert-heading'>{{ title | safe }}</h3>
       {% endif %}

--- a/templates/components/clin_dollar_amount.html
+++ b/templates/components/clin_dollar_amount.html
@@ -57,7 +57,7 @@
             <span class='usa-input__message'>{{ "forms.task_order.clin_funding_errors.obligated_amount_error" | translate }}</span>
           </template>
           <template v-else-if='showError'>
-            <span class='usa-input__message' v-html='validationError'></span>
+            <span class='usa-input__message' v-text='validationError'></span>
           </template>
           <template v-else>
             <span class='usa-input__message'></span>

--- a/templates/components/clin_fields.html
+++ b/templates/components/clin_fields.html
@@ -68,7 +68,7 @@
                   <input type='hidden' v-bind:value='rawValue' :name='name' />
 
                   <template v-if='showError'>
-                    <span class='usa-input__message' v-html='validationError'></span>
+                    <span class='usa-input__message' v-text='validationError'></span>
                   </template>
                   <template v-else>
                     <span class='usa-input__message'></span>

--- a/templates/components/multi_checkbox_input.html
+++ b/templates/components/multi_checkbox_input.html
@@ -54,7 +54,7 @@
 
 
         <template v-if='showError'>
-          <span class='usa-input__message' v-html='validationError'></span>
+          <span class='usa-input__message' v-text='validationError'></span>
         </template>
 
       </fieldset>

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -48,7 +48,7 @@
         {{ field(disabled=disabled) }}
 
         <template v-if='showError'>
-          <span class='usa-input__message' v-html='validationError'></span>
+          <span class='usa-input__message' v-text='validationError'></span>
         </template>
 
       </fieldset>

--- a/templates/components/text_input.html
+++ b/templates/components/text_input.html
@@ -107,7 +107,7 @@
       />
 
       {% if show_validation %}
-        <span v-if='showError' class='usa-input__message' v-html='validationError'></span>
+        <span v-if='showError' class='usa-input__message' v-text='validationError'></span>
       {% endif %}
 
     </div>


### PR DESCRIPTION
Addresses: https://www.pivotaltracker.com/story/show/170636527

No more `v-html` anywhere!

I was able to do this safely because the remaining `v-html` calls were being used on `validationError`s from [`input_validations.js`](https://github.com/dod-ccpo/atst/blob/bugfix/use-v-text-where-possible/js/lib/input_validations.js), and a few ([1](https://github.com/dod-ccpo/atst/blob/bugfix/use-v-text-where-possible/translations.yaml#L317)) places ([2](https://github.com/dod-ccpo/atst/blob/bugfix/use-v-text-where-possible/translations.yaml#L110)) in `translations.yaml`. None of these entries use markup, so I switched them to `v-text`. This has benefits that were previously explored in https://github.com/dod-ccpo/atst/pull/1314