### PR TITLE
Update CAs in the container.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,5 +101,7 @@ RUN mkdir /var/run/uwsgi && \
       chown -R atst:atat /var/run/uwsgi && \
       chown -R atst:atat "${APP_DIR}"
 
+RUN update-ca-certificates
+
 # Run as the unprivileged APP user
 USER atst


### PR DESCRIPTION
In order for the app to make > TLS 1.2 connections to Redis, we need to
update the local certificate store in the container.