### PR TITLE
Fix URL for user role creation.

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1882,7 +1882,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
         assignment_guid = str(uuid4())
 
-        url = f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Management/managementGroups/{payload.management_group_id}/providers/Microsoft.Authorization/roleAssignments/{assignment_guid}?api-version=2015-07-01"
+        url = f"{self.sdk.cloud.endpoints.resource_manager}{payload.management_group_id}/providers/Microsoft.Authorization/roleAssignments/{assignment_guid}?api-version=2015-07-01"
 
         response = self.sdk.requests.put(url, headers=auth_header, json=request_body)
 


### PR DESCRIPTION
In this commit (0c3d8112b54be46078599da9f1be558d6c127da1) I updated the
management group ID path for the role definition ID needed to create an
Azure Role Assignment to represent an environment role. I failed to
update the corresponding URL, which also uses the Azure management group
full path for IDs. It's updated here. Tested by running the hybrid tests
locally.