### PR TITLE
Configure processes, threads, and increase CPU/memory limits

### DIFF
--- a/deploy/azure/autoscaling.yml
+++ b/deploy/azure/autoscaling.yml
@@ -17,7 +17,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 70
+        targetAverageUtilization: 60
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -37,4 +37,4 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 70
+        targetAverageUtilization: 60

--- a/deploy/azure/autoscaling.yml
+++ b/deploy/azure/autoscaling.yml
@@ -17,7 +17,7 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        targetAverageUtilization: 70
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -37,4 +37,4 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: 60
+        targetAverageUtilization: 70

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -31,7 +31,7 @@ spec:
           image: $CONTAINER_IMAGE
           env:
             - name: UWSGI_PROCESSES
-              value: "4"
+              value: "2"
             - name: UWSGI_THREADS
               value: "2"
             - name: UWSGI_ENABLE_THREADS
@@ -58,10 +58,10 @@ spec:
           resources:
             requests:
               memory: 400Mi
-              cpu: 1200m
+              cpu: 940m
             limits:
               memory: 400Mi
-              cpu: 1200m
+              cpu: 940m
         - name: nginx
           image: nginx:alpine
           ports:
@@ -93,10 +93,10 @@ spec:
           resources:
             requests:
               memory: 20Mi
-              cpu: 100m
+              cpu: 25m
             limits:
               memory: 20Mi
-              cpu: 100m
+              cpu: 25m
       volumes:
         - name: nginx-client-ca-bundle
           configMap:

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -29,6 +29,13 @@ spec:
       containers:
         - name: atst
           image: $CONTAINER_IMAGE
+          env:
+            - name: UWSGI_PROCESSES
+              value: "4"
+            - name: UWSGI_THREADS
+              value: "2"
+            - name: UWSGI_ENABLE_THREADS
+              value: "1"
           envFrom:
             - configMapRef:
                 name: atst-envvars
@@ -50,11 +57,11 @@ spec:
               mountPath: "/config"
           resources:
             requests:
-              memory: 200Mi
-              cpu: 400m
+              memory: 400Mi
+              cpu: 1200m
             limits:
-              memory: 200Mi
-              cpu: 400m
+              memory: 400Mi
+              cpu: 1200m
         - name: nginx
           image: nginx:alpine
           ports:
@@ -86,10 +93,10 @@ spec:
           resources:
             requests:
               memory: 20Mi
-              cpu: 10m
+              cpu: 100m
             limits:
               memory: 20Mi
-              cpu: 10m
+              cpu: 100m
       volumes:
         - name: nginx-client-ca-bundle
           configMap:

--- a/deploy/overlays/staging/autoscaling.yml
+++ b/deploy/overlays/staging/autoscaling.yml
@@ -1,0 +1,16 @@
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: atst
+spec:
+  minReplicas: 1
+  maxReplicas: 2
+---
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: atst-worker
+spec:
+  minReplicas: 1
+  maxReplicas: 2

--- a/deploy/overlays/staging/kustomization.yaml
+++ b/deploy/overlays/staging/kustomization.yaml
@@ -5,6 +5,7 @@ resources:
   - namespace.yml
   - reset-cron-job.yml
 patchesStrategicMerge:
+  - autoscaling.yml
   - ports.yml
   - envvars.yml
   - flex_vol.yml


### PR DESCRIPTION
Based on [this benchmarking](https://gist.github.com/raydds/8802da6ff6a79bb4dbdd4351be0ed7d8), 4 processes and 2 threads seems to produce the highest number of requests per second.

However, running with 2 processes and 2 threads allows us to fit two replicas on a node with 2vcpus. Therefore, I'm advocating for running with 2 processes and 2 threads. Keep in mind, that each node has 1930m CPU available. That means, in order to fit two replicas on a single node, we need to limit the web process and nginx to 965m CPU (combined).

Increasing the number of processes and threads did increase CPU/memory usage, so I had to bump the limits.

[Here's what it looks like when we're really hitting the app with some load](https://gist.github.com/raydds/ac45ff5e6fff127316ef9ba4d824a60b). Previously, we were getting ~2.5RPS, but with these changes, I saw the app get up to 9.5RPS.
