### PR TITLE
Fix column type on portfolios defense_component

### DIFF
--- a/atst/models/portfolio.py
+++ b/atst/models/portfolio.py
@@ -22,7 +22,7 @@ class Portfolio(
     id = types.Id()
     name = Column(String, nullable=False)
     defense_component = Column(
-        String, nullable=False
+        ARRAY(String), nullable=False
     )  # Department of Defense Component
 
     app_migration = Column(String)  # App Migration


### PR DESCRIPTION
## Description
I noticed that the column type of portfolios defense_component had reverted back to `String` when I created a migration.