### PR TITLE
[AT-4890] Abstract azure error handling

### DIFF
--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -231,7 +231,11 @@ def test_disable_user(mock_azure: AzureCloudProvider):
     assert result.get("name") == assignment_guid
 
 
-def test_create_tenant(mock_azure: AzureCloudProvider):
+def test_create_tenant(mock_azure: AzureCloudProvider, monkeypatch):
+    monkeypatch.setattr(
+        "atat.domain.csp.cloud.azure_cloud_provider.AzureCloudProvider.generate_valid_domain_name",
+        lambda *a: "domain_name",
+    )
     mock_result = Mock()
     mock_result.json.return_value = {
         "objectId": "0a5f4926-e3ee-4f47-a6e3-8b0a30a40e3d",


### PR DESCRIPTION
This is my current solution to [AT-4890](https://ccpo.atlassian.net/browse/AT-4890). Other things I'm thinking about:
- If I were to go one step further, instead of using a decorator, I'd use a `requests` [event hook](https://2.python-requests.org/en/master/user/advanced/#event-hooks). This would make it so that `raise_for_status()` (and logging in the case of an error) would be called automatically on the response.
- If I were to go one step _further_, I'd use a [`session object`](https://2.python-requests.org/en/master/user/advanced/#session-objects) to make API calls. This way, we wouldn't have to remember to register the status checking and error logging hook for each API call -- it would be included automatically. 

That being said -- I think that would take some non-trivial refactoring of our tests to implement either of these setups. There's a lot of mocking that happens that would have to be changed.

There's also some opportunity to DRY stuff that has to do with token-getting, but that might be a better task for [AT-5195](https://ccpo.atlassian.net/browse/AT-5195)

Questions:
- would it be worth it to further explore the event hook method, with the caveat that it would bump up the story points for this ticket?
- There's probably a reason that we import requests in each SDK class class and use that in the cloud provider class (e.g. `self.sdk.requests.<method>`) instead of just importing requests in the module and using it directly in the class, but, why?