### PR TITLE
Provisioning script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,6 @@ js/test_templates
 # terraform
 *.tfstate
 *.backup
+
+# vscode config files
+.vscode/

--- a/sample.json
+++ b/sample.json
@@ -1,0 +1,42 @@
+{
+    "creds": {
+        "root_sp_client_id": "FILL",
+        "root_sp_key": "ME",
+        "root_tenant_id": "IN"
+    },
+    "config": {
+        "AZURE_POLICY_LOCATION": "UNUSED BUT REQUIRED",
+        "AZURE_CLIENT_ID": "UNUSED BUT REQUIRED",
+        "AZURE_SECRET_KEY": "UNUSED BUT REQUIRED",
+        "AZURE_TENANT_ID": "UNUSED BUT REQUIRED",
+        "AZURE_VAULT_URL": "UNUSED BUT REQUIRED",
+        "POWERSHELL_CLIENT_ID": "1950a258-227b-4e31-a9cf-717495945fc2",
+        "AZURE_OWNER_ROLE_DEF_ID": "8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "AZURE_GRAPH_RESOURCE": "https://graph.microsoft.com",
+        "AZURE_AADP_QTY": 1
+    },
+    "initial_inputs": {
+        "user_id": "admin",
+        "password": "insert secure password here",
+        "domain_name": "someuniquedomain",
+        "country_code": "US",
+        "first_name": "First",
+        "last_name": "Last",
+        "password_recovery_email_address": "first_last@example.com",
+        "address": {
+            "address_line_1": "FILL",
+            "company_name": "US",
+            "city": "Washington",
+            "region": "DC",
+            "country": "US",
+            "postal_code": "IN"
+        },
+        "billing_account_name": "FILL ME IN",
+        "amount": 1000.00,
+        "start_date": "YYYY/MM/DD",
+        "end_date": "YYYY/MM/DD",
+        "clin_type": "1",
+        "task_order_id": "TO ID (only alphanumerics, ignore dashes)"
+    },
+    "csp_data": {}
+}

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -6,7 +6,7 @@ You need to start by copying sample.json in this directory and filling in your r
 
 Once you've set up ATAT as prescribed in the root [README](../../README.md) and have populated the file with correct values, you can run each script in turn. The general format of each script call would be as follows.
 ```
-pipenv run ./script/provision/name_of_script.py input.json output.json
+pipenv run python ./script/provision/name_of_script.py input.json output.json
 ```
 Note: Run this script from the root of the project, the paths to your json files need to be relative to where you're running the command from
 
@@ -16,12 +16,12 @@ You should see output detailing each thing the script is doing, or error details
 
 If there are no errors, running the below with a valid input.json would be a complete process:
 ```
-pipenv run ./script/provision/a_create_tenant.py input.json tenant_output.json
-pipenv run ./script/provision/b_setup_billing.py tenant_output.json billing_output.json
-pipenv run ./script/provision/c_billing_profile_tenant_access.py billing_output.json ta_output.json
-pipenv run ./script/provision/d_setup_to_billing.py ta_output.json to_billing_output.json
-pipenv run ./script/provision/e_report_clin.py to_billing_output.json clin_report_output.json
-pipenv run ./script/provision/f_purchase_aadp.py clin_report_output.json purchase_output.json
+pipenv run python ./script/provision/a_create_tenant.py input.json tenant_output.json
+pipenv run python ./script/provision/b_setup_billing.py tenant_output.json billing_output.json
+pipenv run python ./script/provision/c_billing_profile_tenant_access.py billing_output.json ta_output.json
+pipenv run python ./script/provision/d_setup_to_billing.py ta_output.json to_billing_output.json
+pipenv run python ./script/provision/e_report_clin.py to_billing_output.json clin_report_output.json
+pipenv run python ./script/provision/f_purchase_aadp.py clin_report_output.json purchase_output.json
 ```
 
 When a script completes successfully, you should see `writing to output.json` as the final output (with whatever output file you provided). Below is what fields to look for in the output after each step to make sure the correct information was gathered:
@@ -103,7 +103,7 @@ The initial process expects a single initial CLIN to bill against, for the purpo
 Once you've updated the input file, you can run this script like you have previously:
 
 ```
-pipenv run ./script/provision/report_new_clin.py updated_purchase_output.json clins_reported.json
+pipenv run python ./script/provision/report_new_clin.py updated_purchase_output.json clins_reported.json
 ```
 
 Once you've run this, you should see a new section inside of the `"csp_data"` section of the output json with a string for each CLIN that was successfully reported. If the length of the list does not match the length of the list of CLINs you provided, check the terminal output for any error messages.

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -1,4 +1,19 @@
-This folder contains a series of scripts to do the parts of provisioning that do not have UIs.
+This folder contains a series of scripts that cover a subset of the provisioning steps. The scripts cover everything up thru `PRODUCT_PURCHASE_VERIFICATION`. This does not include the following:
+
+- TENANT_PRINCIPAL_APP
+- TENANT_PRINCIPAL
+- TENANT_PRINCIPAL_CREDENTIAL
+- ADMIN_ROLE_DEFINITION
+- PRINCIPAL_ADMIN_ROLE
+- INITIAL_MGMT_GROUP
+- INITIAL_MGMT_GROUP_VERIFICATION
+- TENANT_ADMIN_OWNERSHIP
+- TENANT_PRINCIPAL_OWNERSHIP
+- BILLING_OWNER
+- TENANT_ADMIN_CREDENTIAL_RESET
+- POLICIES
+
+Some work might need to be done in the future to be able to manually run provisioning, but currently all steps are in the UI. 
 
 ## Initial Provisioning
 

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -1,16 +1,20 @@
 This folder contains a series of scripts to do the parts of provisioning that do not have UIs.
 
