### PR TITLE
Standardize names for entities the HybridCloudProvider creates.

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -216,10 +216,10 @@ class AzureCloudProvider(CloudProviderInterface):
     def create_initial_mgmt_group(self, payload: InitialMgmtGroupCSPPayload):
         """Creates the root management group for the Portfolio tenant.
 
-        The management group created in this step is the parent to all future 
+        The management group created in this step is the parent to all future
         management groups created for applications and environments.
-        
-        A management group is a collection of subscriptions and management 
+
+        A management group is a collection of subscriptions and management
         groups to which "governance conditions" can be applied. These resources
         can be nested.
 
@@ -245,8 +245,8 @@ class AzureCloudProvider(CloudProviderInterface):
         self, payload: InitialMgmtGroupVerificationCSPPayload
     ):
         """Verify the creation of the root management group.
-        
-        A management group is a collection of subscriptions and management 
+
+        A management group is a collection of subscriptions and management
         groups to which "governance conditions" can be applied. These resources
         can be nested.
 
@@ -411,9 +411,9 @@ class AzureCloudProvider(CloudProviderInterface):
     def create_policies(self, payload: PoliciesCSPPayload):
         """
         Creates and applies the default JEDI Policy Set to a portfolio's root management group.
-        
+
         The underlying API calls seem to be idempotent, despite the fact that most of them repeatedly
-        return 201. The _create_policy_set API call is the one exception. It returns 201 on initial 
+        return 201. The _create_policy_set API call is the one exception. It returns 201 on initial
         creation, and then 200 thereafter
         """
 
@@ -568,7 +568,7 @@ class AzureCloudProvider(CloudProviderInterface):
     def create_billing_profile_creation(
         self, payload: BillingProfileCreationCSPPayload
     ):
-        """Create a billing profile which specifies which products are included 
+        """Create a billing profile which specifies which products are included
             in an invoice, and how the invoice is paid for.
 
             Billing profiles include:
@@ -633,7 +633,7 @@ class AzureCloudProvider(CloudProviderInterface):
     ):
         """Verify that a billing profile has been created.
 
-            A billing profile specifies which products are included in an invoice, 
+            A billing profile specifies which products are included in an invoice,
             and how the invoice is paid for. They include:
             - Payment methods
             - Contact info
@@ -1100,8 +1100,8 @@ class AzureCloudProvider(CloudProviderInterface):
     ):
         """Reset tenant admin password to random value.
 
-        The purpose of this call is to set the password for the tenant admin 
-        user to a value that is not stored anywhere. You're essentially making 
+        The purpose of this call is to set the password for the tenant admin
+        user to a value that is not stored anywhere. You're essentially making
         ATAT "forget" the human admin's login creds when it's done with them.
         """
 
@@ -1177,7 +1177,7 @@ class AzureCloudProvider(CloudProviderInterface):
     ):
         """Gives the service principal the owner role over the root management group.
 
-        The security principal object defines the access policy and permissions 
+        The security principal object defines the access policy and permissions
         for the user/application in the Azure AD tenant.
 
         https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
@@ -1239,11 +1239,11 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def create_tenant_principal_app(self, payload: TenantPrincipalAppCSPPayload):
         """Creates an app registration for a Profile.
-        
-        An Azure AD application is defined by its one and only application 
-        object, which resides in the Azure AD tenant where the application was 
+
+        An Azure AD application is defined by its one and only application
+        object, which resides in the Azure AD tenant where the application was
         registered, known as the application's "home" tenant.
-        
+
         https://docs.microsoft.com/en-us/azure/active-directory/develop/app-objects-and-service-principals
         https://docs.microsoft.com/en-us/graph/api/resources/application?view=graph-rest-1.0
         """
@@ -1295,7 +1295,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def create_tenant_principal(self, payload: TenantPrincipalCSPPayload):
         """Creates a service principal for a Profile.
-        A service principal represents an instance of an application in a 
+        A service principal represents an instance of an application in a
         directory.
 
         https://docs.microsoft.com/en-us/graph/api/resources/serviceprincipal?view=graph-rest-beta
@@ -1470,7 +1470,7 @@ class AzureCloudProvider(CloudProviderInterface):
             )
 
     def create_principal_admin_role(self, payload: PrincipalAdminRoleCSPPayload):
-        """Grant the "Global Admin" / "Company Admin" role to the service 
+        """Grant the "Global Admin" / "Company Admin" role to the service
         principal (create a role assignment).
         """
 
@@ -1524,7 +1524,7 @@ class AzureCloudProvider(CloudProviderInterface):
             )
 
     def create_billing_owner(self, payload: BillingOwnerCSPPayload):
-        """Create a billing account owner, which is a billing role that can 
+        """Create a billing account owner, which is a billing role that can
         manage everything for a billing account.
 
         https://docs.microsoft.com/en-us/azure/cost-management-billing/manage/understand-mca-roles

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -17,6 +17,9 @@ def monkeypatched(object_, name, patch):
     setattr(object_, name, pre_patched_value)
 
 
