### PR TITLE
Enable re-uploading files after an error

### DIFF
--- a/js/components/upload_input.js
+++ b/js/components/upload_input.js
@@ -72,7 +72,7 @@ export default {
       const uploader = await this.getUploader()
       const response = await uploader.upload(file)
       if (uploadResponseOkay(response)) {
-        this.attachment = e.target.value
+        this.attachment = file.name
         this.objectName = uploader.objectName
         this.$refs.attachmentFilename.value = file.name
         this.$refs.attachmentObjectName.value = response.objectName

--- a/templates/components/upload_input.html
+++ b/templates/components/upload_input.html
@@ -43,7 +43,6 @@
           :id="name"
           :name="name"
           aria-label="Task Order Upload"
-          v-bind:value="attachment"
           type="file">
           <input type="hidden" name="{{ field.filename.name }}" id="{{ field.filename.name }}" ref="attachmentFilename">
           <input type="hidden" name="{{ field.object_name.name }}" id="{{ field.object_name.name }}" ref="attachmentObjectName" v-bind:value='objectName'>


### PR DESCRIPTION
## Description
Fixes a bug where a user could not upload a file after there was an error. 
One of the issues was that e.target.value was coming through as an empty string, which was making it behave weird. This was fixed this by using the file name instead.
The other issue was that Vue couldn't assign the value of `attachment` to the input. This was fixed by removing that v-bind, I tested it a bunch locally and it seems to still work as expected. 

##Pivotal
https://www.pivotaltracker.com/story/show/171161871