-You need to start by copying sample.json in this directory and filling in your real values.
+## Initial Provisioning
 
-Then you can run each script in turn, with the following:
+You need to start by copying sample.json in this directory and filling in your real values. The instructions for what the fill in for these values can be found in the provisioning guide, please reach out to a member of CCPO to access that document.
+
+Once you've set up ATAT as prescribed in the root [README](../../README.md) and have populated the file with correct values, you can run each script in turn. The general format of each script call would be as follows.
 ```
 pipenv run ./script/provisiong/name_of_script.py input.json output.json
 ```
 Note: Run this script from the root of the project, the paths to your json files need to be relative to where you're running the command from
 
+Each script takes it's `input.json` file, pulls the necessary data from it, makes the appropriate API calls, and the pushes all the info from the `input.json` file along with new information gained from the API calls to the `output.json` This means that the output of each step is everything that's needed for the next step.
+
 You should see output detailing each thing the script is doing, or error details if it fails. Once the script is done, it writes all the input (from the input.json) updated with new values from the script.
 
-These are meant to be run in sequence, consuming the output of the previous script:
+If there are no errors, running the below with a valid input.json would be a complete process:
 ```
 pipenv run ./script/provisiong/a_create_tenant.py input.json tenant_output.json
 pipenv run ./script/provisiong/b_setup_billing.py tenant_output.json billing_output.json
@@ -20,4 +24,102 @@ pipenv run ./script/provisiong/e_report_clin.py to_billing_output.json clin_repo
 pipenv run ./script/provisiong/f_purchase_aadp.py clin_report_output.json purchase_output.json
 ```
 
