### PR TITLE
Set shell for failing docker login command.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -96,6 +96,7 @@ commands:
             apk del --purge build
       - run:
           name: Login to Azure CLI
+          shell: /bin/sh -o pipefail
           command: |
             az login \
               --service-principal \


### PR DESCRIPTION
On my last PR to fix this, I didn't notice that CircleCI was setting the
shell to execute with `/bin/sh -eo pipefail`, which means that the
commands will fail if any part of the command exits with 1, regardless
of whether the result is being piped anywhere else. This updates the
shell that that section of the config uses.

https://circleci.com/docs/2.0/configuration-reference/#default-shell-options