+HYBRID_PREFIX = "Hybrid ::"
+
+
 class HybridCloudProvider(object):
     def __init__(self, azure: AzureCloudProvider, mock: MockCloudProvider):
         self.azure = azure
@@ -117,7 +120,7 @@ class HybridCloudProvider(object):
         with monkeypatched(
             self.azure,
             "tenant_principal_app_display_name",
-            f"Hybrid :: {payload.display_name} :: ATAT Remote Admin",
+            f"{HYBRID_PREFIX} {payload.display_name} :: ATAT Remote Admin",
         ):
             return self.azure.create_tenant_principal_app(payload)
 
@@ -161,7 +164,7 @@ class HybridCloudProvider(object):
     def create_initial_mgmt_group(
         self, payload: InitialMgmtGroupCSPPayload
     ) -> InitialMgmtGroupCSPResult:
-        payload.display_name = f"Hybrid :: {payload.display_name}"
+        payload.display_name = f"{HYBRID_PREFIX} {payload.display_name}"
         return self.azure.create_initial_mgmt_group(payload)
 
     def create_initial_mgmt_group_verification(
@@ -215,7 +218,7 @@ class HybridCloudProvider(object):
         with monkeypatched(
             self.azure, "_get_tenant_principal_token", lambda *a, **kw: token
         ):
-            payload.display_name = f"Hybrid {payload.display_name} Billing"
+            payload.display_name = f"{HYBRID_PREFIX} {payload.display_name} :: Billing"
             return self.azure.create_billing_owner(payload)
 
     def create_tenant_admin_credential_reset(
@@ -227,12 +230,13 @@ class HybridCloudProvider(object):
         return self.azure.create_policies(payload)
 
     def create_application(self, payload):
+        payload.display_name = f"{HYBRID_PREFIX} {payload.display_name}"
         return self.azure.create_application(payload)
 
     def create_environment(
         self, payload: EnvironmentCSPPayload
     ) -> EnvironmentCSPResult:
-        payload.management_group_name = f"hybrid-{payload.management_group_name}"
+        payload.display_name = f"{HYBRID_PREFIX} {payload.display_name}"
         return self.azure.create_environment(payload)
 
     def create_user(self, payload: UserCSPPayload) -> UserCSPResult:

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -1,3 +1,6 @@
+import string
+import re
+
 from flask import current_app as app
 
 
@@ -6,5 +9,8 @@ def generate_user_principal_name(name, domain_name):
     return f"{mail_name}@{domain_name}.{app.config.get('OFFICE_365_DOMAIN')}"
 
 
+ESCAPED_PUNCTUATION = re.escape(string.punctuation)
+
+
 def generate_mail_nickname(name):
-    return name.replace(" ", ".").lower()
+    return re.sub(f"[{ESCAPED_PUNCTUATION} ]+", ".", name).lower()

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -241,8 +241,8 @@ class PortfolioStateMachine(
 
     @property
     def current_stage(self) -> str:
-        """Returns the current stage of the CSP provisioning process       
-        
+        """Returns the current stage of the CSP provisioning process
+
         E.g. TENANT_IN_PROGRESS -> tenant
         """
         for stage_state in StageStates:

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -164,7 +164,7 @@ class TestBillingOwnerCSPPayload:
 
     def test_mail_nickname(self):
         payload = BillingOwnerCSPPayload(**self.user_payload)
-        assert payload.mail_nickname == "billing_admin"
+        assert payload.mail_nickname == "billing.admin"
 
     def test_password(self):
         payload = BillingOwnerCSPPayload(**self.user_payload)
@@ -174,7 +174,7 @@ class TestBillingOwnerCSPPayload:
         payload = BillingOwnerCSPPayload(**self.user_payload)
         assert (
             payload.user_principal_name
-            == f"billing_admin@rebelalliance.{app.config.get('OFFICE_365_DOMAIN')}"
+            == f"billing.admin@rebelalliance.{app.config.get('OFFICE_365_DOMAIN')}"
         )
 
     def test_email(self):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -375,7 +375,7 @@ def test_send_ppoc_email(monkeypatch, app):
     monkeypatch.setattr("atat.jobs.send_mail", mock)
 
     ppoc_email = "example@example.com"
-    user_id = "user_id"
+    user_id = "userid"
     domain_name = "domain"
 
     send_PPOC_email(


### PR DESCRIPTION
All entities the HybridCloudProvider makes in a tenant will now begin
with the prefix "Hybrid ::". This will make them easier to identify for
QA and teardown. Other small changes:

- I updated the methods related to management groups to modify the
  display name attribute instead of the management group name (the
  latter is basically an ID and does not appear in lists in the Azure UI).
- I updated the function that standardizes the mailNickname field for AD
  users so that it replaces any punctuation characters with a single
  period. The MS Graph API returns validation errors for the colon in
  the Hybrid name prefix, so I opted to strip al punctuation from that
  field.