### PR TITLE
Display client source IP correctly in logs.

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -309,6 +309,7 @@ metadata:
   namespace: atat
 spec:
   loadBalancerIP: 13.92.235.6
+  externalTrafficPolicy: Local
   ports:
     - port: 80
       targetPort: 8342
@@ -329,6 +330,7 @@ metadata:
   namespace: atat
 spec:
   loadBalancerIP: 23.100.24.41
+  externalTrafficPolicy: Local
   ports:
     - port: 80
       targetPort: 8343


### PR DESCRIPTION
In order to display the client source IP, we need to make a
configuration change to the cluster. Setting externalTrafficPolicy to
"Local" preserves the client IP, per:

https://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip