### PR TITLE
Bandaid docker network fails on build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,6 +284,7 @@ workflows:
           filters:
             branches:
               only:
+                - fix-docker_network_fails_on_build
                 - staging
                 - master
       - deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ commands:
         type: string
         default: -e PGHOST=postgres -e REDIS_HOST=redis:6379
     steps:
-      - run: 
+      - run:
           nane: Remove left over temporary docker network
           command: docker network rm atat
       - run:
@@ -284,6 +284,7 @@ workflows:
           filters:
             branches:
               only:
+                - fix-docker_network_fails_on_build
                 - staging
                 - master
       - deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,6 +32,10 @@ commands:
         type: string
         default: -e PGHOST=postgres -e REDIS_HOST=redis:6379
     steps:
+      - run: 
+          nane: Remove left over temporary docker network
+	  command: docker network rm atat
+	
       - run:
           name: Set up temporary docker network
           command: docker network create atat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,7 +284,6 @@ workflows:
           filters:
             branches:
               only:
-                - fix-docker_network_fails_on_build
                 - staging
                 - master
       - deploy-staging:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,8 +34,7 @@ commands:
     steps:
       - run: 
           nane: Remove left over temporary docker network
-	  command: docker network rm atat
-	
+          command: docker network rm atat
       - run:
           name: Set up temporary docker network
           command: docker network create atat


### PR DESCRIPTION
for the sake of unblocking dev, runs docker network rm (defensively) to test isolation of parallel tests phases and hopefully for the short term remove errors in the build.