### PR TITLE
Update Azure CLI login to container registry.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,7 +103,7 @@ commands:
               --password $AZURE_SP_PASSWORD \
               --username $AZURE_SP
             echo "Successfully logged in to Azure CLI."
-            az acr login --name $AZURE_REGISTRY
+            az acr login --name $AZURE_REGISTRY | grep "Succeeded"
       - run:
           name: Install kubectl
           command: |


### PR DESCRIPTION
The Azure CLI now returns an exit code of "1" if there are any warnings
when logging into a container registry. Since our longterm goal is to
move away from CircleCI, I chose to fix this in-place rather than
integrate a credentials store or pass more config values to a `docker
login` command. Instead, this just grep the output from the Azure CLI
command to ensure it succeeded.