### PR TITLE
Include filename in downloaded task order dictionary.

### DIFF
--- a/atat/domain/csp/files.py
+++ b/atat/domain/csp/files.py
@@ -30,11 +30,14 @@ class MockFileService(FileService):
         with open("tests/fixtures/sample.pdf", "rb") as some_bytes:
             return {
                 "name": object_name,
-                "content": some_bytes,
+                "content": some_bytes.read(),
+                "filename": "sample.pdf",
             }
 
 
 class AzureFileService(FileService):
+    DEFAULT_FILENAME = "task-order.pdf"
+
     def __init__(self, config):
         self.account_name = config["AZURE_ACCOUNT_NAME"]
         self.storage_key = config["AZURE_STORAGE_KEY"]
@@ -101,7 +104,13 @@ class AzureFileService(FileService):
         b = block_blob_service.get_blob_to_bytes(
             container_name=self.container_name, blob_name=object_name,
         )
+
+        filename = AzureFileService.DEFAULT_FILENAME
+        if b.metadata:
+            filename = b.metadata.get("filename", AzureFileService.DEFAULT_FILENAME)
+
         return {
             "name": b.name,
+            "filename": filename,
             "content": b.content,
         }

--- a/tests/domain/cloud/test_azure_file_service.py
+++ b/tests/domain/cloud/test_azure_file_service.py
@@ -1,22 +1,54 @@
+import pytest
+
 from atat.domain.csp.files import AzureFileService
 from azure.storage.blob.models import Blob
 
 
 class MockBlockBlobService(object):
+    blob_name = "1s4lsd45"
+    content = b"mock content"
+    metadata = {"filename": "test.pdf"}
+
     def __init__(self, exception=None, **kwargs):
         self.exception = exception
 
-    def get_blob_to_bytes(self, blob_name="test.pdf", **kwargs):
+    def get_blob_to_bytes(self, blob_name, **kwargs):
         if self.exception:
             raise self.exception
         else:
-            return Blob(name=blob_name, content=b"mock content")
+            return Blob(
+                name=MockBlockBlobService.blob_name,
+                content=MockBlockBlobService.content,
+                metadata=MockBlockBlobService.metadata,
+            )
 
 
-def test_download_task_order_success(app, monkeypatch):
-    file_service = AzureFileService(config=app.config)
-    file_service.BlockBlobService = MockBlockBlobService
+class Test_download_task_order:
+    @pytest.fixture
+    def file_service(self, app):
+        file_service = AzureFileService(config=app.config)
+        file_service.BlockBlobService = MockBlockBlobService
+        return file_service
 
-    task_order = file_service.download_task_order("test.pdf")
-    assert task_order["name"] == "test.pdf"
-    assert task_order["content"] == b"mock content"
+    @pytest.fixture
+    def task_order(self, file_service):
+        return file_service.download_task_order(MockBlockBlobService.blob_name)
+
+    def test_name(self, task_order):
+        assert task_order["name"] == MockBlockBlobService.blob_name
+
+    def test_content(self, task_order):
+        assert task_order["content"] == MockBlockBlobService.content
+
+    def test_filename(self, task_order):
+        assert task_order["filename"] == MockBlockBlobService.metadata["filename"]
+
+    def test_no_metadata(self, file_service):
+        MockBlockBlobService.metadata = None
+        task_order = file_service.download_task_order(MockBlockBlobService.blob_name)
+        assert task_order["filename"] == AzureFileService.DEFAULT_FILENAME
+
+    def test_no_filename_in_metadata(self, file_service):
+        MockBlockBlobService.metadata = {}
+        task_order = file_service.download_task_order(MockBlockBlobService.blob_name)
+        assert task_order["filename"] == AzureFileService.DEFAULT_FILENAME


### PR DESCRIPTION
When ATAT downloads a task order, it should add the the filename to the
dictionary of data it returns for the Azure Blob object. This is useful
for including in email attachments. The "name" property is the name ATAT
assigned the object in Azure blob storage, which is not the same as the
filename (the object name must be unique within the storage container,
so we use a GUID). ATAT's frontend should add the filename as metadata
to the storage object and it should still be available to ATAT when
downloading the task order. We'll supply a default filename for cases
where the filename is not available.

This also updates:
- the mock Files interface so that it provides a filename
- the tests for `send_task_order_files`, the Celery task responsible for
  downloading and transmitting task orders to the CSP

[AT-5192](https://ccpo.atlassian.net/browse/AT-5192)