### PR TITLE
Disable container privilege escalation.

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -29,6 +29,8 @@ spec:
       containers:
         - name: atst
           image: $CONTAINER_IMAGE
+          securityContext:
+            allowPrivilegeEscalation: false
           env:
             - name: UWSGI_PROCESSES
               value: "2"
@@ -64,6 +66,8 @@ spec:
               cpu: 940m
         - name: nginx
           image: nginx:alpine
+          securityContext:
+            allowPrivilegeEscalation: false
           ports:
             - containerPort: 8342
               name: main-upgrade
@@ -189,6 +193,8 @@ spec:
       containers:
         - name: atst-worker
           image: $CONTAINER_IMAGE
+          securityContext:
+            allowPrivilegeEscalation: false
           args:
             [
               "/opt/atat/atst/.venv/bin/python",
@@ -261,6 +267,8 @@ spec:
       containers:
         - name: atst-beat
           image: $CONTAINER_IMAGE
+          securityContext:
+            allowPrivilegeEscalation: false
           args:
             [
               "/opt/atat/atst/.venv/bin/python",

--- a/deploy/azure/crls-sync.yaml
+++ b/deploy/azure/crls-sync.yaml
@@ -20,6 +20,8 @@ spec:
           containers:
           - name: crls
             image: $CONTAINER_IMAGE
+            securityContext:
+              allowPrivilegeEscalation: false
             command: [
               "/bin/sh", "-c"
             ]

--- a/deploy/shared/migration.yaml
+++ b/deploy/shared/migration.yaml
@@ -16,6 +16,8 @@ spec:
       containers:
       - name: migration
         image: $CONTAINER_IMAGE
+        securityContext:
+          allowPrivilegeEscalation: false
         command: [
           "/bin/sh", "-c"
         ]


### PR DESCRIPTION
Per Azure best practice, disable a container's ability to escalate its
privileges.

https://docs.microsoft.com/en-us/azure/aks/developer-best-practices-pod-security#secure-pod-access-to-resources