### PR TITLE
Tweak what "total portfolio value" represents

### DIFF
--- a/atst/routes/portfolios/index.py
+++ b/atst/routes/portfolios/index.py
@@ -50,9 +50,7 @@ def reports(portfolio_id):
         "portfolios/reports/index.html",
         portfolio=portfolio,
         # wrapped in str() because this sum returns a Decimal object
-        total_portfolio_value=str(
-            portfolio.total_obligated_funds + portfolio.upcoming_obligated_funds
-        ),
+        total_portfolio_value=str(portfolio.total_obligated_funds),
         current_obligated_funds=current_obligated_funds,
         expired_task_orders=Reports.expired_task_orders(portfolio),
         retrieved=pendulum.now(),  # mocked datetime of reporting data retrival

--- a/translations.yaml
+++ b/translations.yaml
@@ -516,7 +516,7 @@ portfolios:
     estimate_warning: Reports displayed in JEDI are estimates and not a system of record. To manage your costs, go to Azure by selecting the Login to Azure button above.
     total_value:
       header: Total Portfolio Value
-      tooltip: Total portfolio value is all obligated funds for current and upcoming task orders in this portfolio.
+      tooltip: Total portfolio value is all obligated funds for active task orders in this portfolio.
 task_orders:
   add_new_button: Add New Task Order
   review:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171243757

On the reports page, "total portfolio value" should represent the sum of obligated funds for active task orders.