### PR TITLE
[AT-5184] Retry failed portfolio provisioning jobs (part 1)

### DIFF
--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -33,20 +33,34 @@ class AzureStages(Enum):
     POLICIES = "policies"
 
 
-def _build_csp_states(csp_stages):
-    states = {
+def _build_csp_states(csp_stages: Enum) -> dict:
+    """Builds a complete dictionary of portfolio provisioning states for a CSP
+    
+    Includes system states, plus each CSP stage combined with each Stage State. 
+    E.g. Given two CSP Stages, `TENANT` & `BILLING_PROFILE`, and three possible 
+    stage states, `CREATED`, `IN_PROGRESS`, & FAILED, this function generates a 
+    dictionary of system states + states that correspond with:
+    - TENANT_CREATED
+    - TENANT_IN_PROGRESS
+    - TENANT_FAILED
+    - BILLING_PROFILE_CREATION_CREATED
+    - BILLING_PROFILE_CREATION_IN_PROGRESS
+    - BILLING_PROFILE_CREATION_FAILED
+    """
+
+    system_states = {
         "UNSTARTED": "unstarted",
         "STARTING": "starting",
         "STARTED": "started",
         "COMPLETED": "completed",
         "FAILED": "failed",
     }
-    for csp_stage in csp_stages:
-        for state in StageStates:
-            states[csp_stage.name + "_" + state.name] = (
-                csp_stage.value + " " + state.value
-            )
-    return states
+    csp_states = {
+        f"{csp_stage.name}_{stage_state.name}": f"{csp_stage.value} {stage_state.value}"
+        for csp_stage in csp_stages
+        for stage_state in StageStates
+    }
+    return {**system_states, **csp_states}
 
 
 FSMStates = Enum("FSMStates", _build_csp_states(AzureStages))

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -239,12 +239,18 @@ class PortfolioStateMachine(
             # TODO: Ensure that failing the stage does not preclude a Celery retry
             self.fail_stage(self.current_stage)
 
-    def _stage_state_to_stage_name(self, stage_state):
-        return self.current_state.name.split(f"_{stage_state.name}")[0].lower()
-
     @property
-    def current_stage(self):
-        return self._stage_state_to_stage_name(StageStates.IN_PROGRESS)
+    def current_stage(self) -> str:
+        """Returns the current stage of the CSP provisioning process       
+        
+        E.g. TENANT_IN_PROGRESS -> tenant
+        """
+        for stage_state in StageStates:
+            if self.current_state.name.endswith(stage_state.name):
+                stage, stage_state = self.current_state.name.split(
+                    f"_{stage_state.name}"
+                )
+                return stage.lower()
 
     def after_in_progress_callback(self, event):
         payload = event.kwargs.get("csp_data")

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -193,21 +193,23 @@ class PortfolioStateMachine(
             if create_trigger is not None:
                 self.trigger(create_trigger, **kwargs)
 
-    def after_in_progress_callback(self, event):
-        # Accumulate payload w/ creds
-        payload = event.kwargs.get("csp_data")
-        current_stage = _stage_state_to_stage_name(
-            self.current_state, StageStates.IN_PROGRESS
-        )
+    def _get_payload_data_class(self, current_stage):
+        """Retrieves the appropriate payload class for the current provisioning step.
+        """
+
         payload_data_cls = get_stage_csp_class(current_stage, "payload")
 
-        if not payload_data_cls:
+        if payload_data_cls is None:
             app.logger.info(
                 f"could not resolve payload data class for stage {current_stage}"
             )
             self.fail_stage(current_stage)
+
+        return payload_data_cls
+
+    def _get_payload_data(self, payload_data_class, payload, current_stage):
         try:
-            payload_data = payload_data_cls(**payload)
+            return payload_data_class(**payload)
         except PydanticValidationError as exc:
             app.logger.error(
                 f"Payload Validation Error in {self.__repr__()}:", exc_info=1
@@ -217,14 +219,11 @@ class PortfolioStateMachine(
             app.logger.info(payload)
             self.fail_stage(current_stage)
 
+    def _provision_stage(self, payload_data, current_stage):
         try:
             func_name = f"create_{current_stage}"
             response = getattr(self.cloud, func_name)(payload_data)
-            if self.portfolio.csp_data is None:
-                self.portfolio.csp_data = {}
-            self.portfolio.csp_data.update(response.dict())
-            db.session.add(self.portfolio)
-            db.session.commit()
+            return response
         except PydanticValidationError as exc:
             app.logger.error(
                 f"Failed to cast response to valid result class {self.__repr__()}:",
@@ -235,6 +234,7 @@ class PortfolioStateMachine(
             app.logger.info(payload_data)
             # TODO: Ensure that failing the stage does not preclude a Celery retry
             self.fail_stage(current_stage)
+
         # TODO: catch and handle general CSP exception here
         except (ConnectionException, UnknownServerException) as exc:
             app.logger.error(
@@ -242,6 +242,22 @@ class PortfolioStateMachine(
             )
             # TODO: Ensure that failing the stage does not preclude a Celery retry
             self.fail_stage(current_stage)
+
+    def after_in_progress_callback(self, event):
+        current_stage = _stage_state_to_stage_name(
+            self.current_state, StageStates.IN_PROGRESS
+        )
+        payload = event.kwargs.get("csp_data")
+        payload_data_class = self._get_payload_data_class(current_stage)
+        payload_data = self._get_payload_data(
+            payload_data_class, payload, current_stage
+        )
+        response = self._provision_stage(payload_data, current_stage)
+        if self.portfolio.csp_data is None:
+            self.portfolio.csp_data = {}
+        self.portfolio.csp_data.update(response.dict())
+        db.session.add(self.portfolio)
+        db.session.commit()
 
         self.finish_stage(current_stage)
 

--- a/tests/models/mixins/test_state_machines.py
+++ b/tests/models/mixins/test_state_machines.py
@@ -14,6 +14,7 @@ from atat.models.mixins.state_machines import (
 
 class AzureStagesTest(Enum):
     TENANT = "tenant"
+    POLICIES = "policies"
 
 
 @pytest.mark.state_machine
@@ -23,19 +24,35 @@ def test_build_transitions():
         "TENANT_CREATED",
         "TENANT_IN_PROGRESS",
         "TENANT_FAILED",
+        "POLICIES_CREATED",
+        "POLICIES_IN_PROGRESS",
+        "POLICIES_FAILED",
     ]
     assert [s.get("tags") for s in states] == [
         ["TENANT", "CREATED"],
         ["TENANT", "IN_PROGRESS"],
         ["TENANT", "FAILED"],
+        ["POLICIES", "CREATED"],
+        ["POLICIES", "IN_PROGRESS"],
+        ["POLICIES", "FAILED"],
     ]
     assert [t.get("trigger") for t in transitions] == [
-        "complete",
         "create_tenant",
         "finish_tenant",
         "fail_tenant",
         "resume_progress_tenant",
+        "create_policies",
+        "finish_policies",
+        "fail_policies",
+        "resume_progress_policies",
+        "complete",
     ]
+
+    created_to_in_progress_trigger = next(
+        (t for t in transitions if t.get("trigger") == "create_policies")
+    )
+    assert created_to_in_progress_trigger["source"] == FSMStates.TENANT_CREATED
+    assert created_to_in_progress_trigger["dest"] == FSMStates.POLICIES_IN_PROGRESS
 
 
 @pytest.mark.state_machine
@@ -50,6 +67,9 @@ def test_build_csp_states():
         "TENANT_CREATED",
         "TENANT_IN_PROGRESS",
         "TENANT_FAILED",
+        "POLICIES_CREATED",
+        "POLICIES_IN_PROGRESS",
+        "POLICIES_FAILED",
     ]
 
 

--- a/tests/models/mixins/test_state_machines.py
+++ b/tests/models/mixins/test_state_machines.py
@@ -1,0 +1,61 @@
+from enum import Enum
+
+import pytest
+
+from atat.models.portfolio_state_machine import FSMStates
+from atat.models.mixins.state_machines import (
+    AzureStages,
+    StageStates,
+    _build_csp_states,
+    _build_transitions,
+    compose_state,
+)
+
+
+class AzureStagesTest(Enum):
+    TENANT = "tenant"
+
+
+@pytest.mark.state_machine
+def test_build_transitions():
+    states, transitions = _build_transitions(AzureStagesTest)
+    assert [s.get("name").name for s in states] == [
+        "TENANT_CREATED",
+        "TENANT_IN_PROGRESS",
+        "TENANT_FAILED",
+    ]
+    assert [s.get("tags") for s in states] == [
+        ["TENANT", "CREATED"],
+        ["TENANT", "IN_PROGRESS"],
+        ["TENANT", "FAILED"],
+    ]
+    assert [t.get("trigger") for t in transitions] == [
+        "complete",
+        "create_tenant",
+        "finish_tenant",
+        "fail_tenant",
+        "resume_progress_tenant",
+    ]
+
+
+@pytest.mark.state_machine
+def test_build_csp_states():
+    states = _build_csp_states(AzureStagesTest)
+    assert list(states) == [
+        "UNSTARTED",
+        "STARTING",
+        "STARTED",
+        "COMPLETED",
+        "FAILED",
+        "TENANT_CREATED",
+        "TENANT_IN_PROGRESS",
+        "TENANT_FAILED",
+    ]
+
+
+@pytest.mark.state_machine
+def test_compose_state():
+    assert (
+        compose_state(AzureStages.TENANT, StageStates.CREATED)
+        == FSMStates.TENANT_CREATED
+    )

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from unittest.mock import Mock
 
 import pendulum
@@ -13,26 +12,16 @@ from tests.factories import (
     UserFactory,
 )
 
-from atat.models import FSMStates, PortfolioStateMachine
-from atat.models.mixins.state_machines import (
-    AzureStages,
-    StageStates,
-    _build_csp_states,
-    _build_transitions,
-    compose_state,
-)
+from atat.models.mixins.state_machines import AzureStages, StageStates, FSMStates
 from atat.models.portfolio_state_machine import (
     StateMachineMisconfiguredError,
     _stage_state_to_stage_name,
     _stage_to_classname,
     get_stage_csp_class,
+    PortfolioStateMachine,
 )
 
 # TODO: Write failure case tests
-
-
-class AzureStagesTest(Enum):
-    TENANT = "tenant"
 
 
 @pytest.fixture
@@ -82,14 +71,6 @@ def test_state_machine_trigger_next_transition(state_machine):
 
 
 @pytest.mark.state_machine
-def test_state_machine_compose_state():
-    assert (
-        compose_state(AzureStages.TENANT, StageStates.CREATED)
-        == FSMStates.TENANT_CREATED
-    )
-
-
-@pytest.mark.state_machine
 def test_stage_to_classname():
     assert (
         _stage_to_classname(AzureStages.BILLING_PROFILE_CREATION.name)
@@ -110,43 +91,6 @@ def test_get_stage_csp_class_import_fail():
 
 
 @pytest.mark.state_machine
-def test_build_transitions():
-    states, transitions = _build_transitions(AzureStagesTest)
-    assert [s.get("name").name for s in states] == [
-        "TENANT_CREATED",
-        "TENANT_IN_PROGRESS",
-        "TENANT_FAILED",
-    ]
-    assert [s.get("tags") for s in states] == [
-        ["TENANT", "CREATED"],
-        ["TENANT", "IN_PROGRESS"],
-        ["TENANT", "FAILED"],
-    ]
-    assert [t.get("trigger") for t in transitions] == [
-        "complete",
-        "create_tenant",
-        "finish_tenant",
-        "fail_tenant",
-        "resume_progress_tenant",
-    ]
-
-
-@pytest.mark.state_machine
-def test_build_csp_states():
-    states = _build_csp_states(AzureStagesTest)
-    assert list(states) == [
-        "UNSTARTED",
-        "STARTING",
-        "STARTED",
-        "COMPLETED",
-        "FAILED",
-        "TENANT_CREATED",
-        "TENANT_IN_PROGRESS",
-        "TENANT_FAILED",
-    ]
-
-
-@pytest.mark.state_machine
 def test_state_machine_valid_data_classes_for_stages():
     for stage in AzureStages:
         assert get_stage_csp_class(stage.name.lower(), "payload") is not None
@@ -155,19 +99,18 @@ def test_state_machine_valid_data_classes_for_stages():
 
 @pytest.mark.state_machine
 def test_attach_machine(state_machine):
-    state_machine.machine = None
-    state_machine.attach_machine(stages=AzureStagesTest)
-    assert list(state_machine.machine.events) == [
+    initial_stages = [
         "init",
         "start",
         "reset",
         "fail",
-        "complete",
         "create_tenant",
         "finish_tenant",
         "fail_tenant",
         "resume_progress_tenant",
     ]
+    state_machine.attach_machine()
+    assert list(state_machine.machine.events)[: len(initial_stages)] == initial_stages
 
 
 @pytest.mark.state_machine

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -15,7 +15,6 @@ from tests.factories import (
 from atat.models.mixins.state_machines import AzureStages, StageStates, FSMStates
 from atat.models.portfolio_state_machine import (
     StateMachineMisconfiguredError,
-    _stage_state_to_stage_name,
     _stage_to_classname,
     get_stage_csp_class,
     PortfolioStateMachine,
@@ -175,11 +174,9 @@ def test_finish_stage_invalid_stage(state_machine):
 
 
 @pytest.mark.state_machine
-def test_stage_state_to_stage_name():
-    stage = _stage_state_to_stage_name(
-        FSMStates.TENANT_IN_PROGRESS, StageStates.IN_PROGRESS
-    )
-    assert stage == "tenant"
+def test_stage_state_to_stage_name(state_machine):
+    state_machine.state = FSMStates.TENANT_IN_PROGRESS
+    assert state_machine.current_stage == "tenant"
 
 
 @pytest.mark.state_machine

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -174,8 +174,16 @@ def test_finish_stage_invalid_stage(state_machine):
 
 
 @pytest.mark.state_machine
-def test_stage_state_to_stage_name(state_machine):
-    state_machine.state = FSMStates.TENANT_IN_PROGRESS
+@pytest.mark.parametrize(
+    "state_machine_state",
+    [
+        (FSMStates.TENANT_IN_PROGRESS),
+        (FSMStates.TENANT_CREATED),
+        (FSMStates.TENANT_FAILED),
+    ],
+)
+def test_current_stage(state_machine_state, state_machine):
+    state_machine.state = state_machine_state
     assert state_machine.current_stage == "tenant"
 
 


### PR DESCRIPTION
This is part 1 (of probably 2) of [AT-5184](https://ccpo.atlassian.net/browse/AT-5184)

In this PR, I:
- Added / refactored tests to cover `provision_portfolio` and `do_provision_portfolio` in `atat/jobs.py`
- Split `PortfolioStateMachine.after_in_progress_callback` into separate methods
- Moved tests related to state machine mixins into their own module

The next PR will ensure that all of the cases where we call `PortfolioStateMachine.fail_stage` trigger the appropriate exception so that Celery knows to retry them.