-If there were no errors, running the above with a valid input.json would be a complete process.
+When a script completes successfully, you should see `writing to output.json` as the final output (with whatever output file you provided). Below is what fields to look for in the output after each step to make sure the correct information was gathered:
+
+### a_create_tenant.py
+* "creds" should have values for:
+  * "tenant_id"
+  * "tenant_admin_username"
+  * "tenant_admin_password"
+* "csp_data" should have values for:
+  * "user_id"
+  * "tenant_id"
+  * "user_object_id"
+  * "domain_name"
+
+### b_setup_billing.py
+* "csp_data" should have values for:
+  * "billing_profile_id"
+  * "billing_profile_name"
+  * "billing_profile_properties"
+    * This should be a nested object with address and invoice section information
+
+### c_billing_profile_tenant_access.py
+* "csp_data" should have values for:
+  * "billing_role_assignment_id"
+  * "billing_role_assignment_name"
+
+### d_setup_to_billing.py
+* "csp_data" should have values for:
+  * "billing_profile_enabled_plan_details" the body of which should look like this:
+    ```json
+    {
+        "enabled_azure_plans": [
+            {
+                "skuId": "0001",
+                "skuDescription": "Microsoft Azure Plan"
+            }
+        ]
+    }
+    ```
+
+### e_report_clin.py
+* "csp_data" should have values for:
+  * "reported_clin_name"
+    * The value of this should look like this: "X:CLIN00Y"
+      * Where `X` is the the value of "initial_task_order_id"
+      * Where `Y` is the CLIN type (1 or 2)
+
+### f_purchase_aadp.py
+* "csp_data" should have values for:
+  * "premium_purchase_date" - should be roughly the time/date when the script was run
+
+## Reporting Additional CLINs
+
+The initial process expects a single initial CLIN to bill against, for the purposes of constructing all the necessary Azure resources. After that, additional CLINs, including CLINs for support services. To report these new clins, you need the final output file from the process above (if you used all the examples, it'd be called `purchase_output.json`). You need to add a new section to the bottom of the file, called `"new_clins"`, below is an example (`...` placeholders for filled in values):
+
+```json
+{
+    "creds": {...},
+    "config": {...},
+    "initial_inputs": {...},
+    "csp_data": {...},
+    "new_clins": [{
+        "amount": 1300.00,
+        "start_date": "2020/02/01",
+        "end_date": "2021/02/01",
+        "type": "1",
+        "task_order_id": "FAKE2"
+    }, {
+        "amount": 2200.00,
+        "start_date": "2020/02/01",
+        "end_date": "2021/02/01",
+        "type": "2",
+        "task_order_id": "FAKE2"
+    }]
+}
+```
+
+Once you've updated the input file, you can run this script like you have previously:
+
+```
+pipenv run ./script/provisiong/report_new_clin.py updated_purchase_output.json clins_reported.json
+```
+
+Once you've run this, you should see a new section inside of the `"csp_data"` section of the output json with a string for each CLIN that was successfully reported. If the length of the list does not match the length of the list of CLINs you provided, check the terminal output for any error messages.
+
+```json
+{
+    "creds": {...},
+    "config": {...},
+    "initial_inputs": {...},
+    "csp_data": {
+        ...other fields...,
+        "reported_clins": [
+            "FAKE2:CLIN001",
+            "FAKE2:CLIN002"
+        ]
+    }
+}
+```
+

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -6,7 +6,7 @@ You need to start by copying sample.json in this directory and filling in your r
 
 Once you've set up ATAT as prescribed in the root [README](../../README.md) and have populated the file with correct values, you can run each script in turn. The general format of each script call would be as follows.
 ```
-pipenv run ./script/provisiong/name_of_script.py input.json output.json
+pipenv run ./script/provision/name_of_script.py input.json output.json
 ```
 Note: Run this script from the root of the project, the paths to your json files need to be relative to where you're running the command from
 
@@ -16,12 +16,12 @@ You should see output detailing each thing the script is doing, or error details
 
 If there are no errors, running the below with a valid input.json would be a complete process:
 ```
-pipenv run ./script/provisiong/a_create_tenant.py input.json tenant_output.json
-pipenv run ./script/provisiong/b_setup_billing.py tenant_output.json billing_output.json
-pipenv run ./script/provisiong/c_billing_profile_tenant_access.py billing_output.json ta_output.json
-pipenv run ./script/provisiong/d_setup_to_billing.py ta_output.json to_billing_output.json
-pipenv run ./script/provisiong/e_report_clin.py to_billing_output.json clin_report_output.json
-pipenv run ./script/provisiong/f_purchase_aadp.py clin_report_output.json purchase_output.json
+pipenv run ./script/provision/a_create_tenant.py input.json tenant_output.json
+pipenv run ./script/provision/b_setup_billing.py tenant_output.json billing_output.json
+pipenv run ./script/provision/c_billing_profile_tenant_access.py billing_output.json ta_output.json
+pipenv run ./script/provision/d_setup_to_billing.py ta_output.json to_billing_output.json
+pipenv run ./script/provision/e_report_clin.py to_billing_output.json clin_report_output.json
+pipenv run ./script/provision/f_purchase_aadp.py clin_report_output.json purchase_output.json
 ```
 
 When a script completes successfully, you should see `writing to output.json` as the final output (with whatever output file you provided). Below is what fields to look for in the output after each step to make sure the correct information was gathered:
@@ -103,7 +103,7 @@ The initial process expects a single initial CLIN to bill against, for the purpo
 Once you've updated the input file, you can run this script like you have previously:
 
 ```
-pipenv run ./script/provisiong/report_new_clin.py updated_purchase_output.json clins_reported.json
+pipenv run ./script/provision/report_new_clin.py updated_purchase_output.json clins_reported.json
 ```
 
 Once you've run this, you should see a new section inside of the `"csp_data"` section of the output json with a string for each CLIN that was successfully reported. If the length of the list does not match the length of the list of CLINs you provided, check the terminal output for any error messages.

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -1,0 +1,23 @@
+This folder contains a series of scripts to do the parts of provisioning that do not have UIs.
+
+You need to start by copying sample.json in this directory and filling in your real values.
+
+Then you can run each script in turn, with the following:
+```
+pipenv run ./script/provisiong/name_of_script.py input.json output.json
+```
+Note: Run this script from the root of the project, the paths to your json files need to be relative to where you're running the command from
+
+You should see output detailing each thing the script is doing, or error details if it fails. Once the script is done, it writes all the input (from the input.json) updated with new values from the script.
+
+These are meant to be run in sequence, consuming the output of the previous script:
+```
+pipenv run ./script/provisiong/a_create_tenant.py input.json tenant_output.json
+pipenv run ./script/provisiong/b_setup_billing.py tenant_output.json billing_output.json
+pipenv run ./script/provisiong/c_billing_profile_tenant_access.py billing_output.json ta_output.json
+pipenv run ./script/provisiong/d_setup_to_billing.py ta_output.json to_billing_output.json
+pipenv run ./script/provisiong/e_report_clin.py to_billing_output.json clin_report_output.json
+pipenv run ./script/provisiong/f_purchase_aadp.py clin_report_output.json purchase_output.json
+```
+
+If there were no errors, running the above with a valid input.json would be a complete process.

--- a/script/provision/README.md
+++ b/script/provision/README.md
@@ -6,7 +6,7 @@ You need to start by copying sample.json in this directory and filling in your r
 
 Once you've set up ATAT as prescribed in the root [README](../../README.md) and have populated the file with correct values, you can run each script in turn. The general format of each script call would be as follows.
 ```
-pipenv run python ./script/provision/name_of_script.py input.json output.json
+poetry run python ./script/provision/name_of_script.py input.json output.json
 ```
 Note: Run this script from the root of the project, the paths to your json files need to be relative to where you're running the command from
 
@@ -16,12 +16,12 @@ You should see output detailing each thing the script is doing, or error details
 
 If there are no errors, running the below with a valid input.json would be a complete process:
 ```
-pipenv run python ./script/provision/a_create_tenant.py input.json tenant_output.json
-pipenv run python ./script/provision/b_setup_billing.py tenant_output.json billing_output.json
-pipenv run python ./script/provision/c_billing_profile_tenant_access.py billing_output.json ta_output.json
-pipenv run python ./script/provision/d_setup_to_billing.py ta_output.json to_billing_output.json
-pipenv run python ./script/provision/e_report_clin.py to_billing_output.json clin_report_output.json
-pipenv run python ./script/provision/f_purchase_aadp.py clin_report_output.json purchase_output.json
+poetry run python ./script/provision/a_create_tenant.py input.json tenant_output.json
+poetry run python ./script/provision/b_setup_billing.py tenant_output.json billing_output.json
+poetry run python ./script/provision/c_billing_profile_tenant_access.py billing_output.json ta_output.json
+poetry run python ./script/provision/d_setup_to_billing.py ta_output.json to_billing_output.json
+poetry run python ./script/provision/e_report_clin.py to_billing_output.json clin_report_output.json
+poetry run python ./script/provision/f_purchase_aadp.py clin_report_output.json purchase_output.json
 ```
 
 When a script completes successfully, you should see `writing to output.json` as the final output (with whatever output file you provided). Below is what fields to look for in the output after each step to make sure the correct information was gathered:
@@ -103,7 +103,7 @@ The initial process expects a single initial CLIN to bill against, for the purpo
 Once you've updated the input file, you can run this script like you have previously:
 
 ```
-pipenv run python ./script/provision/report_new_clin.py updated_purchase_output.json clins_reported.json
+poetry run python ./script/provision/report_new_clin.py updated_purchase_output.json clins_reported.json
 ```
 
 Once you've run this, you should see a new section inside of the `"csp_data"` section of the output json with a string for each CLIN that was successfully reported. If the length of the list does not match the length of the list of CLINs you provided, check the terminal output for any error messages.

--- a/script/provision/a_create_tenant.py
+++ b/script/provision/a_create_tenant.py
@@ -23,9 +23,6 @@ def create_tenant(csp, inputs):
     csp.update_tenant_creds = get_creds
     result = csp.create_tenant(create_tenant_payload)
     if result.get("status") == "ok":
-        import ipdb
-
-        ipdb.set_trace()
         inputs.get("creds").update({k: v for k, v in creds.dict().items() if v})
         return result.get("body").dict()
     else:

--- a/script/provision/a_create_tenant.py
+++ b/script/provision/a_create_tenant.py
@@ -14,9 +14,19 @@ def create_tenant(csp, inputs):
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
 
-    csp.update_tenant_creds = lambda a, b: None
+    creds = None
+
+    def get_creds(tenant_id, new_creds):
+        nonlocal creds
+        creds = new_creds
+
+    csp.update_tenant_creds = get_creds
     result = csp.create_tenant(create_tenant_payload)
     if result.get("status") == "ok":
+        import ipdb
+
+        ipdb.set_trace()
+        inputs.get("creds").update({k: v for k, v in creds.dict().items() if v})
         return result.get("body").dict()
     else:
         print("there was an error during the request:")

--- a/script/provision/a_create_tenant.py
+++ b/script/provision/a_create_tenant.py
@@ -1,0 +1,28 @@
+import os
+import sys
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+from script.provision.provision_base import handle
+
+from atst.domain.csp.cloud.models import TenantCSPPayload
+
+
+def create_tenant(csp, inputs):
+    create_tenant_payload = TenantCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+
+    csp.update_tenant_creds = lambda a, b: None
+    result = csp.create_tenant(create_tenant_payload)
+    if result.get("status") == "ok":
+        return result.get("body").dict()
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(create_tenant)
+

--- a/script/provision/a_create_tenant.py
+++ b/script/provision/a_create_tenant.py
@@ -6,7 +6,7 @@ sys.path.append(parent_dir)
 
 from script.provision.provision_base import handle
 
-from atst.domain.csp.cloud.models import TenantCSPPayload
+from atat.domain.csp.cloud.models import TenantCSPPayload
 
 
 def create_tenant(csp, inputs):
@@ -32,4 +32,3 @@ def create_tenant(csp, inputs):
 
 if __name__ == "__main__":
     handle(create_tenant)
-

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -2,14 +2,14 @@ import os
 import sys
 import time
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
 from atst.domain.csp.cloud.models import (
     BillingProfileCreationCSPPayload,
     BillingProfileVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-sys.path.append(parent_dir)
 
 
 def poll_billing(csp, inputs, csp_response):
@@ -21,7 +21,7 @@ def poll_billing(csp, inputs, csp_response):
         result = csp.create_billing_profile_verification(get_billing_profile)
         if result.get("status") == "ok":
             csp_response = result.get("body").dict()
-            poll_billing(csp, inputs, csp_response)
+            return poll_billing(csp, inputs, csp_response)
         else:
             return result.get("body").dict()
     else:
@@ -29,6 +29,9 @@ def poll_billing(csp, inputs, csp_response):
 
 
 def setup_billing(csp, inputs):
+    import ipdb
+
+    ipdb.set_trace()
     create_billing_profile = BillingProfileCreationCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
@@ -36,7 +39,7 @@ def setup_billing(csp, inputs):
     result = csp.create_billing_profile_creation(create_billing_profile)
     if result.get("status") == "ok":
         csp_response = result.get("body").dict()
-        poll_billing(csp, inputs, csp_response)
+        return poll_billing(csp, inputs, csp_response)
     else:
         print("there was an error during the request:")
         print(result.get("body"))

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -29,9 +29,6 @@ def poll_billing(csp, inputs, csp_response):
 
 
 def setup_billing(csp, inputs):
-    import ipdb
-
-    ipdb.set_trace()
     create_billing_profile = BillingProfileCreationCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -5,7 +5,7 @@ import time
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
 
-from atst.domain.csp.cloud.models import (
+from atat.domain.csp.cloud.models import (
     BillingProfileCreationCSPPayload,
     BillingProfileVerificationCSPPayload,
 )

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -1,0 +1,46 @@
+import os
+import sys
+import time
+
+from atst.domain.csp.cloud.models import (
+    BillingProfileCreationCSPPayload,
+    BillingProfileVerificationCSPPayload,
+)
+from script.provision.provision_base import handle
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def poll_billing(csp, inputs, csp_response):
+    if csp_response.get("billing_profile_verify_url") is not None:
+        time.sleep(csp_response.get("billing_profile_retry_after"))
+        get_billing_profile = BillingProfileVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
+        )
+        result = csp.create_billing_profile_verification(get_billing_profile)
+        if result.get("status") == "ok":
+            csp_response = result.get("body").dict()
+            poll_billing(csp, inputs, csp_response)
+        else:
+            return result.get("body").dict()
+    else:
+        return csp_response
+
+
+def setup_billing(csp, inputs):
+    create_billing_profile = BillingProfileCreationCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+
+    result = csp.create_billing_profile_creation(create_billing_profile)
+    if result.get("status") == "ok":
+        csp_response = result.get("body").dict()
+        poll_billing(csp, inputs, csp_response)
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(setup_billing)

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -14,7 +14,7 @@ from script.provision.provision_base import handle
 
 def poll_billing(csp, inputs, csp_response):
     if csp_response.get("billing_profile_verify_url") is not None:
-        time.sleep(csp_response.get("billing_profile_retry_after"))
+        time.sleep(10)
         get_billing_profile = BillingProfileVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
         )

--- a/script/provision/c_billing_profile_tenant_access.py
+++ b/script/provision/c_billing_profile_tenant_access.py
@@ -1,11 +1,11 @@
 import os
 import sys
 
-from atst.domain.csp.cloud.models import BillingProfileTenantAccessCSPPayload
-from script.provision.provision_base import handle
-
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
+
+from atst.domain.csp.cloud.models import BillingProfileTenantAccessCSPPayload
+from script.provision.provision_base import handle
 
 
 def grant_access(csp, inputs):

--- a/script/provision/c_billing_profile_tenant_access.py
+++ b/script/provision/c_billing_profile_tenant_access.py
@@ -4,7 +4,7 @@ import sys
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
 
-from atst.domain.csp.cloud.models import BillingProfileTenantAccessCSPPayload
+from atat.domain.csp.cloud.models import BillingProfileTenantAccessCSPPayload
 from script.provision.provision_base import handle
 
 

--- a/script/provision/c_billing_profile_tenant_access.py
+++ b/script/provision/c_billing_profile_tenant_access.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from atst.domain.csp.cloud.models import BillingProfileTenantAccessCSPPayload
+from script.provision.provision_base import handle
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def grant_access(csp, inputs):
+    tenant_access = BillingProfileTenantAccessCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+    result = csp.create_billing_profile_tenant_access(tenant_access)
+    if result.get("status") == "ok":
+        return result.get("body").dict()
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(grant_access)

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -1,14 +1,15 @@
 import os
 import sys
+import time
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
 
 from atst.domain.csp.cloud.models import (
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-sys.path.append(parent_dir)
 
 
 def poll_billing(csp, inputs, csp_response):
@@ -20,7 +21,7 @@ def poll_billing(csp, inputs, csp_response):
         result = csp.create_task_order_billing_verification(enable_to_billing)
         if result.get("status") == "ok":
             csp_response = result.get("body").dict()
-            poll_billing(csp, inputs, csp_response)
+            return poll_billing(csp, inputs, csp_response)
         else:
             return result.get("body").dict()
     else:
@@ -35,7 +36,7 @@ def setup_to_billing(csp, inputs):
     result = csp.create_task_order_billing_creation(enable_to_billing)
     if result.get("status") == "ok":
         csp_response = result.get("body").dict()
-        poll_billing(csp, inputs, csp_response)
+        return poll_billing(csp, inputs, csp_response)
     else:
         print("there was an error during the request:")
         print(result.get("body"))

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+from atst.domain.csp.cloud.models import (
+    TaskOrderBillingCreationCSPPayload,
+    TaskOrderBillingVerificationCSPPayload,
+)
+from script.provision.provision_base import handle
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def poll_billing(csp, inputs, csp_response):
+    if csp_response.get("task_order_billing_verify_url") is not None:
+        time.sleep(csp_response.get("task_order_billing_retry_after"))
+        enable_to_billing = TaskOrderBillingVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
+        )
+        result = csp.create_task_order_billing_verification(enable_to_billing)
+        if result.get("status") == "ok":
+            csp_response = result.get("body").dict()
+            poll_billing(csp, inputs, csp_response)
+        else:
+            return result.get("body").dict()
+    else:
+        return csp_response
+
+
+def setup_to_billing(csp, inputs):
+    enable_to_billing = TaskOrderBillingCreationCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+
+    result = csp.create_task_order_billing_creation(enable_to_billing)
+    if result.get("status") == "ok":
+        csp_response = result.get("body").dict()
+        poll_billing(csp, inputs, csp_response)
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(setup_to_billing)

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -9,12 +9,12 @@ from atst.domain.csp.cloud.models import (
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingVerificationCSPPayload,
 )
-from script.provision.provision_base import handle
+from script.provision.provision_base import handle, wait
 
 
 def poll_billing(csp, inputs, csp_response):
     if csp_response.get("task_order_billing_verify_url") is not None:
-        time.sleep(csp_response.get("task_order_billing_retry_after"))
+        time.sleep(10)
         enable_to_billing = TaskOrderBillingVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
         )
