### PR TITLE
Add cloud method to get reporting data

### DIFF
--- a/atst/domain/csp/cloud/mock_cloud_provider.py
+++ b/atst/domain/csp/cloud/mock_cloud_provider.py
@@ -25,12 +25,15 @@ from .models import (
     BillingProfileTenantAccessCSPResult,
     BillingProfileVerificationCSPPayload,
     BillingProfileVerificationCSPResult,
+    CostManagementQueryCSPResult,
+    CostManagementQueryProperties,
     ProductPurchaseCSPPayload,
     ProductPurchaseCSPResult,
     ProductPurchaseVerificationCSPPayload,
     ProductPurchaseVerificationCSPResult,
     PrincipalAdminRoleCSPPayload,
     PrincipalAdminRoleCSPResult,
+    ReportingCSPPayload,
     SubscriptionCreationCSPPayload,
     SubscriptionCreationCSPResult,
     SubscriptionVerificationCSPPayload,
@@ -487,3 +490,25 @@ class MockCloudProvider(CloudProviderInterface):
 
     def update_tenant_creds(self, tenant_id, secret):
         return secret
+
+    def get_reporting_data(self, payload: ReportingCSPPayload):
+        self._maybe_raise(self.NETWORK_FAILURE_PCT, self.NETWORK_EXCEPTION)
+        self._maybe_raise(self.SERVER_FAILURE_PCT, self.SERVER_EXCEPTION)
+        self._maybe_raise(self.UNAUTHORIZED_RATE, self.AUTHORIZATION_EXCEPTION)
+        object_id = str(uuid4())
+
+        properties = CostManagementQueryProperties(
+            **dict(
+                columns=[
+                    {"name": "PreTaxCost", "type": "Number"},
+                    {"name": "UsageDate", "type": "Number"},
+                    {"name": "InvoiceId", "type": "String"},
+                    {"name": "Currency", "type": "String"},
+                ],
+                rows=[],
+            )
+        )
+
+        return CostManagementQueryCSPResult(
+            **dict(name=object_id, properties=properties,)
+        )

--- a/atst/domain/csp/cloud/models.py
+++ b/atst/domain/csp/cloud/models.py
@@ -499,3 +499,34 @@ class UserCSPPayload(BaseCSPPayload):
 
 class UserCSPResult(AliasModel):
     id: str
+
+
+class QueryColumn(AliasModel):
+    name: str
+    type: str
+
+
+class CostManagementQueryProperties(AliasModel):
+    columns: List[QueryColumn]
+    rows: List[Optional[list]]
+
+
+class CostManagementQueryCSPResult(AliasModel):
+    name: str
+    properties: CostManagementQueryProperties
+
+
+class ReportingCSPPayload(BaseCSPPayload):
+    invoice_section_id: str
+    from_date: str
+    to_date: str
+
+    @root_validator(pre=True)
+    def extract_invoice_section(cls, values):
+        try:
+            values["invoice_section_id"] = values["billing_profile_properties"][
+                "invoice_sections"
+            ][0]["invoice_section_id"]
+            return values
+        except (KeyError, IndexError):
+            raise ValueError("Invoice section ID not present in payload")


### PR DESCRIPTION
First PR for https://www.pivotaltracker.com/story/show/170268176

Adds a method to `azure_cloud_provider` to query the Cost Management API for usage data per invoice.  For now, this query is relatively static. We're always calling the API at the billing invoice section scope, with the widest timeframe possible (one year), and with the same requested dataset. As the scope of the application's reporting needs changes, this function may change to be more general and/or revert back to the SDK.