### PR TITLE
Alert for revoking an invite

### DIFF
--- a/atst/routes/applications/settings.py
+++ b/atst/routes/applications/settings.py
@@ -467,9 +467,10 @@ def revoke_invite(application_id, application_role_id):
     if invite.is_pending:
         ApplicationInvitations.revoke(invite.token)
         flash(
-            "application_invite_revoked",
+            "invite_revoked",
+            resource="Application",
             user_name=app_role.user_name,
-            application_name=g.application.name,
+            resource_name=g.application.name,
         )
     else:
         flash(

--- a/atst/routes/portfolios/invitations.py
+++ b/atst/routes/portfolios/invitations.py
@@ -37,8 +37,14 @@ def accept_invitation(portfolio_token):
 )
 @user_can(Permissions.EDIT_PORTFOLIO_USERS, message="revoke invitation")
 def revoke_invitation(portfolio_id, portfolio_token):
-    PortfolioInvitations.revoke(portfolio_token)
+    invite = PortfolioInvitations.revoke(portfolio_token)
 
+    flash(
+        "invite_revoked",
+        resource="Portfolio",
+        user_name=invite.user_name,
+        resource_name=g.portfolio.name,
+    )
     return redirect(
         url_for(
             "portfolios.admin",

--- a/atst/utils/flash.py
+++ b/atst/utils/flash.py
@@ -33,11 +33,6 @@ MESSAGES = {
         "message": "flash.application_invite.resent.message",
         "category": "success",
     },
-    "application_invite_revoked": {
-        "title": "flash.application_invite.revoked.title",
-        "message": "flash.application_invite.revoked.message",
-        "category": "success",
-    },
     "application_member_removed": {
         "title": "flash.application_member.removed.title",
         "message": "flash.application_member.removed.message",
@@ -102,6 +97,11 @@ MESSAGES = {
         "title": "flash.task_order.insufficient_funds.title",
         "message": None,
         "category": "warning",
+    },
+    "invite_revoked": {
+        "title": "flash.invite_revoked.title",
+        "message": "flash.invite_revoked.message",
+        "category": "success",
     },
     "logged_out": {
         "title": "flash.logged_out.title",

--- a/translations.yaml
+++ b/translations.yaml
@@ -128,9 +128,6 @@ flash:
       message: There was an error processing the invitation for {user_name} from {application_name}
     resent:
       message: "{email} has been sent an invitation to access this Application"
-    revoked:
-      title: Application invitation revoked
-      message: You have successfully revoked the invite for {user_name} from {application_name}
   application_member:
     removed:
       title: Team member removed from application
@@ -166,6 +163,9 @@ flash:
     errors:
       title: There were some errors
       message: Please see below.
+  invite_revoked:
+    title: "{resource} invitation revoked"
+    message: "You have successfully revoked the invite for {user_name} from {resource_name}"
   login_required_message: After you log in, you will be redirected to your destination page.
   login_required_title: Log in required
   logged_out:


### PR DESCRIPTION
## Description
Add success flash message for revoked portfolio invite. Updates the flash messages and translations so the same message can be used for revoking a portfolio or application invite

## Pivotal
https://www.pivotaltracker.com/story/show/170831810

## Screenshot
<img width="2032" alt="Screen Shot 2020-02-03 at 4 34 20 PM" src="https://user-images.githubusercontent.com/43828539/73692857-286bfa00-46a3-11ea-9bd7-74c1392615a4.png">