@@ -32,10 +32,12 @@ def setup_to_billing(csp, inputs):
     enable_to_billing = TaskOrderBillingCreationCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
-
     result = csp.create_task_order_billing_creation(enable_to_billing)
     if result.get("status") == "ok":
         csp_response = result.get("body").dict()
+        import ipdb
+
+        ipdb.set_trace()
         return poll_billing(csp, inputs, csp_response)
     else:
         print("there was an error during the request:")

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -9,7 +9,7 @@ from atst.domain.csp.cloud.models import (
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingVerificationCSPPayload,
 )
-from script.provision.provision_base import handle, wait
+from script.provision.provision_base import handle
 
 
 def poll_billing(csp, inputs, csp_response):

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -35,9 +35,6 @@ def setup_to_billing(csp, inputs):
     result = csp.create_task_order_billing_creation(enable_to_billing)
     if result.get("status") == "ok":
         csp_response = result.get("body").dict()
-        import ipdb
-
-        ipdb.set_trace()
         return poll_billing(csp, inputs, csp_response)
     else:
         print("there was an error during the request:")

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -5,7 +5,7 @@ import time
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
 
-from atst.domain.csp.cloud.models import (
+from atat.domain.csp.cloud.models import (
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingVerificationCSPPayload,
 )

--- a/script/provision/e_report_clin.py
+++ b/script/provision/e_report_clin.py
@@ -5,7 +5,7 @@ parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
 
 
-from atst.domain.csp.cloud.models import BillingInstructionCSPPayload
+from atat.domain.csp.cloud.models import BillingInstructionCSPPayload
 from script.provision.provision_base import handle
 
 

--- a/script/provision/e_report_clin.py
+++ b/script/provision/e_report_clin.py
@@ -1,11 +1,12 @@
 import os
 import sys
 
-from atst.domain.csp.cloud.models import BillingInstructionCSPPayload
-from script.provision.provision_base import handle
-
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
+
+
+from atst.domain.csp.cloud.models import BillingInstructionCSPPayload
+from script.provision.provision_base import handle
 
 
 def report_clin(csp, inputs):

--- a/script/provision/e_report_clin.py
+++ b/script/provision/e_report_clin.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+from atst.domain.csp.cloud.models import BillingInstructionCSPPayload
+from script.provision.provision_base import handle
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def report_clin(csp, inputs):
+    billing_instruction = BillingInstructionCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+    result = csp.create_billing_instruction(billing_instruction)
+    if result.get("status") == "ok":
+        return result.get("body").dict()
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(report_clin)

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -5,7 +5,7 @@ import time
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)
 
