### PR TITLE
Require `get_portfolios_pending_provisioning` to return signed TOs

### DIFF
--- a/atat/domain/portfolios/portfolios.py
+++ b/atat/domain/portfolios/portfolios.py
@@ -178,6 +178,6 @@ class Portfolios(object):
                     PortfolioStateMachine.state.like("%CREATED"),
                 )
             )
-            .filter(TaskOrder.signed_at != None)
+            .filter(TaskOrder.signed_at.isnot(None))
         )
         return [id_ for id_, in results]

--- a/atat/domain/portfolios/portfolios.py
+++ b/atat/domain/portfolios/portfolios.py
@@ -1,3 +1,5 @@
+import pendulum
+
 from sqlalchemy import or_
 from typing import List
 from uuid import UUID
@@ -146,9 +148,8 @@ class Portfolios(object):
         return db.session.query(Portfolio.id)
 
     @classmethod
-    def get_portfolios_pending_provisioning(cls, now) -> List[UUID]:
-        """
-        Any portfolio with
+    def get_portfolios_pending_provisioning(cls, now: pendulum.DateTime) -> List[UUID]:
+        """Retrieve UUIDs for any portfolio with the following properties:
             - Active CLINs (within the period of performance)
             - Not soft-deleted
             - No state machine attached OR
@@ -157,6 +158,7 @@ class Portfolios(object):
               - STARTING
               - STARTED
               - any that string-match /*CREATED$/
+            - A signed task order
         """
 
         results = (
@@ -176,5 +178,6 @@ class Portfolios(object):
                     PortfolioStateMachine.state.like("%CREATED"),
                 )
             )
+            .filter(TaskOrder.signed_at != None)
         )
         return [id_ for id_, in results]

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -380,7 +380,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: Portfolio is associated with an unsigned task order
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.TENANT_CREATED.name,
+            state_machine_status=FSMStates.UNSTARTED.name,
             task_order_signed_at=None,
         )
         # When I query for portfolios pending provisioning

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -105,9 +105,9 @@ def test_environment_role_job_failure(session, celery_app, celery_worker):
     assert job_failure.task == task
 
 
-now = pendulum.now()
-yesterday = now.subtract(days=1)
-tomorrow = now.add(days=1)
+NOW = pendulum.now()
+YESTERDAY = NOW.subtract(days=1)
+TOMORROW = NOW.add(days=1)
 
 
 def test_create_environment_job(session, csp):
@@ -227,14 +227,7 @@ def test_dispatch_create_environment(session, monkeypatch):
     portfolio = PortfolioFactory.create(
         applications=[{"environments": [{}, {}], "cloud_id": uuid4().hex}],
         task_orders=[
-            {
-                "create_clins": [
-                    {
-                        "start_date": pendulum.now().subtract(days=1),
-                        "end_date": pendulum.now().add(days=1),
-                    }
-                ]
-            }
+            {"create_clins": [{"start_date": YESTERDAY, "end_date": TOMORROW,}]}
         ],
     )
     [e1, e2] = portfolio.applications[0].environments
@@ -295,14 +288,7 @@ def test_create_environment_no_dupes(session, celery_app, celery_worker):
     portfolio = PortfolioFactory.create(
         applications=[{"environments": [{"cloud_id": uuid4().hex}]}],
         task_orders=[
-            {
-                "create_clins": [
-                    {
-                        "start_date": pendulum.now().subtract(days=1),
-                        "end_date": pendulum.now().add(days=1),
-                    }
-                ]
-            }
+            {"create_clins": [{"start_date": YESTERDAY, "end_date": TOMORROW,}]}
         ],
     )
     environment = portfolio.applications[0].environments[0]
@@ -327,13 +313,8 @@ def test_dispatch_provision_portfolio(csp, monkeypatch):
     portfolio = PortfolioFactory.create(
         task_orders=[
             {
-                "create_clins": [
-                    {
-                        "start_date": pendulum.now().subtract(days=1),
-                        "end_date": pendulum.now().add(days=1),
-                    }
-                ],
-                "signed_at": pendulum.now(),
+                "create_clins": [{"start_date": YESTERDAY, "end_date": TOMORROW,}],
+                "signed_at": NOW,
             }
         ],
     )
@@ -535,7 +516,7 @@ class TestSendTaskOrderFiles:
 class TestCreateBillingInstructions:
     @pytest.fixture
     def unsent_clin(self):
-        start_date = pendulum.now().subtract(days=1)
+        start_date = YESTERDAY
         portfolio = PortfolioFactory.create(
             csp_data={
                 "tenant_id": str(uuid4()),
@@ -575,7 +556,7 @@ class TestCreateBillingInstructions:
         session.rollback()
 
     def test_task_order_with_multiple_clins(self, session):
-        start_date = pendulum.now(tz="UTC").subtract(days=1)
+        start_date = YESTERDAY
         portfolio = PortfolioFactory.create(
             csp_data={
                 "tenant_id": str(uuid4()),

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -332,7 +332,8 @@ def test_dispatch_provision_portfolio(csp, monkeypatch):
                         "start_date": pendulum.now().subtract(days=1),
                         "end_date": pendulum.now().add(days=1),
                     }
-                ]
+                ],
+                "signed_at": pendulum.now(),
             }
         ],
     )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -86,6 +86,7 @@ class EnvQueryTest:
         env_data=None,
         app_data=None,
         state_machine_status=None,
+        task_order_signed_at=pendulum.now(),
     ):
         env_data = env_data or {}
         app_data = app_data or {}
@@ -104,7 +105,8 @@ class EnvQueryTest:
                     "create_clins": [
                         {"start_date": start_date, "end_date": end_date}
                         for (start_date, end_date) in start_and_end_dates
-                    ]
+                    ],
+                    "signed_at": task_order_signed_at,
                 }
             ],
         )


### PR DESCRIPTION
When a user enters a task order, and enters a start date for a CLIN POP that is on or before the current date, but does NOT sign the TO, provisioning will begin immediately. Only fully signed TOs should ‘count’ for the purposes of determining whether a portfolio is funded.

https://ccpo.atlassian.net/browse/AT-5182