### PR TITLE
Fix bug in EnvironmentRoles.disable

### DIFF
--- a/atat/domain/environment_roles.py
+++ b/atat/domain/environment_roles.py
@@ -119,9 +119,9 @@ class EnvironmentRoles(object):
     def disable(cls, environment_role_id):
         environment_role = EnvironmentRoles.get_by_id(environment_role_id)
 
-        if environment_role.cloud_id and not environment_role.environment.cloud_id:
-            tenant_id = environment_role.environment.portfolio.csp_data.get("tenant_id")
-            app.csp.cloud.disable_user(tenant_id, environment_role.csp_user_id)
+        if environment_role.cloud_id:
+            tenant_id = environment_role.environment.portfolio.tenant_id
+            app.csp.cloud.disable_user(tenant_id, environment_role.cloud_id)
 
         environment_role.status = EnvironmentRole.Status.DISABLED
         db.session.add(environment_role)

--- a/atat/models/environment_role.py
+++ b/atat/models/environment_role.py
@@ -38,6 +38,8 @@ class EnvironmentRole(
 
     cloud_id = Column(String())
 
+    # TODO: Why is this implemented as a status enum? Seems like we only use
+    # the DISABLED state.
     class Status(Enum):
         PENDING = "pending"
         COMPLETED = "completed"

--- a/atat/models/portfolio.py
+++ b/atat/models/portfolio.py
@@ -208,6 +208,10 @@ class Portfolio(
     def application_id(self):
         return None
 
+    @property
+    def tenant_id(self):
+        return self.csp_data.get("tenant_id") if self.csp_data else None
+
     def to_dictionary(self):
         return {
             "user_id": generate_mail_nickname(

--- a/tests/models/test_portfolio.py
+++ b/tests/models/test_portfolio.py
@@ -234,3 +234,17 @@ class TestInitialClinDict:
             ],
         )
         assert portfolio.initial_clin_dict["initial_clin_number"] == "1001"
+
+
+class Test_tenant_id:
+    def test_tenant_id(self):
+        portfolio = PortfolioFactory.create(csp_data={"tenant_id": "123"})
+        assert portfolio.tenant_id == "123"
+
+    def test_no_csp_data(self):
+        portfolio = PortfolioFactory.create(csp_data=None)
+        assert portfolio.tenant_id is None
+
+    def test_no_tenant_id(self):
+        portfolio = PortfolioFactory.create(csp_data={})
+        assert portfolio.tenant_id is None


### PR DESCRIPTION
Previously, this method would only invoke the cloud interface method for
disabling an Azure role assignment if the associated environment did
_not_ have an associated management group in Azure (signified by a value
in the `cloud_id` column for that environment). This doesn't make any
sense and is a mistake that crept in at some point (probably from me!).

This commit also introduces a property to the portfolio model to allow
easier access to the tenant ID for that portfolio. This way callers
don't have to know the implementation details for that data.

AT-5246