-from atst.domain.csp.cloud.models import (
+from atat.domain.csp.cloud.models import (
     ProductPurchaseCSPPayload,
     ProductPurchaseVerificationCSPPayload,
 )

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -1,14 +1,14 @@
 import os
 import sys
 
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
 from atst.domain.csp.cloud.models import (
     ProductPurchaseCSPPayload,
     ProductPurchaseVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-
-parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
-sys.path.append(parent_dir)
 
 
 def poll_purchase(csp, inputs, csp_response):
@@ -32,7 +32,7 @@ def purchase_aadp(csp, inputs):
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
 
-    result = csp.create_product_purchase_creation(purchase_premium)
+    result = csp.create_product_purchase(purchase_premium)
     if result.get("status") == "ok":
         csp_response = result.get("body").dict()
         poll_purchase(csp, inputs, csp_response)

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import time
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -13,7 +13,7 @@ from script.provision.provision_base import handle
 
 def poll_purchase(csp, inputs, csp_response):
     if csp_response.get("product_purchase_verify_url") is not None:
-        time.sleep(csp_response.get("product_purchase_retry_after"))
+        time.sleep(10)
         purchase_premium = ProductPurchaseVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
         )

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+from atst.domain.csp.cloud.models import (
+    ProductPurchaseCSPPayload,
+    ProductPurchaseVerificationCSPPayload,
+)
+from script.provision.provision_base import handle
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def poll_purchase(csp, inputs, csp_response):
+    if csp_response.get("product_purchase_verify_url") is not None:
+        time.sleep(csp_response.get("product_purchase_retry_after"))
+        purchase_premium = ProductPurchaseVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
+        )
+        result = csp.create_product_purchase_verification(purchase_premium)
+        if result.get("status") == "ok":
+            csp_response = result.get("body").dict()
+            poll_purchase(csp, inputs, csp_response)
+        else:
+            return result.get("body").dict()
+    else:
+        return csp_response
+
+
+def purchase_aadp(csp, inputs):
+    purchase_premium = ProductPurchaseCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+
+    result = csp.create_product_purchase_creation(purchase_premium)
+    if result.get("status") == "ok":
+        csp_response = result.get("body").dict()
+        poll_purchase(csp, inputs, csp_response)
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+if __name__ == "__main__":
+    handle(purchase_aadp)

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -1,0 +1,53 @@
+import json
+import os
+import pprint
+import sys
+
+from atst.domain.csp.cloud import AzureCloudProvider
+from atst.domain.csp.cloud.models import KeyVaultCredentials
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+
+def get_provider_and_inputs(input_path):
+    with open(input_path, "r") as input_file:
+        details = json.loads(input_file.read())
+        creds = details.get("creds")
+        config = details.get("config")
+
+        cloud = AzureCloudProvider(config)
+
+        def fake_source_creds(tenant_id=None):
+            return KeyVaultCredentials(**creds)
+
+        cloud._source_creds = fake_source_creds
+
+        return (cloud, details)
+
+
+def update_and_write(inputs, result, output_path):
+    inputs["csp_data"].update(result)
+    print(f"Updated inputs {pprint.pformat(inputs, indent=2)}")
+    with open(output_path, "w") as output_file:
+        print(f"writing to {output_path}")
+        output_file.write(json.dumps(inputs, indent=4))
+
+
+def handle(f):
+    input_path = sys.argv[1]
+    output_path = sys.argv[2]
+
+    (provider, inputs) = get_provider_and_inputs(input_path)
+    try:
+        result = f(provider, inputs)
+        if result:
+            print("Writing ")
+            update_and_write(inputs, result, output_path)
+        else:
+            print("no result")
+    except Exception as exc:
+        print("Failed to create tenant")
+        print(f"Inputs: {inputs}")
+        print("Exception:")
+        print(exc)

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -46,8 +46,10 @@ def handle(f):
             update_and_write(inputs, result, output_path)
         else:
             print("no result")
