### PR TITLE
Add additional config for Hybrid interface to master.

### DIFF
--- a/deploy/overlays/cloudzero-pwdev-master/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-master/envvars.yml
@@ -4,19 +4,29 @@ kind: ConfigMap
 metadata:
   name: atst-worker-envvars
 data:
+  AZURE_ADMIN_ROLE_ASSIGNMENT_ID: foo
+  AZURE_BILLING_ACCOUNT_NAME: foo
+  AZURE_TENANT_ADMIN_USERNAME: HybridCSPIntegrationTestUser@dancorriganpromptworks.onmicrosoft.com
+  AZURE_VAULT_URL: "https://hybridcz-pwdev-keyvault.vault.azure.net/"
   CELERY_DEFAULT_QUEUE: celery-master
+  CSP: hybrid
   FLASK_ENV: master
-  SERVER_NAME: azure.atat.cloud.mil
   PGDATABASE: cloudzero_pwdev_atat_master
+  SERVER_NAME: azure.atat.cloud.mil
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: atst-envvars
 data:
+  AZURE_ADMIN_ROLE_ASSIGNMENT_ID: foo
+  AZURE_BILLING_ACCOUNT_NAME: foo
+  AZURE_TENANT_ADMIN_USERNAME: HybridCSPIntegrationTestUser@dancorriganpromptworks.onmicrosoft.com
+  AZURE_VAULT_URL: "https://hybridcz-pwdev-keyvault.vault.azure.net/"
   CAC_URL: https://auth-azure.atat.cloud.mil
   CDN_ORIGIN: https://azure.atat.cloud.mil
   CELERY_DEFAULT_QUEUE: celery-master
+  CSP: hybrid
   FLASK_ENV: master
   PGDATABASE: cloudzero_pwdev_atat_master
   STATIC_URL: "https://azure.atat.code.mil/static/"

--- a/deploy/overlays/cloudzero-pwdev-master/flex_vol.yml
+++ b/deploy/overlays/cloudzero-pwdev-master/flex_vol.yml
@@ -10,3 +10,56 @@ spec:
           flexVolume:
             options:
               keyvaultobjectnames: "dhparam4096;mastercert;mastercert"
+        - name: flask-secret
+          flexVolume:
+            options:
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-POWERSHELL-CLIENT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_POWERSHELL_CLIENT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: atst-worker
+spec:
+  template:
+    spec:
+      volumes:
+        - name: flask-secret
+          flexVolume:
+            options:
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-POWERSHELL-CLIENT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_POWERSHELL_CLIENT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: atst-beat
+spec:
+  template:
+    spec:
+      volumes:
+        - name: flask-secret
+          flexVolume:
+            options:
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-POWERSHELL-CLIENT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_POWERSHELL_CLIENT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: crls
+spec:
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          volumes:
+            - name: flask-secret
+              flexVolume:
+                options:
+                  keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-POWERSHELL-CLIENT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY"
+                  keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_POWERSHELL_CLIENT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY"
+                  keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"


### PR DESCRIPTION
The Hybrid interface requires additional configuration to run. This is
set in the form of ConfigMap values and FlexVol secrets. There are some
pieces of data--notably IDs--which isn't secret per se but is best not
committed to an open source repo, so I decided to make those FlexVol
secrets as well.