### PR TITLE
Highlight portfolio name in sidenav

### DIFF
--- a/templates/navigation/global_sidenav.html
+++ b/templates/navigation/global_sidenav.html
@@ -21,10 +21,10 @@
           </template>
         </div>
         <ul class="sidenav__list" v-if="isVisible">
-          {% for other_portfolio in portfolios|sort(attribute='name') %}
-            {{ SidenavItem(other_portfolio.name,
-              href=url_for("applications.portfolio_applications", portfolio_id=other_portfolio.id),
-              active=(other_portfolio.id | string) == request.view_args.get('portfolio_id')
+          {% for portfolio in portfolios|sort(attribute='name') %}
+            {{ SidenavItem(portfolio.name,
+              href=url_for("applications.portfolio_applications", portfolio_id=portfolio.id),
+              active=portfolio == g.portfolio
               ) }}
           {% endfor %}
         </ul>


### PR DESCRIPTION
## Description
Fix the sidenav so the active portfolio is highlighted when navigating to an application or task order. 

## Pivotal
https://www.pivotaltracker.com/story/show/171185618