-    except Exception as exc:
-        print("Failed to create tenant")
+    except Exception:
+        print("Failed]")
         print(f"Inputs: {inputs}")
         print("Exception:")
-        print(exc)
+        import traceback
+
+        traceback.print_exc()

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -3,8 +3,8 @@ import os
 import pprint
 import sys
 
-from atst.domain.csp.cloud import AzureCloudProvider
-from atst.domain.csp.cloud.models import KeyVaultCredentials
+from atat.domain.csp.cloud import AzureCloudProvider
+from atat.domain.csp.cloud.models import KeyVaultCredentials
 
 parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 sys.path.append(parent_dir)

--- a/script/provision/report_new_clin.py
+++ b/script/provision/report_new_clin.py
@@ -1,0 +1,55 @@
+import os
+import sys
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.append(parent_dir)
+
+from atst.domain.csp.cloud.models import BillingInstructionCSPPayload
+from script.provision.provision_base import handle
+
+
+def report_clin(csp, inputs):
+    billing_instruction = BillingInstructionCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
+    )
+    result = csp.create_billing_instruction(billing_instruction)
+    if result.get("status") == "ok":
+        return result.get("body").dict()
+    else:
+        print("there was an error during the request:")
+        print(result.get("body"))
+
+
+def report_clins(csp, inputs):
+    clins_to_report = inputs.get("new_clins", [])
+    initial_inputs = inputs["initial_inputs"]
+    initial_clin_data = {
+        "initial_clin_amount": initial_inputs["initial_clin_amount"],
+        "initial_clin_start_date": initial_inputs["initial_clin_start_date"],
+        "initial_clin_end_date": initial_inputs["initial_clin_end_date"],
+        "initial_clin_type": initial_inputs["initial_clin_type"],
+        "initial_task_order_id": initial_inputs["initial_task_order_id"],
+    }
+    reported_clins = []
+    for clin in clins_to_report:
+        initial_inputs.update(
+            {
+                "initial_clin_amount": clin["amount"],
+                "initial_clin_start_date": clin["start_date"],
+                "initial_clin_end_date": clin["end_date"],
+                "initial_clin_type": clin["type"],
+                "initial_task_order_id": clin["task_order_id"],
+            }
+        )
+        reported_clin = report_clin(csp, inputs)
+        if reported_clin:
+            reported_clins.append(reported_clin.get("reported_clin_name"))
+
+    # Reset initial clin
+    initial_inputs.update(initial_clin_data)
+
+    return dict(reported_clins=reported_clins)
+
+
+if __name__ == "__main__":
+    handle(report_clins)

