### PR TITLE
Update portfolio and application validators

### DIFF
--- a/js/lib/input_validations.js
+++ b/js/lib/input_validations.js
@@ -9,6 +9,12 @@ export default {
     unmask: [],
     validationError: 'Please enter a response',
   },
+  applicationName: {
+    mask: false,
+    match: /^[A-Za-z0-9\-_,'".\s]{4,100}$$/,
+    unmask: [],
+    validationError: 'Application names can be between 4-100 characters',
+  },
   clinNumber: {
     mask: false,
     match: /^\d{4}$/,
@@ -42,14 +48,14 @@ export default {
   },
   defaultStringField: {
     mask: false,
-    match: /^[A-Za-z0-9\-_ \.]{1,100}$/,
+    match: /^[A-Za-z0-9\-_,'".\s]{1,1000}$/,
     unmask: [],
     validationError:
       'Please enter a response of no more than 100 alphanumeric characters',
   },
   defaultTextAreaField: {
     mask: false,
-    match: /^[A-Za-z0-9\-_ \.]{1,1000}$/,
+    match: /^[A-Za-z0-9\-_,'".\s]{1,1000}$/,
     unmask: [],
     validationError:
       'Please enter a response of no more than 1000 alphanumeric characters',
@@ -94,7 +100,7 @@ export default {
   },
   portfolioName: {
     mask: false,
-    match: /^.{4,100}$/,
+    match: /^[A-Za-z0-9\-_,'".\s]{4,100}$$/,
     unmask: [],
     validationError: 'Portfolio names can be between 4-100 characters',
   },

--- a/styles/elements/_inputs.scss
+++ b/styles/elements/_inputs.scss
@@ -228,6 +228,7 @@
 
   &--validation {
     &--anything,
+    &--applicationName,
     &--portfolioName,
     &--requiredField,
     &--defaultStringField,

--- a/templates/applications/new/step_1.html
+++ b/templates/applications/new/step_1.html
@@ -26,7 +26,7 @@
       {{ form.csrf_token }}
       <div class="form-row">
         <div class="form-col">
-          {{ TextInput(form.name, validation="name", optional=False) }}
+          {{ TextInput(form.name, validation="applicationName", optional=False) }}
           {{ ('portfolios.applications.new.step_1_form_help_text.name' | translate | safe) }}
         </div>
       </div>

--- a/templates/applications/settings.html
+++ b/templates/applications/settings.html
@@ -22,7 +22,7 @@
     <base-form inline-template>
       <form method="POST" action="{{ url_for('applications.update', application_id=application.id) }}" class="col col--half">
         {{ application_form.csrf_token }}
-        {{ TextInput(application_form.name, validation="name", optional=False) }}
+        {{ TextInput(application_form.name, validation="applicationName", optional=False) }}
         {{ TextInput(application_form.description, validation="defaultTextAreaField", paragraph=True, optional=True, showOptional=False) }}
         <div class="action-group action-group--tight">
           {{ SaveButton(text='common.save_changes'|translate) }}

--- a/templates/portfolios/new/step_1.html
+++ b/templates/portfolios/new/step_1.html
@@ -23,7 +23,7 @@
         {{ form.csrf_token }}
         <div class="form-row form-row--bordered">
           <div class="form-col">
-            {{ TextInput(form.name, validation="name", optional=False, classes="form-col") }}
+            {{ TextInput(form.name, validation="portfolioName", optional=False, classes="form-col") }}
             {{"forms.portfolio.name.help_text" | translate | safe }}
           </div>
         </div>


### PR DESCRIPTION
## Description
Allow commas and quotes in portfolio and application names. Create in…put validator for application names. Previously there was no character limit for the application names, so when I added in the validator I made it the same as the portfolio limits (between 4 and 100 characters). 

## Pivotal
https://www.pivotaltracker.com/story/show/171142818