### PR TITLE
The Hybrid CSP interface should not rotate the admin creds.

### DIFF
--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -172,8 +172,8 @@ class HybridCloudProvider(object):
     def create_tenant_admin_ownership(
         self, payload: TenantAdminOwnershipCSPPayload
     ) -> TenantAdminOwnershipCSPResult:
-        """For this step, we needed to be able to retrieve the elevated management 
-        token from KeyVault with the original tenant id, but make the role assignment 
+        """For this step, we needed to be able to retrieve the elevated management
+        token from KeyVault with the original tenant id, but make the role assignment
         request with the root credentials.
         """
 
@@ -193,8 +193,8 @@ class HybridCloudProvider(object):
         self, payload: TenantPrincipalOwnershipCSPPayload
     ) -> TenantPrincipalOwnershipCSPResult:
 
-        """For this step, we needed to be able to retrieve the elevated 
-        management token from KeyVault with the original tenant id, but make 
+        """For this step, we needed to be able to retrieve the elevated
+        management token from KeyVault with the original tenant id, but make
         the tenant principal ownership request with the root credentials.
         """
 
@@ -221,7 +221,7 @@ class HybridCloudProvider(object):
     def create_tenant_admin_credential_reset(
         self, payload: TenantAdminCredentialResetCSPPayload
     ) -> TenantAdminCredentialResetCSPResult:
-        return self.azure.create_tenant_admin_credential_reset(payload)
+        return self.mock.create_tenant_admin_credential_reset(payload)
 
     def create_policies(self, payload: PoliciesCSPPayload) -> PoliciesCSPResult:
         return self.azure.create_policies(payload)


### PR DESCRIPTION
[AT-5197](https://ccpo.atlassian.net/browse/AT-5197)

In a production CSP setup, each portfolio would have a separate
administrator account that ATAT would use for some initial
bootstrapping. When ATAT is done with portfolio setup, it needs to reset
the credentials for that admin account. In the Hybrid CSP setup, there
is only one administrator account for every portfolio. Because this is
the case, ATAT should not reset the admin creds when using the Hybrid.
When it does, it locks itself out of the account and prevents any
further provisioning.