### PR TITLE
User role assign unassign hybrid

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -460,7 +460,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
         try:
             result = self.sdk.requests.delete(
-                f"{self.sdk.cloud.endpoints.resource_manager}/{role_assignment_cloud_id}?api-version=2015-07-01",
+                f"{self.sdk.cloud.endpoints.resource_manager}{role_assignment_cloud_id}?api-version=2015-07-01",
                 headers=headers,
                 timeout=30,
             )

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -3,7 +3,7 @@ from atat.domain.csp.cloud.azure_cloud_provider import AzureCloudProvider
 from atat.domain.csp.cloud.exceptions import UnknownServerException
 from atat.domain.csp.cloud.mock_cloud_provider import MockCloudProvider
 from atat.domain.csp.cloud.models import *
-from typing import Union
+from typing import Dict, Union
 from uuid import uuid4
 
 
@@ -254,5 +254,5 @@ class HybridCloudProvider(object):
     def create_user_role(self, payload: UserRoleCSPPayload) -> UserRoleCSPResult:
         return self.azure.create_user_role(payload)
 
-    def disable_user(self, tenant_id: str, role_assignment_cloud_id: str) -> object:
+    def disable_user(self, tenant_id: str, role_assignment_cloud_id: str) -> Dict:
         return self.azure.disable_user(tenant_id, role_assignment_cloud_id)

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -250,3 +250,9 @@ class HybridCloudProvider(object):
             UserCSPResult -- a result object containing the AAD ID.
         """
         return self.azure.create_user(payload)
+
+    def create_user_role(self, payload: UserRoleCSPPayload) -> UserRoleCSPResult:
+        return self.azure.create_user_role(payload)
+
+    def disable_user(self, tenant_id: str, role_assignment_cloud_id: str) -> object:
+        return self.azure.disable_user(tenant_id, role_assignment_cloud_id)

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -178,12 +178,11 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
             role = UserRoleCSPPayload.Roles.contributor
 
         payload = UserRoleCSPPayload(
-            tenant_id=csp_details["tenant_id"],
+            tenant_id=csp_details.get("tenant_id"),
             management_group_id=env.cloud_id,
             user_object_id=app_role.cloud_id,
             role=role,
         )
-
         result = csp.create_user_role(payload)
 
         env_role.cloud_id = result.id

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -178,11 +178,12 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
             role = UserRoleCSPPayload.Roles.contributor
 
         payload = UserRoleCSPPayload(
-            tenant_id=csp_details.get("tenant_id"),
+            tenant_id=csp_details["tenant_id"],
             management_group_id=env.cloud_id,
             user_object_id=app_role.cloud_id,
             role=role,
         )
+
         result = csp.create_user_role(payload)
 
         env_role.cloud_id = result.id

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -1,4 +1,3 @@
-import json
 import pendulum
 import pytest
 from unittest.mock import Mock
@@ -9,7 +8,6 @@ from atat.domain.csp.cloud.exceptions import UserProvisioningException
 from atat.domain.csp.cloud.models import (
     EnvironmentCSPPayload,
     KeyVaultCredentials,
-    UserCSPPayload,
     UserRoleCSPPayload,
 )
 from atat.jobs import do_create_application, do_create_environment_role, do_create_user
@@ -26,8 +24,6 @@ from tests.factories import (
     TaskOrderFactory,
     UserFactory,
 )
-from requests import get, post
-from secrets import token_urlsafe
 from uuid import uuid4
 
 
@@ -250,7 +246,6 @@ class TestHybridUserManagement:
         do_create_user(csp, [app_role_1.id])
         session.rollback()
 
-        create_user_role_result = None
         payload = UserRoleCSPPayload(
             tenant_id=csp.azure.tenant_id,
             role="owner",

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 from uuid import uuid4
 
 from atat.domain.csp import HybridCSP
+from atat.domain.csp.cloud.exceptions import UserProvisioningException
 from atat.domain.csp.cloud.models import (
     EnvironmentCSPPayload,
     KeyVaultCredentials,
@@ -250,4 +251,8 @@ def test_hybrid_do_create_environment_role_job(session, csp, portfolio, app):
         ),
     )
 
-    do_create_environment_role(csp, environment_role.id)
+    try:
+        do_create_environment_role(csp, environment_role.id)
+    except UserProvisioningException as e:
+        if "RoleAssignmentExists" not in str(e):
+            raise e


### PR DESCRIPTION
Enables the hybrid interface to create user role assignments and disable them.

https://ccpo.atlassian.net/browse/AT-4886
https://ccpo.atlassian.net/browse/AT-4887
