### PR TITLE
Update CLINs

### DIFF
--- a/atst/domain/csp/cloud/models.py
+++ b/atst/domain/csp/cloud/models.py
@@ -220,14 +220,6 @@ class BillingInstructionCSPPayload(BaseCSPPayload):
     billing_account_name: str
     billing_profile_name: str
 
-    class Config:
-        fields = {
-            "initial_clin_amount": "obligated_amount",
-            "initial_clin_start_date": "start_date",
-            "initial_clin_end_date": "end_date",
-            "initial_clin_type": "number",
-        }
-
 
 class BillingInstructionCSPResult(AliasModel):
     reported_clin_name: str

--- a/atst/domain/csp/cloud/models.py
+++ b/atst/domain/csp/cloud/models.py
@@ -220,6 +220,14 @@ class BillingInstructionCSPPayload(BaseCSPPayload):
     billing_account_name: str
     billing_profile_name: str
 
+    class Config:
+        fields = {
+            "initial_clin_amount": "obligated_amount",
+            "initial_clin_start_date": "start_date",
+            "initial_clin_end_date": "end_date",
+            "initial_clin_type": "number",
+        }
+
 
 class BillingInstructionCSPResult(AliasModel):
     reported_clin_name: str

--- a/atst/domain/task_orders.py
+++ b/atst/domain/task_orders.py
@@ -90,3 +90,13 @@ class TaskOrders(BaseDomainClass):
             )
             .all()
         )
+
+    @classmethod
+    def get_clins_for_create_billing_instructions(cls):
+        return (
+            db.session.query(CLIN)
+            .filter(
+                CLIN.last_sent_at.is_(None), CLIN.start_date < pendulum.now(tz="UTC")
+            )
+            .all()
+        )

--- a/atst/jobs.py
+++ b/atst/jobs.py
@@ -325,15 +325,16 @@ def create_billing_instruction(self):
     clins = TaskOrders.get_clins_for_create_billing_instructions()
     for clin in clins:
         portfolio = clin.task_order.portfolio
-        clin_data = clin.to_dictionary()
-        portfolio_data = portfolio.to_dictionary()
 
         payload = BillingInstructionCSPPayload(
             tenant_id=portfolio.csp_data.get("tenant_id"),
             billing_account_name=portfolio.csp_data.get("billing_account_name"),
             billing_profile_name=portfolio.csp_data.get("billing_profile_name"),
-            **clin_data,
-            **portfolio_data,
+            initial_clin_amount=clin.obligated_amount,
+            initial_clin_start_date=str(clin.start_date),
+            initial_clin_end_date=str(clin.end_date),
+            initial_clin_type=clin.number,
+            initial_task_order_id=str(clin.task_order_id),
         )
 
         try:

--- a/atst/models/clin.py
+++ b/atst/models/clin.py
@@ -71,8 +71,6 @@ class CLIN(Base, mixins.TimestampsMixin):
             for c in self.__table__.columns
             if c.name not in ["id"]
         }
-        data["start_date"] = str(data["start_date"])
-        data["end_date"] = str(data["end_date"])
 
         return data
 

--- a/atst/models/clin.py
+++ b/atst/models/clin.py
@@ -66,11 +66,15 @@ class CLIN(Base, mixins.TimestampsMixin):
         )
 
     def to_dictionary(self):
-        return {
+        data = {
             c.name: getattr(self, c.name)
             for c in self.__table__.columns
             if c.name not in ["id"]
         }
+        data["start_date"] = str(data["start_date"])
+        data["end_date"] = str(data["end_date"])
+
+        return data
 
     @property
     def is_active(self):

--- a/atst/queue.py
+++ b/atst/queue.py
@@ -31,6 +31,10 @@ def update_celery(celery, app):
             "task": "atst.jobs.send_task_order_files",
             "schedule": 60,
         },
+        "beat-create_billing_instruction": {
+            "task": "atst.jobs.create_billing_instruction",
+            "schedule": 60,
+        },
     }
 
     class ContextTask(celery.Task):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -561,6 +561,7 @@ class TestCreateBillingInstructions:
 
         session.begin_nested()
         create_billing_instruction()
+        session.add(sent_clin)
 
         # check that last_sent_at has been update for the new clin only
         assert new_clin.last_sent_at


### PR DESCRIPTION
## Description
Adds a query method to find all CLINs that are active and un-sent to the TaskOrder model. Also adds celery beat worker to send CLIN information to MS using `create_billing_instruction` and mark CLINs as sent. 

## Pivotal 
https://www.pivotaltracker.com/story/show/170930490