### PR TITLE
User creation hybrid mock

### DIFF
--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -234,3 +234,19 @@ class HybridCloudProvider(object):
     ) -> EnvironmentCSPResult:
         payload.management_group_name = f"hybrid-{payload.management_group_name}"
         return self.azure.create_environment(payload)
+
+    def create_user(self, payload: UserCSPPayload) -> UserCSPResult:
+        """Create a user in an Azure Active Directory instance.
+        Unlike most of the methods on this interface, this requires
+        two API calls: one POST to create the user and one PATCH to
+        set the alternate email address. The email address cannot
+        be set on the first API call. The email address is
+        necessary so that users can do Self-Service Password
+        Recovery.
+        Arguments:
+            payload {UserCSPPayload} -- a payload object with the
+            data necessary for both calls
+        Returns:
+            UserCSPResult -- a result object containing the AAD ID.
+        """
+        return self.azure.create_user(payload)

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -1,15 +1,19 @@
 import pendulum
 import pytest
+from unittest.mock import Mock
+from uuid import uuid4
 
 from atat.domain.csp import HybridCSP
 from atat.domain.csp.cloud.models import (
     EnvironmentCSPPayload,
     KeyVaultCredentials,
 )
-from atat.jobs import do_create_application
+from atat.jobs import do_create_application, do_create_user
 from atat.models import FSMStates, PortfolioStateMachine
 from tests.factories import (
     ApplicationFactory,
+    ApplicationRoleFactory,
+    ApplicationRoleStatus,
     CLINFactory,
     EnvironmentFactory,
     PortfolioFactory,
@@ -17,7 +21,6 @@ from tests.factories import (
     TaskOrderFactory,
     UserFactory,
 )
-from uuid import uuid4
 
 
 @pytest.fixture(scope="function")
@@ -128,3 +131,95 @@ def test_hybrid_create_environment_job(session, csp):
     result = csp.create_environment(payload)
 
     assert result.id
+
+
+class TestHybridCreateUserJob:
+    @pytest.fixture
+    def portfolio(self, app, csp):
+        return PortfolioFactory.create(
+            csp_data={
+                "tenant_id": csp.azure.tenant_id,
+                "domain_name": f"dancorriganpromptworks",
+            }
+        )
+
+    @pytest.fixture
+    def app_1(self, portfolio):
+        return ApplicationFactory.create(portfolio=portfolio, cloud_id="321")
+
+    @pytest.fixture
+    def app_2(self, portfolio):
+        return ApplicationFactory.create(portfolio=portfolio, cloud_id="123")
+
+    @pytest.fixture
+    def user(self):
+        return UserFactory.create(
+            first_name=f"test-user-{uuid4()}", last_name="Solo", email="han@example.com"
+        )
+
+    @pytest.fixture
+    def app_role_1(self, app_1, user):
+        return ApplicationRoleFactory.create(
+            application=app_1,
+            user=user,
+            status=ApplicationRoleStatus.ACTIVE,
+            cloud_id=None,
+        )
+
+    @pytest.fixture
+    def app_role_2(self, app_2, user):
+        return ApplicationRoleFactory.create(
+            application=app_2,
+            user=user,
+            status=ApplicationRoleStatus.ACTIVE,
+            cloud_id=None,
+        )
+
+    @pytest.fixture
+    def csp(self, app):
+        return HybridCSP(app).cloud
+
+    def test_hybrid_create_user_job(self, session, csp, app_role_1, portfolio):
+        csp.azure.create_tenant_creds(
+            csp.azure.tenant_id,
+            KeyVaultCredentials(
+                root_tenant_id=csp.azure.tenant_id,
+                root_sp_client_id=csp.azure.client_id,
+                root_sp_key=csp.azure.secret_key,
+                tenant_id=csp.azure.tenant_id,
+                tenant_sp_key=csp.azure.secret_key,
+                tenant_sp_client_id=csp.azure.client_id,
+            ),
+        )
+
+        assert not app_role_1.cloud_id
+
+        session.begin_nested()
+        do_create_user(csp, [app_role_1.id])
+        session.rollback()
+
+        assert app_role_1.cloud_id
+
+    def test_hybrid_create_user_sends_email(
+        self, monkeypatch, csp, app_role_1, app_role_2
+    ):
+        mock = Mock()
+        monkeypatch.setattr("atat.jobs.send_mail", mock)
+
+        do_create_user(csp, [app_role_1.id, app_role_2.id])
+        assert mock.call_count == 1
+
+    def test_hybrid_user_has_tenant(self, session, csp, app_role_1, app_1, user):
+        cloud_id = "123456"
+        ApplicationRoleFactory.create(
+            user=user,
+            status=ApplicationRoleStatus.ACTIVE,
+            cloud_id=cloud_id,
+            application=ApplicationFactory.create(portfolio=app_1.portfolio),
+        )
+
+        session.begin_nested()
+        do_create_user(csp, [app_role_1.id])
+        session.rollback()
+
+        assert app_role_1.cloud_id == cloud_id

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -133,6 +133,7 @@ def test_hybrid_create_environment_job(session, csp):
     assert result.id
 
 
+@pytest.mark.hybrid
 class TestHybridCreateUserJob:
     @pytest.fixture
     def portfolio(self, app, csp):


### PR DESCRIPTION
[Jira issue](https://ccpo.atlassian.net/browse/AT-4883?atlOrigin=eyJpIjoiMjVkNzI4MWYxYjI1NDQwY2I0MjNjZGEyYWU3ZDNhYTgiLCJwIjoiaiJ9)

Adds `create_user` to hybrid cloud which utilizes `azure.create_user`. Also included `TestHybridCreateUserJob` test suite. The 3 tests create users in AD which should eventually be cleaned up if a clean up/tear down script is ever produced. The users have the first name `f"test-user-{uuid4()}",` and last name of "Solo"