### PR TITLE
170237669 - Converts postgres secrets to use keyvault

### DIFF
--- a/terraform/modules/postgres/variables.tf
+++ b/terraform/modules/postgres/variables.tf
@@ -75,13 +75,11 @@ variable "storage_auto_grow" {
 variable "administrator_login" {
   type        = string
   description = "Administrator login"
-  default     = "atat_master" # FIXME - Remove with wrapper using KeyVault
 }
 
 variable "administrator_login_password" {
   type        = string
   description = "Administrator password"
-  default     = "eI0l7yswwtuhHpwzoVjwRKdAcuGNsg" # FIXME - Remove with wrapper using KeyVault
 }
 
 variable "postgres_version" {

--- a/terraform/providers/dev/postgres.tf
+++ b/terraform/providers/dev/postgres.tf
@@ -1,8 +1,20 @@
+data "azurerm_key_vault_secret" "postgres_username" {
+  name         = "postgres-root-user"
+  key_vault_id = module.operator_keyvault.id
+}
+
+data "azurerm_key_vault_secret" "postgres_password" {
+  name         = "postgres-root-password"
+  key_vault_id = module.operator_keyvault.id
+}
+
 module "sql" {
-  source      = "../../modules/postgres"
-  name        = var.name
-  owner       = var.owner
-  environment = var.environment
-  region      = var.region
-  subnet_id   = module.vpc.subnets # FIXME - Should be a map of subnets and specify private
+  source                       = "../../modules/postgres"
+  name                         = var.name
+  owner                        = var.owner
+  environment                  = var.environment
+  region                       = var.region
+  subnet_id                    = module.vpc.subnets # FIXME - Should be a map of subnets and specify private
+  administrator_login          = data.azurerm_key_vault_secret.postgres_username.value
+  administrator_login_password = data.azurerm_key_vault_secret.postgres_password.value
 }

--- a/terraform/providers/dev/secrets.tf
+++ b/terraform/providers/dev/secrets.tf
@@ -1,0 +1,10 @@
+module "operator_keyvault" {
+  source           = "../../modules/keyvault"
+  name             = "operator"
+  region           = var.region
+  owner            = var.owner
+  environment      = var.environment
+  tenant_id        = var.tenant_id
+  principal_id     = ""
+  admin_principals = var.admin_users
+}


### PR DESCRIPTION
This changes the configuration of the postgres master username and
password. Instead of committing to source (short term hack), this now
sources those secrets from KeyVault. Those secrets are generated and
populated via secrets-tool.