--- a/script/provision/sample.json
+++ b/script/provision/sample.json
@@ -2,7 +2,10 @@
     "creds": {
         "root_sp_client_id": "FILL",
         "root_sp_key": "ME",
-        "root_tenant_id": "IN"
+        "root_tenant_id": "IN",
+        "tenant_id": "",
+        "tenant_admin_username": "",
+        "tenant_admin_password": ""
     },
     "config": {
         "AZURE_POLICY_LOCATION": "UNUSED BUT REQUIRED",
@@ -24,19 +27,17 @@
         "last_name": "Last",
         "password_recovery_email_address": "first_last@example.com",
         "address": {
-            "address_line_1": "FILL",
-            "company_name": "US",
             "city": "Washington",
             "region": "DC",
             "country": "US",
-            "postal_code": "IN"
         },
         "billing_account_name": "FILL ME IN",
-        "amount": 1000.00,
-        "start_date": "YYYY/MM/DD",
-        "end_date": "YYYY/MM/DD",
-        "clin_type": "1",
-        "task_order_id": "TO ID (only alphanumerics, ignore dashes)"
+        "billing_profile_display_name": "ATAT Billing Profile",
+        "initial_clin_amounnt": 1000.0,
+        "initial_clin_start_date": "YYYY/MM/DD",
+        "initial_clin_end_date": "YYYY/MM/DD",
+        "initial_clin_type": "1",
+        "initial_task_order_id": "FAKE"
     },
     "csp_data": {}
 }

