### PR TITLE
Fix perms display on portfolio members table

### DIFF
--- a/templates/portfolios/fragments/portfolio_members.html
+++ b/templates/portfolios/fragments/portfolio_members.html
@@ -124,11 +124,9 @@
               </td>
               <td class="toggle-menu__container">
                 {% for perm, value in member.permission_sets.items() -%}
-                  {% if value -%}
-                    <div>
-                      {{ ("portfolios.admin.members.{}.{}".format(perm, value)) | translate }}
-                    </div>
-                  {%- endif %}
+                  <div>
+                    {{ ("portfolios.admin.members.{}.{}".format(perm, value)) | translate }}
+                  </div>
                 {%-endfor %}
                 {% if user_can(permissions.EDIT_PORTFOLIO_USERS) -%}
                   {% call ToggleMenu() %}


### PR DESCRIPTION
## Description
Update the portfolio members table so that the perms for user with view permissions are listed. 

## Pivotal
https://www.pivotaltracker.com/story/show/171519232

## Screenhots
<img width="966" alt="Screen Shot 2020-03-09 at 10 12 41 AM" src="https://user-images.githubusercontent.com/43828539/76221895-293b0300-61f0-11ea-9931-c22514c7505a.png">
