### PR TITLE
Make config adjustments to fix TO uploads on the new sites.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,8 +66,8 @@ commands:
       - run:
           name: Build image
           command: |
-            docker build . --build-arg CSP=azure --build-arg CDN_URL=<< parameters.cdn_url >> -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg CSP=azure --build-arg CDN_URL=<< parameters.cdn_url >> -f ./Dockerfile -t atat:latest
+            docker build . --build-arg AZURE_ACCOUNT_NAME=$AZURE_ACCOUNT_NAME --build-arg CSP=azure --build-arg CDN_URL=<< parameters.cdn_url >> -f ./Dockerfile -t atat:builder --target builder
+            docker build . --build-arg AZURE_ACCOUNT_NAME=$AZURE_ACCOUNT_NAME --build-arg CSP=azure --build-arg CDN_URL=<< parameters.cdn_url >> -f ./Dockerfile -t atat:latest
       - cache_docker_image
 
   deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.3-alpine3.9 AS builder
 
 ARG CSP
 ARG CDN_URL=/static/assets/
+ARG AZURE_ACCOUNT_NAME=atat
 ENV TZ UTC
 
 RUN mkdir -p /install/.venv

--- a/deploy/overlays/cloudzero-pwdev-master/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-master/envvars.yml
@@ -19,3 +19,4 @@ data:
   CELERY_DEFAULT_QUEUE: celery-master
   FLASK_ENV: master
   PGDATABASE: cloudzero_pwdev_atat_master
+  STATIC_URL: "https://azure.atat.code.mil/static/"

--- a/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
@@ -21,6 +21,7 @@ metadata:
 data:
   ASSETS_URL: ""
   AZURE_ACCOUNT_NAME: pwdevtasks
+  BLOB_STORAGE_URL: https://pwdevtasks.blob.core.windows.net/
   CAC_URL: https://auth-staging.atat.cloud.mil
   CDN_ORIGIN: https://staging.atat.cloud.mil
   CELERY_DEFAULT_QUEUE: celery-staging
@@ -31,4 +32,4 @@ data:
   PGSSLMODE: require
   REDIS_HOST: 10.1.3.171:6380
   SESSION_COOKIE_DOMAIN: atat.code.mil
-  STATIC_URL: "/static/"
+  STATIC_URL: "https://staging.atat.code.mil/static/"

--- a/script/write_dotenv
+++ b/script/write_dotenv
@@ -1,7 +1,11 @@
 #!/bin/sh
 
-if [ -z "${CSP+is_set}" ]; then
+if [ -z "${CSP:+is_set}" ]; then
   CSP=mock
+fi
+
+if [ -z "${AZURE_ACCOUNT_NAME:+is_set}" ]; then
+  AZURE_ACCOUNT_NAME=atat
 fi
 
 if [ $CSP = "aws" ]; then
@@ -9,7 +13,7 @@ if [ $CSP = "aws" ]; then
 elif [ $CSP = "azure" ]; then
   cat << EOF > .env
 CLOUD_PROVIDER=azure
-AZURE_ACCOUNT_NAME=atat
+AZURE_ACCOUNT_NAME=${AZURE_ACCOUNT_NAME}
 AZURE_CONTAINER_NAME=task-order-pdfs
 EOF
 else


### PR DESCRIPTION
- Make AZURE_ACCOUNT_NAME configurable in the write_dotenv script that
  generates an environment variables file for the JS build process.
- Add an additional build arg to the docker build to specify the Azure
  storage account name for the client JS bundle. Pass the value in
  CircleCI.
- Specify the STATIC_URL as an FQDN for the staging and master sites so
  that it's valid in the Content-Security-Policy header.
- Update BLOB_STORAGE_URL setting for staging and master sites.

The client side bundle feels very tightly coupled to the backend
configuration in a way that makes it painful to keep everything updated.
We should look to change the JS uploader so that it can receive all the
config it needs from the backend REST endpoint.