### PR TITLE
Update query for finding CLINs to resend to the CSP.

### DIFF
--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -354,9 +354,9 @@ def create_billing_instruction(self):
         portfolio = clin.task_order.portfolio
 
         payload = BillingInstructionCSPPayload(
-            tenant_id=portfolio.csp_data.get("tenant_id"),
-            billing_account_name=portfolio.csp_data.get("billing_account_name"),
-            billing_profile_name=portfolio.csp_data.get("billing_profile_name"),
+            tenant_id=portfolio.csp_data["tenant_id"],
+            billing_account_name=portfolio.csp_data["billing_account_name"],
+            billing_profile_name=portfolio.csp_data["billing_profile_name"],
             initial_clin_amount=clin.obligated_amount,
             initial_clin_start_date=str(clin.start_date),
             initial_clin_end_date=str(clin.end_date),

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -524,6 +524,7 @@ class TestCreateBillingInstructions:
                 "billing_profile_name": "fake",
             },
             task_orders=[{"create_clins": [{"start_date": start_date}]}],
+            state=FSMStates.COMPLETED.name,
         )
         return portfolio.task_orders[0].clins[0]
 
@@ -570,6 +571,7 @@ class TestCreateBillingInstructions:
                     ]
                 }
             ],
+            state=FSMStates.COMPLETED.name,
         )
         task_order = portfolio.task_orders[0]
         sent_clin = task_order.clins[0]


### PR DESCRIPTION
The query method for finding CLINs that need to be sent to the CSP needs
to check whether a portfolio is done being provisioned (i.e., its state
machine has the final state of COMPLETED). There are two cases where we
need to send CLIN information to the CSP:

- during the initial provisioning of the portfolio.
- when CLINs are added or edited after a portfolio has been provisioned.

The query and Celery task it's used by exist to handle the second case.
Before this update, ATAT would try to resend CLINs for portfolios that
had not finished provisioning and were missing necessary information
(such as the billing profile).

This commit also updates the dictionary access method to the portfolio's
csp_data in the Celery task, since we do not handle cases where we don't
find the relevant data.

Found and fixed while working on [AT-5192](https://ccpo.atlassian.net/browse/AT-5192).