### PR TITLE
Rename FSMStates to PortfolioStates

### DIFF
--- a/atat/domain/applications.py
+++ b/atat/domain/applications.py
@@ -17,7 +17,7 @@ from atat.models import (
     Portfolio,
     PortfolioStateMachine,
 )
-from atat.models.mixins.state_machines import FSMStates
+from atat.models.mixins.state_machines import PortfolioStates
 from atat.utils import first_or_none, commit_or_raise_already_exists_error
 
 
@@ -135,7 +135,7 @@ class Applications(BaseDomainClass):
             .join(PortfolioStateMachine)
             .filter(
                 and_(
-                    PortfolioStateMachine.state == FSMStates.COMPLETED,
+                    PortfolioStateMachine.state == PortfolioStates.COMPLETED,
                     Application.deleted == False,
                     Application.cloud_id.is_(None),
                     or_(

--- a/atat/domain/portfolios/portfolios.py
+++ b/atat/domain/portfolios/portfolios.py
@@ -13,7 +13,7 @@ from atat.domain.invitations import PortfolioInvitations
 from atat.models import (
     Portfolio,
     PortfolioStateMachine,
-    FSMStates,
+    PortfolioStates,
     Permissions,
     PortfolioRole,
     PortfolioRoleStatus,
@@ -170,7 +170,7 @@ class Portfolios(object):
             .filter(
                 or_(
                     Portfolio.state_machine == None,
-                    PortfolioStateMachine.state == FSMStates.UNSTARTED,
+                    PortfolioStateMachine.state == PortfolioStates.UNSTARTED,
                     PortfolioStateMachine.state.like("%CREATED"),
                 )
             )

--- a/atat/domain/task_orders.py
+++ b/atat/domain/task_orders.py
@@ -7,7 +7,7 @@ from atat.models import (
     TaskOrder,
     Portfolio,
     PortfolioStateMachine,
-    FSMStates as PortfolioStates,
+    PortfolioStates,
 )
 from atat.models.task_order import SORT_ORDERING
 from . import BaseDomainClass

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -23,7 +23,7 @@ from atat.domain.environments import Environments
 from atat.domain.portfolios import Portfolios
 from atat.domain.task_orders import TaskOrders
 from atat.models import CSPRole, JobFailure
-from atat.models.mixins.state_machines import FSMStates
+from atat.models.mixins.state_machines import PortfolioStates
 from atat.models.utils import claim_for_update, claim_many_for_update
 from atat.queue import celery
 from atat.utils.localization import translate
@@ -273,7 +273,7 @@ def do_provision_portfolio(csp: CloudProviderInterface, portfolio_id=None):
     fsm = Portfolios.get_or_create_state_machine(portfolio)
     app.logger.info(f"Triggering next transition for portfolio {portfolio.id}")
     fsm.trigger_next_transition(csp_data=make_initial_csp_data(portfolio))
-    if fsm.current_state == FSMStates.COMPLETED:
+    if fsm.current_state == PortfolioStates.COMPLETED:
         send_PPOC_email(portfolio.to_dictionary())
 
 

--- a/atat/models/__init__.py
+++ b/atat/models/__init__.py
@@ -12,7 +12,7 @@ from .notification_recipient import NotificationRecipient
 from .permissions import Permissions
 from .permission_set import PermissionSet
 from .portfolio import Portfolio
-from .portfolio_state_machine import PortfolioStateMachine, FSMStates
+from .portfolio_state_machine import PortfolioStateMachine, PortfolioStates
 from .portfolio_invitation import PortfolioInvitation
 from .portfolio_role import PortfolioRole, Status as PortfolioRoleStatus
 from .task_order import TaskOrder

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -68,10 +68,10 @@ def _build_csp_states(csp_stages: Enum) -> dict:
     return {**system_states, **csp_states}
 
 
-FSMStates = Enum("FSMStates", _build_csp_states(AzureStages))
+PortfolioStates = Enum("PortfolioStates", _build_csp_states(AzureStages))
 
 compose_state = lambda csp_stage, state: getattr(
-    FSMStates, f"{csp_stage.name}_{state.name}"
+    PortfolioStates, f"{csp_stage.name}_{state.name}"
 )
 
 
@@ -116,7 +116,7 @@ def _build_transitions(csp_stages):
                         list(csp_stages)[stage_index - 1], StageStates.CREATED
                     )
                 else:
-                    source = FSMStates.UNSTARTED
+                    source = PortfolioStates.UNSTARTED
                 transitions.append(
                     dict(
                         trigger="create_" + csp_stage.name.lower(),
@@ -157,7 +157,7 @@ def _build_transitions(csp_stages):
         dict(
             trigger="complete",
             source=compose_state(list(csp_stages)[-1], StageStates.CREATED),
-            dest=FSMStates.COMPLETED,
+            dest=PortfolioStates.COMPLETED,
         )
     )
 
@@ -167,17 +167,17 @@ def _build_transitions(csp_stages):
 class FSMMixin:
 
     system_states = [
-        {"name": FSMStates.UNSTARTED.name, "tags": ["system"]},
-        {"name": FSMStates.CONFIGURATION_ERROR.name, "tags": ["system"]},
-        {"name": FSMStates.COMPLETED.name, "tags": ["system"]},
+        {"name": PortfolioStates.UNSTARTED.name, "tags": ["system"]},
+        {"name": PortfolioStates.CONFIGURATION_ERROR.name, "tags": ["system"]},
+        {"name": PortfolioStates.COMPLETED.name, "tags": ["system"]},
     ]
 
     system_transitions = [
-        {"trigger": "reset", "source": "*", "dest": FSMStates.UNSTARTED},
+        {"trigger": "reset", "source": "*", "dest": PortfolioStates.UNSTARTED},
         {
             "trigger": "configuration_error",
             "source": "*",
-            "dest": FSMStates.CONFIGURATION_ERROR,
+            "dest": PortfolioStates.CONFIGURATION_ERROR,
         },
     ]
 

--- a/atat/models/portfolio.py
+++ b/atat/models/portfolio.py
@@ -13,7 +13,7 @@ from atat.database import db
 from atat.domain.csp.cloud.utils import generate_mail_nickname
 from atat.domain.permission_sets import PermissionSets
 from atat.models.base import Base
-from atat.models.mixins.state_machines import FSMStates
+from atat.models.mixins.state_machines import PortfolioStates
 from atat.models.portfolio_role import PortfolioRole
 from atat.models.portfolio_role import Status as PortfolioRoleStatus
 from atat.utils import first_or_none
@@ -201,7 +201,7 @@ class Portfolio(
     def is_provisioned(self) -> bool:
         return bool(
             self.state_machine
-            and self.state_machine.state_str == FSMStates.COMPLETED.name
+            and self.state_machine.state_str == PortfolioStates.COMPLETED.name
         )
 
     @property

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -14,7 +14,7 @@ from atat.database import db
 from atat.models.base import Base
 from atat.models.mixins.state_machines import (
     AzureStages,
-    FSMStates,
+    PortfolioStates,
     StageStates,
     _build_transitions,
     StateMachineMisconfiguredError,
@@ -63,8 +63,8 @@ class PortfolioStateMachine(
     portfolio = relationship("Portfolio", back_populates="state_machine")
 
     state = Column(
-        SQLAEnum(FSMStates, native_enum=False, create_constraint=False),
-        default=FSMStates.UNSTARTED,
+        SQLAEnum(PortfolioStates, native_enum=False, create_constraint=False),
+        default=PortfolioStates.UNSTARTED,
         nullable=False,
     )
 
@@ -83,7 +83,7 @@ class PortfolioStateMachine(
     def state_str(self):
         """
         If the state column has not been serialized to the database,
-        it's an instance of FSMStates. If it has been serialized and
+        it's an instance of PortfolioStates. If it has been serialized and
         deserialized, it's a string. This property will always return
         it as a string.
         """
@@ -98,7 +98,7 @@ class PortfolioStateMachine(
         self.machine = StateMachineWithTags(
             model=self,
             send_event=True,
-            initial=self.current_state if self.state else FSMStates.UNSTARTED,
+            initial=self.current_state if self.state else PortfolioStates.UNSTARTED,
             auto_transitions=False,
             after_state_change="after_state_change",
         )
@@ -110,7 +110,7 @@ class PortfolioStateMachine(
     @property
     def current_state(self):
         if isinstance(self.state, str):
-            return getattr(FSMStates, self.state)
+            return getattr(PortfolioStates, self.state)
         return self.state
 
     @property
@@ -130,7 +130,7 @@ class PortfolioStateMachine(
         state_obj = self.machine.get_state(self.state)
 
         kwargs["csp_data"] = kwargs.get("csp_data", {})
-        if self.current_state == FSMStates.UNSTARTED:
+        if self.current_state == PortfolioStates.UNSTARTED:
             self.start_next_stage(**kwargs)
 
         elif state_obj.is_FAILED:

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -11,7 +11,7 @@ from atat.domain.csp.cloud.models import (
     UserRoleCSPPayload,
 )
 from atat.jobs import do_create_application, do_create_environment_role, do_create_user
-from atat.models import FSMStates, PortfolioStateMachine
+from atat.models import PortfolioStates, PortfolioStateMachine
 from tests.factories import (
     ApplicationFactory,
     ApplicationRoleFactory,
@@ -61,7 +61,7 @@ def test_hybrid_provision_portfolio(pytestconfig, state_machine: PortfolioStateM
     csp_data = {}
     config = {"billing_account_name": "billing_account_name"}
 
-    while state_machine.state != FSMStates.COMPLETED:
+    while state_machine.state != PortfolioStates.COMPLETED:
         collected_data = dict(
             list(csp_data.items())
             + list(state_machine.portfolio.to_dictionary().items())
@@ -71,7 +71,7 @@ def test_hybrid_provision_portfolio(pytestconfig, state_machine: PortfolioStateM
         state_machine.trigger_next_transition(csp_data=collected_data)
         assert (
             "created" in state_machine.state.value
-            or state_machine.state == FSMStates.COMPLETED
+            or state_machine.state == PortfolioStates.COMPLETED
         )
 
         csp_data = state_machine.portfolio.csp_data

--- a/tests/domain/test_portfolios.py
+++ b/tests/domain/test_portfolios.py
@@ -19,7 +19,7 @@ from atat.domain.portfolios import (
     Portfolios,
     PortfolioStateMachines,
 )
-from atat.models import ApplicationRoleStatus, PortfolioRoleStatus, FSMStates
+from atat.models import ApplicationRoleStatus, PortfolioRoleStatus, PortfolioStates
 
 
 @pytest.fixture(scope="function")
@@ -256,7 +256,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio's state machine is in its "UNSTARTED" stage
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.UNSTARTED.name,
+            state_machine_status=PortfolioStates.UNSTARTED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -268,7 +268,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio's state machine is in a _CREATED stage
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.TENANT_CREATED.name,
+            state_machine_status=PortfolioStates.TENANT_CREATED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -280,7 +280,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio's state machine is in a _FAILED stage
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.TENANT_FAILED.name,
+            state_machine_status=PortfolioStates.TENANT_FAILED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -301,7 +301,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio has begun the provisioning process
         self.create_portfolio_with_clins(
             [(self.TOMORROW, self.TOMORROW)],
-            state_machine_status=FSMStates.TENANT_CREATED.name,
+            state_machine_status=PortfolioStates.TENANT_CREATED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -322,7 +322,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio is in the middle of the provisioning process
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.YESTERDAY)],
-            state_machine_status=FSMStates.TENANT_CREATED.name,
+            state_machine_status=PortfolioStates.TENANT_CREATED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -343,7 +343,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: The portfolio has begun the provisioning process
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.TENANT_CREATED.name,
+            state_machine_status=PortfolioStates.TENANT_CREATED.name,
         )
         # When I query for portfolios pending provisioning
         portfolios_pending = Portfolios.get_portfolios_pending_provisioning(self.NOW)
@@ -356,7 +356,7 @@ class TestGetPortfoliosPendingCreate(EnvQueryTest):
         # Given: Portfolio is associated with an unsigned task order
         self.create_portfolio_with_clins(
             [(self.YESTERDAY, self.TOMORROW)],
-            state_machine_status=FSMStates.UNSTARTED.name,
+            state_machine_status=PortfolioStates.UNSTARTED.name,
             task_order_signed_at=None,
         )
         # When I query for portfolios pending provisioning

--- a/tests/domain/test_task_orders.py
+++ b/tests/domain/test_task_orders.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 from atat.domain.exceptions import AlreadyExistsError
 from atat.domain.task_orders import TaskOrders
-from atat.models import Attachment, FSMStates as PortfolioStates
+from atat.models import Attachment, PortfolioStates
 from atat.models.task_order import TaskOrder, SORT_ORDERING, Status
 from tests.factories import TaskOrderFactory, CLINFactory, PortfolioFactory
 

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -12,7 +12,7 @@ from atat.domain.permission_sets import PermissionSets
 from atat.domain.portfolio_roles import PortfolioRoles
 from atat.forms import data
 from atat.models import *
-from atat.models.mixins.state_machines import FSMStates
+from atat.models.mixins.state_machines import PortfolioStates
 
 
 def random_choice(choices):
@@ -167,7 +167,7 @@ class PortfolioFactory(Base):
             )
 
         if state:
-            state = getattr(FSMStates, state)
+            state = getattr(PortfolioStates, state)
             fsm = PortfolioStateMachineFactory.create(state=state, portfolio=portfolio)
             # setting it in the factory is not working for some reason
             fsm.state = state

--- a/tests/models/mixins/test_state_machines.py
+++ b/tests/models/mixins/test_state_machines.py
@@ -6,7 +6,7 @@ from pytest import raises
 from atat.models.mixins.state_machines import (
     AzureStages,
     StageStates,
-    FSMStates,
+    PortfolioStates,
     StateMachineMisconfiguredError,
     _build_csp_states,
     _build_transitions,
@@ -23,7 +23,7 @@ class AzureStagesTest(Enum):
 def test_find_and_call_stage_trigger():
     portfolio = PortfolioFactory.create(state="TENANT_IN_PROGRESS")
     portfolio.state_machine._find_and_call_stage_trigger("fail_")
-    assert portfolio.state_machine.state == FSMStates.TENANT_FAILED
+    assert portfolio.state_machine.state == PortfolioStates.TENANT_FAILED
 
 
 def test_find_and_call_stage_trigger_fails():
@@ -32,7 +32,7 @@ def test_find_and_call_stage_trigger_fails():
         portfolio.state_machine._find_and_call_stage_trigger(
             "wont_find_a_trigger_with_this_prefix"
         )
-    assert portfolio.state_machine.state == FSMStates.CONFIGURATION_ERROR
+    assert portfolio.state_machine.state == PortfolioStates.CONFIGURATION_ERROR
 
 
 @pytest.mark.state_machine
@@ -69,8 +69,10 @@ def test_build_transitions():
     created_to_in_progress_trigger = next(
         (t for t in transitions if t.get("trigger") == "create_policies")
     )
-    assert created_to_in_progress_trigger["source"] == FSMStates.TENANT_CREATED
-    assert created_to_in_progress_trigger["dest"] == FSMStates.POLICIES_IN_PROGRESS
+    assert created_to_in_progress_trigger["source"] == PortfolioStates.TENANT_CREATED
+    assert (
+        created_to_in_progress_trigger["dest"] == PortfolioStates.POLICIES_IN_PROGRESS
+    )
 
 
 @pytest.mark.state_machine
@@ -93,5 +95,5 @@ def test_build_csp_states():
 def test_compose_state():
     assert (
         compose_state(AzureStages.TENANT, StageStates.CREATED)
-        == FSMStates.TENANT_CREATED
+        == PortfolioStates.TENANT_CREATED
     )

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -15,7 +15,7 @@ from tests.factories import (
 
 from atat.models.mixins.state_machines import (
     AzureStages,
-    FSMStates,
+    PortfolioStates,
     StateMachineMisconfiguredError,
 )
 from atat.models.portfolio_state_machine import (
@@ -60,18 +60,18 @@ def test_fsm_creation(portfolio):
 @pytest.mark.state_machine
 class TestTriggerNextTransition:
     def test_failed(self, state_machine):
-        state_machine.state = FSMStates.TENANT_FAILED
+        state_machine.state = PortfolioStates.TENANT_FAILED
         state_machine.trigger_next_transition(
             csp_data=state_machine.portfolio.to_dictionary()
         )
-        assert state_machine.current_state == FSMStates.TENANT_CREATED
+        assert state_machine.current_state == PortfolioStates.TENANT_CREATED
 
     def test_started(self, state_machine):
-        state_machine.state = FSMStates.UNSTARTED
+        state_machine.state = PortfolioStates.UNSTARTED
         state_machine.trigger_next_transition(
             csp_data=state_machine.portfolio.to_dictionary()
         )
-        assert state_machine.current_state == FSMStates.TENANT_CREATED
+        assert state_machine.current_state == PortfolioStates.TENANT_CREATED
 
 
 @pytest.mark.state_machine
@@ -128,58 +128,58 @@ def test_after_in_progress_callback(_do_provisioning_stage):
     with raises(Exception):
         portfolio.state_machine.after_in_progress_callback(Mock())
     # Then the state machine fails the stage
-    assert portfolio.state_machine.state == FSMStates.TENANT_FAILED
+    assert portfolio.state_machine.state == PortfolioStates.TENANT_FAILED
 
 
 @pytest.mark.state_machine
 def test_current_state_property(state_machine):
-    assert state_machine.current_state == FSMStates.UNSTARTED
-    state_machine.state = FSMStates.TENANT_IN_PROGRESS
-    assert state_machine.current_state == FSMStates.TENANT_IN_PROGRESS
+    assert state_machine.current_state == PortfolioStates.UNSTARTED
+    state_machine.state = PortfolioStates.TENANT_IN_PROGRESS
+    assert state_machine.current_state == PortfolioStates.TENANT_IN_PROGRESS
     state_machine.state = "UNSTARTED"
-    assert state_machine.current_state == FSMStates.UNSTARTED
+    assert state_machine.current_state == PortfolioStates.UNSTARTED
 
 
 @pytest.mark.state_machine
 def test_start_next_stage(state_machine):
-    state_machine.state = FSMStates.UNSTARTED
+    state_machine.state = PortfolioStates.UNSTARTED
     state_machine.start_next_stage(csp_data=state_machine.portfolio.to_dictionary())
     # _IN_PROGRESS automatically triggers callback which fails or finishes the stage
-    assert state_machine.state == FSMStates.TENANT_CREATED
+    assert state_machine.state == PortfolioStates.TENANT_CREATED
 
 
 @pytest.mark.state_machine
 def test_resume_stage_progress(state_machine):
-    state_machine.state = FSMStates.TENANT_FAILED
+    state_machine.state = PortfolioStates.TENANT_FAILED
     state_machine.resume_stage_progress(
         csp_data=state_machine.portfolio.to_dictionary()
     )
     # _IN_PROGRESS automatically triggers callback which fails or finishes the stage
-    assert state_machine.state == FSMStates.TENANT_CREATED
+    assert state_machine.state == PortfolioStates.TENANT_CREATED
 
 
 @pytest.mark.state_machine
 def test_fail_stage(state_machine):
-    state_machine.state = FSMStates.TENANT_IN_PROGRESS
+    state_machine.state = PortfolioStates.TENANT_IN_PROGRESS
     state_machine.fail_stage()
-    assert state_machine.state == FSMStates.TENANT_FAILED
+    assert state_machine.state == PortfolioStates.TENANT_FAILED
 
 
 @pytest.mark.state_machine
 def test_finish_stage(state_machine):
     state_machine.portfolio.csp_data = {}
-    state_machine.state = FSMStates.TENANT_IN_PROGRESS
+    state_machine.state = PortfolioStates.TENANT_IN_PROGRESS
     state_machine.finish_stage()
-    assert state_machine.state == FSMStates.TENANT_CREATED
+    assert state_machine.state == PortfolioStates.TENANT_CREATED
 
 
 @pytest.mark.state_machine
 @pytest.mark.parametrize(
     "state_machine_state",
     [
-        (FSMStates.TENANT_IN_PROGRESS),
-        (FSMStates.TENANT_CREATED),
-        (FSMStates.TENANT_FAILED),
+        (PortfolioStates.TENANT_IN_PROGRESS),
+        (PortfolioStates.TENANT_CREATED),
+        (PortfolioStates.TENANT_FAILED),
     ],
 )
 def test_current_stage(state_machine_state, state_machine):
@@ -211,7 +211,7 @@ def test_state_machine_initialization(state_machine):
         create_trigger = next(
             filter(
                 lambda trigger: trigger.startswith("create_"),
-                state_machine.machine.get_triggers(FSMStates.UNSTARTED.name),
+                state_machine.machine.get_triggers(PortfolioStates.UNSTARTED.name),
             ),
             None,
         )
@@ -222,33 +222,33 @@ def test_state_machine_initialization(state_machine):
 def test_fsm_transition_start(state_machine: PortfolioStateMachine):
 
     expected_states = [
-        FSMStates.TENANT_CREATED,
-        FSMStates.BILLING_PROFILE_CREATION_CREATED,
-        FSMStates.BILLING_PROFILE_VERIFICATION_CREATED,
-        FSMStates.BILLING_PROFILE_TENANT_ACCESS_CREATED,
-        FSMStates.TASK_ORDER_BILLING_CREATION_CREATED,
-        FSMStates.TASK_ORDER_BILLING_VERIFICATION_CREATED,
-        FSMStates.BILLING_INSTRUCTION_CREATED,
-        FSMStates.PRODUCT_PURCHASE_CREATED,
-        FSMStates.PRODUCT_PURCHASE_VERIFICATION_CREATED,
-        FSMStates.TENANT_PRINCIPAL_APP_CREATED,
-        FSMStates.TENANT_PRINCIPAL_CREATED,
-        FSMStates.TENANT_PRINCIPAL_CREDENTIAL_CREATED,
-        FSMStates.ADMIN_ROLE_DEFINITION_CREATED,
-        FSMStates.PRINCIPAL_ADMIN_ROLE_CREATED,
-        FSMStates.INITIAL_MGMT_GROUP_CREATED,
-        FSMStates.INITIAL_MGMT_GROUP_VERIFICATION_CREATED,
-        FSMStates.TENANT_ADMIN_OWNERSHIP_CREATED,
-        FSMStates.TENANT_PRINCIPAL_OWNERSHIP_CREATED,
-        FSMStates.BILLING_OWNER_CREATED,
-        FSMStates.TENANT_ADMIN_CREDENTIAL_RESET_CREATED,
-        FSMStates.POLICIES_CREATED,
-        FSMStates.COMPLETED,
+        PortfolioStates.TENANT_CREATED,
+        PortfolioStates.BILLING_PROFILE_CREATION_CREATED,
+        PortfolioStates.BILLING_PROFILE_VERIFICATION_CREATED,
+        PortfolioStates.BILLING_PROFILE_TENANT_ACCESS_CREATED,
+        PortfolioStates.TASK_ORDER_BILLING_CREATION_CREATED,
+        PortfolioStates.TASK_ORDER_BILLING_VERIFICATION_CREATED,
+        PortfolioStates.BILLING_INSTRUCTION_CREATED,
+        PortfolioStates.PRODUCT_PURCHASE_CREATED,
+        PortfolioStates.PRODUCT_PURCHASE_VERIFICATION_CREATED,
+        PortfolioStates.TENANT_PRINCIPAL_APP_CREATED,
+        PortfolioStates.TENANT_PRINCIPAL_CREATED,
+        PortfolioStates.TENANT_PRINCIPAL_CREDENTIAL_CREATED,
+        PortfolioStates.ADMIN_ROLE_DEFINITION_CREATED,
+        PortfolioStates.PRINCIPAL_ADMIN_ROLE_CREATED,
+        PortfolioStates.INITIAL_MGMT_GROUP_CREATED,
+        PortfolioStates.INITIAL_MGMT_GROUP_VERIFICATION_CREATED,
+        PortfolioStates.TENANT_ADMIN_OWNERSHIP_CREATED,
+        PortfolioStates.TENANT_PRINCIPAL_OWNERSHIP_CREATED,
+        PortfolioStates.BILLING_OWNER_CREATED,
+        PortfolioStates.TENANT_ADMIN_CREDENTIAL_RESET_CREATED,
+        PortfolioStates.POLICIES_CREATED,
+        PortfolioStates.COMPLETED,
     ]
 
     config = {"billing_account_name": "billing_account_name"}
 
-    assert state_machine.state == FSMStates.UNSTARTED
+    assert state_machine.state == PortfolioStates.UNSTARTED
 
     for expected_state in expected_states:
         if state_machine.portfolio.csp_data is not None:

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -43,7 +43,7 @@ from atat.jobs import (
 )
 from atat.models import (
     ApplicationRoleStatus,
-    FSMStates,
+    PortfolioStates,
     JobFailure,
     Portfolio,
 )
@@ -346,7 +346,7 @@ class TestDoProvisionPortfolio:
 
         # The stage before "COMPLETED"
         last_step = [e.name for e in AzureStages][-1]
-        sm.state = getattr(FSMStates, f"{last_step}_CREATED")
+        sm.state = getattr(PortfolioStates, f"{last_step}_CREATED")
         do_provision_portfolio(csp=csp, portfolio_id=portfolio.id)
 
         assert send_PPOC_email.assert_called_once
@@ -540,7 +540,7 @@ class TestCreateBillingInstructions:
                 "billing_profile_name": "fake",
             },
             task_orders=[{"create_clins": [{"start_date": start_date}]}],
-            state=FSMStates.COMPLETED.name,
+            state=PortfolioStates.COMPLETED.name,
         )
         return portfolio.task_orders[0].clins[0]
 
@@ -587,7 +587,7 @@ class TestCreateBillingInstructions:
                     ]
                 }
             ],
-            state=FSMStates.COMPLETED.name,
+            state=PortfolioStates.COMPLETED.name,
         )
         task_order = portfolio.task_orders[0]
         sent_clin = task_order.clins[0]


### PR DESCRIPTION
Refactored enum name from `FSMStates` to  `PortfolioStates`.

see [AT-5218](https://ccpo.atlassian.net/browse/AT-5218)