### PR TITLE
Operator KeyVault

### DIFF
--- a/terraform/modules/keyvault/main.tf
+++ b/terraform/modules/keyvault/main.tf
@@ -20,7 +20,7 @@ resource "azurerm_key_vault" "keyvault" {
 }
 
 resource "azurerm_key_vault_access_policy" "keyvault_k8s_policy" {
-  count = "${length(var.principal_id) > 0 ? 1 : 0}"
+  count        = length(var.principal_id) > 0 ? 1 : 0
   key_vault_id = azurerm_key_vault.keyvault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id

--- a/terraform/modules/keyvault/main.tf
+++ b/terraform/modules/keyvault/main.tf
@@ -19,7 +19,8 @@ resource "azurerm_key_vault" "keyvault" {
   }
 }
 
-resource "azurerm_key_vault_access_policy" "keyvault" {
+resource "azurerm_key_vault_access_policy" "keyvault_k8s_policy" {
+  count = "${length(var.principal_id) > 0 ? 1 : 0}"
   key_vault_id = azurerm_key_vault.keyvault.id
 
   tenant_id = data.azurerm_client_config.current.tenant_id

--- a/terraform/providers/dev/keyvault.tf
+++ b/terraform/providers/dev/keyvault.tf
@@ -7,3 +7,4 @@ module "keyvault" {
   tenant_id    = var.tenant_id
   principal_id = "f9bcbe58-8b73-4957-aee2-133dc3e58063"
 }
+


### PR DESCRIPTION
This is a new keyvault specifically for storing operator secrets and
things that would not be accessible to applications. The primary use
case for this is for launching things like postgres (root postgres
creds) and other services which would require secrets to be added to the
terraform configuration. This approach avoids adding secrets to
terraform.

An accompanying script will be added to populate the new keyvault.