### PR TITLE
Small updates to CI/CD and database config for new sites.

### DIFF
--- a/deploy/overlays/cloudzero-pwdev-master/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-master/envvars.yml
@@ -7,6 +7,7 @@ data:
   CELERY_DEFAULT_QUEUE: celery-master
   FLASK_ENV: master
   SERVER_NAME: azure.atat.cloud.mil
+  PGDATABASE: cloudzero_pwdev_atat_master
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -17,3 +18,4 @@ data:
   CDN_ORIGIN: https://azure.atat.cloud.mil
   CELERY_DEFAULT_QUEUE: celery-master
   FLASK_ENV: master
+  PGDATABASE: cloudzero_pwdev_atat_master

--- a/deploy/shared/migration.yaml
+++ b/deploy/shared/migration.yaml
@@ -1,3 +1,4 @@
+# TODO: change this to use overlays
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -52,9 +53,11 @@ spec:
           flexVolume:
             driver: "azure/kv"
             options:
-              usepodidentity: "true"
-              keyvaultname: "atat-vault-test"
-              keyvaultobjectnames: "master-AZURE-STORAGE-KEY;master-MAIL-PASSWORD;master-PGPASSWORD;master-REDIS-PASSWORD;master-SECRET-KEY"
+              usepodidentity: "false"
+              usevmmanagedidentity: "true"
+              vmmanagedidentityclientid: $VMSS_CLIENT_ID
+              keyvaultname: "cz-pwdev-keyvault"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY"
               keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY"
               keyvaultobjecttypes: "secret;secret;secret;secret;key"
               tenantid: $TENANT_ID

--- a/script/cluster_migration
+++ b/script/cluster_migration
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+# TODO: update this to rely on overlays for flexvol configuration
+
 if [ -z "${K8S_CONTEXT+is_set}" ]; then
   K8S_CMD="kubectl"
 else


### PR DESCRIPTION
1. I added a second database for the master namespace so that both sites
   are not connecting to the same database. We should create scripts and
   processes to make it easier to maintian multiple sites on the same
   k8s cluster.
2. Update k8s migration job so that it uses the correct flexvol
   configuration. It turns out that the flexvol config for that
   migration job is hard-coded to whatever the secret names are in that
   specific Key Vault. This is fine for the moment but should be updated
   in the future to use kustomize overlays.