### PR TITLE
Fix bug in setting Secure on session cookie.

### DIFF
--- a/atst/app.py
+++ b/atst/app.py
@@ -193,6 +193,7 @@ def map_config(config):
         "CONTRACT_END_DATE": datetime.strptime(
             config.get("default", "CONTRACT_END_DATE"), "%Y-%m-%d"
         ).date(),
+        "SESSION_COOKIE_SECURE": config.getboolean("default", "SESSION_COOKIE_SECURE"),
     }
 
 


### PR DESCRIPTION
This fixes a bug I introduced with commit

6edc7b138b0745d0b3f9d99da76c445fe954c5a7

The value for SESSION_COOKIE_SECURE was being read in as a truthy string
every time. In order for it to be interpreted correctly, we need to map
it to a boolean.