### PR TITLE
Add Redis hostname back for pwdev k8s environment.

### DIFF
--- a/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
@@ -11,7 +11,7 @@ data:
   PGHOST: 191.238.6.43
   PGUSER: atat@cloudzero-pwdev-sql
   PGSSLMODE: require
-  REDIS_HOST: 10.1.3.171:6380
+  REDIS_HOST: cloudzero-pwdev-redis.redis.cache.windows.net:6380
   SERVER_NAME: staging.atat.cloud.mil
 ---
 apiVersion: v1
@@ -30,6 +30,6 @@ data:
   PGHOST: 191.238.6.43
   PGUSER: atat@cloudzero-pwdev-sql
   PGSSLMODE: require
-  REDIS_HOST: 10.1.3.171:6380
+  REDIS_HOST: cloudzero-pwdev-redis.redis.cache.windows.net:6380
   SESSION_COOKIE_DOMAIN: atat.code.mil
   STATIC_URL: "https://staging.atat.code.mil/static/"


### PR DESCRIPTION
The DNS resolution issue for the Kubernetes cluster appears to be
resolved, and so we can add the Redis hostname back to the config. I'm
only committing this single hostname change at the moment because I did
it while debugging Redis downtime.

The DNS issue was resolved by associating a route table that AKS
provisions for itself (that resolves the cluster's IP space to node IPs)
to the subnet the AKS cluster resides in. We'll follow up on managing
this in the Terraform configuration separately.

In the future we should:
- Restore the Postgres hostname
- Configure Redis and Postgres TLS connections to do full verification
  against their respective hostnames

PT: https://www.pivotaltracker.com/story/show/171469501