### PR TITLE
Hybrid CSP should use real file storage.

### DIFF
--- a/atat/domain/csp/__init__.py
+++ b/atat/domain/csp/__init__.py
@@ -34,7 +34,7 @@ class HybridCSP:
             with_authorization=simulate_failures,
         )
         self.cloud = HybridCloudProvider(azure, mock)
-        self.files = MockFileService(app)
+        self.files = AzureFileService(app.config)
         self.reports = MockReportingProvider()
 
 


### PR DESCRIPTION
Since the Hybrid CSP interface is meant to be deployed to dev and
staging environments, it should use real file storage for task orders.
This way, users can upload and download TOs.