### PR TITLE
[AT-5225] Normalize management group IDs for role creation.

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1867,7 +1867,7 @@ class AzureCloudProvider(CloudProviderInterface):
             )
 
         role_guid = self.roles[payload.role]
-        role_definition_id = f"/providers/Microsoft.Management/managementGroups/{payload.management_group_id}/providers/Microsoft.Authorization/roleDefinitions/{role_guid}"
+        role_definition_id = f"{payload.management_group_id}/providers/Microsoft.Authorization/roleDefinitions/{role_guid}"
 
         request_body = {
             "properties": {

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -23,6 +23,14 @@ SUBSCRIPTION_ID_REGEX = re.compile(
 )
 
 
+def normalize_management_group_id(cls, id_):
+    if id_:
+        if AZURE_MGMNT_PATH not in id_:
+            return f"{AZURE_MGMNT_PATH}{id_}"
+        else:
+            return id_
+
+
 class AliasModel(BaseModel):
     """
     This provides automatic camel <-> snake conversion for serializing to/from json
@@ -341,6 +349,10 @@ class ManagementGroupCSPPayload(AliasModel):
     display_name: str
     parent_id: Optional[str]
 
+    _normalize_parent_id = validator("parent_id", allow_reuse=True)(
+        normalize_management_group_id
+    )
+
     @validator("management_group_name", pre=True, always=True)
     def supply_management_group_name_default(cls, name):
         if name:
@@ -356,14 +368,6 @@ class ManagementGroupCSPPayload(AliasModel):
     @validator("display_name", pre=True, always=True)
     def enforce_display_name_length(cls, name):
         return name[0:90]
-
-    @validator("parent_id", pre=True, always=True)
-    def enforce_parent_id_pattern(cls, id_):
-        if id_:
-            if AZURE_MGMNT_PATH not in id_:
-                return f"{AZURE_MGMNT_PATH}{id_}"
-            else:
-                return id_
 
 
 class ManagementGroupCSPResponse(AliasModel):
@@ -576,6 +580,10 @@ class UserRoleCSPPayload(BaseCSPPayload):
     management_group_id: str
     role: Roles
     user_object_id: str
+
+    _normalize_management_group_id = validator("management_group_id", allow_reuse=True)(
+        normalize_management_group_id
+    )
 
 
 class UserRoleCSPResult(AliasModel):

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -8,6 +8,7 @@ from atat.domain.csp.cloud.models import (
     ManagementGroupCSPPayload,
     ManagementGroupCSPResponse,
     UserCSPPayload,
+    UserRoleCSPPayload,
     BillingOwnerCSPPayload,
 )
 
@@ -180,3 +181,24 @@ class TestBillingOwnerCSPPayload:
     def test_email(self):
         payload = BillingOwnerCSPPayload(**self.user_payload)
         assert payload.email == self.user_payload["password_recovery_email_address"]
+
+
+class TestUserRoleCSPPayload:
+    def test_management_group_id_without_path(self):
+        payload = UserRoleCSPPayload(
+            tenant_id="123",
+            management_group_id="mid",
+            role="owner",
+            user_object_id="123",
+        )
+        assert payload.management_group_id == f"{AZURE_MGMNT_PATH}mid"
+
+    def test_management_group_id_with_path(self):
+        full_path = f"{AZURE_MGMNT_PATH}mid"
+        payload = UserRoleCSPPayload(
+            tenant_id="123",
+            management_group_id=full_path,
+            role="owner",
+            user_object_id="123",
+        )
+        assert payload.management_group_id == full_path


### PR DESCRIPTION
There was a bug in user role creation (the `create_user_role` method on
the `AzureCloudProvider`). ATAT is storing environments' management
group IDs as full Azure paths, but that method was expecting them as
simple GUIDs. To address this, I've made it so that the corresponding
payload model (`UserRoleCSPPayload`) normalizes its management group ID
to always be a full path. That way, the user role creation method can
always expect to have a full path. This involved extracting an existing
validator function from another model so that it can be re-used, as
explained in the pydantic docs here:
https://pydantic-docs.helpmanual.io/usage/validators/#reuse-validators

[AT-5225](https://ccpo.atlassian.net/browse/AT-5225)