### PR TITLE
Update SQL query to find pending portfolios.

### DIFF
--- a/atst/jobs.py
+++ b/atst/jobs.py
@@ -203,7 +203,7 @@ def dispatch_provision_portfolio(self):
     """
     Iterate over portfolios with a corresponding State Machine that have not completed.
     """
-    for portfolio_id in Portfolios.get_portfolios_pending_provisioning():
+    for portfolio_id in Portfolios.get_portfolios_pending_provisioning(pendulum.now()):
         provision_portfolio.delay(portfolio_id=portfolio_id)
 
 

--- a/atst/models/portfolio_state_machine.py
+++ b/atst/models/portfolio_state_machine.py
@@ -175,11 +175,14 @@ class PortfolioStateMachine(
             app.logger.info(exc.json())
             print(exc.json())
             app.logger.info(payload_data)
+            # TODO: Ensure that failing the stage does not preclude a Celery retry
             self.fail_stage(stage)
+        # TODO: catch and handle general CSP exception here
         except (ConnectionException, UnknownServerException) as exc:
             app.logger.error(
                 f"CSP api call. Caught exception for {self.__repr__()}.", exc_info=1,
             )
+            # TODO: Ensure that failing the stage does not preclude a Celery retry
             self.fail_stage(stage)
 
         self.finish_stage(stage)

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -1,5 +1,4 @@
 import pytest
-import pendulum
 from uuid import uuid4
 
 from atst.domain.environments import Environments
@@ -14,6 +13,7 @@ from tests.factories import (
     EnvironmentRoleFactory,
     ApplicationRoleFactory,
 )
+from tests.utils import EnvQueryTest
 
 
 def test_create_environments():
@@ -117,40 +117,6 @@ def test_update_does_not_duplicate_names_within_application():
 
     with pytest.raises(AlreadyExistsError):
         Environments.update(dupe_env, name)
-
-
-class EnvQueryTest:
-    @property
-    def NOW(self):
-        return pendulum.now()
-
-    @property
-    def YESTERDAY(self):
-        return self.NOW.subtract(days=1)
-
-    @property
-    def TOMORROW(self):
-        return self.NOW.add(days=1)
-
-    def create_portfolio_with_clins(self, start_and_end_dates, env_data=None):
-        env_data = env_data or {}
-        return PortfolioFactory.create(
-            applications=[
-                {
-                    "name": "Mos Eisley",
-                    "description": "Where Han shot first",
-                    "environments": [{"name": "thebar", **env_data}],
-                }
-            ],
-            task_orders=[
-                {
-                    "create_clins": [
-                        {"start_date": start_date, "end_date": end_date}
-                        for (start_date, end_date) in start_and_end_dates
-                    ]
-                }
-            ],
-        )
 
 
 class TestGetEnvironmentsPendingCreate(EnvQueryTest):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -286,9 +286,19 @@ def test_create_environment_no_dupes(session, celery_app, celery_worker):
     assert environment.claimed_until == None
 
 
-def test_dispatch_provision_portfolio(
-    csp, session, portfolio, celery_app, celery_worker, monkeypatch
-):
+def test_dispatch_provision_portfolio(csp, monkeypatch):
+    portfolio = PortfolioFactory.create(
+        task_orders=[
+            {
+                "create_clins": [
+                    {
+                        "start_date": pendulum.now().subtract(days=1),
+                        "end_date": pendulum.now().add(days=1),
+                    }
+                ]
+            }
+        ],
+    )
     sm = PortfolioStateMachineFactory.create(portfolio=portfolio)
     mock = Mock()
     monkeypatch.setattr("atst.jobs.provision_portfolio", mock)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -5,8 +5,11 @@ from unittest.mock import Mock
 from OpenSSL import crypto
 from cryptography.hazmat.backends import default_backend
 from flask import template_rendered
+import pendulum
 
 from atst.utils.notification_sender import NotificationSender
+
+import tests.factories as factories
 
 
 @contextmanager
@@ -62,3 +65,40 @@ def make_crl_list(x509_obj, x509_path):
     issuer = x509_obj.issuer.public_bytes(default_backend())
     filename = os.path.basename(x509_path)
     return [(filename, issuer.hex())]
+
+
+class EnvQueryTest:
+    @property
+    def NOW(self):
+        return pendulum.now()
+
+    @property
+    def YESTERDAY(self):
+        return self.NOW.subtract(days=1)
+
+    @property
+    def TOMORROW(self):
+        return self.NOW.add(days=1)
+
+    def create_portfolio_with_clins(
+        self, start_and_end_dates, env_data=None, state_machine_status=None
+    ):
+        env_data = env_data or {}
+        return factories.PortfolioFactory.create(
+            state=state_machine_status,
+            applications=[
+                {
+                    "name": "Mos Eisley",
+                    "description": "Where Han shot first",
+                    "environments": [{"name": "thebar", **env_data}],
+                }
+            ],
+            task_orders=[
+                {
+                    "create_clins": [
+                        {"start_date": start_date, "end_date": end_date}
+                        for (start_date, end_date) in start_and_end_dates
+                    ]
+                }
+            ],
+        )


### PR DESCRIPTION
The query to find portfolios that are pending provisioning is updated to
check for:

- a period of performance that has started
- a portfolio state machine that has an UNSTARTED or one of the CREATED
  states

I left several TODOs to ensure that the orchestration functions
correctly for portfolio.