--- a/script/provision/sample.json
+++ b/script/provision/sample.json
@@ -2,10 +2,7 @@
     "creds": {
         "root_sp_client_id": "FILL",
         "root_sp_key": "ME",
-        "root_tenant_id": "IN",
-        "tenant_id": "",
-        "tenant_admin_username": "",
-        "tenant_admin_password": ""
+        "root_tenant_id": "IN"
     },
     "config": {
         "AZURE_POLICY_LOCATION": "UNUSED BUT REQUIRED",
@@ -20,20 +17,22 @@
     },
     "initial_inputs": {
         "user_id": "admin",
-        "password": "insert secure password here",
         "domain_name": "someuniquedomain",
         "country_code": "US",
         "first_name": "First",
         "last_name": "Last",
         "password_recovery_email_address": "first_last@example.com",
         "address": {
+            "address_line_1": "FILL ME IN",
+            "company_name": "FILL ME IN",
             "city": "Washington",
             "region": "DC",
             "country": "US",
+            "postal_code": "FILL ME IN"
         },
         "billing_account_name": "FILL ME IN",
         "billing_profile_display_name": "ATAT Billing Profile",
-        "initial_clin_amounnt": 1000.0,
+        "initial_clin_amount": 1000.0,
         "initial_clin_start_date": "YYYY/MM/DD",
         "initial_clin_end_date": "YYYY/MM/DD",
         "initial_clin_type": "1",


### PR DESCRIPTION
A while back @tomdds created a set of scripts to assist with manually running the state machine.  This PR is to move those scripts into the staging branch and document any states they do not cover.  

The scripts cover everything up thru`PRODUCT_PURCHASE_VERIFICATION`.  This does not include the following:

-   TENANT_PRINCIPAL_APP
-   TENANT_PRINCIPAL
-    TENANT_PRINCIPAL_CREDENTIAL
-    ADMIN_ROLE_DEFINITION
-    PRINCIPAL_ADMIN_ROLE 
-    INITIAL_MGMT_GROUP 
-    INITIAL_MGMT_GROUP_VERIFICATION
-    TENANT_ADMIN_OWNERSHIP 
-    TENANT_PRINCIPAL_OWNERSHIP
-    BILLING_OWNER
-    TENANT_ADMIN_CREDENTIAL_RESET
-    POLICIES 

See Jira issue https://ccpo.atlassian.net/browse/AT-4880