### PR TITLE
Set Redis verification mode for TLS connections.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -3,7 +3,7 @@
     "files": "^.secrets.baseline$|^.*pgsslrootcert.yml$",
     "lines": null
   },
-  "generated_at": "2020-01-27T19:24:43Z",
+  "generated_at": "2020-02-10T21:40:38Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -82,7 +82,7 @@
         "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_secret": false,
         "is_verified": false,
-        "line_number": 32,
+        "line_number": 33,
         "type": "Secret Keyword"
       }
     ],

--- a/atst/app.py
+++ b/atst/app.py
@@ -233,12 +233,18 @@ def make_config(direct_config=None):
     config.set("default", "DATABASE_URI", database_uri)
 
     # Assemble REDIS_URI value
+    redis_use_tls = config["default"].getboolean("REDIS_TLS")
     redis_uri = "redis{}://{}:{}@{}".format(  # pragma: allowlist secret
-        ("s" if config["default"].getboolean("REDIS_TLS") else ""),
+        ("s" if redis_use_tls else ""),
         (config.get("default", "REDIS_USER") or ""),
         (config.get("default", "REDIS_PASSWORD") or ""),
         config.get("default", "REDIS_HOST"),
     )
+    if redis_use_tls:
+        tls_mode = config.get("default", "REDIS_SSLMODE")
+        tls_mode_str = tls_mode.lower() if tls_mode else "none"
+        redis_uri = f"{redis_uri}/?ssl_cert_reqs={tls_mode_str}"
+
     config.set("default", "REDIS_URI", redis_uri)
 
     return map_config(config)

--- a/config/base.ini
+++ b/config/base.ini
@@ -38,6 +38,7 @@ PGUSER = postgres
 PORT=8000
 REDIS_HOST=localhost:6379
 REDIS_PASSWORD
+REDIS_SSLMODE
 REDIS_TLS=False
 REDIS_USER
 SECRET_KEY = change_me_into_something_secret

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -7,6 +7,7 @@ from atst.app import (
     make_crl_validator,
     apply_config_from_directory,
     apply_config_from_environment,
+    make_config,
 )
 
 
@@ -67,3 +68,18 @@ def test_apply_config_from_environment_skips_unknown_settings(
     monkeypatch.setenv("FLARF", "MAYO")
     apply_config_from_environment(config_object)
     assert "FLARF" not in config_object.options("default")
+
+
+class TestMakeConfig:
+    def test_redis_ssl_connection(self):
+        config = make_config({"REDIS_TLS": True})
+        uri = config.get("REDIS_URI")
+        assert "rediss" in uri
+        assert "ssl_cert_reqs" in uri
+
+    def test_non_redis_ssl_connection(self):
+        config = make_config({"REDIS_TLS": False})
+        uri = config.get("REDIS_URI")
+        assert "rediss" not in uri
+        assert "redis" in uri
+        assert "ssl_cert_reqs" not in uri


### PR DESCRIPTION
If the app is making a TLS connection to Redis, the new config setting
REDIS_SSLMODE determines whether CA verification should be performed.
Acceptable values are Python `None` or strings "none", "optional", and
"required".