### PR TITLE
Claimed_until audit

### DIFF
--- a/atst/domain/applications.py
+++ b/atst/domain/applications.py
@@ -1,5 +1,5 @@
 from flask import g
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, and_
 from typing import List
 from uuid import UUID
 
@@ -132,13 +132,15 @@ class Applications(BaseDomainClass):
             db.session.query(Application.id)
             .join(Portfolio)
             .join(PortfolioStateMachine)
-            .filter(PortfolioStateMachine.state == FSMStates.COMPLETED)
-            .filter(Application.deleted == False)
-            .filter(Application.cloud_id.is_(None))
             .filter(
-                or_(
-                    Application.claimed_until.is_(None),
-                    Application.claimed_until <= func.now(),
+                and_(
+                    PortfolioStateMachine.state == FSMStates.COMPLETED,
+                    Application.deleted == False,
+                    Application.cloud_id.is_(None),
+                    or_(
+                        Application.claimed_until.is_(None),
+                        Application.claimed_until <= func.now(),
+                    ),
                 )
             )
         ).all()

--- a/atst/domain/environments.py
+++ b/atst/domain/environments.py
@@ -1,4 +1,4 @@
-from sqlalchemy import func, or_
+from sqlalchemy import func, or_, and_
 from sqlalchemy.orm.exc import NoResultFound
 from typing import List
 from uuid import UUID
@@ -125,8 +125,16 @@ class Environments(object):
         """
         results = (
             cls.base_provision_query(now)
-            .filter(Application.cloud_id != None)
-            .filter(Environment.cloud_id.is_(None))
+            .filter(
+                and_(
+                    Application.cloud_id != None,
+                    Environment.cloud_id.is_(None),
+                    or_(
+                        Environment.claimed_until.is_(None),
+                        Environment.claimed_until <= func.now(),
+                    ),
+                )
+            )
             .all()
         )
         return [id_ for id_, in results]

--- a/atst/jobs.py
+++ b/atst/jobs.py
@@ -307,14 +307,6 @@ def dispatch_create_environment(self):
 
 
 @celery.task(bind=True)
-def dispatch_create_atat_admin_user(self):
-    for environment_id in Environments.get_environments_pending_atat_user_creation(
-        pendulum.now()
-    ):
-        create_atat_admin_user.delay(environment_id=environment_id)
-
-
-@celery.task(bind=True)
 def send_task_order_files(self):
     task_orders = TaskOrders.get_for_send_task_order_files()
     recipients = [app.config.get("MICROSOFT_TASK_ORDER_EMAIL_ADDRESS")]


### PR DESCRIPTION
## Description
Did an audit of our use of `claimed_until` in queries related to provisioning and use of `claim_for_update` in the `do_` functions for celery tasks. 
The celery helper functions were all using `claim_for_update` or `claim_many_for_update`, so no changes there! 
Several of the queries to get resources for provisioning were not filtering out instances that were claimed, so those were updated to appropriately filter and were refactored to use sqlachemy `and_` and `or`.

I also deleted the task `dispatch_create_atat_admin_user` because it was not used anywhere and the query that was called in that task does not exist, so I assumed it is leftover cruft!

## Pivotal
https://www.pivotaltracker.com/story/show/171385168