### PR TITLE
Point to local static directory for assets.

### DIFF
--- a/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
@@ -31,3 +31,4 @@ data:
   PGSSLMODE: require
   REDIS_HOST: 10.1.3.171:6380
   SESSION_COOKIE_DOMAIN: atat.code.mil
+  STATIC_URL: "/static/"


### PR DESCRIPTION
Since we cannot use the CDN in production, we should make sure the site
is configured to serve static assets from its local static directory for
now. This sets the config for the staging and master sites.

You can verify this is working by visiting staging.atat.code.mil and azure.atat.code.mil and checking the origins in the Network tab of your browser tools when you do a hard refresh of the page. You should only see the site itself as the origin, even for static assets like images.