### PR TITLE
Give the cluster perms to create load balancers.

### DIFF
--- a/terraform/modules/k8s/main.tf
+++ b/terraform/modules/k8s/main.tf
@@ -81,3 +81,9 @@ resource "azurerm_monitor_diagnostic_setting" "k8s_diagnostic-1" {
     }
   }
 }
+
+resource "azurerm_role_assignment" "k8s_network_contrib" {
+  scope                = var.vnet_id
+  role_definition_name = "Network Contributor"
+  principal_id         = azurerm_kubernetes_cluster.k8s.identity[0].principal_id
+}

--- a/terraform/modules/k8s/variables.tf
+++ b/terraform/modules/k8s/variables.tf
@@ -67,3 +67,8 @@ variable "workspace_id" {
   description = "Log Analytics workspace for this resource to log to"
   type        = string
 }
+
+variable "vnet_id" {
+  description = "The ID of the VNET that the AKS cluster app registration needs to provision load balancers in"
+  type        = string
+}

--- a/terraform/modules/vpc/outputs.tf
+++ b/terraform/modules/vpc/outputs.tf
@@ -7,3 +7,7 @@ output "subnet_list" {
     for k, id in azurerm_subnet.subnet : k => id
   }
 }
+
+output "id" {
+  value = azurerm_virtual_network.vpc.id
+}

--- a/terraform/providers/dev/k8s.tf
+++ b/terraform/providers/dev/k8s.tf
@@ -23,6 +23,7 @@ module "k8s" {
   client_id           = data.azurerm_key_vault_secret.k8s_client_id.value
   client_secret       = data.azurerm_key_vault_secret.k8s_client_secret.value
   workspace_id        = module.logs.workspace_id
+  vnet_id             = module.vpc.id
 }
 
 #module "main_lb" {


### PR DESCRIPTION
In order for the cluster app registration to create new load balancers,
it needs to have the Network Contributor role for the virtual network.
In the future, we should create a custom policy scoped to exactly the
permissions the cluster needs, per:

https://docs.microsoft.com/en-us/azure/aks/configure-azure-cni#prerequisites

<img width="1435" alt="Screen Shot 2020-01-30 at 4 49 19 PM" src="https://user-images.githubusercontent.com/38955503/73493987-cdc05e80-4381-11ea-898a-822fc2434fc1.png">
