### PR TITLE
Update TO number text to remove references to 13-digits

### DIFF
--- a/translations.yaml
+++ b/translations.yaml
@@ -313,7 +313,7 @@ forms:
     upload_error: There was an error uploading your file. Please try again. If you encounter repeated problems uploading this file, please contact CCPO.
     size_error: "The file you have selected is too large. Please choose a file no larger than {file_size_limit}MB."
     filename_error: File names can only contain the characters A-Z, 0-9, space, hyphen, underscore, and period.
-    number_description: 13-Digit Task Order Number
+    number_description: Task Order Number
     pop_errors:
       date_order: PoP start date must be before end date.
       range: Date must be between {start} and {end}.
@@ -530,7 +530,7 @@ task_orders:
   form:
     add_clin: Add Another CLIN
     add_to_header: Enter the Task Order number
-    add_to_description: Please input your 13-digit Task Order number. This number may be listed under "Order Number" if your Contracting Officer used form 1149, or "Delivery Order/Call No." if form 1155 was used. Moving forward, this portion of funding will be referenced by the recorded Task Order number.
+    add_to_description: Please input your Task Order number. This number may be listed under "Order Number" if your Contracting Officer used form 1149, or "Delivery Order/Call No." if form 1155 was used. Moving forward, this portion of funding will be referenced by the recorded Task Order number.
     builder_base:
       cancel_modal: Do you want to save this draft?
       delete_draft: No, delete it


### PR DESCRIPTION
## Description
Update text in TO forms to remove references to a 13-digit TO number.

## Pivotal
https://www.pivotaltracker.com/story/show/170985969