### PR TITLE
Remove delete environments from app members form

### DIFF
--- a/atst/forms/application_member.py
+++ b/atst/forms/application_member.py
@@ -46,13 +46,6 @@ class PermissionsForm(FlaskForm):
             "portfolios.applications.members.form.team_mgmt.description"
         ),
     )
-    perms_del_env = BooleanField(
-        translate("portfolios.applications.members.form.del_env.label"),
-        default=False,
-        description=translate(
-            "portfolios.applications.members.form.del_env.description"
-        ),
-    )
 
     @property
     def data(self):
@@ -65,9 +58,6 @@ class PermissionsForm(FlaskForm):
 
         if _data["perms_team_mgmt"]:
             perm_sets.append(PermissionSets.EDIT_APPLICATION_TEAM)
-
-        if _data["perms_del_env"]:
-            perm_sets.append(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
 
         _data["permission_sets"] = perm_sets
         return _data

--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -64,9 +64,6 @@ def filter_perm_sets_data(member):
         "perms_env_mgmt": bool(
             member.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
         ),
-        "perms_del_env": bool(
-            member.has_permission_set(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
-        ),
     }
 
     return perm_sets_data

--- a/templates/applications/fragments/member_form_fields.html
+++ b/templates/applications/fragments/member_form_fields.html
@@ -89,16 +89,13 @@
     {% if new %}
       {% set team_mgmt = form.perms_team_mgmt.name %}
       {% set env_mgmt = form.perms_env_mgmt.name %}
-      {% set del_env = form.perms_del_env.name %}
     {% else %}
       {% set team_mgmt = "perms_team_mgmt-{}".format(member_role_id) %}
       {% set env_mgmt = "perms_env_mgmt-{}".format(member_role_id) %}
-      {% set del_env = "perms_del_env-{}".format(member_role_id) %}
     {% endif %}
 
     {{ CheckboxInput(form.perms_team_mgmt, classes="input__inline-fields", key=team_mgmt, id=team_mgmt, optional=True) }}
     {{ CheckboxInput(form.perms_env_mgmt, classes="input__inline-fields", key=env_mgmt, id=env_mgmt, optional=True) }}
-    {{ CheckboxInput(form.perms_del_env, classes="input__inline-fields", key=del_env, id=del_env, optional=True) }}
   </div>
   <hr class="full-width">
   <div class="environment_roles environment-roles-new">

--- a/tests/forms/test_application_member.py
+++ b/tests/forms/test_application_member.py
@@ -43,10 +43,8 @@ def test_update_member_form():
     form_data = {
         "perms_team_mgmt": True,
         "perms_env_mgmt": False,
-        "perms_del_env": False,
     }
     form = UpdateMemberForm(data=form_data)
     assert form.validate()
     assert form.perms_team_mgmt.data
     assert not form.perms_env_mgmt.data
-    assert not form.perms_del_env.data

--- a/tests/routes/applications/test_new.py
+++ b/tests/routes/applications/test_new.py
@@ -160,7 +160,6 @@ def test_post_new_member(monkeypatch, client, user_session, session):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         },
     )
 
@@ -208,7 +207,6 @@ def test_post_update_member(client, user_session):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         },
     )
 

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -206,7 +206,6 @@ def test_get_members_data(app, client, user_session):
         assert member["permission_sets"] == {
             "perms_team_mgmt": False,
             "perms_env_mgmt": False,
-            "perms_del_env": False,
         }
         assert member["environment_roles"] == [
             {
@@ -409,7 +408,6 @@ def test_create_member(monkeypatch, client, user_session, session):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         },
     )
 
@@ -538,7 +536,6 @@ def test_update_member(client, user_session, session):
             "environment_roles-2-environment_name": env_2.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         },
     )
 
@@ -557,9 +554,6 @@ def test_update_member(client, user_session, session):
     assert bool(app_role.has_permission_set(PermissionSets.EDIT_APPLICATION_TEAM))
     assert bool(
         app_role.has_permission_set(PermissionSets.EDIT_APPLICATION_ENVIRONMENTS)
-    )
-    assert bool(
-        app_role.has_permission_set(PermissionSets.DELETE_APPLICATION_ENVIRONMENTS)
     )
 
     environment_roles = application.roles[0].environment_roles
@@ -702,7 +696,6 @@ def test_handle_create_member(monkeypatch, set_g, session):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         }
     )
     handle_create_member(application.id, form_data)
@@ -739,7 +732,6 @@ def test_handle_update_member_success(set_g):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         }
     )
 
@@ -780,7 +772,6 @@ def test_handle_update_member_with_error(set_g, monkeypatch, mock_logger):
             "environment_roles-1-environment_name": env_1.name,
             "perms_env_mgmt": True,
             "perms_team_mgmt": True,
-            "perms_del_env": True,
         }
     )
     handle_update_member(application.id, app_role.id, form_data)

--- a/translations.yaml
+++ b/translations.yaml
@@ -448,11 +448,9 @@ portfolios:
         "False": View Team
         "True": Edit Team
       perms_env_mgmt:
+
         "False": View Environments
         "True": Edit Environments
-      perms_del_env:
-        "False": ""
-        "True": Delete Application
       roles:
         ADMIN: Admin
         BILLING_READ: Billing Read-only


### PR DESCRIPTION
## Description
Remove check box for perms to delete an environment from the application member form. Fixed related tests and routes. 

## Pivotal
https://www.pivotaltracker.com/story/show/170391462