### PR TITLE
Delete removed envs and restore deleted envs

### DIFF
--- a/atat/domain/applications.py
+++ b/atat/domain/applications.py
@@ -60,6 +60,9 @@ class Applications(BaseDomainClass):
             Environments.create_many(
                 g.current_user, application, new_data["environment_names"]
             )
+            Environments.delete_removed_environments(
+                application, new_data["environment_names"]
+            )
 
         db.session.add(application)
         commit_or_raise_already_exists_error(message="application")


### PR DESCRIPTION
During application creation, a user has the opportunity to create environments and edit them.  If a user decides to remove and/or rename an environment, these edits weren't being properly saved.

To resolve this issue, we're now marking removed environments as deleted.  Additionally, when an environment is renamed back to an environment that has been created, it is restored. 

__Open questions__

Instead of deleting environments, should we instead update the name field?  This would require the UI to know the environment's ID. 