### PR TITLE
Error when creating application

### DIFF
--- a/atat/domain/environments.py
+++ b/atat/domain/environments.py
@@ -29,8 +29,11 @@ class Environments(object):
     def create_many(cls, user, application, names):
         environments = []
         for name in names:
-            environment = Environments.create(user, application, name)
-            environments.append(environment)
+            if name not in [
+                existing_envs.name for existing_envs in application.environments
+            ]:
+                environment = Environments.create(user, application, name)
+                environments.append(environment)
 
         db.session.add_all(environments)
         return environments

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -155,6 +155,8 @@ def test_create_many_environments_will_skip_already_created_names():
         application.portfolio.owner, application, ["Staging", "Production"]
     )
     environments_second_run = Environments.create_many(
-        application.portfolio.owner, application, ["Staging", "Production"]
+        application.portfolio.owner,
+        application,
+        ["Staging", "Production", "Development"],
     )
-    assert len(environments_second_run) == 0
+    assert len(application.environments) == 3

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -147,3 +147,14 @@ class TestGetEnvironmentsPendingCreate(EnvQueryTest):
             app_data={"cloud_id": uuid4().hex},
         )
         assert len(Environments.get_environments_pending_creation(self.NOW)) == 0
+
+
+def test_create_many_environments_will_skip_already_created_names():
+    application = ApplicationFactory.create()
+    environments_first_run = Environments.create_many(
+        application.portfolio.owner, application, ["Staging", "Production"]
+    )
+    environments_second_run = Environments.create_many(
+        application.portfolio.owner, application, ["Staging", "Production"]
+    )
+    assert len(environments_second_run) == 0


### PR DESCRIPTION
[AT-4881](https://ccpo.atlassian.net/browse/AT-4881)

This solves a bug that was identified during the creation of application. To quote the Jira ticket:

> *Steps to reproduce*
> 1. start a new application
> 2. complete steps 1 (name and description) and 2 (add environments)
> 3. once on step 3 (add members) click the previous button
> 4. click the next button on step 2

Now instead of erroring after completing the above steps you successfully move back to step 3. 

The problem was that moving from step 2 to step 3 attempted to create the environments currently listed in the add-environments form, regardless of whether they already exist. I solved this problem by skipping any names from the add-environments forms if they already exist. I also add a test for this behavior.

One thing that this ticket highlighted to me was that it's really not communicated to the user is that moving from step 2 to step 3 immediately begins the process of creating the environments. Imagine the following situation:

1. While creating a new application a user accepts the default environments (Staging, Prod, Dev) and moves from step 2 to step 3
2. The user changes their mind, hits back on step 3 to return to the create environments page (step 2)
3. They edit "Staging" to instead be "Pre-Prod"
4. They click "Next" and move to step 3 (add members)

The user has now in fact created 4 environments (Staging, Prod, Dev, Pre-Prod) when in fact that may have thought they were creating 3. 

Not sure if they has already been considered, but I wanted to highlight it.