### PR TITLE
[AT-5184] Retry failed portfolio provisioning jobs

### DIFF
--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -1,13 +1,13 @@
-import pendulum
-from flask import current_app as app
 from smtplib import SMTPException
+
+import pendulum
 from azure.core.exceptions import AzureError
+from flask import current_app as app
 
 from atat.database import db
 from atat.domain.application_roles import ApplicationRoles
 from atat.domain.applications import Applications
 from atat.domain.csp.cloud import CloudProviderInterface
-from atat.domain.csp.cloud.utils import generate_user_principal_name
 from atat.domain.csp.cloud.exceptions import GeneralCSPException
 from atat.domain.csp.cloud.models import (
     ApplicationCSPPayload,
@@ -16,12 +16,13 @@ from atat.domain.csp.cloud.models import (
     UserCSPPayload,
     UserRoleCSPPayload,
 )
-from atat.domain.environments import Environments
+from atat.domain.csp.cloud.utils import generate_user_principal_name
 from atat.domain.environment_roles import EnvironmentRoles
+from atat.domain.environments import Environments
 from atat.domain.portfolios import Portfolios
+from atat.domain.task_orders import TaskOrders
 from atat.models import CSPRole, JobFailure
 from atat.models.mixins.state_machines import FSMStates
-from atat.domain.task_orders import TaskOrders
 from atat.models.utils import claim_for_update, claim_many_for_update
 from atat.queue import celery
 from atat.utils.localization import translate
@@ -251,9 +252,9 @@ def do_provision_portfolio(csp: CloudProviderInterface, portfolio_id=None):
         send_PPOC_email(portfolio.to_dictionary())
 
 
-@celery.task(bind=True, base=RecordFailure)
+@celery.task(bind=True, base=RecordFailure, autoretry_for=(GeneralCSPException,))
 def provision_portfolio(self, portfolio_id=None):
-    do_work(do_provision_portfolio, self, app.csp.cloud, portfolio_id=portfolio_id)
+    do_provision_portfolio(app.csp.cloud, portfolio_id=portfolio_id)
 
 
 @celery.task(bind=True, base=RecordFailure)

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -143,6 +143,7 @@ def _build_transitions(csp_stages):
                         source=compose_state(csp_stage, StageStates.FAILED),
                         dest=compose_state(csp_stage, StageStates.IN_PROGRESS),
                         conditions=["is_ready_resume_progress"],
+                        after="after_in_progress_callback",
                     )
                 )
 

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -1,6 +1,13 @@
 from enum import Enum
 
-from flask import current_app as app
+
+class StateMachineMisconfiguredError(Exception):
+    def __init__(self, class_details):
+        self.class_details = class_details
+
+    @property
+    def message(self):
+        return self.class_details
 
 
 class StageStates(Enum):
@@ -193,14 +200,11 @@ class FSMMixin:
         )
         if trigger is not None:
             self.trigger(trigger, **kwargs)
-            app.logger.info(
-                f"calling {trigger_prefix} trigger '{trigger}' for '{self.__repr__()}'"
-            )
         else:
-            app.logger.info(
-                f"could not locate {trigger_prefix} trigger '{trigger}' for '{self.__repr__()}'"
-            )
             self.trigger("fail")
+            raise StateMachineMisconfiguredError(
+                f"could not locate trigger with prefix '{trigger_prefix}' for '{self.__repr__()}'"
+            )
 
     def start_next_stage(self, **kwargs):
         self._find_and_call_stage_trigger("create_", **kwargs)

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -17,17 +17,9 @@ from atat.models.mixins.state_machines import (
     FSMStates,
     StageStates,
     _build_transitions,
+    StateMachineMisconfiguredError,
 )
 from atat.models.types import Id
-
-
-class StateMachineMisconfiguredError(Exception):
-    def __init__(self, class_details):
-        self.class_details = class_details
-
-    @property
-    def message(self):
-        return self.class_details
 
 
 def _stage_to_classname(stage):
@@ -152,9 +144,6 @@ class PortfolioStateMachine(
 
         elif state_obj.is_CREATED:
             if "complete" in self.machine.get_triggers(state_obj.name):
-                app.logger.info(
-                    "last stage completed. transitioning to COMPLETED state"
-                )
                 self.trigger("complete", **kwargs)
             else:
                 self.start_next_stage(**kwargs)
@@ -198,6 +187,10 @@ class PortfolioStateMachine(
         """
         # TODO: Make this real
         return True
+
+    @property
+    def history(self):
+        return self.get_changes()
 
     @property
     def application_id(self):

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -2,7 +2,6 @@ from unittest.mock import Mock, patch
 
 import pendulum
 import pydantic
-from pydantic import ValidationError as PydanticValidationError
 import pytest
 from pytest import raises
 from tests.factories import (
@@ -13,15 +12,16 @@ from tests.factories import (
     TaskOrderFactory,
     UserFactory,
 )
-from atat.domain.csp.cloud.models import TenantCSPPayload
-from atat.domain.csp.cloud.exceptions import GeneralCSPException, UnknownServerException
 
-from atat.models.mixins.state_machines import AzureStages, FSMStates
-from atat.models.portfolio_state_machine import (
+from atat.models.mixins.state_machines import (
+    AzureStages,
+    FSMStates,
     StateMachineMisconfiguredError,
+)
+from atat.models.portfolio_state_machine import (
+    PortfolioStateMachine,
     _stage_to_classname,
     get_stage_csp_class,
-    PortfolioStateMachine,
 )
 
 # TODO: Write failure case tests


### PR DESCRIPTION
Closes: [AT-5184](https://ccpo.atlassian.net/browse/AT-5184)

This PR ensures that CSP exceptions raised during provisioning get bubbled up so that Celery can retry them.

When our `provision_portfolio` Celery task is called, we move the state machine of a given portfolio to an `*_IN_PROGRESS` state and call `after_in_progress_callback`. All that's needed for Celery to retry the task is for `after_in_progress_callback` to raise a `GeneralCSPException`. This now happens in `PortfolioStateMachine._do_provision_stage`.

At present, if a portfolio fails a provisioning step after 3 retries (the Celery default), it will remain in a failed state and not get picked up again for provisioning.