### PR TITLE
PDF download bug

### DIFF
--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -17,7 +17,7 @@ export default {
     filename: {
       type: String,
     },
-    objectName: {
+    initialObjectName: {
       type: String,
     },
     initialErrors: {
@@ -42,6 +42,7 @@ export default {
       filenameError: false,
       downloadLink: '',
       fileSizeLimit: this.sizeLimit,
+      objectName: this.initialObjectName,
     }
   },
 
@@ -72,6 +73,7 @@ export default {
       const response = await uploader.upload(file)
       if (uploadResponseOkay(response)) {
         this.attachment = e.target.value
+        this.objectName = uploader.objectName
         this.$refs.attachmentFilename.value = file.name
         this.$refs.attachmentObjectName.value = response.objectName
         this.$refs.attachmentInput.disabled = true

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -5,7 +5,7 @@
   inline-template
   {% if not field.errors %}
     v-bind:filename='{{ field.filename.data | tojson }}'
-    v-bind:object-name='{{ field.object_name.data | tojson }}'
+    v-bind:initial-object-name='{{ field.object_name.data | tojson }}'
   {% else %}
     v-bind:initial-errors='true'
   {% endif %}
@@ -46,7 +46,7 @@
           v-bind:value="attachment"
           type="file">
           <input type="hidden" name="{{ field.filename.name }}" id="{{ field.filename.name }}" ref="attachmentFilename">
-          <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName">
+          <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName" v-bind:value='objectName'>
       </div>
       <template v-if="uploadError">
         <span class="usa-input__message">{{ "forms.task_order.upload_error" | translate }}</span>


### PR DESCRIPTION
## Description
Fixes the download PDF link in the TO builder. The issue was two-fold: first `generate_download_link()` had to be updated to use updates to the update python APIS, second the object_name was not being saved on the task_order instances, which was fixed by updating the UploadInput component. 

## Pivotal
https://www.pivotaltracker.com/story/show/171114893