### PR TITLE
[WIP] [AT-5208] VCR Hybrid Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,13 +217,6 @@ To run only the Python unit tests:
     poetry run python -m pytest
 **Integration tests with the Hybrid Interface**
 
-Integration tests that use the hybrid cloud provider are skipped by default and should be run on their own, as some of the required hybrid configuration values may cause certain non-hybrid tests to fail. As a result, it's recommended that you do not `EXPORT` these hybrid config values into your shell environment, but instead load them only for that command with something like the following:
-
-```
-env $(cat .env.hybrid | xargs) poetry run pytest --no-cov --hybrid tests/domain/cloud/test_hybrid_csp.py
-```
-The config values required by the hybrid tests are outlined in the [Hybrid Configuration](#hybrid-configuration) section. Note that the `--hybrid` parameter is also required for hybrid tests to run.
-
 This project also runs Javascript tests using jest. To run the Javascript tests:
 
     yarn test
@@ -425,3 +418,11 @@ fi
 ```
 
 Also note that if the line number of a previously whitelisted secret changes, the whitelist file, `.secrets.baseline`, will be updated and needs to be committed.
+
+### VCR 
+
+We use VCR to cache most HTTP interactions performed by the hybrid tests as "cassette" (yaml) files. 
+When the tests are run with the cassettes present, instead of issuing real requests, the VCR library instead serves the cached response.
+This allows us to have "real" integration tests running in CI/CD which does not generate Azure resources.
+
+https://vcrpy.readthedocs.io/en/latest/

--- a/poetry.lock
+++ b/poetry.lock
@@ -800,6 +800,15 @@ msrest = ">=0.6.0,<2.0.0"
 
 [[package]]
 category = "dev"
+description = "multidict implementation"
+marker = "python_version >= \"3.6\""
+name = "multidict"
+optional = false
+python-versions = ">=3.5"
+version = "4.7.5"
+
+[[package]]
+category = "dev"
 description = "Optional static typing for Python"
 name = "mypy"
 optional = false
@@ -1391,6 +1400,23 @@ secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0
 socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
 
 [[package]]
+category = "dev"
+description = "Automatically mock your HTTP interactions to simplify and speed up testing"
+name = "vcrpy"
+optional = false
+python-versions = ">=3.5"
+version = "4.0.2"
+
+[package.dependencies]
+PyYAML = "*"
+six = ">=1.5"
+wrapt = "*"
+
+[package.dependencies.yarl]
+python = ">=3.6"
+version = "*"
+
+[[package]]
 category = "main"
 description = "Promises, promises, promises."
 name = "vine"
@@ -1449,6 +1475,19 @@ MarkupSafe = "*"
 email = ["email-validator"]
 ipaddress = ["ipaddress"]
 locale = ["Babel (>=1.3)"]
+
+[[package]]
+category = "dev"
+description = "Yet another URL library"
+marker = "python_version >= \"3.6\""
+name = "yarl"
+optional = false
+python-versions = ">=3.5"
+version = "1.4.2"
+
+[package.dependencies]
+idna = ">=2.0"
+multidict = ">=4.0"
 
 [[package]]
 category = "main"
@@ -1837,6 +1876,25 @@ msrestazure = [
     {file = "msrestazure-0.6.3-py2.py3-none-any.whl", hash = "sha256:0ae7f903ff81631512beef39602c4104a8fe04cb7d166f28a1ec43c0f0985749"},
     {file = "msrestazure-0.6.3.tar.gz", hash = "sha256:0ec9db93eeea6a6cf1240624a04f49cd8bbb26b98d84a63a8220cfda858c2a96"},
 ]
+multidict = [
+    {file = "multidict-4.7.5-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:fc3b4adc2ee8474cb3cd2a155305d5f8eda0a9c91320f83e55748e1fcb68f8e3"},
+    {file = "multidict-4.7.5-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:42f56542166040b4474c0c608ed051732033cd821126493cf25b6c276df7dd35"},
+    {file = "multidict-4.7.5-cp35-cp35m-win32.whl", hash = "sha256:7774e9f6c9af3f12f296131453f7b81dabb7ebdb948483362f5afcaac8a826f1"},
+    {file = "multidict-4.7.5-cp35-cp35m-win_amd64.whl", hash = "sha256:c2c37185fb0af79d5c117b8d2764f4321eeb12ba8c141a95d0aa8c2c1d0a11dd"},
+    {file = "multidict-4.7.5-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:e439c9a10a95cb32abd708bb8be83b2134fa93790a4fb0535ca36db3dda94d20"},
+    {file = "multidict-4.7.5-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:85cb26c38c96f76b7ff38b86c9d560dea10cf3459bb5f4caf72fc1bb932c7136"},
+    {file = "multidict-4.7.5-cp36-cp36m-win32.whl", hash = "sha256:620b37c3fea181dab09267cd5a84b0f23fa043beb8bc50d8474dd9694de1fa6e"},
+    {file = "multidict-4.7.5-cp36-cp36m-win_amd64.whl", hash = "sha256:6e6fef114741c4d7ca46da8449038ec8b1e880bbe68674c01ceeb1ac8a648e78"},
+    {file = "multidict-4.7.5-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:a326f4240123a2ac66bb163eeba99578e9d63a8654a59f4688a79198f9aa10f8"},
+    {file = "multidict-4.7.5-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:dc561313279f9d05a3d0ffa89cd15ae477528ea37aa9795c4654588a3287a9ab"},
+    {file = "multidict-4.7.5-cp37-cp37m-win32.whl", hash = "sha256:4b7df040fb5fe826d689204f9b544af469593fb3ff3a069a6ad3409f742f5928"},
+    {file = "multidict-4.7.5-cp37-cp37m-win_amd64.whl", hash = "sha256:317f96bc0950d249e96d8d29ab556d01dd38888fbe68324f46fd834b430169f1"},
+    {file = "multidict-4.7.5-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:b51249fdd2923739cd3efc95a3d6c363b67bbf779208e9f37fd5e68540d1a4d4"},
+    {file = "multidict-4.7.5-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ae402f43604e3b2bc41e8ea8b8526c7fa7139ed76b0d64fc48e28125925275b2"},
+    {file = "multidict-4.7.5-cp38-cp38-win32.whl", hash = "sha256:bb519becc46275c594410c6c28a8a0adc66fe24fef154a9addea54c1adb006f5"},
+    {file = "multidict-4.7.5-cp38-cp38-win_amd64.whl", hash = "sha256:544fae9261232a97102e27a926019100a9db75bec7b37feedd74b3aa82f29969"},
+    {file = "multidict-4.7.5.tar.gz", hash = "sha256:aee283c49601fa4c13adc64c09c978838a7e812f85377ae130a24d7198c0331e"},
+]
 mypy = [
     {file = "mypy-0.770-cp35-cp35m-macosx_10_6_x86_64.whl", hash = "sha256:a34b577cdf6313bf24755f7a0e3f3c326d5c1f4fe7422d1d06498eb25ad0c600"},
     {file = "mypy-0.770-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:86c857510a9b7c3104cf4cde1568f4921762c8f9842e987bc03ed4f160925754"},
@@ -2194,6 +2252,10 @@ urllib3 = [
     {file = "urllib3-1.25.9-py2.py3-none-any.whl", hash = "sha256:88206b0eb87e6d677d424843ac5209e3fb9d0190d0ee169599165ec25e9d9115"},
     {file = "urllib3-1.25.9.tar.gz", hash = "sha256:3018294ebefce6572a474f0604c2021e33b3fd8006ecd11d62107a5d2a963527"},
 ]
+vcrpy = [
+    {file = "vcrpy-4.0.2-py2.py3-none-any.whl", hash = "sha256:c4ddf1b92c8a431901c56a1738a2c797d965165a96348a26f4b2bbc5fa6d36d9"},
+    {file = "vcrpy-4.0.2.tar.gz", hash = "sha256:9740c5b1b63626ec55cefb415259a2c77ce00751e97b0f7f214037baaf13c7bf"},
+]
 vine = [
     {file = "vine-1.3.0-py2.py3-none-any.whl", hash = "sha256:ea4947cc56d1fd6f2095c8d543ee25dad966f78692528e68b4fada11ba3f98af"},
     {file = "vine-1.3.0.tar.gz", hash = "sha256:133ee6d7a9016f177ddeaf191c1f58421a1dcc6ee9a42c58b34bed40e1d2cd87"},
@@ -2216,6 +2278,25 @@ wrapt = [
 wtforms = [
     {file = "WTForms-2.3.1-py2.py3-none-any.whl", hash = "sha256:6ff8635f4caeed9f38641d48cfe019d0d3896f41910ab04494143fc027866e1b"},
     {file = "WTForms-2.3.1.tar.gz", hash = "sha256:861a13b3ae521d6700dac3b2771970bd354a63ba7043ecc3a82b5288596a1972"},
+]
+yarl = [
+    {file = "yarl-1.4.2-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:3ce3d4f7c6b69c4e4f0704b32eca8123b9c58ae91af740481aa57d7857b5e41b"},
+    {file = "yarl-1.4.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a4844ebb2be14768f7994f2017f70aca39d658a96c786211be5ddbe1c68794c1"},
+    {file = "yarl-1.4.2-cp35-cp35m-win32.whl", hash = "sha256:d8cdee92bc930d8b09d8bd2043cedd544d9c8bd7436a77678dd602467a993080"},
+    {file = "yarl-1.4.2-cp35-cp35m-win_amd64.whl", hash = "sha256:c2b509ac3d4b988ae8769901c66345425e361d518aecbe4acbfc2567e416626a"},
+    {file = "yarl-1.4.2-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:308b98b0c8cd1dfef1a0311dc5e38ae8f9b58349226aa0533f15a16717ad702f"},
+    {file = "yarl-1.4.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:944494be42fa630134bf907714d40207e646fd5a94423c90d5b514f7b0713fea"},
+    {file = "yarl-1.4.2-cp36-cp36m-win32.whl", hash = "sha256:5b10eb0e7f044cf0b035112446b26a3a2946bca9d7d7edb5e54a2ad2f6652abb"},
+    {file = "yarl-1.4.2-cp36-cp36m-win_amd64.whl", hash = "sha256:a161de7e50224e8e3de6e184707476b5a989037dcb24292b391a3d66ff158e70"},
+    {file = "yarl-1.4.2-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:26d7c90cb04dee1665282a5d1a998defc1a9e012fdca0f33396f81508f49696d"},
+    {file = "yarl-1.4.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:0c2ab325d33f1b824734b3ef51d4d54a54e0e7a23d13b86974507602334c2cce"},
+    {file = "yarl-1.4.2-cp37-cp37m-win32.whl", hash = "sha256:e15199cdb423316e15f108f51249e44eb156ae5dba232cb73be555324a1d49c2"},
+    {file = "yarl-1.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:2098a4b4b9d75ee352807a95cdf5f10180db903bc5b7270715c6bbe2551f64ce"},
+    {file = "yarl-1.4.2-cp38-cp38-macosx_10_13_x86_64.whl", hash = "sha256:c9959d49a77b0e07559e579f38b2f3711c2b8716b8410b320bf9713013215a1b"},
+    {file = "yarl-1.4.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:25e66e5e2007c7a39541ca13b559cd8ebc2ad8fe00ea94a2aad28a9b1e44e5ae"},
+    {file = "yarl-1.4.2-cp38-cp38-win32.whl", hash = "sha256:6faa19d3824c21bcbfdfce5171e193c8b4ddafdf0ac3f129ccf0cdfcb083e462"},
+    {file = "yarl-1.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:0ca2f395591bbd85ddd50a82eb1fde9c1066fafe888c5c7cc1d810cf03fd3cc6"},
+    {file = "yarl-1.4.2.tar.gz", hash = "sha256:58cd9c469eced558cd81aa3f484b2924e8897049e06889e8ff2510435b7ef74b"},
 ]
 zipp = [
     {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ beautifulsoup4 = "*"
 mypy = "*"
 rope = "*"
 black = "^19.10b0"
+vcrpy = "*"
 
 
 [tool.black]

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -132,6 +132,8 @@ def before_record_response(response):
     try:
         if response["headers"].get("WWW-Authenticate"):
             response["headers"]["WWW-Authenticate"] = "*****"
+        if response["headers"].get("Location"):
+            response["headers"]["Location"] = "*****"
         string = response["body"]["string"]
         if isinstance(string, bytes):
             string = string.decode()
@@ -301,7 +303,7 @@ def test_hybrid_create_environment_job(session, csp):
     assert result.id
 
 
-@pytest.mark.hybrid
+@hybrid_vcr.use_cassette()
 def test_get_reporting_data(csp):
     from_date = pendulum.now().subtract(years=1).add(days=1).format("YYYY-MM-DD")
     to_date = pendulum.now().format("YYYY-MM-DD")
@@ -321,6 +323,17 @@ def test_get_reporting_data(csp):
 @pytest.mark.xfail(reason="This test cannot complete due to permission issues.")
 def test_create_subscription(csp):
     environment = EnvironmentFactory.create()
+
+
+class TestHybridUserManagement:
+    @pytest.fixture
+    def portfolio(self, app, csp):
+        return PortfolioFactory.create(
+            csp_data={
+                "tenant_id": csp.azure.tenant_id,
+                "domain_name": f"dancorriganpromptworks",
+            }
+        )
 
     payload = SubscriptionCreationCSPPayload(
         display_name=environment.name,

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -239,9 +239,11 @@ def state_machine(app, csp, portfolio):
 
 
 @hybrid_vcr.use_cassette()
-def test_hybrid_provision_portfolio(pytestconfig, state_machine: PortfolioStateMachine):
+def test_hybrid_provision_portfolio(
+    pytestconfig, app, state_machine: PortfolioStateMachine
+):
     csp_data = {}
-    config = {"billing_account_name": "billing_account_name"}
+    config = {"billing_account_name": app.config["AZURE_BILLING_ACCOUNT_NAME"]}
 
     while state_machine.state != PortfolioStates.COMPLETED:
         collected_data = dict(

--- a/tests/fixtures/cassettes/test_get_reporting_data.yaml
+++ b/tests/fixtures/cassettes/test_get_reporting_data.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:47 GMT
+      - Tue, 28 Apr 2020 19:18:22 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AkqHLD3AXJxKhSwrQlaNJr5J34YQAQAAAJZ4OtYOAAAA; expires=Thu, 28-May-2020
-        19:18:47 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ask5scXsJPJHkV-pKSwOfdZJ34YQAQAAAH54OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:22 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 00fb021d-8c36-4e28-9cfb-ae460efe6b00
+      - 0f679100-6f2b-4d34-90c0-af0b93e17f00
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 1557bae2-8985-11ea-b591-acde48001122
+      - 06a77348-8985-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1588101527, "updated": 1588101527,
+        "attributes": {"enabled": true, "created": 1588101502, "updated": 1588101502,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:47 GMT
+      - Tue, 28 Apr 2020 19:18:22 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - ba1387a3-eebb-4947-b60c-176ccdd90b9e
+      - 7d9d417a-2630-41e0-a08b-d521546c0350
     status:
       code: 200
       message: OK
@@ -141,7 +141,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:48 GMT
+      - Tue, 28 Apr 2020 19:18:22 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AsT-ffa0YclGgyAsha9MsQdJ34YQAQAAAJd4OtYOAAAA; expires=Thu, 28-May-2020
-        19:18:48 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AosEpFA9vM9Nj3inG1sQJeJJ34YQAQAAAH54OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:23 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 0b0336c2-e901-4a78-92e6-c3995ab48800
+      - 8b5c07ca-57c4-43ff-9e96-776881e78100
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 15d207f2-8985-11ea-b591-acde48001122
+      - 0701701e-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1588101527, "updated": 1588101527,
+        "attributes": {"enabled": true, "created": 1588101502, "updated": 1588101502,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:48 GMT
+      - Tue, 28 Apr 2020 19:18:22 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 4e6b6e98-3b50-40e3-99a2-f801edaee542
+      - a9fe4490-b2cd-4005-bd2a-b9beb80c22cd
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 6953334e-4a59-425a-bf91-a33345c31678
+      - 864417ed-3432-4456-a76a-22959942584f
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -255,7 +255,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1588105128", "not_before": "1588101228", "resource": "https://management.azure.com/",
+        "expires_on": "1588105103", "not_before": "1588101203", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:47 GMT
+      - Tue, 28 Apr 2020 19:18:23 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgY0zecrRJNPlpIOlCT9u4fZVRABAQAAAJd4OtYOAAAA; expires=Thu, 28-May-2020
-        19:18:48 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhaoKb5uB3hGtkemeXKO1d3ZVRABAQAAAH94OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:23 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,19 +282,21 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 6953334e-4a59-425a-bf91-a33345c31678
+      - 864417ed-3432-4456-a76a-22959942584f
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 0f679100-6f2b-4d34-90c0-af0b14e57f00
+      - 12d5d861-1e9f-43af-b969-e6279b498300
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleDefinitions/*****",
-      "principalId": "*****"}}'
+    body: '{"type": "Usage", "timeframe": "Custom", "timePeriod": {"from": "2019-04-29",
+      "to": "2020-04-28"}, "dataset": {"granularity": "Monthly", "aggregation": {"totalCost":
+      {"name": "PreTaxCost", "function": "Sum"}}, "grouping": [{"type": "Dimension",
+      "name": "InvoiceId"}]}}'
     headers:
       Accept:
       - '*/*'
@@ -303,45 +305,72 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '267'
+      - '268'
       Content-Type:
       - application/json
       User-Agent:
       - python-requests/2.23.0
-    method: PUT
-    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
+    method: POST
+    uri: https://management.azure.com//providers/Microsoft.Billing/billingAccounts/*****:*****_2019-05-31/billingProfiles/YCML-ZQL7-BG7-PGB/invoiceSections/3IYQ-4XVD-PJA-PGB/providers/Microsoft.CostManagement/query?api-version=2019-11-01
   response:
     body:
-      string: '{"error": {"code": "RoleAssignmentExists", "message": "The role assignment
-        already exists."}}'
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cfrerqspjldXP3i2JaV0113o6fFGVZLC/uTuTn8XRarZdtczeb3v/0/l6+v71z/uDh9v3z6b3t
+        yc798+29h3l2/3xy7zyb7j3amRzcm+Y72fan2cO97f3znZ3tyaf5w+3zvZ08n+zls3uT6e+/t7P7
+        cHvn/va9XdPJy7o6L8q8ufv7nHzxfPunfuL5g+0nnz/Yfvn5k7vF8rIqpvnrfNoW1bK5e+/s9/mJ
+        7f3f+yefbr/8zjG3iA3ipGraL7JldpEv8mV79xet8/r67qeT+5/uTKfn27s7s0+39/c+3ds+OKcR
+        zPJsOjmY5Lv3Hxx8NPpomS1yos0tW7fXK7Te3DW1K6tphhF89Gi5LsvRR83btfk1f5NdmN9pMKu8
+        bou8+ejRL/5omb9rnxfLt+bbaVWuF0v66nv0naD5sqbX36FT6kSRebFeTPL6o18ysq10Ur+olu3c
+        tXuatXlbUAOv5ZnQ+2zmmr1ua3rXb3Syrut8OcW4Om2+P/qorq6A4fd27+2Odx4efHpvf2fv03v3
+        Hnz66egjmfoH2zu7b3Z2HvH/CEa+c39n5+AH+/v36Y+vXj/96Puj7x3cH+/ufvrw0/sPH9z79NO9
+        e+bdg1u8u/vp7vhg/+Dg4e7ug51PH3y6t7/x7YcP9i4e0B/6NvX8cIeeg4O9h/f27j24v2fepv/d
+        +Pbu/f3xwcN79x/uPrz3KX23bzGn/0XePv/pbEV/6NsHn47vHVDvBzuf3tvZe3B/90Df3t25xdu7
+        Bzvj+7s7+3sH9+4/IOLtPtz89nK1s6Q/zNv7e2PCHm8Cws6DB+bt3Vu8vXdwML5/nyb64d7DB/v3
+        9u7vbn776mFzTn/o27ufPiDMH+x/uvNgZ+/+p/SLeXvvFm9/uvPp+IBeu7ezu0dz7rqOvpzt/6L5
+        Ff2hLxPnjA8O9h98+vDgAc35/sP7eHsPFKP/3fT2/Yd74/3dB7sHBzv393d39w94uoffnk1zj1n2
+        dmm+6d3d3Yf79w8O7u8xyfF2HPPw7U+JU3d2d4jb9+/RsB8eMLMMv734dLlLf5i393bHn2Ki9j59
+        uL9DU8Ykx9v3bvH2/oPxgSVU94WLHULrPsmu98IuseT4ge2DzEjwCv2PG37/l/yS/wfkcz9OnAYA
+        AA==
     headers:
+      Access-Control-Allow-Origin:
+      - '*'
       Cache-Control:
       - no-cache
-      Content-Length:
-      - '89'
+      Content-Encoding:
+      - gzip
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 28 Apr 2020 19:18:49 GMT
+      - Tue, 28 Apr 2020 19:18:35 GMT
       Expires:
       - '-1'
       Pragma:
       - no-cache
-      Set-Cookie:
-      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
       X-Content-Type-Options:
       - nosniff
+      session-id:
+      - 3853f433-2f29-476c-ae69-7fd389d5a4aa
+      x-ms-client-request-id:
+      - ba9ee9dd-921d-42c9-92c1-4102069ab121
+      x-ms-correlation-id:
+      - d6b5f5c0-19d9-472b-8c93-6d9007ca0c5e
       x-ms-correlation-request-id:
-      - 40e97116-6630-48b6-8519-f1999b00fdf2
-      x-ms-ratelimit-remaining-tenant-writes:
-      - '1198'
+      - a0c0dd6c-a143-4fce-9815-99ede623c407
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11998'
       x-ms-request-id:
-      - 8621bc54-fa0b-432d-ade3-965bcb9e37f9
+      - 56caf3b9-6e2b-492a-8372-c3442f276170
       x-ms-routing-request-id:
-      - CENTRALUS:20200428T191849Z:40e97116-6630-48b6-8519-f1999b00fdf2
+      - CENTRALUS:20200428T191836Z:a0c0dd6c-a143-4fce-9815-99ede623c407
     status:
-      code: 409
-      message: Conflict
+      code: 200
+      message: OK
 version: 1

--- a/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:46 GMT
+      - Tue, 28 Apr 2020 19:17:33 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ar9UGhZfNk5Fp2zLRD9LFmVJ34YQAQAAALs7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:47 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhTik5It0qpFqgcSdCwdyzdJ34YQAQAAAE14OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:34 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 8e77b773-75a5-40fc-9706-571a21d70d00
+      - 927d8acf-854d-4d68-a6b0-a442e09f7f00
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - de8a55aa-8665-11ea-83d2-acde48001122
+      - e9c1dad4-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758268, "updated": 1587758268,
+        "attributes": {"enabled": true, "created": 1588101454, "updated": 1588101454,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:47 GMT
+      - Tue, 28 Apr 2020 19:17:34 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 3840756c-61bd-46e1-b2ca-07b0d947bb7a
+      - a98daadb-6742-41af-99e7-0bd2449211b2
     status:
       code: 200
       message: OK
@@ -141,7 +141,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:48 GMT
+      - Tue, 28 Apr 2020 19:17:34 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AtWform-fLxMtEv93cwOtktJ34YQAQAAALs7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:48 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ara4F9l3VpZKk7_Z0Qp-2k5J34YQAQAAAE54OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:34 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - e77d5dec-7443-41d6-b78c-eaaad9800e00
+      - 0f9e8439-1d93-476a-90e6-2b2cab3f8000
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - df210464-8665-11ea-83d2-acde48001122
+      - ea24dd50-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758268, "updated": 1587758268,
+        "attributes": {"enabled": true, "created": 1588101454, "updated": 1588101454,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:48 GMT
+      - Tue, 28 Apr 2020 19:17:34 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - e15675b1-c142-443a-a168-f74708f614a3
+      - 5fa6440a-b95e-4542-a9d9-dee2360f00a3
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 27aad7e9-c94e-4c06-bbac-6763666b8c94
+      - dae175a2-8da1-4c5c-968d-dbdf76a13a89
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -255,7 +255,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761869", "not_before": "1587757969", "resource": "https://management.azure.com/",
+        "expires_on": "1588105055", "not_before": "1588101155", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:48 GMT
+      - Tue, 28 Apr 2020 19:17:35 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgrZhe43nAxOmIG5DOwM_szZVRABAQAAALw7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:49 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=ApASraJOu6BJlUaZ-Cfaz1bZVRABAQAAAE54OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:35 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 27aad7e9-c94e-4c06-bbac-6763666b8c94
+      - dae175a2-8da1-4c5c-968d-dbdf76a13a89
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 8e77b773-75a5-40fc-9706-571a45d70d00
+      - f63df759-b713-4a51-a72f-64eedf407300
     status:
       code: 200
       message: OK
@@ -314,7 +314,7 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - dfb974ba-8665-11ea-83d2-acde48001122
+      - eac2a59e-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -330,11 +330,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:49 GMT
+      - Tue, 28 Apr 2020 19:17:36 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/df161caf-09e0-46aa-bb84-26535433c46d?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -344,19 +343,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
+      - 8ae451b8-a864-49e1-8be5-a30d0135e73a
       request-id:
-      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
+      - 8ae451b8-a864-49e1-8be5-a30d0135e73a
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
+      - 8ae451b8-a864-49e1-8be5-a30d0135e73a
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - centralus:04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
+      - centralus:8ae451b8-a864-49e1-8be5-a30d0135e73a
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195750Z:04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
+      - CENTRALUS:20200428T191736Z:8ae451b8-a864-49e1-8be5-a30d0135e73a
     status:
       code: 202
       message: Accepted
@@ -373,7 +372,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - dfb974ba-8665-11ea-83d2-acde48001122
+      - eac2a59e-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -389,11 +388,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:00 GMT
+      - Tue, 28 Apr 2020 19:17:46 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/df161caf-09e0-46aa-bb84-26535433c46d?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -403,19 +401,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
+      - dc09ae4e-096f-40fb-b15b-9d905537f03b
       request-id:
-      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
+      - dc09ae4e-096f-40fb-b15b-9d905537f03b
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
+      - dc09ae4e-096f-40fb-b15b-9d905537f03b
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:bfb6c8fa-6101-4da2-8d25-f290815dfedc
+      - centralus:dc09ae4e-096f-40fb-b15b-9d905537f03b
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195800Z:bfb6c8fa-6101-4da2-8d25-f290815dfedc
+      - CENTRALUS:20200428T191747Z:dc09ae4e-096f-40fb-b15b-9d905537f03b
     status:
       code: 202
       message: Accepted
@@ -432,7 +430,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - dfb974ba-8665-11ea-83d2-acde48001122
+      - eac2a59e-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -440,12 +438,12 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d2fnu5/uTrPz7Z2H+c72/qdZ
-        tj2ZHOxv7316/979/Xv3pvufzj4afdRer/KvAZ7eXGYLvHnLfpo2a9cNtX+9nk7zfJbjQ+p0lddt
-        kdMXv/ijNl9my/YMo53czyY7+W5OQM8Ptvf37h9sZ+eTB9vnk90Hn97fn0zvT+7R+7OiWZXZ9QvB
-        5NvXk7qYpY8epcerVVlMs7aolim+THfROG+zouSeLmmc9N1Hj3ZHH61Xs6zNZ28KhrG3s7ezvUPY
-        77/Zffjo/oNH93fHe/sHB3t7P0UgtO2Ta2p578GnO9P7+wfbe7P8fHs/25tsP/x0Ott+cJ8w3dvd
-        2cszHmJWE9HQ6debxltSQifjlq1Dur1huqevqqpNudePfskv+SW/5P8BfSXlWngCAAA=
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d2fTLLu/n+1s3z94sL+9v5dN
+        tg+ms+n2w92De5ODh/nk3u70o9FH7fUq/xrg6c1ltsCbt+ynabN23VD71+vpNM9n+Yw+pE5Xed0W
+        OX3xiz9q82W2bM8w2sn9bLKT7+bbOw/PDwjo/YPt7HzyYPt8svvg0/v7k+n9yT16f1Y0qzK7fiGY
+        fPt6Uhez9NGj9Hi1Kotp1hbVMsWX6S4a521WlNzTJY2Tvvvo0e7oo/VqlrX57E3BMPZ29na2d/a3
+        9w7e7D58tPvg0b2H4x3q/+H+/Z8iGNr4yTU1vffg053p/f2D7b1Zfr69n+1Nth9+Op1tP7hPqO7t
+        7uzlGY8xq4lq6PXrzeMtSaGzccvWIeHeMOHTV1XVptzrR7/kl/ySX/L/AEfa2Yl5AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -454,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:11 GMT
+      - Tue, 28 Apr 2020 19:17:57 GMT
       Expires:
       - '-1'
       Pragma:
@@ -468,19 +466,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - adceb80e-adda-4294-bda2-f7629b9a9ac4
+      - 0b7821de-0c30-43af-a1fd-ce99989e5664
       request-id:
-      - adceb80e-adda-4294-bda2-f7629b9a9ac4
+      - 0b7821de-0c30-43af-a1fd-ce99989e5664
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - adceb80e-adda-4294-bda2-f7629b9a9ac4
+      - 0b7821de-0c30-43af-a1fd-ce99989e5664
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:adceb80e-adda-4294-bda2-f7629b9a9ac4
+      - centralus:0b7821de-0c30-43af-a1fd-ce99989e5664
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195811Z:adceb80e-adda-4294-bda2-f7629b9a9ac4
+      - CENTRALUS:20200428T191757Z:0b7821de-0c30-43af-a1fd-ce99989e5664
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
@@ -1,0 +1,548 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 000ad968-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"error": {"code": "Unauthorized", "message": "Request is missing a
+        Bearer or PoP token."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '87'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:09 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      WWW-Authenticate:
+      - Bearer authorization="https://login.windows.net/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3",
+        resource="https://vault.azure.net"
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - ea7e6d72-b477-4fff-8a74-fce9effe1fc3
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:09 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=At3QfBZqyA1Fl8IEVm0GMJJJ34YQAQAAAEXYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:10 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 225b1c71-f1af-4a8a-b4af-f8bc5d760000
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 000ad968-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667270, "updated": 1587667270,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:10 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 9f579ae6-cecd-46d9-b1cb-ec5f063b5f6f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:10 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Av3wIrI2oVVChOMd9ClW3LlJ34YQAQAAAEbYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - 61ebf40c-789b-4389-ac3f-aa9906fc1700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 0090e936-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667270, "updated": 1587667270,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:10 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 92ff71d4-a837-494c-a43d-4a610680dcc9
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - cbf423f5-2267-4ba3-8a70-53af95629f79
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670871", "not_before": "1587666971", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1420'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:11 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AnppaX2P2R9PjCXmq8aaFErZVRABAQAAAEfYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - cbf423f5-2267-4ba3-8a70-53af95629f79
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - NCUS ProdSlices
+      x-ms-request-id:
+      - f03f6c26-7ba3-403f-a990-716fb78c1800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "951449da-5fe8-4076-9a5b-d22350ee23ba", "properties": {"displayName":
+      "Hybrid :: Application Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+      x-ms-client-request-id:
+      - 0100c8f0-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba",
+        "type": "/providers/Microsoft.Management/managementGroups", "name": "951449da-5fe8-4076-9a5b-d22350ee23ba",
+        "status": "NotStarted"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:15 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      request-id:
+      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - centralus:7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184115Z:7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - 0100c8f0-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba",
+        "type": "/providers/Microsoft.Management/managementGroups", "name": "951449da-5fe8-4076-9a5b-d22350ee23ba",
+        "status": "Running"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:25 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      request-id:
+      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:17875111-95e9-4bf6-ae50-700921cb0c58
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184126Z:17875111-95e9-4bf6-ae50-700921cb0c58
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - 0100c8f0-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dx/e393ffzjLtu+f5wfb+zsP
+        Pt1+mN2fbM/29u7d38nzvXuT7KPRR+31Kv8a4OnNZbbAm7fsp2mzdt1Q+9fr6TTPZ/mMPqROV3nd
+        Fjl98Ys/avNltmzPMNrJ/Wyyk+/m2zsPzwno3v2D7ex88mD7fLL74NP7+5Pp/ck9en9WNKsyu34h
+        mHz7elIXs/TRo/R4tSqLadYW1TLFl+kuGudtVpTc0yWNk7776NHu6KP1apa1+exNwTD2dvZ2tnf2
+        t/fuvdk9eLS/+2j3wXh/d39vf/enCIS2fXJNLe89+HRnen//YHtvlp9v72d7k+2Hn05n2w/uE6Z7
+        uzt7ecZDzGoiGjr9etOYze7f273/6YPt/fOD3e39yezTbepqb3tvMvn0YX5v5/z84IC60cm4ZeuQ
+        budV9dEv+SW/5Jf8P1kJZlpqAgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:36 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - b8092864-0237-499d-9e38-2383b42c4c2b
+      request-id:
+      - b8092864-0237-499d-9e38-2383b42c4c2b
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - b8092864-0237-499d-9e38-2383b42c4c2b
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:b8092864-0237-499d-9e38-2383b42c4c2b
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184136Z:b8092864-0237-499d-9e38-2383b42c4c2b
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_application_job.yaml
@@ -3,66 +3,6 @@ interactions:
     body: '*****'
     headers:
       Accept:
-      - application/json
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json; charset=utf-8
-      User-Agent:
-      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
-      x-ms-client-request-id:
-      - 000ad968-8592-11ea-8f64-acde48001122
-    method: PUT
-    uri: https://my-vault.vault.azure.net/secret/*****
-  response:
-    body:
-      string: '{"error": {"code": "Unauthorized", "message": "Request is missing a
-        Bearer or PoP token."}}'
-    headers:
-      Cache-Control:
-      - no-cache
-      Content-Length:
-      - '87'
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Thu, 23 Apr 2020 18:41:09 GMT
-      Expires:
-      - '-1'
-      Pragma:
-      - no-cache
-      Server:
-      - Microsoft-IIS/10.0
-      Strict-Transport-Security:
-      - max-age=31536000;includeSubDomains
-      WWW-Authenticate:
-      - Bearer authorization="https://login.windows.net/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3",
-        resource="https://vault.azure.net"
-      X-AspNet-Version:
-      - 4.0.30319
-      X-Content-Type-Options:
-      - nosniff
-      X-Powered-By:
-      - ASP.NET
-      x-ms-keyvault-network-info:
-      - addr=72.13.132.150;act_addr_fam=InterNetwork;
-      x-ms-keyvault-region:
-      - eastus
-      x-ms-keyvault-service-version:
-      - 1.1.0.898
-      x-ms-request-id:
-      - ea7e6d72-b477-4fff-8a74-fce9effe1fc3
-    status:
-      code: 401
-      message: Unauthorized
-- request:
-    body: '*****'
-    headers:
-      Accept:
       - '*/*'
       Accept-Encoding:
       - gzip, deflate
@@ -75,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -84,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:09 GMT
+      - Fri, 24 Apr 2020 19:57:46 GMT
       Expires:
       - '-1'
       P3P:
@@ -96,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=At3QfBZqyA1Fl8IEVm0GMJJJ34YQAQAAAEXYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:10 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ar9UGhZfNk5Fp2zLRD9LFmVJ34YQAQAAALs7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:47 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -107,7 +47,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 225b1c71-f1af-4a8a-b4af-f8bc5d760000
+      - 8e77b773-75a5-40fc-9706-571a21d70d00
     status:
       code: 200
       message: OK
@@ -127,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 000ad968-8592-11ea-8f64-acde48001122
+      - de8a55aa-8665-11ea-83d2-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -136,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667270, "updated": 1587667270,
+        "attributes": {"enabled": true, "created": 1587758268, "updated": 1587758268,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -146,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:10 GMT
+      - Fri, 24 Apr 2020 19:57:47 GMT
       Expires:
       - '-1'
       Pragma:
@@ -168,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 9f579ae6-cecd-46d9-b1cb-ec5f063b5f6f
+      - 3840756c-61bd-46e1-b2ca-07b0d947bb7a
     status:
       code: 200
       message: OK
@@ -188,7 +128,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -197,11 +137,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:10 GMT
+      - Fri, 24 Apr 2020 19:57:48 GMT
       Expires:
       - '-1'
       P3P:
@@ -209,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Av3wIrI2oVVChOMd9ClW3LlJ34YQAQAAAEbYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AtWform-fLxMtEv93cwOtktJ34YQAQAAALs7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:48 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -218,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 61ebf40c-789b-4389-ac3f-aa9906fc1700
+      - e77d5dec-7443-41d6-b78c-eaaad9800e00
     status:
       code: 200
       message: OK
@@ -236,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 0090e936-8592-11ea-8f64-acde48001122
+      - df210464-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -245,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667270, "updated": 1587667270,
+        "attributes": {"enabled": true, "created": 1587758268, "updated": 1587758268,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -255,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:10 GMT
+      - Fri, 24 Apr 2020 19:57:48 GMT
       Expires:
       - '-1'
       Pragma:
@@ -277,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 92ff71d4-a837-494c-a43d-4a610680dcc9
+      - e15675b1-c142-443a-a168-f74708f614a3
     status:
       code: 200
       message: OK
@@ -297,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - cbf423f5-2267-4ba3-8a70-53af95629f79
+      - 27aad7e9-c94e-4c06-bbac-6763666b8c94
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -311,21 +251,21 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670871", "not_before": "1587666971", "resource": "https://management.azure.com/",
+        "expires_on": "1587761869", "not_before": "1587757969", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1420'
+      - '1487'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:11 GMT
+      - Fri, 24 Apr 2020 19:57:48 GMT
       Expires:
       - '-1'
       P3P:
@@ -333,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AnppaX2P2R9PjCXmq8aaFErZVRABAQAAAEfYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AgrZhe43nAxOmIG5DOwM_szZVRABAQAAALw7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:49 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -342,19 +282,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - cbf423f5-2267-4ba3-8a70-53af95629f79
+      - 27aad7e9-c94e-4c06-bbac-6763666b8c94
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - NCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - f03f6c26-7ba3-403f-a990-716fb78c1800
+      - 8e77b773-75a5-40fc-9706-571a45d70d00
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "951449da-5fe8-4076-9a5b-d22350ee23ba", "properties": {"displayName":
-      "Hybrid :: Application Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88"}}}}'
+    body: '{"name": "*****", "properties": {"displayName": "Hybrid :: Application
+      Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/*****"}}}}'
     headers:
       Accept:
       - application/json
@@ -374,14 +314,14 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - 0100c8f0-8592-11ea-8f64-acde48001122
+      - dfb974ba-8665-11ea-83d2-acde48001122
     method: PUT
-    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba",
-        "type": "/providers/Microsoft.Management/managementGroups", "name": "951449da-5fe8-4076-9a5b-d22350ee23ba",
-        "status": "NotStarted"}'
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "NotStarted"}'
     headers:
       Cache-Control:
       - no-cache
@@ -390,11 +330,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:15 GMT
+      - Fri, 24 Apr 2020 19:57:49 GMT
       Expires:
       - '-1'
       Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/df161caf-09e0-46aa-bb84-26535433c46d?api-version=2018-03-01-preview
       Pragma:
       - no-cache
       Retry-After:
@@ -404,19 +344,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
       request-id:
-      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      - 04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - centralus:7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      - centralus:04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184115Z:7f30ca3c-f2b1-4c48-8368-4b4aabf7cc74
+      - CENTRALUS:20200424T195750Z:04eb11c3-f14b-4fc4-8374-d79ccc8fa6a2
     status:
       code: 202
       message: Accepted
@@ -433,14 +373,14 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - 0100c8f0-8592-11ea-8f64-acde48001122
+      - dfb974ba-8665-11ea-83d2-acde48001122
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.Management/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba",
-        "type": "/providers/Microsoft.Management/managementGroups", "name": "951449da-5fe8-4076-9a5b-d22350ee23ba",
-        "status": "Running"}'
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "Running"}'
     headers:
       Cache-Control:
       - no-cache
@@ -449,11 +389,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:25 GMT
+      - Fri, 24 Apr 2020 19:58:00 GMT
       Expires:
       - '-1'
       Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/df161caf-09e0-46aa-bb84-26535433c46d?api-version=2018-03-01-preview
       Pragma:
       - no-cache
       Retry-After:
@@ -463,19 +403,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
       request-id:
-      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 17875111-95e9-4bf6-ae50-700921cb0c58
+      - bfb6c8fa-6101-4da2-8d25-f290815dfedc
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:17875111-95e9-4bf6-ae50-700921cb0c58
+      - centralus:bfb6c8fa-6101-4da2-8d25-f290815dfedc
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184126Z:17875111-95e9-4bf6-ae50-700921cb0c58
+      - CENTRALUS:20200424T195800Z:bfb6c8fa-6101-4da2-8d25-f290815dfedc
     status:
       code: 202
       message: Accepted
@@ -492,21 +432,20 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - 0100c8f0-8592-11ea-8f64-acde48001122
+      - dfb974ba-8665-11ea-83d2-acde48001122
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/951449da-5fe8-4076-9a5b-d22350ee23ba?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dx/e393ffzjLtu+f5wfb+zsP
-        Pt1+mN2fbM/29u7d38nzvXuT7KPRR+31Kv8a4OnNZbbAm7fsp2mzdt1Q+9fr6TTPZ/mMPqROV3nd
-        Fjl98Ys/avNltmzPMNrJ/Wyyk+/m2zsPzwno3v2D7ex88mD7fLL74NP7+5Pp/ck9en9WNKsyu34h
-        mHz7elIXs/TRo/R4tSqLadYW1TLFl+kuGudtVpTc0yWNk7776NHu6KP1apa1+exNwTD2dvZ2tnf2
-        t/fuvdk9eLS/+2j3wXh/d39vf/enCIS2fXJNLe89+HRnen//YHtvlp9v72d7k+2Hn05n2w/uE6Z7
-        uzt7ecZDzGoiGjr9etOYze7f273/6YPt/fOD3e39yezTbepqb3tvMvn0YX5v5/z84IC60cm4ZeuQ
-        budV9dEv+SW/5Jf8P1kJZlpqAgAA
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d2fnu5/uTrPz7Z2H+c72/qdZ
+        tj2ZHOxv7316/979/Xv3pvufzj4afdRer/KvAZ7eXGYLvHnLfpo2a9cNtX+9nk7zfJbjQ+p0lddt
+        kdMXv/ijNl9my/YMo53czyY7+W5OQM8Ptvf37h9sZ+eTB9vnk90Hn97fn0zvT+7R+7OiWZXZ9QvB
+        5NvXk7qYpY8epcerVVlMs7aolim+THfROG+zouSeLmmc9N1Hj3ZHH61Xs6zNZ28KhrG3s7ezvUPY
+        77/Zffjo/oNH93fHe/sHB3t7P0UgtO2Ta2p578GnO9P7+wfbe7P8fHs/25tsP/x0Ott+cJ8w3dvd
+        2cszHmJWE9HQ6debxltSQifjlq1Dur1huqevqqpNudePfskv+SW/5P8BfSXlWngCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -515,7 +454,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:36 GMT
+      - Fri, 24 Apr 2020 19:58:11 GMT
       Expires:
       - '-1'
       Pragma:
@@ -529,19 +468,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - b8092864-0237-499d-9e38-2383b42c4c2b
+      - adceb80e-adda-4294-bda2-f7629b9a9ac4
       request-id:
-      - b8092864-0237-499d-9e38-2383b42c4c2b
+      - adceb80e-adda-4294-bda2-f7629b9a9ac4
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - b8092864-0237-499d-9e38-2383b42c4c2b
+      - adceb80e-adda-4294-bda2-f7629b9a9ac4
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:b8092864-0237-499d-9e38-2383b42c4c2b
+      - centralus:adceb80e-adda-4294-bda2-f7629b9a9ac4
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184136Z:b8092864-0237-499d-9e38-2383b42c4c2b
+      - CENTRALUS:20200424T195811Z:adceb80e-adda-4294-bda2-f7629b9a9ac4
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -24,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:36 GMT
+      - Fri, 24 Apr 2020 19:58:11 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AkgdGQ1UzPhLo2v1EGZEc45J34YQAQAAAGDYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:37 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ak-VzvL8w3lAm4fuF-duEHpJ34YQAQAAANM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:11 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 086e96b4-82e6-4a45-a254-a2beb02f1700
+      - c99cc97f-f8d9-43ad-a805-3406e6341c00
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 101b599a-8592-11ea-8f64-acde48001122
+      - ed20dd8c-8665-11ea-83d2-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667297, "updated": 1587667297,
+        "attributes": {"enabled": true, "created": 1587758292, "updated": 1587758292,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:36 GMT
+      - Fri, 24 Apr 2020 19:58:11 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - d4114353-ee78-4329-986f-7e0b2ce05a6f
+      - fa00b662-a275-40dd-bb06-8ec94f59089f
     status:
       code: 200
       message: OK
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -137,11 +137,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:37 GMT
+      - Fri, 24 Apr 2020 19:58:12 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Al58_23eiahDmJft9Fe7uZlJ34YQAQAAAGHYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:37 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvPgQ4g8EOpFi4AeJ-LayxhJ34YQAQAAANQ7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:12 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 37878c86-4f74-439e-ae30-90d737ce1800
+      - b72b8d48-becd-4f5d-88d5-677a5f381c00
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 10769832-8592-11ea-8f64-acde48001122
+      - ed7999d6-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667297, "updated": 1587667297,
+        "attributes": {"enabled": true, "created": 1587758292, "updated": 1587758292,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:41 GMT
+      - Fri, 24 Apr 2020 19:58:12 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 8d6b11b8-dd43-4f54-8111-6827dc271612
+      - 48826c97-2b7d-4796-8551-5d1892a78dc3
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 95daf892-75b7-4b3f-bb4d-57c2f29a862c
+      - 9caf4979-959a-4f26-9ad1-8d2cbc4b7609
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -251,21 +251,21 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670902", "not_before": "1587667002", "resource": "https://management.azure.com/",
+        "expires_on": "1587761892", "not_before": "1587757992", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1420'
+      - '1487'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:42 GMT
+      - Fri, 24 Apr 2020 19:58:12 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArdlXNxNDudFpG9g9Yv4hKPZVRABAQAAAGbYM9YOAAAA; expires=Sat, 23-May-2020
-        18:41:42 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ag0FThSYSm1ButKSQG9jZN3ZVRABAQAAANQ7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:13 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,19 +282,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 95daf892-75b7-4b3f-bb4d-57c2f29a862c
+      - 9caf4979-959a-4f26-9ad1-8d2cbc4b7609
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 2aaab785-4a72-49a7-88e9-b3b284a11600
+      - 434b179f-7035-47be-9536-79464a8a1b00
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "f80f3472-5f07-4033-a585-fa9274a81be5", "properties": {"displayName":
-      "Hybrid :: Environment Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88"}}}}'
+    body: '{"name": "*****", "properties": {"displayName": "Hybrid :: Environment
+      Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/*****"}}}}'
     headers:
       Accept:
       - application/json
@@ -314,14 +314,14 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - 13920e5c-8592-11ea-8f64-acde48001122
+      - edf873fa-8665-11ea-83d2-acde48001122
     method: PUT
-    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5",
-        "type": "/providers/Microsoft.Management/managementGroups", "name": "f80f3472-5f07-4033-a585-fa9274a81be5",
-        "status": "NotStarted"}'
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "NotStarted"}'
     headers:
       Cache-Control:
       - no-cache
@@ -330,11 +330,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:43 GMT
+      - Fri, 24 Apr 2020 19:58:13 GMT
       Expires:
       - '-1'
       Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/36fb326a-10b0-4744-ae10-b3606776cf9e?api-version=2018-03-01-preview
       Pragma:
       - no-cache
       Retry-After:
@@ -344,19 +344,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      - 815fef1e-4181-43f5-a573-ca7fa70f9664
       request-id:
-      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      - 815fef1e-4181-43f5-a573-ca7fa70f9664
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      - 815fef1e-4181-43f5-a573-ca7fa70f9664
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - centralus:74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      - centralus:815fef1e-4181-43f5-a573-ca7fa70f9664
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184144Z:74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      - CENTRALUS:20200424T195814Z:815fef1e-4181-43f5-a573-ca7fa70f9664
     status:
       code: 202
       message: Accepted
@@ -373,14 +373,14 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - 13920e5c-8592-11ea-8f64-acde48001122
+      - edf873fa-8665-11ea-83d2-acde48001122
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
-      string: '{"id": "/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5",
-        "type": "/providers/Microsoft.Management/managementGroups", "name": "f80f3472-5f07-4033-a585-fa9274a81be5",
-        "status": "Running"}'
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "Running"}'
     headers:
       Cache-Control:
       - no-cache
@@ -389,11 +389,11 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:41:53 GMT
+      - Fri, 24 Apr 2020 19:58:24 GMT
       Expires:
       - '-1'
       Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/36fb326a-10b0-4744-ae10-b3606776cf9e?api-version=2018-03-01-preview
       Pragma:
       - no-cache
       Retry-After:
@@ -403,19 +403,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      - e80a6ce8-3818-49f8-8249-7d797058dde1
       request-id:
-      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      - e80a6ce8-3818-49f8-8249-7d797058dde1
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      - e80a6ce8-3818-49f8-8249-7d797058dde1
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      - centralus:e80a6ce8-3818-49f8-8249-7d797058dde1
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184154Z:dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      - CENTRALUS:20200424T195824Z:e80a6ce8-3818-49f8-8249-7d797058dde1
     status:
       code: 202
       message: Accepted
@@ -432,21 +432,20 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - 13920e5c-8592-11ea-8f64-acde48001122
+      - edf873fa-8665-11ea-83d2-acde48001122
     method: GET
-    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d88Pds7v7T/Y275/vvNge3/n
-        3r3t7P7B/e3z7OHeg/3sYHeS3/9o9FF7vcq/Bnh6c5kt8OYt+2narF031P71ejrN81k+ow+p01Ve
-        t0VOX/zij9p8mS3bM4x2cj+b7OS7+fbOw/OD7f29+wfb2fnkwfb5ZPfBp/f3J9P7k3v0/qxoVmV2
-        /UIw+fb1pC5m6aNH6enysqirJdBN8WW6i8Z5mxUl93RJ4yyq5UePdkcfrVezrM1nbwqGsbezt7O9
-        s7+9d+/N7sGj/d1H+/fHn9578OD+7sOfIhja+Mk1Nb334NOd6f39g+29WX6+vZ/tTbYffjqdbT+4
-        T6ju7e7s5RmPMasJDfT69eYxm92/t3v/UyLt+cHu9v5k9uk2dbW3vTeZfPowv7dzfn5wQN3obNyy
-        dUi486r66Jf8kl/yS/4fQ3kh1GsCAAA=
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d+99ej65t/dptr27M9nZ3n+w
+        v7+d5bs725N7n+58+uDBp9Pzh/lHo4/a61X+NcDTm8tsgTdv2U/TZu26ofav19Npns/yGX1Ina7y
+        ui1y+uIXf9Tmy2zZnmG0k/vZZCffzbd3Hp4fbO/v3T/Yzs4nD7bPJ7sPPr2/P5nen9yj92dFsyqz
+        6xeCybevJ3UxSx89Sk+Xl0VdLYFuii/TXTTO26wouadLGmdRLT96tDv6aL2aZW0+e1MwjL2dvZ3t
+        nf3tvf03uw8f3T94tHsw3t/Z+/TevZ8iENr2yTW1vPfg053p/f2D7b1Zfr69n+1Nth9+Op1tP7hP
+        mO7t7uzlGQ8xqwkLdPr1pvGWlNDJuGXrkG5vmO7pq6pqU+71o1/yS37JL/l/ACACs5t4AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -455,7 +454,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:04 GMT
+      - Fri, 24 Apr 2020 19:58:34 GMT
       Expires:
       - '-1'
       Pragma:
@@ -469,19 +468,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
       request-id:
-      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
       x-ba-restapi:
-      - 1.0.3.1565
+      - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:786ed48d-e11a-46a3-9583-614d45c70bd0
+      - centralus:6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184205Z:786ed48d-e11a-46a3-9583-614d45c70bd0
+      - CENTRALUS:20200424T195835Z:6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
@@ -1,0 +1,488 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:36 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AkgdGQ1UzPhLo2v1EGZEc45J34YQAQAAAGDYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:37 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - 086e96b4-82e6-4a45-a254-a2beb02f1700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 101b599a-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667297, "updated": 1587667297,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:36 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - d4114353-ee78-4329-986f-7e0b2ce05a6f
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:37 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Al58_23eiahDmJft9Fe7uZlJ34YQAQAAAGHYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:37 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - NCUS ProdSlices
+      x-ms-request-id:
+      - 37878c86-4f74-439e-ae30-90d737ce1800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 10769832-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667297, "updated": 1587667297,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:41 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 8d6b11b8-dd43-4f54-8111-6827dc271612
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 95daf892-75b7-4b3f-bb4d-57c2f29a862c
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670902", "not_before": "1587667002", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1420'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:42 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ArdlXNxNDudFpG9g9Yv4hKPZVRABAQAAAGbYM9YOAAAA; expires=Sat, 23-May-2020
+        18:41:42 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 95daf892-75b7-4b3f-bb4d-57c2f29a862c
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - 2aaab785-4a72-49a7-88e9-b3b284a11600
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "f80f3472-5f07-4033-a585-fa9274a81be5", "properties": {"displayName":
+      "Hybrid :: Environment Name 1", "details": {"parent": {"id": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88"}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '231'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+      x-ms-client-request-id:
+      - 13920e5c-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5",
+        "type": "/providers/Microsoft.Management/managementGroups", "name": "f80f3472-5f07-4033-a585-fa9274a81be5",
+        "status": "NotStarted"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:43 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      request-id:
+      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - 74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - centralus:74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184144Z:74d655f2-0b85-4f70-9fd3-dfdeb36360c3
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - 13920e5c-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5",
+        "type": "/providers/Microsoft.Management/managementGroups", "name": "f80f3472-5f07-4033-a585-fa9274a81be5",
+        "status": "Running"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:41:53 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      request-id:
+      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:dd8749d7-fabb-4c72-8bc7-65ca1509c480
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184154Z:dd8749d7-fabb-4c72-8bc7-65ca1509c480
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - 13920e5c-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/f80f3472-5f07-4033-a585-fa9274a81be5?api-version=2018-03-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d88Pds7v7T/Y275/vvNge3/n
+        3r3t7P7B/e3z7OHeg/3sYHeS3/9o9FF7vcq/Bnh6c5kt8OYt+2narF031P71ejrN81k+ow+p01Ve
+        t0VOX/zij9p8mS3bM4x2cj+b7OS7+fbOw/OD7f29+wfb2fnkwfb5ZPfBp/f3J9P7k3v0/qxoVmV2
+        /UIw+fb1pC5m6aNH6enysqirJdBN8WW6i8Z5mxUl93RJ4yyq5UePdkcfrVezrM1nbwqGsbezt7O9
+        s7+9d+/N7sGj/d1H+/fHn9578OD+7sOfIhja+Mk1Nb334NOd6f39g+29WX6+vZ/tTbYffjqdbT+4
+        T6ju7e7s5RmPMasJDfT69eYxm92/t3v/UyLt+cHu9v5k9uk2dbW3vTeZfPowv7dzfn5wQN3obNyy
+        dUi486r66Jf8kl/yS/4fQ3kh1GsCAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:04 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      request-id:
+      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      x-ba-restapi:
+      - 1.0.3.1565
+      x-ms-correlation-request-id:
+      - 786ed48d-e11a-46a3-9583-614d45c70bd0
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:786ed48d-e11a-46a3-9583-614d45c70bd0
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184205Z:786ed48d-e11a-46a3-9583-614d45c70bd0
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_environment_job.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:11 GMT
+      - Tue, 28 Apr 2020 19:17:57 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ak-VzvL8w3lAm4fuF-duEHpJ34YQAQAAANM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AggxlxB0ybdFnTUXPEdSxbZJ34YQAQAAAGV4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:58 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -47,7 +47,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - c99cc97f-f8d9-43ad-a805-3406e6341c00
+      - 8b5c07ca-57c4-43ff-9e96-776879e48100
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - ed20dd8c-8665-11ea-83d2-acde48001122
+      - f80d55e6-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758292, "updated": 1587758292,
+        "attributes": {"enabled": true, "created": 1588101478, "updated": 1588101478,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:11 GMT
+      - Tue, 28 Apr 2020 19:17:57 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - fa00b662-a275-40dd-bb06-8ec94f59089f
+      - 5f8edccd-4ee8-42f5-9e83-2b6a51e77a69
     status:
       code: 200
       message: OK
@@ -141,7 +141,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:12 GMT
+      - Tue, 28 Apr 2020 19:17:58 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvPgQ4g8EOpFi4AeJ-LayxhJ34YQAQAAANQ7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:12 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvsGDG16VahMsL_f6eYzPCJJ34YQAQAAAGZ4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:58 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - b72b8d48-becd-4f5d-88d5-677a5f381c00
+      - 1ebf50ce-f9db-4bc5-8218-76b360dc7a00
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - ed7999d6-8665-11ea-83d2-acde48001122
+      - f877e910-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758292, "updated": 1587758292,
+        "attributes": {"enabled": true, "created": 1588101478, "updated": 1588101478,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:12 GMT
+      - Tue, 28 Apr 2020 19:17:58 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 48826c97-2b7d-4796-8551-5d1892a78dc3
+      - b66278bb-c060-4a1e-bdd3-3791efd6da34
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 9caf4979-959a-4f26-9ad1-8d2cbc4b7609
+      - 34a0d672-8ae7-4632-b608-c32bf329caf3
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -255,7 +255,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761892", "not_before": "1587757992", "resource": "https://management.azure.com/",
+        "expires_on": "1588105079", "not_before": "1588101179", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:12 GMT
+      - Tue, 28 Apr 2020 19:17:58 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ag0FThSYSm1ButKSQG9jZN3ZVRABAQAAANQ7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:13 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ah4CgxMfQXtNkeky1poAQ6XZVRABAQAAAGd4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:59 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 9caf4979-959a-4f26-9ad1-8d2cbc4b7609
+      - 34a0d672-8ae7-4632-b608-c32bf329caf3
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 434b179f-7035-47be-9536-79464a8a1b00
+      - ee1f6ec8-8ea5-453d-9e29-8486e1b27400
     status:
       code: 200
       message: OK
@@ -314,7 +314,7 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - edf873fa-8665-11ea-83d2-acde48001122
+      - f91f7a90-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -330,11 +330,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:13 GMT
+      - Tue, 28 Apr 2020 19:18:01 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/36fb326a-10b0-4744-ae10-b3606776cf9e?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -344,19 +343,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 815fef1e-4181-43f5-a573-ca7fa70f9664
+      - d9d9dbec-5002-45b6-95d3-6702c81d67b7
       request-id:
-      - 815fef1e-4181-43f5-a573-ca7fa70f9664
+      - d9d9dbec-5002-45b6-95d3-6702c81d67b7
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 815fef1e-4181-43f5-a573-ca7fa70f9664
+      - d9d9dbec-5002-45b6-95d3-6702c81d67b7
       x-ms-ratelimit-remaining-tenant-writes:
-      - '1199'
+      - '1198'
       x-ms-request-id:
-      - centralus:815fef1e-4181-43f5-a573-ca7fa70f9664
+      - centralus:d9d9dbec-5002-45b6-95d3-6702c81d67b7
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195814Z:815fef1e-4181-43f5-a573-ca7fa70f9664
+      - CENTRALUS:20200428T191801Z:d9d9dbec-5002-45b6-95d3-6702c81d67b7
     status:
       code: 202
       message: Accepted
@@ -373,7 +372,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - edf873fa-8665-11ea-83d2-acde48001122
+      - f91f7a90-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -389,11 +388,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:24 GMT
+      - Tue, 28 Apr 2020 19:18:11 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/36fb326a-10b0-4744-ae10-b3606776cf9e?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -403,19 +401,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - e80a6ce8-3818-49f8-8249-7d797058dde1
+      - 046fb649-0c5d-4152-811d-0b9dd29f14d5
       request-id:
-      - e80a6ce8-3818-49f8-8249-7d797058dde1
+      - 046fb649-0c5d-4152-811d-0b9dd29f14d5
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - e80a6ce8-3818-49f8-8249-7d797058dde1
+      - 046fb649-0c5d-4152-811d-0b9dd29f14d5
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:e80a6ce8-3818-49f8-8249-7d797058dde1
+      - centralus:046fb649-0c5d-4152-811d-0b9dd29f14d5
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195824Z:e80a6ce8-3818-49f8-8249-7d797058dde1
+      - CENTRALUS:20200428T191811Z:046fb649-0c5d-4152-811d-0b9dd29f14d5
     status:
       code: 202
       message: Accepted
@@ -432,7 +430,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - edf873fa-8665-11ea-83d2-acde48001122
+      - f91f7a90-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -440,12 +438,12 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d+99ej65t/dptr27M9nZ3n+w
-        v7+d5bs725N7n+58+uDBp9Pzh/lHo4/a61X+NcDTm8tsgTdv2U/TZu26ofav19Npns/yGX1Ina7y
-        ui1y+uIXf9Tmy2zZnmG0k/vZZCffzbd3Hp4fbO/v3T/Yzs4nD7bPJ7sPPr2/P5nen9yj92dFsyqz
-        6xeCybevJ3UxSx89Sk+Xl0VdLYFuii/TXTTO26wouadLGmdRLT96tDv6aL2aZW0+e1MwjL2dvZ3t
-        nf3tvf03uw8f3T94tHsw3t/Z+/TevZ8iENr2yTW1vPfg053p/f2D7b1Zfr69n+1Nth9+Op1tP7hP
-        mO7t7uzlGQ8xqwkLdPr1pvGWlNDJuGXrkG5vmO7pq6pqU+71o1/yS37JL/l/ACACs5t4AgAA
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dycHBzsPd/Od7Qf700+393d3
+        H2w//PTe/vbedDK7v/PgfG8yyz4afdRer/KvAZ7eXGYLvHnLfpo2a9cNtX+9nk7zfJbP6EPqdJXX
+        bZHTF7/4ozZfZsv2DKOd3M8mO/luvr3z8Pxge3/v/sF2dj55sH0+2X3w6f39yfT+5B69PyuaVZld
+        vxBMvn09qYtZ+uhRerq8LOpqCXRTfJnuonHeZkXJPV3SOItq+dGj3dFH69Usa/PZm4Jh7O3s7Wzv
+        EPYHb3YfPto9eLRzb3z/wac0qk9/imBo4yfX1PTeg093pvf3D7b3Zvn59n62N6GBT2fbD+4Tqnu7
+        O3t5xmPMakIDvX7NebwdKcxs3K51SLg3TPj0VVW1Kff60S/5Jb/kl/w/k2uhmXkCAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -454,7 +452,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:34 GMT
+      - Tue, 28 Apr 2020 19:18:22 GMT
       Expires:
       - '-1'
       Pragma:
@@ -468,19 +466,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
+      - d8fdb2f3-af67-457b-a247-6d42d3698d5c
       request-id:
-      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
+      - d8fdb2f3-af67-457b-a247-6d42d3698d5c
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
+      - d8fdb2f3-af67-457b-a247-6d42d3698d5c
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
+      - centralus:d8fdb2f3-af67-457b-a247-6d42d3698d5c
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195835Z:6d5adcc5-4593-4ea7-a465-5cdc1a3ec4dd
+      - CENTRALUS:20200428T191822Z:d8fdb2f3-af67-457b-a247-6d42d3698d5c
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:34 GMT
+      - Tue, 28 Apr 2020 19:18:36 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvWrk0QG8d1LgvKeNUAEnf5J34YQAQAAAOs7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:35 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=As93Ba2MA0ZKgPJRT4uEdCRJ34YQAQAAAIx4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:36 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - cc0b565f-da65-46e4-ab74-870dce4a1c00
+      - 0227cf73-ef5c-4874-936d-b35f6d897200
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - fb3d71dc-8665-11ea-83d2-acde48001122
+      - 0f17e06c-8985-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
+        "attributes": {"enabled": true, "created": 1588101517, "updated": 1588101517,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:35 GMT
+      - Tue, 28 Apr 2020 19:18:37 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 1a63f052-28dc-4441-879d-d5ca60714c36
+      - 4df05ac2-4bef-463c-9031-c44609f6766c
     status:
       code: 200
       message: OK
@@ -141,7 +141,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:35 GMT
+      - Tue, 28 Apr 2020 19:18:36 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ak0JkklMbutCn7saBeaDCCdJ34YQAQAAAOw7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:36 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Aq6UY4BRQ6tPqtscsFw6mdFJ34YQAQAAAIx4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:37 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 1bce5676-e328-4c4f-a7c6-1465514f1c00
+      - 146fbbca-a0a5-41da-b62c-3401f3847600
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - fbc56e0c-8665-11ea-83d2-acde48001122
+      - 0f7858ca-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
+        "attributes": {"enabled": true, "created": 1588101517, "updated": 1588101517,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:36 GMT
+      - Tue, 28 Apr 2020 19:18:36 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 1c1bcfcf-0296-44e3-8ec8-ac5fc17e3c91
+      - 9714709b-0323-4804-9d40-06e2af7596b1
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - e64db20a-a5e3-4295-8ac5-73522090f752
+      - fd763f6c-e3b1-4013-bcfd-bebece38a0c1
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -255,7 +255,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761917", "not_before": "1587758017", "resource": "https://graph.microsoft.com",
+        "expires_on": "1588105117", "not_before": "1588101217", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:36 GMT
+      - Tue, 28 Apr 2020 19:18:37 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AsjoXDRfPMpGu2fuEyW7pqv3nB0lAQAAAO07NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:37 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Attjg4tXysJNq1QyUngl1HL3nB0lAQAAAI14OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:37 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - e64db20a-a5e3-4295-8ac5-73522090f752
+      - fd763f6c-e3b1-4013-bcfd-bebece38a0c1
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 183e58f3-bc91-407b-b994-ecb963f61b00
+      - fb52c35e-4b97-4e67-825c-169f348d7c00
     status:
       code: 200
       message: OK
@@ -314,7 +314,7 @@ interactions:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
         "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
         "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
-        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ea9c1f63.517f.419b.b16d.500ef8a97244.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.df7c79ee.1bd1.462a.b55d.cc3467845b23.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -323,19 +323,18 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:37 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b40e4889-af67-47ee-9180-473d1062a4fa/Microsoft.DirectoryServices.User
+      - Tue, 28 Apr 2020 19:18:37 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - e4ca8136-1d50-4306-a02f-5a6c2e034f18
+      - ba918275-197e-4a69-a511-c82c4e89921d
       request-id:
-      - e4ca8136-1d50-4306-a02f-5a6c2e034f18
+      - ba918275-197e-4a69-a511-c82c4e89921d
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_54"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_101"}}'
     status:
       code: 201
       message: Created
@@ -365,15 +364,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Fri, 24 Apr 2020 19:58:37 GMT
+      - Tue, 28 Apr 2020 19:18:38 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 20ba43a0-31fe-4488-adc4-778b73d9281c
+      - 8a1f96ba-5861-4506-b62c-3c2d80414d20
       request-id:
-      - 20ba43a0-31fe-4488-adc4-778b73d9281c
+      - 8a1f96ba-5861-4506-b62c-3c2d80414d20
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_13"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_82"}}'
     status:
       code: 204
       message: No Content

--- a/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -24,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:07 GMT
+      - Fri, 24 Apr 2020 19:58:34 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AjwnLLh2XcFHn77Y_vLZXhxJ34YQAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:08 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvWrk0QG8d1LgvKeNUAEnf5J34YQAQAAAOs7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:35 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - f574abb1-3250-4140-8e96-fd467a571700
+      - cc0b565f-da65-46e4-ab74-870dce4a1c00
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 20ec2b32-8592-11ea-8f64-acde48001122
+      - fb3d71dc-8665-11ea-83d2-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:08 GMT
+      - Fri, 24 Apr 2020 19:58:35 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 72d73240-3300-42b6-ac00-dd81bb962771
+      - 1a63f052-28dc-4441-879d-d5ca60714c36
     status:
       code: 200
       message: OK
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -137,11 +137,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:08 GMT
+      - Fri, 24 Apr 2020 19:58:35 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArjuHHUjuXZJlvoHOjOifUxJ34YQAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ak0JkklMbutCn7saBeaDCCdJ34YQAQAAAOw7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:36 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 5574c59b-6abb-4497-94cf-7099f9601900
+      - 1bce5676-e328-4c4f-a7c6-1465514f1c00
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 23159272-8592-11ea-8f64-acde48001122
+      - fbc56e0c-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:08 GMT
+      - Fri, 24 Apr 2020 19:58:36 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - a235e671-27e1-4a4e-a227-70ee3e472240
+      - 1c1bcfcf-0296-44e3-8ec8-ac5fc17e3c91
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - ee067e83-a27b-4a28-96a2-a4cab0828af2
+      - e64db20a-a5e3-4295-8ac5-73522090f752
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -251,11 +251,11 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670929", "not_before": "1587667029", "resource": "https://graph.microsoft.com",
+        "expires_on": "1587761917", "not_before": "1587758017", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:08 GMT
+      - Fri, 24 Apr 2020 19:58:36 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Amyq8CUx-ARGhNkSNoWTRp_3nB0lAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AsjoXDRfPMpGu2fuEyW7pqv3nB0lAQAAAO07NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:37 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - ee067e83-a27b-4a28-96a2-a4cab0828af2
+      - e64db20a-a5e3-4295-8ac5-73522090f752
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - c4cbb459-52d0-4641-9d84-5000b7721700
+      - 183e58f3-bc91-407b-b994-ecb963f61b00
     status:
       code: 200
       message: OK
@@ -312,10 +312,9 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
-        "id": "b0bc1081-d420-4e08-9744-7eaee8a3e556", "businessPhones": [], "displayName":
-        "test-user-25c8b5a2-ab09-4de1-8159-60fd5dcf3d90 Solo", "givenName": null,
-        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
-        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.25c8b5a2.ab09.4de1.8159.60fd5dcf3d90.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
+        "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ea9c1f63.517f.419b.b16d.500ef8a97244.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -324,19 +323,19 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:09 GMT
+      - Fri, 24 Apr 2020 19:58:37 GMT
       Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b0bc1081-d420-4e08-9744-7eaee8a3e556/Microsoft.DirectoryServices.User
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b40e4889-af67-47ee-9180-473d1062a4fa/Microsoft.DirectoryServices.User
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - b530ee46-412a-419a-92d4-31a8f6b2249d
+      - e4ca8136-1d50-4306-a02f-5a6c2e034f18
       request-id:
-      - b530ee46-412a-419a-92d4-31a8f6b2249d
+      - e4ca8136-1d50-4306-a02f-5a6c2e034f18
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_47"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_54"}}'
     status:
       code: 201
       message: Created
@@ -356,7 +355,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: PATCH
-    uri: https://graph.microsoft.com/v1.0/users/b0bc1081-d420-4e08-9744-7eaee8a3e556
+    uri: https://graph.microsoft.com/v1.0/users/*****
   response:
     body:
       string: ''
@@ -366,15 +365,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 23 Apr 2020 18:42:10 GMT
+      - Fri, 24 Apr 2020 19:58:37 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 87ad2c95-02c0-46ce-ba20-9444b17300b3
+      - 20ba43a0-31fe-4488-adc4-778b73d9281c
       request-id:
-      - 87ad2c95-02c0-46ce-ba20-9444b17300b3
+      - 20ba43a0-31fe-4488-adc4-778b73d9281c
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_37"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_13"}}'
     status:
       code: 204
       message: No Content

--- a/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_job.yaml
@@ -1,0 +1,381 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:07 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AjwnLLh2XcFHn77Y_vLZXhxJ34YQAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:08 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - f574abb1-3250-4140-8e96-fd467a571700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 20ec2b32-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:08 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 72d73240-3300-42b6-ac00-dd81bb962771
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:08 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ArjuHHUjuXZJlvoHOjOifUxJ34YQAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - 5574c59b-6abb-4497-94cf-7099f9601900
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 23159272-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:08 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - a235e671-27e1-4a4e-a227-70ee3e472240
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - ee067e83-a27b-4a28-96a2-a4cab0828af2
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670929", "not_before": "1587667029", "resource": "https://graph.microsoft.com",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1826'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:08 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Amyq8CUx-ARGhNkSNoWTRp_3nB0lAQAAAIDYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - ee067e83-a27b-4a28-96a2-a4cab0828af2
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - c4cbb459-52d0-4641-9d84-5000b7721700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/users
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+        "id": "b0bc1081-d420-4e08-9744-7eaee8a3e556", "businessPhones": [], "displayName":
+        "test-user-25c8b5a2-ab09-4de1-8159-60fd5dcf3d90 Solo", "givenName": null,
+        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
+        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.25c8b5a2.ab09.4de1.8159.60fd5dcf3d90.solo@dancorriganpromptworks.onmicrosoft.com"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '448'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:09 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b0bc1081-d420-4e08-9744-7eaee8a3e556/Microsoft.DirectoryServices.User
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - b530ee46-412a-419a-92d4-31a8f6b2249d
+      request-id:
+      - b530ee46-412a-419a-92d4-31a8f6b2249d
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_47"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PATCH
+    uri: https://graph.microsoft.com/v1.0/users/b0bc1081-d420-4e08-9744-7eaee8a3e556
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 23 Apr 2020 18:42:10 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - 87ad2c95-02c0-46ce-ba20-9444b17300b3
+      request-id:
+      - 87ad2c95-02c0-46ce-ba20-9444b17300b3
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_37"}}'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
@@ -1,0 +1,268 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:11 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=As_9uJbmF3FPkOVEIpZUMX1J34YQAQAAAIPYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - 2aaab785-4a72-49a7-88e9-b3b260a51600
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 24371374-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:11 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 80e5e012-ad33-477c-b0c5-6ec92599c01d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 040491b8-590e-4bbf-bb05-492011ee9f46
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670932", "not_before": "1587667032", "resource": "https://graph.microsoft.com",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1826'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:12 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AvTBDo-4ioRIuvmsNXxgZlX3nB0lAQAAAIPYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:12 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 040491b8-590e-4bbf-bb05-492011ee9f46
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - d8b86fd2-d009-4eb7-b2ea-d16f4b0e1700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/users
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+        "id": "8e9d9073-e893-47c0-807a-e20c656f65b1", "businessPhones": [], "displayName":
+        "test-user-ce9bdbab-c745-4c2d-a66f-f27bac3d754a Solo", "givenName": null,
+        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
+        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ce9bdbab.c745.4c2d.a66f.f27bac3d754a.solo@dancorriganpromptworks.onmicrosoft.com"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '448'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:12 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/8e9d9073-e893-47c0-807a-e20c656f65b1/Microsoft.DirectoryServices.User
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - a60a11ee-d8fc-4bdc-ac7a-6507a42bab9a
+      request-id:
+      - a60a11ee-d8fc-4bdc-ac7a-6507a42bab9a
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_30"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PATCH
+    uri: https://graph.microsoft.com/v1.0/users/8e9d9073-e893-47c0-807a-e20c656f65b1
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 23 Apr 2020 18:42:12 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - c5b77432-86e6-4295-a974-215091da4206
+      request-id:
+      - c5b77432-86e6-4295-a974-215091da4206
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_58"}}'
+    status:
+      code: 204
+      message: No Content
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:37 GMT
+      - Tue, 28 Apr 2020 19:18:38 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArhpFhycFzJMplVCP9ugyqtJ34YQAQAAAO47NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:38 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AsHogjF8mLhIiaEsCN8IOMpJ34YQAQAAAI54OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:39 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -47,7 +47,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 8b5c07ca-57c4-43ff-9e96-7768fece1c00
+      - 12d5d861-1e9f-43af-b969-e627b34b8300
     status:
       code: 200
       message: OK
@@ -63,7 +63,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - fd146114-8665-11ea-83d2-acde48001122
+      - 108d7600-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -72,7 +72,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
+        "attributes": {"enabled": true, "created": 1588101517, "updated": 1588101517,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -82,7 +82,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:38 GMT
+      - Tue, 28 Apr 2020 19:18:38 GMT
       Expires:
       - '-1'
       Pragma:
@@ -104,7 +104,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - f277076a-ba42-4408-bec1-d10f4244e143
+      - 1fc061b3-e33c-4205-90e4-3d6bc4012be2
     status:
       code: 200
       message: OK
@@ -124,7 +124,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 98bcc54e-a950-45a1-88b0-ff2862991bee
+      - 71f27644-a5f4-4a53-af88-b6acf7227da9
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -142,7 +142,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761919", "not_before": "1587758019", "resource": "https://graph.microsoft.com",
+        "expires_on": "1588105119", "not_before": "1588101219", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -152,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:38 GMT
+      - Tue, 28 Apr 2020 19:18:38 GMT
       Expires:
       - '-1'
       P3P:
@@ -160,8 +160,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgaEJZVmOp5BmxM1PDIFUCf3nB0lAQAAAO47NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:39 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AogovOx6H6hAufHSZFuua0j3nB0lAQAAAI54OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:39 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -169,13 +169,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 98bcc54e-a950-45a1-88b0-ff2862991bee
+      - 71f27644-a5f4-4a53-af88-b6acf7227da9
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - e77d5dec-7443-41d6-b78c-eaaae0860e00
+      - 01e83013-712d-4700-903a-023a42f17e00
     status:
       code: 200
       message: OK
@@ -201,7 +201,7 @@ interactions:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
         "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
         "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
-        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.323b25c2.6dee.439c.9e03.a1a05e4f2ed5.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.e4b2ec17.231c.4548.900b.f3cd062cae59.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -210,19 +210,18 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:39 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/fa428073-bf8d-4ec9-8ea7-0ae6d882893a/Microsoft.DirectoryServices.User
+      - Tue, 28 Apr 2020 19:18:40 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - a43ea18c-5c77-4370-bd41-06e96a654c5e
+      - 1868fd30-a3b7-4907-99f4-89cc34f3f82b
       request-id:
-      - a43ea18c-5c77-4370-bd41-06e96a654c5e
+      - 1868fd30-a3b7-4907-99f4-89cc34f3f82b
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_92"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_50"}}'
     status:
       code: 201
       message: Created
@@ -252,15 +251,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Fri, 24 Apr 2020 19:58:39 GMT
+      - Tue, 28 Apr 2020 19:18:40 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 4b4f0091-a4b9-4436-adaf-1bb945405434
+      - 33192bde-8e0f-4727-9ec2-ba8b909139bd
       request-id:
-      - 4b4f0091-a4b9-4436-adaf-1bb945405434
+      - 33192bde-8e0f-4727-9ec2-ba8b909139bd
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_94"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_35"}}'
     status:
       code: 204
       message: No Content

--- a/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_create_user_sends_email.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -24,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:11 GMT
+      - Fri, 24 Apr 2020 19:58:37 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=As_9uJbmF3FPkOVEIpZUMX1J34YQAQAAAIPYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=ArhpFhycFzJMplVCP9ugyqtJ34YQAQAAAO47NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:38 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 2aaab785-4a72-49a7-88e9-b3b260a51600
+      - 8b5c07ca-57c4-43ff-9e96-7768fece1c00
     status:
       code: 200
       message: OK
@@ -63,7 +63,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 24371374-8592-11ea-8f64-acde48001122
+      - fd146114-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -72,7 +72,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667328, "updated": 1587667328,
+        "attributes": {"enabled": true, "created": 1587758315, "updated": 1587758315,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -82,7 +82,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:11 GMT
+      - Fri, 24 Apr 2020 19:58:38 GMT
       Expires:
       - '-1'
       Pragma:
@@ -104,7 +104,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 80e5e012-ad33-477c-b0c5-6ec92599c01d
+      - f277076a-ba42-4408-bec1-d10f4244e143
     status:
       code: 200
       message: OK
@@ -124,7 +124,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 040491b8-590e-4bbf-bb05-492011ee9f46
+      - 98bcc54e-a950-45a1-88b0-ff2862991bee
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -138,11 +138,11 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670932", "not_before": "1587667032", "resource": "https://graph.microsoft.com",
+        "expires_on": "1587761919", "not_before": "1587758019", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -152,7 +152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:12 GMT
+      - Fri, 24 Apr 2020 19:58:38 GMT
       Expires:
       - '-1'
       P3P:
@@ -160,8 +160,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvTBDo-4ioRIuvmsNXxgZlX3nB0lAQAAAIPYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:12 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AgaEJZVmOp5BmxM1PDIFUCf3nB0lAQAAAO47NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:39 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -169,13 +169,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 040491b8-590e-4bbf-bb05-492011ee9f46
+      - 98bcc54e-a950-45a1-88b0-ff2862991bee
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - d8b86fd2-d009-4eb7-b2ea-d16f4b0e1700
+      - e77d5dec-7443-41d6-b78c-eaaae0860e00
     status:
       code: 200
       message: OK
@@ -199,10 +199,9 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
-        "id": "8e9d9073-e893-47c0-807a-e20c656f65b1", "businessPhones": [], "displayName":
-        "test-user-ce9bdbab-c745-4c2d-a66f-f27bac3d754a Solo", "givenName": null,
-        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
-        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ce9bdbab.c745.4c2d.a66f.f27bac3d754a.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
+        "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.323b25c2.6dee.439c.9e03.a1a05e4f2ed5.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -211,19 +210,19 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:12 GMT
+      - Fri, 24 Apr 2020 19:58:39 GMT
       Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/8e9d9073-e893-47c0-807a-e20c656f65b1/Microsoft.DirectoryServices.User
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/fa428073-bf8d-4ec9-8ea7-0ae6d882893a/Microsoft.DirectoryServices.User
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - a60a11ee-d8fc-4bdc-ac7a-6507a42bab9a
+      - a43ea18c-5c77-4370-bd41-06e96a654c5e
       request-id:
-      - a60a11ee-d8fc-4bdc-ac7a-6507a42bab9a
+      - a43ea18c-5c77-4370-bd41-06e96a654c5e
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_30"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_92"}}'
     status:
       code: 201
       message: Created
@@ -243,7 +242,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: PATCH
-    uri: https://graph.microsoft.com/v1.0/users/8e9d9073-e893-47c0-807a-e20c656f65b1
+    uri: https://graph.microsoft.com/v1.0/users/*****
   response:
     body:
       string: ''
@@ -253,15 +252,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 23 Apr 2020 18:42:12 GMT
+      - Fri, 24 Apr 2020 19:58:39 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - c5b77432-86e6-4295-a974-215091da4206
+      - 4b4f0091-a4b9-4436-adaf-1bb945405434
       request-id:
-      - c5b77432-86e6-4295-a974-215091da4206
+      - 4b4f0091-a4b9-4436-adaf-1bb945405434
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_58"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_94"}}'
     status:
       code: 204
       message: No Content

--- a/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
@@ -28,7 +28,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:40 GMT
+      - Tue, 28 Apr 2020 19:18:40 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Aq1lryGV94VIiXbmeDi2nI9J34YQAQAAAPA7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:40 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AldJFossM49Mib8p15-Z_jtJ34YQAQAAAJB4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:40 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 3e0c6de7-583c-483c-b013-944e97701000
+      - 5763eb46-6ff2-4494-bb82-03a5e36c8000
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - fe55e4bc-8665-11ea-83d2-acde48001122
+      - 11974b66-8985-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
+        "attributes": {"enabled": true, "created": 1588101521, "updated": 1588101521,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:40 GMT
+      - Tue, 28 Apr 2020 19:18:40 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 0f79f9c4-da5b-4db8-97fc-e81e4d20642f
+      - 1596be8e-ba59-4d1c-bafe-1ffb3252ca36
     status:
       code: 200
       message: OK
@@ -141,7 +141,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:41 GMT
+      - Tue, 28 Apr 2020 19:18:41 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgEJAz4W4c1NgD8IOOsD7shJ34YQAQAAAPE7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:41 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ag6smOM_YB5LigqFh10t1v5J34YQAQAAAJF4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:41 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - bcac9ace-5502-45e2-a698-eb7364ba1800
+      - 5763eb46-6ff2-4494-bb82-03a5f26c8000
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - fecdb0a0-8665-11ea-83d2-acde48001122
+      - 11e74b48-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
+        "attributes": {"enabled": true, "created": 1588101521, "updated": 1588101521,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:41 GMT
+      - Tue, 28 Apr 2020 19:18:41 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 8e3267ab-d40c-4a41-98c0-8c78775584f5
+      - 4987989d-d871-4fa2-928c-3253efd73bd5
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - bacf19a2-9522-4b3e-aad8-72ec92e003e7
+      - d0edffe6-4aa5-45f7-81aa-edbce2fde081
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -255,7 +255,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761922", "not_before": "1587758022", "resource": "https://graph.microsoft.com",
+        "expires_on": "1588105121", "not_before": "1588101221", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:41 GMT
+      - Tue, 28 Apr 2020 19:18:41 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AqOwHWbvEaVGkL_p3DjCA273nB0lAQAAAPE7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:42 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvAu1Gd-Dt5Hre67zkfdbn33nB0lAQAAAJB4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:42 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - bacf19a2-9522-4b3e-aad8-72ec92e003e7
+      - d0edffe6-4aa5-45f7-81aa-edbce2fde081
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - a286dc0e-668c-4bd1-bb4f-eb62f8111d00
+      - 6fbcec25-50e8-400c-a7cf-c1c90f407200
     status:
       code: 200
       message: OK
@@ -314,7 +314,7 @@ interactions:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
         "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
         "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
-        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ad8ecce9.95ec.48e9.9a41.04551e2c9f36.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.09345505.d905.4642.9afb.3e2163199c8a.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -323,19 +323,18 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:41 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/4a11e140-c87e-43ef-b83c-ba892f0480f1/Microsoft.DirectoryServices.User
+      - Tue, 28 Apr 2020 19:18:42 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 65484340-0d55-4dde-9234-6646fd1b4f21
+      - 6622d9d9-b2b0-499b-83b2-4d86a39b8804
       request-id:
-      - 65484340-0d55-4dde-9234-6646fd1b4f21
+      - 6622d9d9-b2b0-499b-83b2-4d86a39b8804
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_11"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"002","RoleInstance":"AGSFE_IN_40"}}'
     status:
       code: 201
       message: Created
@@ -365,15 +364,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Fri, 24 Apr 2020 19:58:42 GMT
+      - Tue, 28 Apr 2020 19:18:42 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - cf8d9b78-8117-4af1-8c62-8b41be92ffbb
+      - 5f77a168-8bda-4eab-875f-e66fd8ff4225
       request-id:
-      - cf8d9b78-8117-4af1-8c62-8b41be92ffbb
+      - 5f77a168-8bda-4eab-875f-e66fd8ff4225
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_15"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"002","RoleInstance":"AGSFE_IN_93"}}'
     status:
       code: 204
       message: No Content
@@ -406,7 +405,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:42 GMT
+      - Tue, 28 Apr 2020 19:18:42 GMT
       Expires:
       - '-1'
       P3P:
@@ -414,8 +413,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AuRqbwcgGPZBlwdjBvFajh1J34YQAQAAAPI7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:43 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AtnPu0tiVvxFhRcFsG8StqNJ34YQAQAAAJJ4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:43 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -423,9 +422,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 49b45aa1-d286-4d40-a42d-51246cd71a00
+      - 3b4dfdfe-f772-4658-96da-f0e7cd377a00
     status:
       code: 200
       message: OK
@@ -441,7 +440,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - ffe0c14e-8665-11ea-83d2-acde48001122
+      - 12f47d80-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -450,7 +449,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
+        "attributes": {"enabled": true, "created": 1588101521, "updated": 1588101521,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -460,7 +459,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:43 GMT
+      - Tue, 28 Apr 2020 19:18:42 GMT
       Expires:
       - '-1'
       Pragma:
@@ -482,7 +481,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 876a455b-83ab-49af-a54b-082c3bb4f5e7
+      - e1c7f191-d34d-4293-8f14-319d26414550
     status:
       code: 200
       message: OK
@@ -502,7 +501,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 47b8e98d-5fd3-4d33-a076-03aa7da68fec
+      - 3e08ca58-7c42-4b28-bf55-bee7588f938b
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -520,7 +519,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761923", "not_before": "1587758023", "resource": "https://management.azure.com/",
+        "expires_on": "1588105123", "not_before": "1588101223", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -530,7 +529,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:42 GMT
+      - Tue, 28 Apr 2020 19:18:42 GMT
       Expires:
       - '-1'
       P3P:
@@ -538,8 +537,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AhZ7N34cBa9Lsk1ckhf52_nZVRABAQAAAPI7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:43 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AoazL7IMljZKp8UblgwFXzvZVRABAQAAAJJ4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:43 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -547,13 +546,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 47b8e98d-5fd3-4d33-a076-03aa7da68fec
+      - 3e08ca58-7c42-4b28-bf55-bee7588f938b
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
       - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 7dd02b77-6d53-481d-9d8f-e5ff3ee81b00
+      - 8c11ba9c-0abc-41a8-b29e-22806d4c7c00
     status:
       code: 200
       message: OK
@@ -579,7 +578,7 @@ interactions:
     body:
       string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/*****",
         "principalId": "*****", "scope": "/providers/Microsoft.Management/managementGroups/*****",
-        "createdOn": "2020-04-24T19:58:44.2521755Z", "updatedOn": "2020-04-24T19:58:44.2521755Z",
+        "createdOn": "2020-04-28T19:18:44.2938104Z", "updatedOn": "2020-04-28T19:18:44.2938104Z",
         "createdBy": null, "updatedBy": "*****"}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****",
         "type": "Microsoft.Authorization/roleAssignments", "name": "*****"}'
     headers:
@@ -590,7 +589,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:46 GMT
+      - Tue, 28 Apr 2020 19:18:44 GMT
       Expires:
       - '-1'
       Pragma:
@@ -602,13 +601,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 8bdcf10f-26f8-4543-99d3-40d05862e9a1
+      - 4432d163-1634-443e-8310-89a9e2afa423
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - db50a881-ea9a-4514-9f11-5cd77ba0b217
+      - fcadeb64-c25d-4153-b8e1-4a6c769f8b7e
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195847Z:8bdcf10f-26f8-4543-99d3-40d05862e9a1
+      - CENTRALUS:20200428T191844Z:4432d163-1634-443e-8310-89a9e2afa423
     status:
       code: 201
       message: Created
@@ -641,7 +640,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:47 GMT
+      - Tue, 28 Apr 2020 19:18:45 GMT
       Expires:
       - '-1'
       P3P:
@@ -649,8 +648,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AhddGvP6AExCq-7fepqQLWRJ34YQAQAAAPY7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:47 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=ArQ5aZdhatJEvgnXP_k1i6FJ34YQAQAAAJV4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:45 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -658,9 +657,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 1e12e521-955e-4d7b-866c-2ac8defa1800
+      - 5884bbf0-9357-47e9-a894-34646f367000
     status:
       code: 200
       message: OK
@@ -676,7 +675,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 029c0d1c-8666-11ea-83d2-acde48001122
+      - 13f92ea6-8985-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -685,7 +684,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
+        "attributes": {"enabled": true, "created": 1588101521, "updated": 1588101521,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -695,7 +694,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:48 GMT
+      - Tue, 28 Apr 2020 19:18:45 GMT
       Expires:
       - '-1'
       Pragma:
@@ -717,7 +716,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - f008eac5-a6db-4561-a52c-87f43a1b5f9e
+      - 9d025584-8d32-47f2-adec-a5ecb7ca5c6a
     status:
       code: 200
       message: OK
@@ -737,7 +736,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 1c27bf03-c554-46ea-8f43-4053a459c907
+      - 8d652b56-ad04-44cb-b65b-17e5e4583f6e
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -755,7 +754,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761928", "not_before": "1587758028", "resource": "https://management.azure.com/",
+        "expires_on": "1588105126", "not_before": "1588101226", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -765,7 +764,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:47 GMT
+      - Tue, 28 Apr 2020 19:18:45 GMT
       Expires:
       - '-1'
       P3P:
@@ -773,8 +772,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArD1yhz0Ka5PqzYRLFj8bo_ZVRABAQAAAPg7NdYOAAAA; expires=Sun, 24-May-2020
-        19:58:48 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AkVj56xjTMBBv0tGgfQ86RzZVRABAQAAAJZ4OtYOAAAA; expires=Thu, 28-May-2020
+        19:18:46 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -782,13 +781,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 1c27bf03-c554-46ea-8f43-4053a459c907
+      - 8d652b56-ad04-44cb-b65b-17e5e4583f6e
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 01e83013-712d-4700-903a-023a8f611b00
+      - 1ebf50ce-f9db-4bc5-8218-76b32ae27a00
     status:
       code: 200
       message: OK
@@ -813,12 +812,12 @@ interactions:
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
         WuV1W+TNR49+8Ud1VeZP8/NiWbRFtTybffToo7vU4rKY5XVz94tiWldNdd6Oj9ftvKqLH2Rodjd8
-        q7l7kN/Lzj+9/2A7Ozg/397fvzfdzh7cn27vnecH0/3JdPLpvfsfjajrYjktVlnJ/exnu7v57v7O
-        9vTgQb69fy8/354c0JuT7ODh3vnO/sHO+S691EwJX2oeReuLbJld5It82d5d2F8/r6v1qrk7uZ9N
-        dvLdfHvn4fnB9v7e/YPt7HzyYPt8svvg0/uE1f3JPYI/rfOszWdfLqmPvZ29ne2d/e29/Te7Dx/d
-        P3i0vz++9+ne7sHDhz9FTder2W2bKtQn19T03oNPd6b39w+292Y0xv1sb7L98NPpbPvBfcJnb3dn
-        L89m9IpCv/0rv2T0UQFC/qxQJgq0zwXHTVNcLAG7ubs72dl9MNu5v/1ptvtge3/nPN9+eE5MMZ1M
-        p9nuvQcHk12Ms73m+bwlVHphmS3wwq3A/5L/BwyMM1zhAgAA
+        q7l7kN/Lzj+9/2A7Ozg/397fvzfdzh7cn27vnecH0/3JdPLpvfsfjajrYjktVlnJ/ezsPdy5NzmY
+        bc8OptPt/dmD3e2H5/Tbp7sP9vc/Pbj/YHJ+QC81U8KXmkfR+iJbZhf5Il+2dxf218/rar1q7k7u
+        Z5OdfDff3nl4frC9v3f/YDs7nzzYPp/sPvj0PmF1f3KP4E/rPGvz2ZdL6mNvZ29ne2d/e+/gze7D
+        R7sHj/b3x/s7Bwe7Owc/RU3Xq9ltmyrUJ9fU9N6DT3em9/cPtvdmOVEn25tsP/x0Ott+cJ/w2dvd
+        2cuzGb2i0G//yi8ZfVSAkD8rlIkC7XPBcdMUF0vAbu7u7e/mk08fTrdnuw93iQuIFSYP9x9s7+zt
+        Zufns7179x5iQttrns9bQqUXltkCL+zdBvwv+X8AZDkbKuECAAA=
     headers:
       Cache-Control:
       - no-cache
@@ -827,7 +826,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:58:48 GMT
+      - Tue, 28 Apr 2020 19:18:45 GMT
       Expires:
       - '-1'
       Pragma:
@@ -843,13 +842,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - e33c4f44-9faa-4e6b-80d9-62d71410d33a
+      - c089ade9-ee79-45d5-8fc8-9f2d13ba336a
       x-ms-ratelimit-remaining-tenant-deletes:
       - '14999'
       x-ms-request-id:
-      - 08626ec5-7612-42be-ae4e-b15022b64032
+      - f4bb3db2-5a19-4f56-a5cd-eb2841cdf76a
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195848Z:e33c4f44-9faa-4e6b-80d9-62d71410d33a
+      - CENTRALUS:20200428T191846Z:c089ade9-ee79-45d5-8fc8-9f2d13ba336a
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
@@ -1,0 +1,858 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:13 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AkV6IwFaCLFEmnZCBDCwLJ1J34YQAQAAAIXYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:14 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 40894536-8ce5-4650-859d-d12c657c0000
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 25f29aee-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:13 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 0ae27209-d6ec-4767-adb7-c080366cc692
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:14 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ak_Ak3SJOnlOg25255enBGJJ34YQAQAAAIbYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:14 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - 5bd9489f-8ed5-434a-a0e8-6e1ba2ef1400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 265847d6-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:14 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 736de6fe-ad96-433a-9855-1d4461089032
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '182'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 132a3a28-681f-441b-b2cc-df70ad7225b6
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670935", "not_before": "1587667035", "resource": "https://graph.microsoft.com",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1826'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:14 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AlvGz6-YOuBCi_4FD2_ja_r3nB0lAQAAAIbYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:15 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 132a3a28-681f-441b-b2cc-df70ad7225b6
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - NCUS ProdSlices
+      x-ms-request-id:
+      - 6089b3f9-76ca-49ae-9827-9924da981700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '378'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/users
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+        "id": "9250a0ad-947f-43c2-9fd6-726da2d7ae64", "businessPhones": [], "displayName":
+        "test-user-936ab3f5-97bf-43b1-8d23-974ae582594a Solo", "givenName": null,
+        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
+        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.936ab3f5.97bf.43b1.8d23.974ae582594a.solo@dancorriganpromptworks.onmicrosoft.com"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '448'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:15 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/9250a0ad-947f-43c2-9fd6-726da2d7ae64/Microsoft.DirectoryServices.User
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - 30daf27a-e490-4932-90b8-a45b1880dfe3
+      request-id:
+      - 30daf27a-e490-4932-90b8-a45b1880dfe3
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_47"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '35'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PATCH
+    uri: https://graph.microsoft.com/v1.0/users/9250a0ad-947f-43c2-9fd6-726da2d7ae64
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/plain
+      Date:
+      - Thu, 23 Apr 2020 18:42:15 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - be789695-fae1-4a76-8386-701a65b0a3dd
+      request-id:
+      - be789695-fae1-4a76-8386-701a65b0a3dd
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_31"}}'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:16 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Akz8FB6xXCNInPFjuK0HDV9J34YQAQAAAIjYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:16 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 42a63e2b-28a2-4c67-b33c-511c660c0000
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 27853b32-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:16 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - d1f8e680-8cb5-49e7-8cbf-d446830b70af
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - f0dff04a-d140-4859-a916-8f1c51540fb1
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670937", "not_before": "1587667037", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1420'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:16 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ar9pBYBvw1dOp7mYMQ6sql3ZVRABAQAAAIjYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:17 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - f0dff04a-d140-4859-a916-8f1c51540fb1
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - NCUS ProdSlices
+      x-ms-request-id:
+      - 7189b4a1-01e8-4c5a-af69-1c2555b51700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+      "principalId": "9250a0ad-947f-43c2-9fd6-726da2d7ae64"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '267'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0?api-version=2015-07-01
+  response:
+    body:
+      string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+        "principalId": "9250a0ad-947f-43c2-9fd6-726da2d7ae64", "scope": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88",
+        "createdOn": "2020-04-23T18:42:17.6545296Z", "updatedOn": "2020-04-23T18:42:17.6545296Z",
+        "createdBy": null, "updatedBy": "3760c548-2def-4a2b-96cd-75afb2102ead"}, "id":
+        "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0",
+        "type": "Microsoft.Authorization/roleAssignments", "name": "e0711ff2-3bf6-491e-8608-178e95b639b0"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '703'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:17 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - e7bd55c0-48c2-4d5c-a924-6c1dc67a97ad
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - 041fc02a-511c-4cef-a9d6-e91c6f93d310
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184217Z:e7bd55c0-48c2-4d5c-a924-6c1dc67a97ad
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:18 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ApILKwWU9EhOowafHCdsHLdJ34YQAQAAAInYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:18 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - SCUS ProdSlices
+      x-ms-request-id:
+      - 80661c83-9a38-45e1-9d2f-ae3dea721600
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 2892c6c0-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:18 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - febc5b19-37c6-4e8e-a814-31b6f1285dbc
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 29ede287-917a-4324-9840-1671074d081f
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670939", "not_before": "1587667039", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1420'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:18 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AvefRVUiIMVPlIjozMmx0J_ZVRABAQAAAIvYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:19 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 29ede287-917a-4324-9840-1671074d081f
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - bb4dbb27-78c1-4e54-825b-c7aef88e1700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
+    method: DELETE
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0?api-version=2015-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
+        WuV1W+TNR49+8Ud1VeZP8/NiWbRFtTybffToo7vU4rKY5XVz94tiWldNdd6Oj9ftvKqLH2Rodjd8
+        q7l7kN/Lzj+9/2A7Ozg/397fvzfdzh7cn27vnecH0/3JdPLpvfsfjajrYjktVlnJ/Tzcu7+T7WSz
+        7Yf7D+ile9O97Yfns0+3H+x9Osv2Zg+y/NN9eqmZEr7UPIrWF9kyu8gX+bK9u7C/fl5X61VzN5vd
+        v7d7/9MH2/vnB7vb+xMCne1N9rb3JpNPH+b3ds7PDw4I/rTOszaffbmkPvZ29na2d/a39+692T14
+        tL/3aPfB+MGn+/t79x78FDVdr2a3bapQn1xT03sPPt2Z3t8/2N6b5TRQQmL74afT2faD+9n5ZG93
+        Zy/PZvSKQr/9K79k9FEBQv6sUCYKtM8Fx01TXCwBu7mb7zzY3T0/39u+Nzn/dHv/4W6+ffDpzsH2
+        7oOD/OF94oGHkx0aZ3vN83lLqPTCMlvghVuB/yX/D5IZzBjhAgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:19 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - e1c8bd72-2f82-4ed6-8bc3-daa978d0e2d7
+      x-ms-ratelimit-remaining-tenant-deletes:
+      - '14999'
+      x-ms-request-id:
+      - 14507e54-29c8-49a9-b497-662668c1168b
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184220Z:e1c8bd72-2f82-4ed6-8bc3-daa978d0e2d7
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_disable_user.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -24,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:13 GMT
+      - Fri, 24 Apr 2020 19:58:40 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AkV6IwFaCLFEmnZCBDCwLJ1J34YQAQAAAIXYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:14 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Aq1lryGV94VIiXbmeDi2nI9J34YQAQAAAPA7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:40 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -47,7 +47,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 40894536-8ce5-4650-859d-d12c657c0000
+      - 3e0c6de7-583c-483c-b013-944e97701000
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 25f29aee-8592-11ea-8f64-acde48001122
+      - fe55e4bc-8665-11ea-83d2-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:13 GMT
+      - Fri, 24 Apr 2020 19:58:40 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 0ae27209-d6ec-4767-adb7-c080366cc692
+      - 0f79f9c4-da5b-4db8-97fc-e81e4d20642f
     status:
       code: 200
       message: OK
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -137,11 +137,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:14 GMT
+      - Fri, 24 Apr 2020 19:58:41 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ak_Ak3SJOnlOg25255enBGJJ34YQAQAAAIbYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:14 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AgEJAz4W4c1NgD8IOOsD7shJ34YQAQAAAPE7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:41 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 5bd9489f-8ed5-434a-a0e8-6e1ba2ef1400
+      - bcac9ace-5502-45e2-a698-eb7364ba1800
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 265847d6-8592-11ea-8f64-acde48001122
+      - fecdb0a0-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:14 GMT
+      - Fri, 24 Apr 2020 19:58:41 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 736de6fe-ad96-433a-9855-1d4461089032
+      - 8e3267ab-d40c-4a41-98c0-8c78775584f5
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 132a3a28-681f-441b-b2cc-df70ad7225b6
+      - bacf19a2-9522-4b3e-aad8-72ec92e003e7
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -251,11 +251,11 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670935", "not_before": "1587667035", "resource": "https://graph.microsoft.com",
+        "expires_on": "1587761922", "not_before": "1587758022", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -265,7 +265,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:14 GMT
+      - Fri, 24 Apr 2020 19:58:41 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AlvGz6-YOuBCi_4FD2_ja_r3nB0lAQAAAIbYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:15 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AqOwHWbvEaVGkL_p3DjCA273nB0lAQAAAPE7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:42 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,13 +282,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 132a3a28-681f-441b-b2cc-df70ad7225b6
+      - bacf19a2-9522-4b3e-aad8-72ec92e003e7
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 6089b3f9-76ca-49ae-9827-9924da981700
+      - a286dc0e-668c-4bd1-bb4f-eb62f8111d00
     status:
       code: 200
       message: OK
@@ -312,10 +312,9 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
-        "id": "9250a0ad-947f-43c2-9fd6-726da2d7ae64", "businessPhones": [], "displayName":
-        "test-user-936ab3f5-97bf-43b1-8d23-974ae582594a Solo", "givenName": null,
-        "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation": null,
-        "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.936ab3f5.97bf.43b1.8d23.974ae582594a.solo@dancorriganpromptworks.onmicrosoft.com"}'
+        "id": "*****", "businessPhones": [], "displayName": "test-user-***** Solo",
+        "givenName": null, "jobTitle": null, "mail": null, "mobilePhone": null, "officeLocation":
+        null, "preferredLanguage": null, "surname": null, "userPrincipalName": "test.user.ad8ecce9.95ec.48e9.9a41.04551e2c9f36.solo@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
@@ -324,19 +323,19 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:15 GMT
+      - Fri, 24 Apr 2020 19:58:41 GMT
       Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/9250a0ad-947f-43c2-9fd6-726da2d7ae64/Microsoft.DirectoryServices.User
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/4a11e140-c87e-43ef-b83c-ba892f0480f1/Microsoft.DirectoryServices.User
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 30daf27a-e490-4932-90b8-a45b1880dfe3
+      - 65484340-0d55-4dde-9234-6646fd1b4f21
       request-id:
-      - 30daf27a-e490-4932-90b8-a45b1880dfe3
+      - 65484340-0d55-4dde-9234-6646fd1b4f21
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_47"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_11"}}'
     status:
       code: 201
       message: Created
@@ -356,7 +355,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: PATCH
-    uri: https://graph.microsoft.com/v1.0/users/9250a0ad-947f-43c2-9fd6-726da2d7ae64
+    uri: https://graph.microsoft.com/v1.0/users/*****
   response:
     body:
       string: ''
@@ -366,15 +365,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Thu, 23 Apr 2020 18:42:15 GMT
+      - Fri, 24 Apr 2020 19:58:42 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - be789695-fae1-4a76-8386-701a65b0a3dd
+      - cf8d9b78-8117-4af1-8c62-8b41be92ffbb
       request-id:
-      - be789695-fae1-4a76-8386-701a65b0a3dd
+      - cf8d9b78-8117-4af1-8c62-8b41be92ffbb
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_31"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_15"}}'
     status:
       code: 204
       message: No Content
@@ -394,7 +393,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -403,11 +402,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:16 GMT
+      - Fri, 24 Apr 2020 19:58:42 GMT
       Expires:
       - '-1'
       P3P:
@@ -415,8 +414,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Akz8FB6xXCNInPFjuK0HDV9J34YQAQAAAIjYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:16 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AuRqbwcgGPZBlwdjBvFajh1J34YQAQAAAPI7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:43 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -424,9 +423,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 42a63e2b-28a2-4c67-b33c-511c660c0000
+      - 49b45aa1-d286-4d40-a42d-51246cd71a00
     status:
       code: 200
       message: OK
@@ -442,7 +441,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 27853b32-8592-11ea-8f64-acde48001122
+      - ffe0c14e-8665-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -451,7 +450,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -461,7 +460,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:16 GMT
+      - Fri, 24 Apr 2020 19:58:43 GMT
       Expires:
       - '-1'
       Pragma:
@@ -483,7 +482,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - d1f8e680-8cb5-49e7-8cbf-d446830b70af
+      - 876a455b-83ab-49af-a54b-082c3bb4f5e7
     status:
       code: 200
       message: OK
@@ -503,7 +502,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - f0dff04a-d140-4859-a916-8f1c51540fb1
+      - 47b8e98d-5fd3-4d33-a076-03aa7da68fec
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -517,21 +516,21 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670937", "not_before": "1587667037", "resource": "https://management.azure.com/",
+        "expires_on": "1587761923", "not_before": "1587758023", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1420'
+      - '1487'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:16 GMT
+      - Fri, 24 Apr 2020 19:58:42 GMT
       Expires:
       - '-1'
       P3P:
@@ -539,8 +538,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ar9pBYBvw1dOp7mYMQ6sql3ZVRABAQAAAIjYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:17 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhZ7N34cBa9Lsk1ckhf52_nZVRABAQAAAPI7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:43 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -548,19 +547,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - f0dff04a-d140-4859-a916-8f1c51540fb1
+      - 47b8e98d-5fd3-4d33-a076-03aa7da68fec
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 7189b4a1-01e8-4c5a-af69-1c2555b51700
+      - 7dd02b77-6d53-481d-9d8f-e5ff3ee81b00
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-      "principalId": "9250a0ad-947f-43c2-9fd6-726da2d7ae64"}}'
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleDefinitions/*****",
+      "principalId": "*****"}}'
     headers:
       Accept:
       - '*/*'
@@ -575,15 +574,14 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0?api-version=2015-07-01
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
   response:
     body:
-      string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-        "principalId": "9250a0ad-947f-43c2-9fd6-726da2d7ae64", "scope": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88",
-        "createdOn": "2020-04-23T18:42:17.6545296Z", "updatedOn": "2020-04-23T18:42:17.6545296Z",
-        "createdBy": null, "updatedBy": "3760c548-2def-4a2b-96cd-75afb2102ead"}, "id":
-        "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0",
-        "type": "Microsoft.Authorization/roleAssignments", "name": "e0711ff2-3bf6-491e-8608-178e95b639b0"}'
+      string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/*****",
+        "principalId": "*****", "scope": "/providers/Microsoft.Management/managementGroups/*****",
+        "createdOn": "2020-04-24T19:58:44.2521755Z", "updatedOn": "2020-04-24T19:58:44.2521755Z",
+        "createdBy": null, "updatedBy": "*****"}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****",
+        "type": "Microsoft.Authorization/roleAssignments", "name": "*****"}'
     headers:
       Cache-Control:
       - no-cache
@@ -592,7 +590,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:17 GMT
+      - Fri, 24 Apr 2020 19:58:46 GMT
       Expires:
       - '-1'
       Pragma:
@@ -604,13 +602,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - e7bd55c0-48c2-4d5c-a924-6c1dc67a97ad
+      - 8bdcf10f-26f8-4543-99d3-40d05862e9a1
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - 041fc02a-511c-4cef-a9d6-e91c6f93d310
+      - db50a881-ea9a-4514-9f11-5cd77ba0b217
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184217Z:e7bd55c0-48c2-4d5c-a924-6c1dc67a97ad
+      - CENTRALUS:20200424T195847Z:8bdcf10f-26f8-4543-99d3-40d05862e9a1
     status:
       code: 201
       message: Created
@@ -630,7 +628,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -639,11 +637,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:18 GMT
+      - Fri, 24 Apr 2020 19:58:47 GMT
       Expires:
       - '-1'
       P3P:
@@ -651,8 +649,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ApILKwWU9EhOowafHCdsHLdJ34YQAQAAAInYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:18 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhddGvP6AExCq-7fepqQLWRJ34YQAQAAAPY7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:47 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -660,9 +658,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - SCUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 80661c83-9a38-45e1-9d2f-ae3dea721600
+      - 1e12e521-955e-4d7b-866c-2ac8defa1800
     status:
       code: 200
       message: OK
@@ -678,7 +676,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 2892c6c0-8592-11ea-8f64-acde48001122
+      - 029c0d1c-8666-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -687,7 +685,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667334, "updated": 1587667334,
+        "attributes": {"enabled": true, "created": 1587758321, "updated": 1587758321,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -697,7 +695,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:18 GMT
+      - Fri, 24 Apr 2020 19:58:48 GMT
       Expires:
       - '-1'
       Pragma:
@@ -719,7 +717,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - febc5b19-37c6-4e8e-a814-31b6f1285dbc
+      - f008eac5-a6db-4561-a52c-87f43a1b5f9e
     status:
       code: 200
       message: OK
@@ -739,7 +737,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 29ede287-917a-4324-9840-1671074d081f
+      - 1c27bf03-c554-46ea-8f43-4053a459c907
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -753,21 +751,21 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670939", "not_before": "1587667039", "resource": "https://management.azure.com/",
+        "expires_on": "1587761928", "not_before": "1587758028", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1420'
+      - '1487'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:18 GMT
+      - Fri, 24 Apr 2020 19:58:47 GMT
       Expires:
       - '-1'
       P3P:
@@ -775,8 +773,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvefRVUiIMVPlIjozMmx0J_ZVRABAQAAAIvYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:19 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=ArD1yhz0Ka5PqzYRLFj8bo_ZVRABAQAAAPg7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:48 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -784,13 +782,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 29ede287-917a-4324-9840-1671074d081f
+      - 1c27bf03-c554-46ea-8f43-4053a459c907
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - bb4dbb27-78c1-4e54-825b-c7aef88e1700
+      - 01e83013-712d-4700-903a-023a8f611b00
     status:
       code: 200
       message: OK
@@ -808,19 +806,19 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: DELETE
-    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/e0711ff2-3bf6-491e-8608-178e95b639b0?api-version=2015-07-01
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR6u6
         WuV1W+TNR49+8Ud1VeZP8/NiWbRFtTybffToo7vU4rKY5XVz94tiWldNdd6Oj9ftvKqLH2Rodjd8
-        q7l7kN/Lzj+9/2A7Ozg/397fvzfdzh7cn27vnecH0/3JdPLpvfsfjajrYjktVlnJ/Tzcu7+T7WSz
-        7Yf7D+ile9O97Yfns0+3H+x9Osv2Zg+y/NN9eqmZEr7UPIrWF9kyu8gX+bK9u7C/fl5X61VzN5vd
-        v7d7/9MH2/vnB7vb+xMCne1N9rb3JpNPH+b3ds7PDw4I/rTOszaffbmkPvZ29na2d/a39+692T14
-        tL/3aPfB+MGn+/t79x78FDVdr2a3bapQn1xT03sPPt2Z3t8/2N6b5TRQQmL74afT2faD+9n5ZG93
-        Zy/PZvSKQr/9K79k9FEBQv6sUCYKtM8Fx01TXCwBu7mb7zzY3T0/39u+Nzn/dHv/4W6+ffDpzsH2
-        7oOD/OF94oGHkx0aZ3vN83lLqPTCMlvghVuB/yX/D5IZzBjhAgAA
+        q7l7kN/Lzj+9/2A7Ozg/397fvzfdzh7cn27vnecH0/3JdPLpvfsfjajrYjktVlnJ/exnu7v57v7O
+        9vTgQb69fy8/354c0JuT7ODh3vnO/sHO+S691EwJX2oeReuLbJld5It82d5d2F8/r6v1qrk7uZ9N
+        dvLdfHvn4fnB9v7e/YPt7HzyYPt8svvg0/uE1f3JPYI/rfOszWdfLqmPvZ29ne2d/e29/Te7Dx/d
+        P3i0vz++9+ne7sHDhz9FTder2W2bKtQn19T03oNPd6b39w+292Y0xv1sb7L98NPpbPvBfcJnb3dn
+        L89m9IpCv/0rv2T0UQFC/qxQJgq0zwXHTVNcLAG7ubs72dl9MNu5v/1ptvtge3/nPN9+eE5MMZ1M
+        p9nuvQcHk12Ms73m+bwlVHphmS3wwq3A/5L/BwyMM1zhAgAA
     headers:
       Cache-Control:
       - no-cache
@@ -829,7 +827,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:19 GMT
+      - Fri, 24 Apr 2020 19:58:48 GMT
       Expires:
       - '-1'
       Pragma:
@@ -845,13 +843,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - e1c8bd72-2f82-4ed6-8bc3-daa978d0e2d7
+      - e33c4f44-9faa-4e6b-80d9-62d71410d33a
       x-ms-ratelimit-remaining-tenant-deletes:
       - '14999'
       x-ms-request-id:
-      - 14507e54-29c8-49a9-b497-662668c1168b
+      - 08626ec5-7612-42be-ae4e-b15022b64032
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184220Z:e1c8bd72-2f82-4ed6-8bc3-daa978d0e2d7
+      - CENTRALUS:20200424T195848Z:e33c4f44-9faa-4e6b-80d9-62d71410d33a
     status:
       code: 200
       message: OK

--- a/tests/fixtures/cassettes/test_hybrid_do_create_environment_role_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_do_create_environment_role_job.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -24,11 +24,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:20 GMT
+      - Fri, 24 Apr 2020 19:58:48 GMT
       Expires:
       - '-1'
       P3P:
@@ -36,8 +36,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Al2D07R3IjdGj64MYnbCKghJ34YQAQAAAIzYM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:20 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AgufJSbqXphIt3VGd_iT_hlJ34YQAQAAAPg7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:49 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -45,9 +45,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - fdf32cc4-48f3-440c-ac59-fecbf8ef1900
+      - dd9f3d1d-6fb5-498b-b2f6-caee33560d00
     status:
       code: 200
       message: OK
@@ -67,7 +67,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 2a0eccba-8592-11ea-8f64-acde48001122
+      - 037987aa-8666-11ea-83d2-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -76,7 +76,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667341, "updated": 1587667341,
+        "attributes": {"enabled": true, "created": 1587758329, "updated": 1587758329,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:20 GMT
+      - Fri, 24 Apr 2020 19:58:49 GMT
       Expires:
       - '-1'
       Pragma:
@@ -108,7 +108,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - f11c3adf-d900-4e88-89b1-b00190a16a3b
+      - e9ced9ab-5883-4f7a-be94-6c4217cadefb
     status:
       code: 200
       message: OK
@@ -128,7 +128,7 @@ interactions:
       User-Agent:
       - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
@@ -137,11 +137,11 @@ interactions:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1313'
+      - '1380'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:20 GMT
+      - Fri, 24 Apr 2020 19:58:49 GMT
       Expires:
       - '-1'
       P3P:
@@ -149,8 +149,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AupOb-DoaYBLpx2wNS5qlChJ34YQAQAAAI3YM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:21 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Am1R7NOC5JFGt5-EvMpl8xdJ34YQAQAAAPk7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:50 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -158,9 +158,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.13 - EUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 7a371a31-a67c-426f-ac31-a00652041800
+      - 146fbbca-a0a5-41da-b62c-3401b0191700
     status:
       code: 200
       message: OK
@@ -176,7 +176,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - 2a746a98-8592-11ea-8f64-acde48001122
+      - 03ddb46e-8666-11ea-83d2-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -185,7 +185,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587667341, "updated": 1587667341,
+        "attributes": {"enabled": true, "created": 1587758329, "updated": 1587758329,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -195,7 +195,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:20 GMT
+      - Fri, 24 Apr 2020 19:58:49 GMT
       Expires:
       - '-1'
       Pragma:
@@ -217,7 +217,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 58355db8-c820-487b-9b5e-86be8c925f8b
+      - 778848fe-bfe8-46a2-b2f7-0630632ad011
     status:
       code: 200
       message: OK
@@ -237,7 +237,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 84cc9ad1-1d63-4f37-a7a2-9cea7329bbc3
+      - 2dda1d09-ba17-4183-a059-6d18429d508d
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -251,21 +251,21 @@ interactions:
       x-client-Ver:
       - 1.2.2
     method: POST
-    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+    uri: https://login.microsoftonline.com/*****/oauth2/token
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587670942", "not_before": "1587667042", "resource": "https://management.azure.com/",
+        "expires_on": "1587761930", "not_before": "1587758030", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1420'
+      - '1487'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:21 GMT
+      - Fri, 24 Apr 2020 19:58:50 GMT
       Expires:
       - '-1'
       P3P:
@@ -273,8 +273,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AhAaMnhrJlhAuQqLnxR2vnfZVRABAQAAAI7YM9YOAAAA; expires=Sat, 23-May-2020
-        18:42:22 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvGLddcwKNBJhCPQZr2DlwTZVRABAQAAAPk7NdYOAAAA; expires=Sun, 24-May-2020
+        19:58:50 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -282,19 +282,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 84cc9ad1-1d63-4f37-a7a2-9cea7329bbc3
+      - 2dda1d09-ba17-4183-a059-6d18429d508d
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 66d77fe6-063b-4476-91e0-e91be10f0000
+      - 9e76dd79-8134-4fa4-88f6-66dd35351800
     status:
       code: 200
       message: OK
 - request:
-    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
-      "principalId": "3c53cafc-4937-4337-87a6-6ccc783ac6fc"}}'
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleDefinitions/*****",
+      "principalId": "*****"}}'
     headers:
       Accept:
       - '*/*'
@@ -309,20 +309,20 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
     method: PUT
-    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/a76e980b-a6bb-4ad4-b9d6-1b45a3d23c6b?api-version=2015-07-01
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
   response:
     body:
-      string: '{"error": {"code": "PrincipalNotFound", "message": "Principal 3c53cafc4937433787a66ccc783ac6fc
-        does not exist in the directory b5ab0e1e-09f8-4258-afb7-fb17654bc5b3."}}'
+      string: '{"error": {"code": "RoleAssignmentExists", "message": "The role assignment
+        already exists."}}'
     headers:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '163'
+      - '89'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Thu, 23 Apr 2020 18:42:25 GMT
+      - Fri, 24 Apr 2020 19:58:50 GMT
       Expires:
       - '-1'
       Pragma:
@@ -334,14 +334,14 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - a80c157b-681b-46b5-ab7f-62223cb47a77
+      - 1c99df5c-31e8-46e9-8b6b-e4b0a5d7762c
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - bfb0c8a3-5c1c-444b-9d0e-1c89fe294a1f
+      - 3ab863a5-ebdf-4697-b062-19e2f0687df7
       x-ms-routing-request-id:
-      - CENTRALUS:20200423T184225Z:a80c157b-681b-46b5-ab7f-62223cb47a77
+      - CENTRALUS:20200424T195851Z:1c99df5c-31e8-46e9-8b6b-e4b0a5d7762c
     status:
-      code: 400
-      message: Bad Request
+      code: 409
+      message: Conflict
 version: 1

--- a/tests/fixtures/cassettes/test_hybrid_do_create_environment_role_job.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_do_create_environment_role_job.yaml
@@ -1,0 +1,347 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:20 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Al2D07R3IjdGj64MYnbCKghJ34YQAQAAAIzYM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:20 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - fdf32cc4-48f3-440c-ac59-fecbf8ef1900
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '442'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 2a0eccba-8592-11ea-8f64-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667341, "updated": 1587667341,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:20 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - f11c3adf-d900-4e88-89b1-b00190a16a3b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1313'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:20 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AupOb-DoaYBLpx2wNS5qlChJ34YQAQAAAI3YM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:21 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.13 - EUS ProdSlices
+      x-ms-request-id:
+      - 7a371a31-a67c-426f-ac31-a00652041800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - 2a746a98-8592-11ea-8f64-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587667341, "updated": 1587667341,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '714'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:20 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 58355db8-c820-487b-9b5e-86be8c925f8b
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 84cc9ad1-1d63-4f37-a7a2-9cea7329bbc3
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587670942", "not_before": "1587667042", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1420'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:21 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AhAaMnhrJlhAuQqLnxR2vnfZVRABAQAAAI7YM9YOAAAA; expires=Sat, 23-May-2020
+        18:42:22 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 84cc9ad1-1d63-4f37-a7a2-9cea7329bbc3
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 66d77fe6-063b-4476-91e0-e91be10f0000
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleDefinitions/8e3af657-a8ff-443c-a75c-2fe8c4bcb635",
+      "principalId": "3c53cafc-4937-4337-87a6-6ccc783ac6fc"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '267'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com//providers/Microsoft.Management/managementGroups/ad531567-4f81-4bd6-a2b2-2bb69e30ff88/providers/Microsoft.Authorization/roleAssignments/a76e980b-a6bb-4ad4-b9d6-1b45a3d23c6b?api-version=2015-07-01
+  response:
+    body:
+      string: '{"error": {"code": "PrincipalNotFound", "message": "Principal 3c53cafc4937433787a66ccc783ac6fc
+        does not exist in the directory b5ab0e1e-09f8-4258-afb7-fb17654bc5b3."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '163'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Thu, 23 Apr 2020 18:42:25 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - a80c157b-681b-46b5-ab7f-62223cb47a77
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - bfb0c8a3-5c1c-444b-9d0e-1c89fe294a1f
+      x-ms-routing-request-id:
+      - CENTRALUS:20200423T184225Z:a80c157b-681b-46b5-ab7f-62223cb47a77
+    status:
+      code: 400
+      message: Bad Request
+version: 1

--- a/tests/fixtures/cassettes/test_hybrid_provision_portfolio.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_provision_portfolio.yaml
@@ -15,7 +15,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - bcd60cc4-8665-11ea-83d2-acde48001122
+      - bddb3154-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -30,7 +30,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:50 GMT
+      - Tue, 28 Apr 2020 19:16:20 GMT
       Expires:
       - '-1'
       Pragma:
@@ -53,7 +53,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 676ae521-6754-48e4-aeac-f1f67da7136a
+      - afe4425c-b167-4ce5-b65d-136d784cf5e3
     status:
       code: 401
       message: Unauthorized
@@ -86,7 +86,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:51 GMT
+      - Tue, 28 Apr 2020 19:16:20 GMT
       Expires:
       - '-1'
       P3P:
@@ -94,8 +94,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgvJkM3iQMZLm7B_viG0X4JJ34YQAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:56:51 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ap9rrSWQ2QZHuMQqzKOwTlZJ34YQAQAAAAN4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:20 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -103,9 +103,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - c33a5397-30d8-4b83-86c5-dd2522380e00
+      - 5519b32f-ff59-48a7-a5eb-49e3c1047e00
     status:
       code: 200
       message: OK
@@ -125,7 +125,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - bcd60cc4-8665-11ea-83d2-acde48001122
+      - bddb3154-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -134,7 +134,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "attributes": {"enabled": true, "created": 1588101380, "updated": 1588101380,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -144,7 +144,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:50 GMT
+      - Tue, 28 Apr 2020 19:16:20 GMT
       Expires:
       - '-1'
       Pragma:
@@ -166,7 +166,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - acf193a6-24ba-4538-8a17-8fff595f0a67
+      - 0c962c7c-32f9-49e4-afb4-9891ca92400a
     status:
       code: 200
       message: OK
@@ -199,7 +199,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:51 GMT
+      - Tue, 28 Apr 2020 19:16:21 GMT
       Expires:
       - '-1'
       P3P:
@@ -207,8 +207,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AuqKJYWwSpdNtuwvdtfBypJJ34YQAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:56:51 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AkuSfKRaSTVDuDwlWEjrIb1J34YQAQAAAAR4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:21 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -218,7 +218,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 1e12e521-955e-4d7b-866c-2ac807ec1800
+      - 4f9b3af8-8291-49d3-96b1-d033c4e37900
     status:
       code: 200
       message: OK
@@ -234,7 +234,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - bd75601c-8665-11ea-83d2-acde48001122
+      - be53fd64-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -243,7 +243,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "attributes": {"enabled": true, "created": 1588101380, "updated": 1588101380,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -253,7 +253,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:51 GMT
+      - Tue, 28 Apr 2020 19:16:21 GMT
       Expires:
       - '-1'
       Pragma:
@@ -275,7 +275,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 0061e43a-c6e9-4049-b7e9-59c257856d33
+      - 0c85c81b-10bd-4150-aeaa-8980efc2f6c1
     status:
       code: 200
       message: OK
@@ -293,7 +293,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      - c9fa4685-b845-4146-8edc-41f51f012dab
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -320,7 +320,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:52 GMT
+      - Tue, 28 Apr 2020 19:16:21 GMT
       Expires:
       - '-1'
       P3P:
@@ -328,7 +328,7 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ary0yhAuuRxCmYSdOVnDeUY; expires=Sun, 24-May-2020 19:56:52 GMT; path=/;
+      - fpc=AoV6okUJpY9JjZ7E9KFKDUg; expires=Thu, 28-May-2020 19:16:21 GMT; path=/;
         secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
@@ -337,11 +337,11 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      - c9fa4685-b845-4146-8edc-41f51f012dab
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 8e77b773-75a5-40fc-9706-571afecf0d00
+      - 2fc4ad85-4bb9-4965-9d0d-76dbf1de7900
     status:
       code: 200
       message: OK
@@ -361,7 +361,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      - c9fa4685-b845-4146-8edc-41f51f012dab
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -379,10 +379,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761812", "not_before":
-        "1587757912", "resource": "https://graph.microsoft.com", "access_token": "*****",
-        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41hnibL7ZMy1yN6Y_4a2TsX2Kd79aPnU9T-kzXV8t7WxVkJNZlmARukdhSCw2t4PT3-KxhOrfLlc4CyCm4xOY5fV5HvEdcKPV7cy3mpy5TKlolkTWkIGrghjHfBcxFbKsNVb-3TAz29pblMi5_UDI0s3EwQvgW6disYcEUebej3v3R-suCQLzhKtiG1xL1eMMvCzRlZP8A399RIwRASG-O0THUArbmU8etGUnUf3w2ZuvWo0VVsfygvVH8YSQ44uDOLi34KYSB4oUAdF0-B_Pojxoe014bGSWNMBEICCfNOz95sXhZbqtpR1vaqT0EouBgaEcrlHezU8TlhgwR1ASAdPJb7eNNONDHWxP9kMvryklBE42C_ZXE_oBDjebMMEsyalBW-X6eIzLS-esczkaNqPwd0MiOwrgzNx0uk5F3PRreFFq53l7wp9-3f6Q_ICPlfpQCkRRlUVtN2cdAAzzxVqpCGxMHnqsWfCRW7XjYlfd1NnOIdOjMEekbwnQbYm669y_w1ArhwdZWiUwZWWR1Lu0lfQ3lo2pNYBeqvZe9ehHsaSqwz7UAhe8XggsViGz5QCl4ozQU-gN4CMwDqfJJL2qsWyJjk-Xb2Ef3Ao0Ixafyy7QoCwmedUeWqHc2jZLVIAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTEyLCJuYmYiOjE1ODc3NTc5MTIsImV4cCI6MTU4Nzc2MTgxMiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588104981", "not_before":
+        "1588101081", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41J0lahDm_-1Jsl9scbk9MRJ2m1LVtE2vD2hTgSvJr9J539lBgx86n5zb1OqNB9hkwtFK6PBNqyMRbN7faldD0ma7V4sRF_wbtIsCWzBxQhfV41Brxq29tboORaOmMMshCbpAgHvuo4HEHcXB24K3P1QBi7MThQyrGdnyPwFRWUEnWMQxBVKcsMKyKeQY-Xb_EghLpHKVaPwoTZYJU4bUayhruy44E6ftvHVfwphMwcm_QWbQpjohVx2J-UKbIBSMsVcGNuaV2NSlbM668EUyz3zXmOyhWk1qCjBiXK8GxuO7IspTKwBSHnMdQJDxqBXOIv_8lHWzJ-r1xvDWG8L3bX8n3zJlrghc33cGepRb1-pfTNqXQf-hMwvaJZ4MXmTcp7FMQuXboBP0yXUN769okHIHroOZJ0J3Qyit89_d65-MBa6Ra4i9uMlrdYYxwB3ALYz8mMO5TED43qo_ShMWp60Nd0ft20iS1edcmABXTUePv076RpkuBFg5ZlgJ61OwuF3okIMWjDte32i1JMRN0vdOqJ9iPncyN404L1jxWjfPilTidCTC7x3RTl0ePpLJ4csfM5hKBmTLply0XrvCPpO20mlwnObhNB3lhSQr7tjZdfABQY0YXoYTcJGwj1wVlIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMDgxLCJuYmYiOjE1ODgxMDEwODEsImV4cCI6MTU4ODEwNDk4MSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -391,7 +391,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:52 GMT
+      - Tue, 28 Apr 2020 19:16:21 GMT
       Expires:
       - '-1'
       P3P:
@@ -399,8 +399,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AlhfOGlL8vNIokFtHQMHtAkz3-LjAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:56:52 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AuMhb5_w2-xJj5U3PH7_nRUz3-LjAQAAAAV4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:21 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -408,18 +408,18 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      - c9fa4685-b845-4146-8edc-41f51f012dab
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - eaa75759-5375-4922-8556-4bd1619b1800
+      - 92e74d17-7511-4b97-81fb-30e557687f00
     status:
       code: 200
       message: OK
 - request:
-    body: '{"displayName": "Hybrid :: Hernandez, Robbins and Kane :: ATAT Remote Admin"}'
+    body: '{"displayName": "Hybrid :: Adams-Jimenez :: ATAT Remote Admin"}'
     headers:
       Accept:
       - '*/*'
@@ -428,7 +428,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '77'
+      - '63'
       Content-Type:
       - application/json
       User-Agent:
@@ -439,11 +439,11 @@ interactions:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
         "id": "*****", "deletedDateTime": null, "appId": "*****", "applicationTemplateId":
-        null, "createdDateTime": "2020-04-24T19:56:53.9670113Z", "displayName": "Hybrid
-        :: Hernandez, Robbins and Kane :: ATAT Remote Admin", "groupMembershipClaims":
-        null, "identifierUris": [], "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient":
-        null, "optionalClaims": null, "publisherDomain": "dancorriganpromptworks.onmicrosoft.com",
-        "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": [], "tokenEncryptionKeyId":
+        null, "createdDateTime": "2020-04-28T19:16:23.2628264Z", "displayName": "Hybrid
+        :: Adams-Jimenez :: ATAT Remote Admin", "groupMembershipClaims": null, "identifierUris":
+        [], "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient": null, "optionalClaims":
+        null, "publisherDomain": "dancorriganpromptworks.onmicrosoft.com", "signInAudience":
+        "AzureADandPersonalMicrosoftAccount", "tags": [], "tokenEncryptionKeyId":
         null, "spa": {"redirectUris": []}, "addIns": [], "api": {"acceptMappedClaims":
         null, "knownClientApplications": [], "requestedAccessTokenVersion": 2, "oauth2PermissionScopes":
         [], "preAuthorizedApplications": []}, "appRoles": [], "info": {"logoUrl":
@@ -457,23 +457,22 @@ interactions:
       Cache-Control:
       - private
       Content-Length:
-      - '1303'
+      - '1289'
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:55 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/09661d5f-679b-47b1-8202-a9888e41597b/Microsoft.DirectoryServices.Application
+      - Tue, 28 Apr 2020 19:16:24 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 102769f9-4369-4460-a9a5-462248b2acce
+      - 00941b68-24ed-4c77-867e-49826534bd93
       request-id:
-      - 102769f9-4369-4460-a9a5-462248b2acce
+      - 00941b68-24ed-4c77-867e-49826534bd93
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_17"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_89"}}'
     status:
       code: 201
       message: Created
@@ -506,7 +505,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:54 GMT
+      - Tue, 28 Apr 2020 19:16:24 GMT
       Expires:
       - '-1'
       P3P:
@@ -514,8 +513,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArgigYkJkWVEglS0U6MGOW5J34YQAQAAAIc7NdYOAAAA; expires=Sun, 24-May-2020
-        19:56:55 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AkNMzFWmYYVKhVaaAxKxA9hJ34YQAQAAAAh4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:24 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -523,9 +522,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 8f9cc3ec-379e-41db-86ad-d9eac7691600
+      - 8fc0f85e-918a-4180-9465-bdf377b57d00
     status:
       code: 200
       message: OK
@@ -541,7 +540,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - bfa6b228-8665-11ea-83d2-acde48001122
+      - c08d91ee-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -550,7 +549,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "attributes": {"enabled": true, "created": 1588101380, "updated": 1588101380,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -560,7 +559,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:55 GMT
+      - Tue, 28 Apr 2020 19:16:24 GMT
       Expires:
       - '-1'
       Pragma:
@@ -582,7 +581,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 77ae1cc8-6d31-4ef6-a3f1-3232c6397405
+      - cf7143e1-f70a-4f01-b674-34e96a05f03f
     status:
       code: 200
       message: OK
@@ -600,7 +599,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      - 0a4988c9-3887-46f4-90cd-c084ed53a15d
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -627,7 +626,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:55 GMT
+      - Tue, 28 Apr 2020 19:16:25 GMT
       Expires:
       - '-1'
       P3P:
@@ -635,7 +634,7 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AjvLU7-w8n1IhiDXl3ARCvA; expires=Sun, 24-May-2020 19:56:56 GMT; path=/;
+      - fpc=AgQEBJhXLzFGs1fPLY6goWU; expires=Thu, 28-May-2020 19:16:25 GMT; path=/;
         secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
@@ -644,11 +643,11 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      - 0a4988c9-3887-46f4-90cd-c084ed53a15d
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 81f84ab9-678d-4639-a04f-85c790bc0d00
+      - 7181a3fe-53da-4f0e-831a-754e7b2e7900
     status:
       code: 200
       message: OK
@@ -668,7 +667,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      - 0a4988c9-3887-46f4-90cd-c084ed53a15d
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -686,10 +685,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761816", "not_before":
-        "1587757916", "resource": "https://graph.microsoft.com", "access_token": "*****",
-        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41h5RCM1fqoz9-mdQnJmmdVIv3D-6yM_cnYKRzp3_IbsCUjCG7O-vejl61JlyNw9iiooedFyoIpWIGzP-8OCD1uDGEy3XFJysMUqy07Fg8bCmJO-dnr18c-YthG6JQaR5nXW2-4uO7U5H8rJ2SCCRXgzxzdmbt60uL-viX_56PnNWU0IcUSQhUCcVnCBrppU7d2LJhwmHZfNg8Zsp53erXU7cdDJ0hZCO6INRVIyTRE6slTLT9qZlFtD_6qloblsh-pJQYCczYeXtK6B9e-p9asA0RoQkltXLNmTfCoR7esJ3s5g9qGieG_SNgRSCYn6M2LgnptHgK-f4C6Ms7vEY7acaJou1ZqQFhdqXyN_xCOGQDU9lWMBRLik2SPr1k7k33ru_zTCU2J44A3j7rEF3NTJTULq63gA_PAA6Ied2T_ISiXMxZxeO84kWKjgDsRYOqlV2rSSA3pb7CP6lfLAh9RlOSxUtHZuW_Jo_oPzPvmC80uh7GmEqwg1rYjoNtKHdwI_oR90yaieZsipdo3bO4IahnosfFApCc94wN25HqCM39ESa2a_Zxc8rqcUwo9sKXkz-khC-uo8Ezz3Nd0q65oMdkvIdSBrNxVpmYAT4mD2bYCMugBra7f-xutFvA8KgaIAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTE2LCJuYmYiOjE1ODc3NTc5MTYsImV4cCI6MTU4Nzc2MTgxNiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588104985", "not_before":
+        "1588101085", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ4109xAqgA9wsuvxq3cKsbKdsSdHGPZva1ajrOkIJ35k6eOMCRwHiSXPn7jqvayXmbDukoNL2-PqEpVivZCtJrgFZ6OewI2glkctsXb2JtrendRO9mkM6Rv5yxmbaFlwilTQ1Qm-5UKWBoXSb5hmqgm_O_kQqHn3yQ_ETO0RhbdjUpbg_W2qPMdcm8Dz4TkEzwFhxO-BjuRhfNxgtVMQNBeoQfzG-mpoBas1umX3xRgBllq89g-nFf8c5ScsBP4PgShBAaQyCvMnxwqlCHN_1hPt_oTdBkHsf5Y_jrj45yR5Hy59NaFGU-o55FV7wYcaLt0qLznorBXOiTtdguRrhVcJ4W0E1z7CstK_vDsY6h54bEo3WjF5yPy-tB55HcESzmmwSPxq6sSKdMN6hQ1muDZO5iWaQqIM-ytK1AkJ9558amw1KUJrAgcyK1UfKwGEYqkDtq6bX6yhSabRUgffuBgNeubwppywpW_qbw2pDvmsrd3yRSlyps2hE0qQWng4cNnyG5FAmmqzveh7Ps5ArKhQy4BMzppbcckjHCWHanKlug7IOTv6JHN9MlRZYQe-orArPYzjPmYBwIKKI3lZ81hokPsSFgtSp9afF6p0ZRJF5TrxIQvfTMC4O0LY33JsnPOIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMDg1LCJuYmYiOjE1ODgxMDEwODUsImV4cCI6MTU4ODEwNDk4NSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -698,7 +697,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:55 GMT
+      - Tue, 28 Apr 2020 19:16:25 GMT
       Expires:
       - '-1'
       P3P:
@@ -706,8 +705,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgnH4owRQUxEn0wVS-sYDkkz3-LjAQAAAIc7NdYOAAAA; expires=Sun, 24-May-2020
-        19:56:56 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AkgnRnyzGjxGr-sctQJGSCMz3-LjAQAAAAl4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:25 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -715,13 +714,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      - 0a4988c9-3887-46f4-90cd-c084ed53a15d
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - faa9525a-448a-4d0c-80dc-b17aafd71c00
+      - f6e348f2-5a7c-470a-8ea8-fe20e3d57700
     status:
       code: 200
       message: OK
@@ -746,12 +745,12 @@ interactions:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals/$entity",
         "id": "*****", "deletedDateTime": null, "accountEnabled": true, "alternativeNames":
-        [], "appDisplayName": "Hybrid :: Hernandez, Robbins and Kane :: ATAT Remote
-        Admin", "appId": "*****", "applicationTemplateId": null, "appOwnerOrganizationId":
-        "*****", "appRoleAssignmentRequired": false, "displayName": "Hybrid :: Hernandez,
-        Robbins and Kane :: ATAT Remote Admin", "errorUrl": null, "homepage": null,
-        "isAuthorizationServiceEnabled": false, "loginUrl": null, "logoutUrl": null,
-        "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyEndDateTime":
+        [], "appDisplayName": "Hybrid :: Adams-Jimenez :: ATAT Remote Admin", "appId":
+        "*****", "applicationTemplateId": null, "appOwnerOrganizationId": "*****",
+        "appRoleAssignmentRequired": false, "displayName": "Hybrid :: Adams-Jimenez
+        :: ATAT Remote Admin", "errorUrl": null, "homepage": null, "isAuthorizationServiceEnabled":
+        false, "loginUrl": null, "logoutUrl": null, "notificationEmailAddresses":
+        [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyEndDateTime":
         null, "preferredTokenSigningKeyThumbprint": null, "publisherName": "Default
         Directory", "replyUrls": [], "samlMetadataUrl": null, "samlSingleSignOnSettings":
         null, "servicePrincipalNames": ["*****"], "servicePrincipalType": "Application",
@@ -765,23 +764,22 @@ interactions:
       Cache-Control:
       - private
       Content-Length:
-      - '1437'
+      - '1409'
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:56:56 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b14032fd-5473-4c2f-aca2-1eb71fba6d43/Microsoft.DirectoryServices.ServicePrincipal
+      - Tue, 28 Apr 2020 19:16:26 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - c31eab6c-c41c-431c-b45f-e5b5c3011165
+      - 4c9d8a1e-be41-41f3-b91b-d6f4ebaf427e
       request-id:
-      - c31eab6c-c41c-431c-b45f-e5b5c3011165
+      - 4c9d8a1e-be41-41f3-b91b-d6f4ebaf427e
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_26"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_7"}}'
     status:
       code: 201
       message: Created
@@ -814,7 +812,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:01 GMT
+      - Tue, 28 Apr 2020 19:16:25 GMT
       Expires:
       - '-1'
       P3P:
@@ -822,8 +820,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvyJaV4oE_9DsEyg78QBkaBJ34YQAQAAAI07NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:01 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AjaJqyYFAAVPvkh-6D-olFxJ34YQAQAAAAl4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:26 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -833,7 +831,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - a6ff2930-54bd-410c-b9d3-c1737cb01c00
+      - 81930870-fdc3-4d46-a631-78ada6b68800
     status:
       code: 200
       message: OK
@@ -849,7 +847,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c0a2991c-8665-11ea-83d2-acde48001122
+      - c17bfc6c-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -858,7 +856,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "attributes": {"enabled": true, "created": 1588101380, "updated": 1588101380,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -868,7 +866,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:01 GMT
+      - Tue, 28 Apr 2020 19:16:26 GMT
       Expires:
       - '-1'
       Pragma:
@@ -890,7 +888,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 8aff5939-242e-4985-a596-55192e078f69
+      - 7d7eaab2-4c23-461a-acda-cd8ec844e0ad
     status:
       code: 200
       message: OK
@@ -908,7 +906,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      - 312beb5f-a333-42e9-868c-b4522509b4be
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -935,7 +933,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:01 GMT
+      - Tue, 28 Apr 2020 19:16:26 GMT
       Expires:
       - '-1'
       P3P:
@@ -943,7 +941,7 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Atpn2RpGxA1EpEhMridEcaQ; expires=Sun, 24-May-2020 19:57:02 GMT; path=/;
+      - fpc=ArctDUakKFZGlJ_rpY6mA1o; expires=Thu, 28-May-2020 19:16:26 GMT; path=/;
         secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
@@ -952,11 +950,11 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      - 312beb5f-a333-42e9-868c-b4522509b4be
       x-ms-ests-server:
       - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 183e58f3-bc91-407b-b994-ecb988ea1b00
+      - cdc5db41-78c5-478f-82e8-d45121237d00
     status:
       code: 200
       message: OK
@@ -976,7 +974,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      - 312beb5f-a333-42e9-868c-b4522509b4be
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -994,10 +992,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761822", "not_before":
-        "1587757922", "resource": "https://graph.microsoft.com", "access_token": "*****",
-        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41enoqg8C4s9KmdLR68UoBt5Iiu5qZNXY1tCc0fDP2XQLMVd1PgKB-UdFuz7oxBdKfBy5dihq0h-BODitkUhdLfw_uoySS1tx73vThBdSbu_c19HE0CJhDhhz0MfAdmU0d9nabH1-I01OsbjbUvp_D3IM2r2Kl8LKbWBgo6m-P4GHlAR7glbjP4-7gGeSraFFEEUoKl8xWQLnNxK-9vk5oBESzaVxQudo7eF6U9b-PdtBAJV9aCXf4pJqIS_BSuJh-VwAWstfQSeMzxYWXZ3hOTyN3_ayWCz-zjZaTuoRWVKXtaNi1NMiXLWBt2aMXxTEhH1XUIi1Ip5fsjI3j8DpOCB4plxpAbDMQqF3o4U2fW7ed5svf0jY5akcP6HfU3v2abkYJDyVE2ZszYBsK9LeJn9qcd1ZJEMv2sn1hxxOkmwzGr59P55dJecfd1isnKJb4m3WOq7g4O3eLFOq0zERu5CZCsbyhIQB1gK-tESbXC_-IDhBmyNp_tYbmARCyDBtkkdRhlcdSXpjeIqgSUAPs6bwgLY1Bxz6h9vh1WFpRx9s5P4cHysYHvPVA45LOH2xKoh2KSIeVHbkApccA7ppFgA8XNxoKne-dAEpiOmn424cbicrrPGhmkDhhs2IQwf51IAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTIyLCJuYmYiOjE1ODc3NTc5MjIsImV4cCI6MTU4Nzc2MTgyMiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588104987", "not_before":
+        "1588101087", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ410207JOycuJRckTRanfhKtdufdqUxU1LqPCtIoCbnacMBXjfG_-nQS3s97AXhFghhw8WvB-FkjVIHpsnl6TnsgKgiIlZqguAf_ACYe8ce8Nw9mYKvNu3aBmZ1GP39xzPwCIJJaScme1QX5zZpEjAHsrrglS9nrtklvfavNKgNdui1beEeKfJEJ53bUL2l9mPB3ZuPmThiCg4PlOz1QvWRZ-2cPmwwqR7VWvq9tUGkVJVFpwzL5qWszed3ktK0Q800PqB50r3ZheQVRfKFxp5xCyxncvdU5VPjgzfHjHnKz9mU34FCGgMa-3nQz_1UT3Fy-d3imFlW0mZAxAU92ImBHUrWk4uXJl0ccDFBbs0sDwLveLZyK25eqEK3wqQnZgit1UUg1Wf5q8ioyYGioSYBgYpeJUyDQCwpIuxo8TJq7SV2EW06vsxuWgyCz1JobeyYxgZYgP0ubv8GPCbmh15KxS4_yak0evgU0OE_NUPpeSwzZHRHG6ZYDQO7wfA9MAlxcWwrKT3SNt37tvkBV56CV4Oik8u--Qz_y1423X4T_g_E9O0qFkfybhUReizqKOfSyK_l4FsA6V0gkqq_6th55XLgoAhgCcvTYss0kR8aFk59RPmUX7s7Sagum-u3nXjEIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMDg3LCJuYmYiOjE1ODgxMDEwODcsImV4cCI6MTU4ODEwNDk4NywiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -1006,7 +1004,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:02 GMT
+      - Tue, 28 Apr 2020 19:16:26 GMT
       Expires:
       - '-1'
       P3P:
@@ -1014,8 +1012,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AsNQqfa3zf9DoEJe8FgSobgz3-LjAQAAAI47NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:03 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AhHG-BTxC55Nl0WLjJG_BEEz3-LjAQAAAAp4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:27 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1023,13 +1021,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      - 312beb5f-a333-42e9-868c-b4522509b4be
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - a9a74ab1-656e-4978-be41-db9dcf0f0d00
+      - 01e83013-712d-4700-903a-023adfe07e00
     status:
       code: 200
       message: OK
@@ -1057,9 +1055,9 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR79n
         NcvabDytlm3+rv3o0Ufztl01j+7evaiz1Xy8KKZ11VTnLbVY3L3cHe/c/d0WeZvhpR93X0rjVdY0
         V1U9O6nzWb5si6z8aPTRdN201eL3yq/P+LPzIq8/erRcl+Xoo1nRrMrs+kW2yM1H+XL2NGvzNwU+
-        +mhvZ29ve2d/e2//ze7DR/cfPNq5N7738GD/3qf3f4pAz4slMN7+7AH98RY90F+z+9N7Dx/m59sP
-        s93J9v6nk3v0W35/e7o3y/Ps3nRv+vCAmjf5tM7bNzJmgnCy/Oze9366+mr5U1+UXz7b2WsWD37P
-        R7Pf/83D/b033L7N6jZEbWcQtV/y/wDRHXOEWAEAAA==
+        +mhvZ29ve2d/e+/gze7DR7ufPtp7ML6/s3v//u5PEeR5sQTCWbVLf7xFB/TXg3z3/H52fn97eu98
+        f3s/O9jfnuzuPNieHtyb7GfTvWx/dk7Nm3xa5+0bGTJBeH6+/onydP7pt5/8/jvr8ge/x++/eLpX
+        Tb/36e6j7b2XaN9mdRtitjOE2S/5fwDApCF6VgEAAA==
     headers:
       Cache-Control:
       - private
@@ -1070,9 +1068,8 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:04 GMT
-      Location:
-      - https://graph.microsoft.com
+      - Tue, 28 Apr 2020 19:16:27 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
@@ -1080,11 +1077,11 @@ interactions:
       Vary:
       - Accept-Encoding
       client-request-id:
-      - 7baf27d8-89a0-46db-952c-ac0d0010c7c6
+      - d3252367-21d4-4846-a3ba-82261f03d169
       request-id:
-      - 7baf27d8-89a0-46db-952c-ac0d0010c7c6
+      - d3252367-21d4-4846-a3ba-82261f03d169
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"002","RoleInstance":"AGSFE_IN_20"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"002","RoleInstance":"AGSFE_IN_22"}}'
     status:
       code: 200
       message: OK
@@ -1117,7 +1114,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:04 GMT
+      - Tue, 28 Apr 2020 19:16:27 GMT
       Expires:
       - '-1'
       P3P:
@@ -1125,8 +1122,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AlbMiVzuExxGrZCEevnMjyZJ34YQAQAAAI87NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:04 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AnupBGQop6lIqnleLbxpcARJ34YQAQAAAAt4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:28 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1134,9 +1131,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - f797948b-3812-466f-9424-4a9fa0831800
+      - ea87cc7e-ca45-4c14-ad56-d730dba37a00
     status:
       code: 200
       message: OK
@@ -1152,7 +1149,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c513e082-8665-11ea-83d2-acde48001122
+      - c2b20374-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -1161,7 +1158,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "attributes": {"enabled": true, "created": 1588101380, "updated": 1588101380,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -1171,7 +1168,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:04 GMT
+      - Tue, 28 Apr 2020 19:16:28 GMT
       Expires:
       - '-1'
       Pragma:
@@ -1193,7 +1190,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 6eb90e23-5463-430a-8434-306ebec5b16c
+      - 0fd6ae4f-e6b1-4455-b8ac-8ba193630ed9
     status:
       code: 200
       message: OK
@@ -1226,7 +1223,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:05 GMT
+      - Tue, 28 Apr 2020 19:16:28 GMT
       Expires:
       - '-1'
       P3P:
@@ -1234,8 +1231,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AphkXkPWEo5Mi4hxyv8593RJ34YQAQAAAJA7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:05 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AuUo5C1UsqtPhsgZtYqwdahJ34YQAQAAAAx4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:29 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1243,9 +1240,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 1dd12d1a-a64b-42d8-b9d5-0e7972b21b00
+      - 2e679522-22cf-4db3-bf49-056157677300
     status:
       code: 200
       message: OK
@@ -1265,7 +1262,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c5889350-8665-11ea-83d2-acde48001122
+      - c2fbd3d2-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -1274,7 +1271,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -1284,7 +1281,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:05 GMT
+      - Tue, 28 Apr 2020 19:16:28 GMT
       Expires:
       - '-1'
       Pragma:
@@ -1306,7 +1303,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 4f55755a-159a-49f0-a7fa-e8f00d7dddfe
+      - 3ee0bef3-08d0-4905-980b-10ca7006ed04
     status:
       code: 200
       message: OK
@@ -1339,7 +1336,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:05 GMT
+      - Tue, 28 Apr 2020 19:16:29 GMT
       Expires:
       - '-1'
       P3P:
@@ -1347,8 +1344,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AhKgGfUkj_NHgXHsVVVM8IFJ34YQAQAAAJE7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:05 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AqOovyp_ukNFpaY_w3s6QU1J34YQAQAAAA14OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:29 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1356,9 +1353,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - 3bd1ac16-0211-4f42-ab03-15ce30451b00
+      - 8fc0f85e-918a-4180-9465-bdf3eeb57d00
     status:
       code: 200
       message: OK
@@ -1374,7 +1371,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c5d833ec-8665-11ea-83d2-acde48001122
+      - c35cd722-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -1383,7 +1380,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -1393,7 +1390,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:05 GMT
+      - Tue, 28 Apr 2020 19:16:29 GMT
       Expires:
       - '-1'
       Pragma:
@@ -1415,7 +1412,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 294fc9ef-b7af-455d-819e-7d6a64d9a861
+      - a6a22fac-ee4b-451a-88a4-75d4738e941a
     status:
       code: 200
       message: OK
@@ -1433,7 +1430,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      - 7f0fc3d7-ce61-4ca8-a36d-7d3a3e5f40c4
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -1460,7 +1457,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:07 GMT
+      - Tue, 28 Apr 2020 19:16:29 GMT
       Expires:
       - '-1'
       P3P:
@@ -1468,20 +1465,20 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AgiTVqka-AxIqHmLqB47ZuY; expires=Sun, 24-May-2020 19:57:07 GMT; path=/;
+      - fpc=Aj0N_ToooG1BmZeUujc-zbM; expires=Thu, 28-May-2020 19:16:30 GMT; path=/;
         secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
-      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      - 7f0fc3d7-ce61-4ca8-a36d-7d3a3e5f40c4
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - EST ProdSlices
       x-ms-request-id:
-      - 9e76dd79-8134-4fa4-88f6-66dd5a291800
+      - d2eb0224-7c92-4dd5-ada3-1ddd8c833500
     status:
       code: 200
       message: OK
@@ -1501,7 +1498,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      - 7f0fc3d7-ce61-4ca8-a36d-7d3a3e5f40c4
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -1519,10 +1516,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761827", "not_before":
-        "1587757927", "resource": "https://graph.microsoft.com", "access_token": "*****",
-        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41WDDX9upJRhXwc3LQ7kJGwPYfUsaZ6rtkwpkwxLGZ5ErnbtarlP1hdcgf4Y58CuBzQoROtVoTn4CzQsOKEBYJbqwmxeeGitoT1oehCcJp7vaI0mGycCV0odo61P4eg0WjfGQ9Gw4HSOWmIFzu4Pl9Lsl7jHQ2XjIsavz1bY7rNkWiGkA9-07iijX7-BsBjknyt2OApISS0lLrcSLr65kZDd_j4GrnOpAuUCNSVmMxK2Xwfvu4cBW3-GO1aL7cPFQl0Zd2GsG-N6A2Nq44GviKkRbqGeZWxDmoMrHwwHpN9ff_scQ5QUumfkZynpvPLBco5CYTYjJpFvEe0jC7LGUvbs3jQZvlVLM0OdBWymMfHKJ_xkMnF0x3N9FR7V8e41KWweHZaCDc2MNAm-KqSbwdd7Lm4JE-ZNq_vmZDMgcdiVD37zvJh_K0soXmpIDQmIxtGmOqowlI2uc9rCJtCG00nrvVGRj_5RZMNG-dcsKjC9sOI1_AUgSaKRHAmJiwht_2isli7S5K51me3pJcE2MJnVODfeuHopa8FfrZKWznSRXcYebXj6yXHCH8KJbyS1N_FsNj-N0EQ3ca0anmWQY8Cgye1JsIKj4iuhj3LQICW23mUjWVpYivziiLGmr957r0IAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTI3LCJuYmYiOjE1ODc3NTc5MjcsImV4cCI6MTU4Nzc2MTgyNywiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588104990", "not_before":
+        "1588101090", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41h0V4iimGe1sRRYhyHe0lrzAjxlH1TiKFtRMAP_a2_9W1hLMgAgqGNdJbpwPvNI3CgMb5pp1knFRuIdXKlwYh6z8e9C2rXbjiaFUVsOg2a6aIcq2ngnJtczgcTy6Y8yshDQkxnS-Pa5tWPG1X9Q_S22QX9fBCrru3FV6bciJstzhjPy8RxkqXURwfWJZAP0tzu9hA_zubaqxBLHWXrwNtR8KRC4HbwmSiwJNK_zIZmzmsHIDlvf7x3zJP_Vy2lNv5-PN9ROmAJ7r-IA4t52hpd0CZr7DRqYHhrYAu47g46_J7Fje-UC6QZRgSpbYgg5x8fsDtTAn59O6Sb7HMmrGdEu2e-_JkExUGWFT3B_L-nZK-8kyC7d8tfFslaxI_zA_fW2RjHfIDlRe9N-f6CcQlRl5dtVEEN9_TeUFJXRxFvTX09ZLbAWWuStL8UrlQ3QPksauHlAYF2iSKoz3I1MprxSlNYYrw9JW0HiQZu-inLXpORA7j1eyjnTygOl7fJEWTqPdpOcfAcbOaKC_XuIqWWZqhaJjs5naFxmRI3IwROEqlbJ8kSbla5DCcPGDQOl06MkVwcvC0eYPMOa98y2EeMEooebcqX2FH2THlSKHNhDllwwGKxTOslOiJrt9P4dUKIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMDkwLCJuYmYiOjE1ODgxMDEwOTAsImV4cCI6MTU4ODEwNDk5MCwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -1531,7 +1528,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:07 GMT
+      - Tue, 28 Apr 2020 19:16:29 GMT
       Expires:
       - '-1'
       P3P:
@@ -1539,8 +1536,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ApAJruUy3WFAgAUj4Xds1Wcz3-LjAQAAAJM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:07 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=At8nYlc4CZ9FsBoACjcUQqIz3-LjAQAAAA14OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:30 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1548,13 +1545,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      - 7f0fc3d7-ce61-4ca8-a36d-7d3a3e5f40c4
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 5ea75fa6-dad8-4ffc-9e14-6069bcb40e00
+      - ee1f6ec8-8ea5-453d-9e29-8486eaa77400
     status:
       code: 200
       message: OK
@@ -1799,7 +1796,7 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:07 GMT
+      - Tue, 28 Apr 2020 19:16:30 GMT
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
@@ -1807,11 +1804,11 @@ interactions:
       Vary:
       - Accept-Encoding
       client-request-id:
-      - 1a8cfa68-3f64-475e-9c2a-520d8d9ce911
+      - 6e286770-cf1b-4a86-b9e3-6ccbd824f945
       request-id:
-      - 1a8cfa68-3f64-475e-9c2a-520d8d9ce911
+      - 6e286770-cf1b-4a86-b9e3-6ccbd824f945
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_26"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_92"}}'
     status:
       code: 200
       message: OK
@@ -1844,7 +1841,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:08 GMT
+      - Tue, 28 Apr 2020 19:16:30 GMT
       Expires:
       - '-1'
       P3P:
@@ -1852,8 +1849,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ar-pP5jdO5tDhdUp7m-8QW9J34YQAQAAAJM7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:08 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Ah9XqSNn4A1LrO8oVAY96axJ34YQAQAAAA54OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:31 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -1861,9 +1858,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 5342f97b-a7cd-4f64-946f-c55f30db0d00
+      - 146fbbca-a0a5-41da-b62c-3401bb747600
     status:
       code: 200
       message: OK
@@ -1879,7 +1876,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c750d508-8665-11ea-83d2-acde48001122
+      - c42ac3d0-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -1888,7 +1885,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -1898,7 +1895,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:08 GMT
+      - Tue, 28 Apr 2020 19:16:30 GMT
       Expires:
       - '-1'
       Pragma:
@@ -1920,7 +1917,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - f07488df-6c49-4c8a-b68e-c9593222c9b1
+      - 1a57c8b2-87a7-4b39-a09e-a791a159f9a3
     status:
       code: 200
       message: OK
@@ -1938,7 +1935,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      - c3eaf697-9fd9-4b4e-b7a3-3bc331216eed
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -1965,7 +1962,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:09 GMT
+      - Tue, 28 Apr 2020 19:16:31 GMT
       Expires:
       - '-1'
       P3P:
@@ -1973,20 +1970,20 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ArLpbKjFoBdMqFyIo5guGME; expires=Sun, 24-May-2020 19:57:09 GMT; path=/;
+      - fpc=AgOQoEoBEj1GvtuaFTaBxec; expires=Thu, 28-May-2020 19:16:31 GMT; path=/;
         secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
-      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      - c3eaf697-9fd9-4b4e-b7a3-3bc331216eed
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - EST ProdSlices
       x-ms-request-id:
-      - ee1f6ec8-8ea5-453d-9e29-84862e190f00
+      - e5c87f1a-eaf3-4e45-8ab4-1519fcf73000
     status:
       code: 200
       message: OK
@@ -2006,7 +2003,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      - c3eaf697-9fd9-4b4e-b7a3-3bc331216eed
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -2024,10 +2021,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761829", "not_before":
-        "1587757929", "resource": "https://graph.microsoft.com", "access_token": "*****",
-        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41EsrjpNCjj2hsZBGzuDR5ig4LCVvWtOqrMOqBs8ljhrd9Hk44SBx6gr1RvZYioMPlHJ_l-45IA4iMFqZB4VseVMMkb1SzgE80LeNeNCxnUcfl0c5dggOG78M186VdKsZwmnH3aRpj7KLnV5K2YiKwGCf_Yhx-OoPd6irqfRfxVk1KgzlmXQCi7MT23ukPBVpoT1uiERJXKGeUn8gUh259cuh85slOZpSZos699YKXcrz6QrouQDj13dSxNJclM98j5ki2ufGQhQaoF7yGDpaUP-zFd2rHLg3qAxKJWheSo5zTESOmR35lPLrqFOmdaNq80BlAvYcxEAERTKbDCRbkckNxoPTS8JTVQb08c0vc3sePnVrzhJC_ID8VwbDCvzrjidPoHhgXqdViVRppws3U_IGCI9FSTw9diq8T58_AWkwPjOQRph2bnuIHbnNuVxZK26KHs8PhPzkLLiZ305nCeh99zBMLY5tu5s3-O3cQQ1pK9iRRdBTe_c7KzwfPK57r9v3EgXamM3ZDuFPUM1cUyVBkMt3uHhJ8dcD_QbuRu7LtP5WRLhLQR1BEICzrbinv52eZ3v8qIv2SUnUTOp42IhZi_aDzT7tv29a_LRvauktdQEUzwrj9LZHn8VxBeu4YIAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTI5LCJuYmYiOjE1ODc3NTc5MjksImV4cCI6MTU4Nzc2MTgyOSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588104991", "not_before":
+        "1588101091", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41GuZw38PEeqDVVP3fZihqHddiwBTYTZTWOliL-gFhTnQFKOfd6_yxOweL91OH69Gl_I8nwv-OyrWwmrh2iyOhTu7ntq9Im03MifrsKlgskz7CEHmLvFI_KQUqekOEh1_g3wPUyaGiZc-WSc-UjP-k9FTU3yMbUovtNAlgDl756sDQAjxvtPoP_2rdgJEpZ9vMHDzoMWWVljMMq-U5PTHTLhXHx1t0OxV9EBxlu2IlFGn9mL3Iww_g0wMfrS-446z2n2wlLloCIiSJvJwLZvdUCy0vm5arU4g_uwmrd7Px9_WYCIVS5CRLyM0Y2nqYLlu-Drhzyapt-3NT8tlrhHPt_3mgLgfciAjbbm9ZksGLYpaYyg-E7O0ca1esH1SKGAswPdnC1bfTGnS_1q-sKv2cJ9HpbipgZlI_4olktY1gdTokeEtgXSSTs_2YiYUz2FwpfxBgcB_bSvBFiBbkxq4M4xOryUuyFMCLK_xW_XoGQPx2WqiOkvrIvC7ocQwo_eMHJihNro01_0j9Nr6YQiSi8j5zTz29cpZrFkSDFgzZm-wyDY41WSU7_-TMAHwYNQflh5X3Dw9xhZby8EjaVV9qlFcqGaj9Ae70rJuzt2jRKK652mfd25n9Jh4eB0lvLtemIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMDkxLCJuYmYiOjE1ODgxMDEwOTEsImV4cCI6MTU4ODEwNDk5MSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -2036,7 +2033,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:08 GMT
+      - Tue, 28 Apr 2020 19:16:31 GMT
       Expires:
       - '-1'
       P3P:
@@ -2044,8 +2041,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AtZX7c6shkdDlJffF907PwUz3-LjAQAAAJU7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AvTxKYq6ivVFgPP2Q4u9LaMz3-LjAQAAAA94OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:31 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2053,13 +2050,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      - c3eaf697-9fd9-4b4e-b7a3-3bc331216eed
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - a9a74ab1-656e-4978-be41-db9d92100d00
+      - 4f9b3af8-8291-49d3-96b1-d03311e57900
     status:
       code: 200
       message: OK
@@ -2084,7 +2081,7 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#roleManagement/directory/roleAssignments/$entity",
-        "id": "lAPpYvVpN0KRkAEhdxReEP0yQLFzVC9MrKIetx-6bUM-1", "principalId": "*****",
+        "id": "lAPpYvVpN0KRkAEhdxReEMDU-lM_Eo9LgIqVCEVKAJ4-1", "principalId": "*****",
         "resourceScope": "/", "directoryScopeId": "/", "roleDefinitionId": "*****"}'
     headers:
       Cache-Control:
@@ -2094,19 +2091,18 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:10 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/roleAssignments/lAPpYvVpN0KRkAEhdxReEP0yQLFzVC9MrKIetx-6bUM-1
+      - Tue, 28 Apr 2020 19:16:32 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 2c9f8d57-dced-4a60-974b-5c47dfd53ceb
+      - 533acea9-d5c9-4515-a178-f2f2860c4b28
       request-id:
-      - 2c9f8d57-dced-4a60-974b-5c47dfd53ceb
+      - 533acea9-d5c9-4515-a178-f2f2860c4b28
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_88"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_80"}}'
     status:
       code: 201
       message: Created
@@ -2139,7 +2135,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:10 GMT
+      - Tue, 28 Apr 2020 19:16:31 GMT
       Expires:
       - '-1'
       P3P:
@@ -2147,8 +2143,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AvrhejyiRiVAkvWJt2ay2d5J34YQAQAAAJY7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:10 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AuEosViGaJVCoQGFTSFRPjdJ34YQAQAAABB4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:32 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2156,9 +2152,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - c226a040-1c76-4759-93bc-29c58c7d1c00
+      - 2fc4ad85-4bb9-4965-9d0d-76db4ae07900
     status:
       code: 200
       message: OK
@@ -2174,7 +2170,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - c89bc8a0-8665-11ea-83d2-acde48001122
+      - c51bcb7c-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -2183,7 +2179,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -2193,7 +2189,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:10 GMT
+      - Tue, 28 Apr 2020 19:16:32 GMT
       Expires:
       - '-1'
       Pragma:
@@ -2215,7 +2211,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - bc7e3bd4-b64b-497a-8768-fb599c154571
+      - fe9b4426-a3c8-4d9d-9961-ca9e662528b2
     status:
       code: 200
       message: OK
@@ -2235,7 +2231,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 66dbd017-a859-4fd0-b367-dc2477007e88
+      - ab273d0a-b062-4776-a378-6d3e0ca2a1eb
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -2253,7 +2249,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761831", "not_before": "1587757931", "resource": "https://management.azure.com/",
+        "expires_on": "1588104993", "not_before": "1588101093", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -2263,7 +2259,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:10 GMT
+      - Tue, 28 Apr 2020 19:16:32 GMT
       Expires:
       - '-1'
       P3P:
@@ -2271,8 +2267,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ak_dr-sHyLFHgIwKabAKtTbZVRABAQAAAJY7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AjKlQjACn7hDrhhyo0FgW3XZVRABAQAAABB4OtYOAAAA; expires=Thu, 28-May-2020
+        19:16:33 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2280,19 +2276,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 66dbd017-a859-4fd0-b367-dc2477007e88
+      - ab273d0a-b062-4776-a378-6d3e0ca2a1eb
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 171aad2a-99cb-4c9a-a89b-2bb24e461b00
+      - 400e507f-e1a8-4c49-b65e-0fd0181e7e00
     status:
       code: 200
       message: OK
 - request:
-    body: '{"name": "*****", "properties": {"displayName": "Hybrid :: Hernandez, Robbins
-      and Kane", "details": {"parent": {}}}}'
+    body: '{"name": "*****", "properties": {"displayName": "Hybrid :: Adams-Jimenez",
+      "details": {"parent": {}}}}'
     headers:
       Accept:
       - application/json
@@ -2303,7 +2299,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '147'
+      - '133'
       Content-Type:
       - application/json; charset=utf-8
       User-Agent:
@@ -2312,7 +2308,7 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - c90ef7b2-8665-11ea-83d2-acde48001122
+      - c5a03a10-8984-11ea-b591-acde48001122
     method: PUT
     uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -2328,11 +2324,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:12 GMT
+      - Tue, 28 Apr 2020 19:16:59 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/972b3ded-0da4-4a40-a7c9-e869dff56b26?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -2342,19 +2337,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      - 596cfad7-c1ae-4093-bddf-ed6da6340621
       request-id:
-      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      - 596cfad7-c1ae-4093-bddf-ed6da6340621
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      - 596cfad7-c1ae-4093-bddf-ed6da6340621
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - centralus:0ad4add2-275c-4b85-971b-91e76ce3653a
+      - centralus:596cfad7-c1ae-4093-bddf-ed6da6340621
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195712Z:0ad4add2-275c-4b85-971b-91e76ce3653a
+      - CENTRALUS:20200428T191659Z:596cfad7-c1ae-4093-bddf-ed6da6340621
     status:
       code: 202
       message: Accepted
@@ -2371,7 +2366,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - c90ef7b2-8665-11ea-83d2-acde48001122
+      - c5a03a10-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -2387,11 +2382,10 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:22 GMT
+      - Tue, 28 Apr 2020 19:17:09 GMT
       Expires:
       - '-1'
-      Location:
-      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/972b3ded-0da4-4a40-a7c9-e869dff56b26?api-version=2018-03-01-preview
+      Location: '*****'
       Pragma:
       - no-cache
       Retry-After:
@@ -2401,19 +2395,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      - a04bef81-b4e7-4b95-ba38-ad58f2a7ed85
       request-id:
-      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      - a04bef81-b4e7-4b95-ba38-ad58f2a7ed85
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      - a04bef81-b4e7-4b95-ba38-ad58f2a7ed85
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      - centralus:a04bef81-b4e7-4b95-ba38-ad58f2a7ed85
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195722Z:d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      - CENTRALUS:20200428T191710Z:a04bef81-b4e7-4b95-ba38-ad58f2a7ed85
     status:
       code: 202
       message: Accepted
@@ -2430,7 +2424,7 @@ interactions:
       - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
         azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
       x-ms-client-request-id:
-      - c90ef7b2-8665-11ea-83d2-acde48001122
+      - c5a03a10-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -2438,13 +2432,12 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
-        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dx8+2Jvcm+Wz7Z1Ztr+9n+3v
-        bGcPpg+384NPH87Oz+9/Otn79KPRR+31Kv8a4OnNZbbAm7fsp2mzdt1Q+9fr6TTP6QX6kDpd5XVb
-        5PTFL/6ozZfZsj3DaCf3s8lOvptv7zw8P9je37t/sJ2dTx5sn092H3x6f38yvT+5R+/PimZVZtcv
-        BJNvX0/qYpY+epR+O68J1Cz/wSh9VU0mxbJJ6c/098qWOd7K26wouctLGnBRLT96tDv6aL2aZW0+
-        e1MwsL2dvZ3tnf3tvf03uw8f3X/waPfe+N6n+w/u7e7+FMHQxk+uqem9B5/uTO/vH2zvzfJzosDe
-        ZPvhp9PZ9oP7hPPe7s5envFgs5rIh16/3oTekiY6LbdsHVLwDc8A0axqU+71o1/yS37JL/l/ABtL
-        eIGCAgAA
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41d/f3Z/sHO5PJ9v6nD3a397OH
+        +fbD6XR3e/rw3oN7D+9/ej6dfvrR6KP2epV/DfD05jJb4M1b9tO0WbtuqP3r9XSa57N8Rh9Sp6u8
+        boucvvjFH7X5Mlu2Zxjt5H422cl38+2dh+cH2/t79w+2s/PJg+3zye6DT+/vT6b3J/fo/VnRrMrs
+        +oVg8u3rSV3M0keP0uNZtmi2v1MQvvkP0C5vs6LkTi5piEW1/OjR7uij9WqWtfnsDbWj1/d29na2
+        d/a39w7e7D58tPvg0c7e+OD+vQcHOw9/imBo4yfX1PTeg093pvf3D7b3Zvk5jXlvsv3w0+ls+8F9
+        wnJvd2cvz3h4WU0EQ69fbwpvSQWdiFu2Dmn2hmmevqqqNuVeP/olv+SX/JL/B2Onjnp0AgAA
     headers:
       Cache-Control:
       - no-cache
@@ -2453,7 +2446,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:32 GMT
+      - Tue, 28 Apr 2020 19:17:20 GMT
       Expires:
       - '-1'
       Pragma:
@@ -2467,19 +2460,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      - 33fdcec4-2639-45e3-98d5-871e2040af40
       request-id:
-      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      - 33fdcec4-2639-45e3-98d5-871e2040af40
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      - 33fdcec4-2639-45e3-98d5-871e2040af40
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:71d95b25-73f0-445d-92d3-a2729d1d0e01
+      - centralus:33fdcec4-2639-45e3-98d5-871e2040af40
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195733Z:71d95b25-73f0-445d-92d3-a2729d1d0e01
+      - CENTRALUS:20200428T191720Z:33fdcec4-2639-45e3-98d5-871e2040af40
     status:
       code: 200
       message: OK
@@ -2512,7 +2505,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:34 GMT
+      - Tue, 28 Apr 2020 19:17:21 GMT
       Expires:
       - '-1'
       P3P:
@@ -2520,8 +2513,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AiRPjsj5jepJrdMj7TOz4C9J34YQAQAAAK07NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:34 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=Alz6SFnFIP5FrlS-vbWfi7ZJ34YQAQAAAEB4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:21 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2531,7 +2524,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - e77d5dec-7443-41d6-b78c-eaaa1f7f0e00
+      - d02c0162-8a95-4517-a2e1-f957357b7100
     status:
       code: 200
       message: OK
@@ -2547,7 +2540,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - d678b708-8665-11ea-83d2-acde48001122
+      - e2144f10-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -2556,7 +2549,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -2566,7 +2559,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:33 GMT
+      - Tue, 28 Apr 2020 19:17:21 GMT
       Expires:
       - '-1'
       Pragma:
@@ -2588,7 +2581,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 00e47acd-8e3a-442a-b013-184bc9e87b58
+      - 08c9e96c-562d-4c88-8762-a38a7140ac4d
     status:
       code: 200
       message: OK
@@ -2608,7 +2601,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - e3732c4a-764d-4f9a-9546-65f6fdf8592a
+      - 014ba93d-87a2-4a94-ba5d-1d502a3a3466
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -2626,7 +2619,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761855", "not_before": "1587757955", "resource": "https://management.azure.com/",
+        "expires_on": "1588105041", "not_before": "1588101141", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -2636,7 +2629,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:34 GMT
+      - Tue, 28 Apr 2020 19:17:22 GMT
       Expires:
       - '-1'
       P3P:
@@ -2644,8 +2637,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Ahf77jhCWh1JgMnPCJAB_QPZVRABAQAAAK47NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:35 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AmJXCgIJus9Ns9_bGHbxiETZVRABAQAAAEF4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:22 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2653,13 +2646,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - e3732c4a-764d-4f9a-9546-65f6fdf8592a
+      - 014ba93d-87a2-4a94-ba5d-1d502a3a3466
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - NCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - c226a040-1c76-4759-93bc-29c5ad801c00
+      - 6b37aa9f-e751-46ac-975b-ffa9c9857300
     status:
       code: 200
       message: OK
@@ -2680,7 +2673,7 @@ interactions:
       accept-language:
       - en-US
       x-ms-client-request-id:
-      - d77ce700-8665-11ea-83d2-acde48001122
+      - e2c51408-8984-11ea-b591-acde48001122
     method: GET
     uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
   response:
@@ -2700,7 +2693,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:35 GMT
+      - Tue, 28 Apr 2020 19:17:22 GMT
       Expires:
       - '-1'
       Pragma:
@@ -2714,19 +2707,19 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      - fdd22679-fa59-4907-9820-287157a6f98c
       request-id:
-      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      - fdd22679-fa59-4907-9820-287157a6f98c
       x-ba-restapi:
       - 1.0.3.1566
       x-ms-correlation-request-id:
-      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      - fdd22679-fa59-4907-9820-287157a6f98c
       x-ms-ratelimit-remaining-tenant-reads:
       - '11999'
       x-ms-request-id:
-      - centralus:43830dca-b9d3-48e5-9bb3-db232fac24c7
+      - centralus:fdd22679-fa59-4907-9820-287157a6f98c
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195735Z:43830dca-b9d3-48e5-9bb3-db232fac24c7
+      - CENTRALUS:20200428T191722Z:fdd22679-fa59-4907-9820-287157a6f98c
     status:
       code: 200
       message: OK
@@ -2759,7 +2752,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:35 GMT
+      - Tue, 28 Apr 2020 19:17:22 GMT
       Expires:
       - '-1'
       P3P:
@@ -2767,8 +2760,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Aktsv0nW6IFDmX8LTVb17GRJ34YQAQAAAK87NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:36 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AqnrUeUBOoZJi7xi16mCC1xJ34YQAQAAAEF4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:22 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2778,7 +2771,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - EUS ProdSlices
       x-ms-request-id:
-      - a7ff9419-f74c-48be-876f-80c8cfd51b00
+      - 0cf2a51d-1ceb-4941-ab48-ae0bf5c97e00
     status:
       code: 200
       message: OK
@@ -2794,7 +2787,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - d7d95db4-8665-11ea-83d2-acde48001122
+      - e30e1d9c-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -2803,7 +2796,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -2813,7 +2806,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:35 GMT
+      - Tue, 28 Apr 2020 19:17:22 GMT
       Expires:
       - '-1'
       Pragma:
@@ -2835,7 +2828,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 8af926db-0124-421b-b240-f5b182633d36
+      - d0af2ef3-c920-4f04-8e99-dcc380a647b5
     status:
       code: 200
       message: OK
@@ -2853,7 +2846,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 0b400214-fca5-4115-8a0a-7a73666da715
+      - c70c2fac-f654-4cc9-94df-28391a0fe3cb
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -2880,7 +2873,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:35 GMT
+      - Tue, 28 Apr 2020 19:17:22 GMT
       Expires:
       - '-1'
       P3P:
@@ -2888,20 +2881,20 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AqigbENHpTFEtN0wx2jaS-U; expires=Sun, 24-May-2020 19:57:36 GMT; path=/;
+      - fpc=AhdI6czRqytMuRBiZKikLPE; expires=Thu, 28-May-2020 19:17:23 GMT; path=/;
         secure; HttpOnly; SameSite=None
-      - x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly
-      - stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
       - max-age=31536000; includeSubDomains
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 0b400214-fca5-4115-8a0a-7a73666da715
+      - c70c2fac-f654-4cc9-94df-28391a0fe3cb
       x-ms-ests-server:
-      - 2.1.10393.22 - EST ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 63d79287-8704-4314-870d-754866c04900
+      - 6b37aa9f-e751-46ac-975b-ffa9fb857300
     status:
       code: 200
       message: OK
@@ -2921,7 +2914,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 0b400214-fca5-4115-8a0a-7a73666da715
+      - c70c2fac-f654-4cc9-94df-28391a0fe3cb
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -2939,19 +2932,19 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761856", "not_before":
-        "1587757956", "resource": "https://management.azure.com/", "access_token":
-        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41rr6heuxCTOned7TDSbRuXID7P_boxs77OIqyDuuo4AOwL8s8VRlj69zPIEgGeMJzZ31AdECx1FETuME6xnmiMWeRsY5WqLGJ9PrWNo8p6wjpWzCP0RGUwnqJhldECL0ZtwbAdwZUvUteBCmINvTZ_tumzmFE25AQ65r4fl6KoM_ukVap52DYCZ24VpWw4r6N6HgNAIgEFpmPWc00FBZ7RW63IoMG8c3QJ-8NGtw5r3rNDoktv55l8IDt2RckiXzEcWjIjCNo2EvfwyQHRZTRJtTp_W-ffwRE1Sid-PRaX4J4QxOLId-YTomdotM9W7A8ItYxeJEI0HfCJXg4dKHNNaZX0dDEz-wG2TpbyEtzTooi4mhWq8WDW_TWDdqf1JZa_3tzd_ZfpRXCmfTohKx0hUm_FtodsjooEGNSkR0aIN1mRHGe2Ob441_0Haprhr7M5Uq5Tb_ZyEoDdfKqqY6pVTEETmUmJG5vQkv_1Q7VZWA8t-fs_fP9dlVIca4iCh_LFJER5etgIoa3HgXTBLa0jAB5jVf1ef75ePMG5f8Zb8LFHPTmD56hAtmz47nRtnoebdp_704qhtixZiJocsNRucjTHINPHRtCjzFBkA0wAyTgnA8b8izaP0JHxJENM9TmIAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTU2LCJuYmYiOjE1ODc3NTc5NTYsImV4cCI6MTU4Nzc2MTg1NiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588105043", "not_before":
+        "1588101143", "resource": "https://management.azure.com/", "access_token":
+        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41kptbFu1rb71hw7Xzuyo8shs8AB7AyseA3r6c07vZHufLr6XTqZOQKzKaRyIo3e1NWtT5_0y4NspMDjXiVexV4W6Q12X0s57vqJAKtLizMT8G4ozNRb7xsnKSCNY5sqQeg3f0UyGdAtFbrjrKV94pDEfINB0iWUq-KK2YEyb7Q7wxTO3htLUCabhTQu5kRrHCJXV5dL_w02hwc85HCbb7ZQ7iEbKR4AKt8VyEUFJdhY77qmIRuvluGjTlHMEBq2kjxHI29vAGkfIY4U26hIcg4KEU2_KvZsvRi9pL9g_WvakW1OsEaTOMYta1ilvjp6Q5ie7rsZNsos5nH6mJnbyYexe8mTyVh24KCQp6BE-dCqlQVy1BUd73Yy33pyyVGTS31wv7lpyXQcrxsdk2ff1OVsjvS5URp7em27cyaWXI7QlAGkGEdI1-HF7bobqjDWS_borHBCi6559Vs5GbiQfYfL4zE0CgKQUhzFmHjMvaEPufsZMFfDtOI5v13gpCmQYTR5lTP644HpG0EhxexhQ2mVa_WQBM-PT4xgT-Z5lTQja2pC-dn3FiJXRJ2pBKDcCF6TraNlze1J-MZMV81aI_2tDkz-W23YgYlXYuujt-Vzt1mIjwhDZ6bm3UbDQPafv1IAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMTQzLCJuYmYiOjE1ODgxMDExNDMsImV4cCI6MTU4ODEwNTA0MywiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '3424'
+      - '3429'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:36 GMT
+      - Tue, 28 Apr 2020 19:17:23 GMT
       Expires:
       - '-1'
       P3P:
@@ -2959,8 +2952,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AiJtBNjsUm9GoIgxuF8Gl6cz99dOAQAAALA7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:36 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AnOW2oWzXK5OoU8VAagzxU4z99dOAQAAAEN4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:23 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -2968,13 +2961,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 0b400214-fca5-4115-8a0a-7a73666da715
+      - c70c2fac-f654-4cc9-94df-28391a0fe3cb
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 8fc0f85e-918a-4180-9465-bdf3bbe01c00
+      - 0f9e8439-1d93-476a-90e6-2b2c673e8000
     status:
       code: 200
       message: OK
@@ -3002,7 +2995,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Fri, 24 Apr 2020 19:57:36 GMT
+      - Tue, 28 Apr 2020 19:17:23 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3014,13 +3007,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 3cc4f2fa-ac46-42b8-b38a-22a8bea4c605
+      - 90c00770-2c81-41c7-8c44-04912bbb4d5e
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - d1009d6b-a522-477c-93c4-e0672160e650
+      - cb477ac4-dc9e-4c86-859e-6ba3dcc52c89
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195737Z:3cc4f2fa-ac46-42b8-b38a-22a8bea4c605
+      - CENTRALUS:20200428T191724Z:90c00770-2c81-41c7-8c44-04912bbb4d5e
     status:
       code: 200
       message: OK
@@ -3054,7 +3047,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:36 GMT
+      - Tue, 28 Apr 2020 19:17:24 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3066,13 +3059,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - d0443cd3-6853-45ca-9bb4-212c6ba13fe5
+      - 19df463d-f479-4e70-a393-feddb4aa298e
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - 82a2fd72-6c69-41b0-ab2d-b133807e4797
+      - cddf5b47-4f9f-47f6-87c2-1884a61bf883
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195737Z:d0443cd3-6853-45ca-9bb4-212c6ba13fe5
+      - CENTRALUS:20200428T191725Z:19df463d-f479-4e70-a393-feddb4aa298e
     status:
       code: 409
       message: Conflict
@@ -3105,7 +3098,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:37 GMT
+      - Tue, 28 Apr 2020 19:17:24 GMT
       Expires:
       - '-1'
       P3P:
@@ -3113,8 +3106,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AuP7I4AMaYJOuaQ-aUbEQudJ34YQAQAAALE7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:38 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AjwgZ19MWXlHnU-tVMrdLAlJ34YQAQAAAEV4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:25 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3122,9 +3115,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - NCUS ProdSlices
       x-ms-request-id:
-      - 7246db70-f73f-45af-acec-ccd806fb1700
+      - 452daaec-02d2-4ab5-9b65-c5602d387e00
     status:
       code: 200
       message: OK
@@ -3140,7 +3133,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - d90b69ac-8665-11ea-83d2-acde48001122
+      - e4987234-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -3149,7 +3142,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -3159,7 +3152,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:37 GMT
+      - Tue, 28 Apr 2020 19:17:25 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3181,7 +3174,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 45d8833c-11d4-4964-bf6f-f732a69eaad7
+      - 0e679c86-2981-4dbf-8654-2da0560107b1
     status:
       code: 200
       message: OK
@@ -3199,7 +3192,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      - 3fa6e379-72aa-428d-a325-dcc3bc02c5bf
       return-client-request-id:
       - 'true'
       x-client-CPU:
@@ -3226,7 +3219,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:38 GMT
+      - Tue, 28 Apr 2020 19:17:25 GMT
       Expires:
       - '-1'
       P3P:
@@ -3234,7 +3227,7 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AtFsXXwsIrlDi3svtbjPwHo; expires=Sun, 24-May-2020 19:57:38 GMT; path=/;
+      - fpc=AsLFCnE0C3FCvQWaD1J7a3s; expires=Thu, 28-May-2020 19:17:26 GMT; path=/;
         secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
@@ -3243,11 +3236,11 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      - 3fa6e379-72aa-428d-a325-dcc3bc02c5bf
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - dd9f3d1d-6fb5-498b-b2f6-caee7d4e0d00
+      - 6ae9eb7d-31c8-4b70-a6ac-94c04cf07d00
     status:
       code: 200
       message: OK
@@ -3267,7 +3260,7 @@ interactions:
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      - 3fa6e379-72aa-428d-a325-dcc3bc02c5bf
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -3285,10 +3278,10 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
-        "3599", "ext_expires_in": "3599", "expires_on": "1587761859", "not_before":
-        "1587757959", "resource": "https://management.azure.com/", "access_token":
-        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41bwLKtMXEajbPJ12SHCHvNXN-qf6GYs59RuKMnvfckN3-7n6AzR_YQ8ZJkf80A0L7CZ5VvfvxvB7nl9a6HanDV6K4DJ74SvZPhkmBuxUfk-S56I9vTPFEIjmje8DIyI5SzGZJpzrpXvjh6twV7BdXsKtiWQKWiU4RcaQrqtGPYRyBqCvmudjDpxGPfKVOZbfE9vUCDMhjIo9Ku7kWYYLjCrdwwFIpzoL9LzV0fPkpUacFaREQPm9HzzpQFnKHZbmRMYlcXVqC1YD8_GKYLfbBoelk-RbRRP0e8WgVjboP9jFxRvoLGjJakgc6XwQaA8BGKtb4VckGCCi2ao5VILDhc114HwuQckFa6LpCu-dsE6kYYAUf3bQYYXYalLp-5tSBEqcsTaqmacA494HmpULd-X6aut07vPieyXCem3M6o331TufGtm-9PFkeEuyXIiZuj40-voFfN31cC1jLve3_8YdgOVFT8v-OxuvisQIpRjNCs9Dq51Ih3i6hfCG6U2MA-c0Tk39YwblskQwGIcCvVxdPBxx56pbQOAcGGi66vm1J_vj5H1YgGDUJKfulaWkvAtPTzCvU3kioJD8KWAa-McGgU9VwMkLQrTEV5lSN6sDMX-I6LbAYhL5r51nPp2dmIAA",
-        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTU5LCJuYmYiOjE1ODc3NTc5NTksImV4cCI6MTU4Nzc2MTg1OSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+        "3599", "ext_expires_in": "3599", "expires_on": "1588105046", "not_before":
+        "1588101146", "resource": "https://management.azure.com/", "access_token":
+        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41Lk5lfXk6nFVHoLmC8IHMaW7xeKP5BSOXBknTNt3rekDTM6URppjHscLjmLmFSss7JquHIEVgJ1W_9YA2Uu2Fsg3nc6won0UFEz6nlHHJ9X9E0bty6o-HKOYYAP4zI2ssJ8DMsqeZfIrPGNAk68fpQwBY6b5USiSFuBtYqs4sTzWOfXUZWKpSrbZC_U2VstW1Y1fM6DKTbwf8chVJASmkhW33QHDziux-xGUBTSS-jOg4I1G392RJUTY2_H0_qXgEEXP-DxyItZrl56s3iM4ohlmzCkK9XfcWyNHUa6GqmthbeV-5y-gq3Q1FlOooz21coSgB9ZNrOLUj-8Gxj5ssXqafSEygAkHaeTqHl-4dgdInlizPx6-IcwuE2zdUmHcB9P5U8fx1QGSMQ2G1u3fE0FKgFaBScGnUrKAryggsVTmDm2aUlq7G0guN61PFQ2CjkWoBC6GpdiWh6ttMcjYp38MmllFZ3unpFg3rNwwV9Bavmz3CcRBO5TDlq4Jbbbtug4pife2gPoEZK0DGSJvix01DyOCnVJGm8kbeshq41K8aVB86dGOAb2BaF36zBS9pOa1PXYzTPr9dmTRpMmYtF7S3q27CdGU60Auh_UJyhb_5AyoWmnWXwbp5a_fiNuZ4IAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg4MTAxMTQ2LCJuYmYiOjE1ODgxMDExNDYsImV4cCI6MTU4ODEwNTA0NiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
     headers:
       Cache-Control:
       - no-cache, no-store
@@ -3297,7 +3290,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:38 GMT
+      - Tue, 28 Apr 2020 19:17:26 GMT
       Expires:
       - '-1'
       P3P:
@@ -3305,8 +3298,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=ApYP2Oa4LQtGtZaJQ8yB1w4z99dOAQAAALI7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:39 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AoP-4B-i99xAhw-MHs6aKtsz99dOAQAAAEV4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:26 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3314,13 +3307,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      - 3fa6e379-72aa-428d-a325-dcc3bc02c5bf
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - SCUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 8f9cc3ec-379e-41db-86ad-d9ea1a6f1600
+      - 0571ea8c-3373-413d-b344-7509d3a87300
     status:
       code: 200
       message: OK
@@ -3348,7 +3341,7 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Fri, 24 Apr 2020 19:57:39 GMT
+      - Tue, 28 Apr 2020 19:17:26 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3360,13 +3353,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 4028a972-b68e-4916-9657-0d0fd9df9aa5
+      - 7d7208f3-674f-4e17-bcff-f3c18976346c
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - 1b81cd8a-30dc-4d7f-88c5-1b98eeeae063
+      - 34346d84-da72-4c59-8af0-1b580e05538e
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195739Z:4028a972-b68e-4916-9657-0d0fd9df9aa5
+      - CENTRALUS:20200428T191727Z:7d7208f3-674f-4e17-bcff-f3c18976346c
     status:
       code: 200
       message: OK
@@ -3392,7 +3385,7 @@ interactions:
     body:
       string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/*****",
         "principalId": "*****", "scope": "/providers/Microsoft.Management/managementGroups/*****",
-        "createdOn": "2020-04-24T19:57:40.4261798Z", "updatedOn": "2020-04-24T19:57:40.4261798Z",
+        "createdOn": "2020-04-28T19:17:27.5099952Z", "updatedOn": "2020-04-28T19:17:27.5099952Z",
         "createdBy": null, "updatedBy": "*****"}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****",
         "type": "Microsoft.Authorization/roleAssignments", "name": "*****"}'
     headers:
@@ -3403,7 +3396,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:40 GMT
+      - Tue, 28 Apr 2020 19:17:27 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3415,13 +3408,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 155dd86d-8232-4695-b1da-f3950c989ea7
+      - e837240f-1f69-408e-bf6e-4bd291c66647
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - 64528b6f-d664-4546-936a-62dcc7f6fcd1
+      - 6ef40172-6b63-4ad5-abf5-39c483966a15
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195741Z:155dd86d-8232-4695-b1da-f3950c989ea7
+      - CENTRALUS:20200428T191727Z:e837240f-1f69-408e-bf6e-4bd291c66647
     status:
       code: 201
       message: Created
@@ -3454,7 +3447,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:41 GMT
+      - Tue, 28 Apr 2020 19:17:28 GMT
       Expires:
       - '-1'
       P3P:
@@ -3462,8 +3455,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=Aiwl2DAyQbFCv0a7g6wGvaFJ34YQAQAAALU7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:41 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AorO3jbH-kNGr21D_OSNjjZJ34YQAQAAAEd4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:28 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3471,9 +3464,9 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-ests-server:
-      - 2.1.10433.14 - EUS ProdSlices
+      - 2.1.10433.14 - WUS2 ProdSlices
       x-ms-request-id:
-      - 8fc0f85e-918a-4180-9465-bdf356e11c00
+      - 0571ea8c-3373-413d-b344-75091fa97300
     status:
       code: 200
       message: OK
@@ -3489,7 +3482,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - daff109c-8665-11ea-83d2-acde48001122
+      - e6485e28-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -3498,7 +3491,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -3508,7 +3501,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:41 GMT
+      - Tue, 28 Apr 2020 19:17:27 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3530,7 +3523,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - e6f5166a-c6c8-47f9-9f0c-5b52a3d7e28c
+      - 46f33494-c177-41ed-ac48-a56f581c00bc
     status:
       code: 200
       message: OK
@@ -3546,11 +3539,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '176'
+      - '172'
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - f3bb436d-7f78-4129-a194-3d51b366b2d0
+      - 3c6829c4-dfb4-4c28-929e-bbc6c4a8d410
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -3568,17 +3561,17 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761862", "not_before": "1587757962", "resource": "https://graph.microsoft.com",
+        "expires_on": "1588105048", "not_before": "1588101148", "resource": "https://graph.microsoft.com",
         "access_token": "*****"}'
     headers:
       Cache-Control:
       - no-cache, no-store
       Content-Length:
-      - '1622'
+      - '1604'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:42 GMT
+      - Tue, 28 Apr 2020 19:17:28 GMT
       Expires:
       - '-1'
       P3P:
@@ -3586,8 +3579,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AuFbh3_CSABHlpWupt05IvQ8RRv1AQAAALU7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:42 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AgU_QpWcjrRAvBpaatlIzRCrn63TAQAAAEh4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:29 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3595,13 +3588,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - f3bb436d-7f78-4129-a194-3d51b366b2d0
+      - 3c6829c4-dfb4-4c28-929e-bbc6c4a8d410
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
-      - 2.1.10433.14 - WUS2 ProdSlices
+      - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 6b37aa9f-e751-46ac-975b-ffa9f10a0e00
+      - 5d1d9321-d914-4c74-bca0-467c330c7b00
     status:
       code: 200
       message: OK
@@ -3615,7 +3608,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '355'
+      - '315'
       Content-Type:
       - application/json
       User-Agent:
@@ -3625,31 +3618,30 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
-        "id": "*****", "businessPhones": [], "displayName": "Hybrid :: Hernandez,
-        Robbins and Kane :: Billing", "givenName": null, "jobTitle": null, "mail":
-        null, "mobilePhone": null, "officeLocation": null, "preferredLanguage": null,
-        "surname": null, "userPrincipalName": "hybrid.hernandez.robbins.and.kane.billing@dancorriganpromptworks.onmicrosoft.com"}'
+        "id": "*****", "businessPhones": [], "displayName": "Hybrid :: Adams-Jimenez
+        :: Billing", "givenName": null, "jobTitle": null, "mail": null, "mobilePhone":
+        null, "officeLocation": null, "preferredLanguage": null, "surname": null,
+        "userPrincipalName": "hybrid.adams.jimenez.billing@dancorriganpromptworks.onmicrosoft.com"}'
     headers:
       Cache-Control:
       - private
       Content-Length:
-      - '435'
+      - '408'
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:41 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/5e938647-664e-42a9-bf4d-3b2b5f3ca215/Microsoft.DirectoryServices.User
+      - Tue, 28 Apr 2020 19:17:29 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - f7defca6-edee-459d-90aa-32a6f6c51a3d
+      - 4951ec1c-8b60-4907-a5c9-f9699e5f7701
       request-id:
-      - f7defca6-edee-459d-90aa-32a6f6c51a3d
+      - 4951ec1c-8b60-4907-a5c9-f9699e5f7701
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_91"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_43"}}'
     status:
       code: 201
       message: Created
@@ -3663,7 +3655,7 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '46'
+      - '48'
       Content-Type:
       - application/json
       User-Agent:
@@ -3679,15 +3671,15 @@ interactions:
       Content-Type:
       - text/plain
       Date:
-      - Fri, 24 Apr 2020 19:57:42 GMT
+      - Tue, 28 Apr 2020 19:17:29 GMT
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - d544b3f6-be93-4b49-9aa6-81abc3c3ea52
+      - e1ba2d93-f8e8-4704-9aa5-b50ae7e1fb50
       request-id:
-      - d544b3f6-be93-4b49-9aa6-81abc3c3ea52
+      - e1ba2d93-f8e8-4704-9aa5-b50ae7e1fb50
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_48"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_0"}}'
     status:
       code: 204
       message: No Content
@@ -3740,7 +3732,7 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:43 GMT
+      - Tue, 28 Apr 2020 19:17:30 GMT
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
@@ -3748,11 +3740,11 @@ interactions:
       Vary:
       - Accept-Encoding
       client-request-id:
-      - 126df737-8b05-49ac-ac0c-91c9317e62d2
+      - 38d11ca0-f910-45e5-9fec-74b1a7162978
       request-id:
-      - 126df737-8b05-49ac-ac0c-91c9317e62d2
+      - 38d11ca0-f910-45e5-9fec-74b1a7162978
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_60"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_102"}}'
     status:
       code: 200
       message: OK
@@ -3777,7 +3769,7 @@ interactions:
   response:
     body:
       string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#roleManagement/directory/roleAssignments/$entity",
-        "id": "YUb1sHQtUEyvox7IA_Eu_keGk15OZqlCv007K188ohU-1", "principalId": "*****",
+        "id": "YUb1sHQtUEyvox7IA_Eu_kjSseoA5F9AmGANGgkax9I-1", "principalId": "*****",
         "resourceScope": "/", "directoryScopeId": "/", "roleDefinitionId": "*****"}'
     headers:
       Cache-Control:
@@ -3787,19 +3779,18 @@ interactions:
       Content-Type:
       - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:43 GMT
-      Location:
-      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/roleAssignments/YUb1sHQtUEyvox7IA_Eu_keGk15OZqlCv007K188ohU-1
+      - Tue, 28 Apr 2020 19:17:30 GMT
+      Location: '*****'
       OData-Version:
       - '4.0'
       Strict-Transport-Security:
       - max-age=31536000
       client-request-id:
-      - 37d89e7c-8c97-469c-9e43-ecf20c9d4f7e
+      - 0801871a-c34e-45ed-9c04-0e5945d5a08c
       request-id:
-      - 37d89e7c-8c97-469c-9e43-ecf20c9d4f7e
+      - 0801871a-c34e-45ed-9c04-0e5945d5a08c
       x-ms-ags-diagnostic:
-      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_8"}}'
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_55"}}'
     status:
       code: 201
       message: Created
@@ -3832,7 +3823,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:44 GMT
+      - Tue, 28 Apr 2020 19:17:30 GMT
       Expires:
       - '-1'
       P3P:
@@ -3840,8 +3831,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AlISLHE_F3BKihLdTL6QgT5J34YQAQAAALc7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:44 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AuSAGer6KXVLrui5GDsbXVpJ34YQAQAAAEp4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:31 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3851,7 +3842,7 @@ interactions:
       x-ms-ests-server:
       - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 5d1d9321-d914-4c74-bca0-467c02071800
+      - 400e507f-e1a8-4c49-b65e-0fd0d9257e00
     status:
       code: 200
       message: OK
@@ -3867,7 +3858,7 @@ interactions:
       User-Agent:
       - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
       x-ms-client-request-id:
-      - dca209ea-8665-11ea-83d2-acde48001122
+      - e8032842-8984-11ea-b591-acde48001122
     method: GET
     uri: https://my-vault.vault.azure.net/secret/*****
   response:
@@ -3876,7 +3867,7 @@ interactions:
         \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
         \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
         \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
-        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "attributes": {"enabled": true, "created": 1588101389, "updated": 1588101389,
         "recoveryLevel": "Recoverable+Purgeable"}}'
     headers:
       Cache-Control:
@@ -3886,7 +3877,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:44 GMT
+      - Tue, 28 Apr 2020 19:17:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -3908,7 +3899,7 @@ interactions:
       x-ms-keyvault-service-version:
       - 1.1.0.898
       x-ms-request-id:
-      - 730f5203-72f1-4c8a-8f8b-293f72713e9d
+      - 9d9cf526-9930-416c-8699-abb5d63a3e75
     status:
       code: 200
       message: OK
@@ -3924,11 +3915,11 @@ interactions:
       Connection:
       - keep-alive
       Content-Length:
-      - '180'
+      - '176'
       User-Agent:
       - python-requests/2.23.0
       client-request-id:
-      - 4eec6b4a-3bc2-4da2-bb4e-f8e0060e418a
+      - 7c202ab3-e6fa-45b1-8fbf-1be7c3c0539d
       content-type:
       - application/x-www-form-urlencoded
       return-client-request-id:
@@ -3946,7 +3937,7 @@ interactions:
   response:
     body:
       string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
-        "expires_on": "1587761864", "not_before": "1587757964", "resource": "https://management.azure.com/",
+        "expires_on": "1588105051", "not_before": "1588101151", "resource": "https://management.azure.com/",
         "access_token": "*****"}'
     headers:
       Cache-Control:
@@ -3956,7 +3947,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:44 GMT
+      - Tue, 28 Apr 2020 19:17:31 GMT
       Expires:
       - '-1'
       P3P:
@@ -3964,8 +3955,8 @@ interactions:
       Pragma:
       - no-cache
       Set-Cookie:
-      - fpc=AlWvWwcdrVpFsBbgKLWAbwOtcNdbAQAAALg7NdYOAAAA; expires=Sun, 24-May-2020
-        19:57:44 GMT; path=/; secure; HttpOnly; SameSite=None
+      - fpc=AiHCR3TX6lFAizDnHQa2-h6AEJtkAQAAAEt4OtYOAAAA; expires=Thu, 28-May-2020
+        19:17:31 GMT; path=/; secure; HttpOnly; SameSite=None
       - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
       - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
       Strict-Transport-Security:
@@ -3973,13 +3964,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       client-request-id:
-      - 4eec6b4a-3bc2-4da2-bb4e-f8e0060e418a
+      - 7c202ab3-e6fa-45b1-8fbf-1be7c3c0539d
       x-ms-clitelem:
       - 1,0,0,,
       x-ms-ests-server:
       - 2.1.10433.14 - SCUS ProdSlices
       x-ms-request-id:
-      - 400e507f-e1a8-4c49-b65e-0fd0991e1800
+      - b4c86d86-442d-47fe-9b7f-09923aab7a00
     status:
       code: 200
       message: OK
@@ -4010,7 +4001,7 @@ interactions:
     body:
       string: '{"properties": {"displayName": "Allowed resource types", "policyType":
         "Custom", "mode": "Indexed", "description": "The list of resource types that
-        can be deployed", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:45.5003123Z",
+        can be deployed", "metadata": {"createdBy": "*****", "createdOn": "2020-04-28T19:17:32.2894911Z",
         "updatedBy": null, "updatedOn": null}, "parameters": {"listOfResourceTypesAllowed":
         {"type": "Array", "metadata": {"description": "The list of resource types
         that can be deployed", "displayName": "Allowed resource types", "strongType":
@@ -4026,7 +4017,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:44 GMT
+      - Tue, 28 Apr 2020 19:17:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -4036,13 +4027,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - c6aa01e6-4daf-461d-b403-49251c48b9bb
+      - 465c7542-b1f6-45e2-9b2e-32621292bc45
       x-ms-ratelimit-remaining-tenant-writes:
       - '1199'
       x-ms-request-id:
-      - centralus:9b4e1d1b-5449-4555-8095-22eef51e7359
+      - centralus:68217a2e-55a9-4039-a5ba-5a92318b24fa
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195745Z:c6aa01e6-4daf-461d-b403-49251c48b9bb
+      - CENTRALUS:20200428T191732Z:465c7542-b1f6-45e2-9b2e-32621292bc45
     status:
       code: 201
       message: Created
@@ -4076,7 +4067,7 @@ interactions:
       string: '{"properties": {"displayName": "Allowed Regions", "policyType": "Custom",
         "mode": "Indexed", "description": "The list of locations that can be specified
         when deploying resources.", "metadata": {"createdBy": "*****", "createdOn":
-        "2020-04-24T19:57:45.8077322Z", "updatedBy": null, "updatedOn": null}, "parameters":
+        "2020-04-28T19:17:32.4457711Z", "updatedBy": null, "updatedOn": null}, "parameters":
         {"listOfAllowedLocations": {"type": "Array", "metadata": {"displayName": "Allowed
         Regions", "description": "The list of locations that can be specified when
         deploying resources.", "strongType": "location"}}}, "policyRule": {"if": {"allOf":
@@ -4094,7 +4085,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:44 GMT
+      - Tue, 28 Apr 2020 19:17:31 GMT
       Expires:
       - '-1'
       Pragma:
@@ -4104,13 +4095,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 351260d5-f443-4a1d-9d2a-948772b0cb5e
+      - e1a2d0b4-87d4-4ab8-b0f5-e9194638628d
       x-ms-ratelimit-remaining-tenant-writes:
       - '1198'
       x-ms-request-id:
-      - centralus:e51f1737-d561-43ca-ab55-a58004ddc888
+      - centralus:94fdf6e0-4a6f-4d0c-a6fb-2a7a65254675
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195745Z:351260d5-f443-4a1d-9d2a-948772b0cb5e
+      - CENTRALUS:20200428T191732Z:e1a2d0b4-87d4-4ab8-b0f5-e9194638628d
     status:
       code: 201
       message: Created
@@ -4142,7 +4133,7 @@ interactions:
     body:
       string: '{"properties": {"displayName": "Allowed VM SKUs", "policyType": "Custom",
         "mode": "Indexed", "description": "The list of SKUs that can be specified
-        for virtual machines.", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.0116091Z",
+        for virtual machines.", "metadata": {"createdBy": "*****", "createdOn": "2020-04-28T19:17:32.633255Z",
         "updatedBy": null, "updatedOn": null}, "parameters": {"listOfAllowedSKUs":
         {"type": "Array", "metadata": {"description": "The list of SKUs that can be
         specified for virtual machines.", "displayName": "Allowed SKUs", "strongType":
@@ -4155,11 +4146,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '958'
+      - '957'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:45 GMT
+      - Tue, 28 Apr 2020 19:17:32 GMT
       Expires:
       - '-1'
       Pragma:
@@ -4169,13 +4160,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 833d8064-beab-4c8c-bfd6-9cf3c96fbd17
+      - b0857c34-1e85-4329-9c1e-f319a421d0b4
       x-ms-ratelimit-remaining-tenant-writes:
       - '1197'
       x-ms-request-id:
-      - centralus:7c50dabf-af60-4fb0-ac02-d0b3489e6578
+      - centralus:ea1eb9ca-c24e-49c9-a97f-28cb69df3890
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195746Z:833d8064-beab-4c8c-bfd6-9cf3c96fbd17
+      - CENTRALUS:20200428T191732Z:b0857c34-1e85-4329-9c1e-f319a421d0b4
     status:
       code: 201
       message: Created
@@ -4717,7 +4708,7 @@ interactions:
   response:
     body:
       string: '{"properties": {"displayName": "Default JEDI Policy Set", "policyType":
-        "Custom", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.608718Z",
+        "Custom", "metadata": {"createdBy": "*****", "createdOn": "2020-04-28T19:17:33.3060022Z",
         "updatedBy": null, "updatedOn": null}, "policyDefinitions": [{"policyDefinitionReferenceId":
         "Allowed resource types", "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
         resource types", "parameters": {"listOfResourceTypesAllowed": {"value": ["microsoft.apimanagement/checkfeedbackrequired",
@@ -5255,11 +5246,11 @@ interactions:
       Cache-Control:
       - no-cache
       Content-Length:
-      - '52001'
+      - '52002'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:45 GMT
+      - Tue, 28 Apr 2020 19:17:32 GMT
       Expires:
       - '-1'
       Pragma:
@@ -5269,13 +5260,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - 45a4d7a8-f9ca-442d-af9b-9c53b6295d13
+      - 6f42b617-e32c-41d2-bcec-37d8ea9a41bd
       x-ms-ratelimit-remaining-tenant-writes:
       - '1196'
       x-ms-request-id:
-      - centralus:52022b29-04e0-42f7-a52f-e6a854839540
+      - centralus:75c17a81-ea82-4435-8a90-5ff26d3b6bfc
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195746Z:45a4d7a8-f9ca-442d-af9b-9c53b6295d13
+      - CENTRALUS:20200428T191733Z:6f42b617-e32c-41d2-bcec-37d8ea9a41bd
     status:
       code: 201
       message: Created
@@ -5303,7 +5294,7 @@ interactions:
       string: '{"sku": {"name": "A0", "tier": "Free"}, "properties": {"displayName":
         "Default JEDI Policy Set", "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policySetDefinitions/Default
         JEDI Policy Set", "scope": "/providers/Microsoft.Management/managementGroups/*****",
-        "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.8546562Z",
+        "metadata": {"createdBy": "*****", "createdOn": "2020-04-28T19:17:33.5560078Z",
         "updatedBy": null, "updatedOn": null}, "enforcementMode": "Default"}, "id":
         "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyAssignments/Default
         JEDI Policy Set", "type": "Microsoft.Authorization/policyAssignments", "name":
@@ -5316,7 +5307,7 @@ interactions:
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Fri, 24 Apr 2020 19:57:45 GMT
+      - Tue, 28 Apr 2020 19:17:33 GMT
       Expires:
       - '-1'
       Pragma:
@@ -5326,13 +5317,13 @@ interactions:
       X-Content-Type-Options:
       - nosniff
       x-ms-correlation-request-id:
-      - f94b9fba-0fb8-477b-820d-b23e189c8b3c
+      - 9396441c-979d-45da-a265-585ddbd73ed0
       x-ms-ratelimit-remaining-tenant-writes:
       - '1195'
       x-ms-request-id:
-      - centralus:d87ac137-42cd-49ab-a49c-39a3eff3a5ce
+      - centralus:30770582-f537-4852-b862-205782027847
       x-ms-routing-request-id:
-      - CENTRALUS:20200424T195746Z:f94b9fba-0fb8-477b-820d-b23e189c8b3c
+      - CENTRALUS:20200428T191733Z:9396441c-979d-45da-a265-585ddbd73ed0
     status:
       code: 201
       message: Created

--- a/tests/fixtures/cassettes/test_hybrid_provision_portfolio.yaml
+++ b/tests/fixtures/cassettes/test_hybrid_provision_portfolio.yaml
@@ -1,0 +1,5339 @@
+interactions:
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - bcd60cc4-8665-11ea-83d2-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"error": {"code": "Unauthorized", "message": "Request is missing a
+        Bearer or PoP token."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '87'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:50 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      WWW-Authenticate: '*****'
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 676ae521-6754-48e4-aeac-f1f67da7136a
+    status:
+      code: 401
+      message: Unauthorized
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:51 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AgvJkM3iQMZLm7B_viG0X4JJ34YQAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:56:51 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - c33a5397-30d8-4b83-86c5-dd2522380e00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '444'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - bcd60cc4-8665-11ea-83d2-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '716'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:50 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - acf193a6-24ba-4538-8a17-8fff595f0a67
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:51 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AuqKJYWwSpdNtuwvdtfBypJJ34YQAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:56:51 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 1e12e521-955e-4d7b-866c-2ac807ec1800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - bd75601c-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '716'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:51 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 0061e43a-c6e9-4049-b7e9-59c257856d33
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:52 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ary0yhAuuRxCmYSdOVnDeUY; expires=Sun, 24-May-2020 19:56:52 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 8e77b773-75a5-40fc-9706-571afecf0d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761812", "not_before":
+        "1587757912", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41hnibL7ZMy1yN6Y_4a2TsX2Kd79aPnU9T-kzXV8t7WxVkJNZlmARukdhSCw2t4PT3-KxhOrfLlc4CyCm4xOY5fV5HvEdcKPV7cy3mpy5TKlolkTWkIGrghjHfBcxFbKsNVb-3TAz29pblMi5_UDI0s3EwQvgW6disYcEUebej3v3R-suCQLzhKtiG1xL1eMMvCzRlZP8A399RIwRASG-O0THUArbmU8etGUnUf3w2ZuvWo0VVsfygvVH8YSQ44uDOLi34KYSB4oUAdF0-B_Pojxoe014bGSWNMBEICCfNOz95sXhZbqtpR1vaqT0EouBgaEcrlHezU8TlhgwR1ASAdPJb7eNNONDHWxP9kMvryklBE42C_ZXE_oBDjebMMEsyalBW-X6eIzLS-esczkaNqPwd0MiOwrgzNx0uk5F3PRreFFq53l7wp9-3f6Q_ICPlfpQCkRRlUVtN2cdAAzzxVqpCGxMHnqsWfCRW7XjYlfd1NnOIdOjMEekbwnQbYm669y_w1ArhwdZWiUwZWWR1Lu0lfQ3lo2pNYBeqvZe9ehHsaSqwz7UAhe8XggsViGz5QCl4ozQU-gN4CMwDqfJJL2qsWyJjk-Xb2Ef3Ao0Ixafyy7QoCwmedUeWqHc2jZLVIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTEyLCJuYmYiOjE1ODc3NTc5MTIsImV4cCI6MTU4Nzc2MTgxMiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3546'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:52 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AlhfOGlL8vNIokFtHQMHtAkz3-LjAQAAAIM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:56:52 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - d3db4718-1eeb-4275-8704-15cd78a5f8e4
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - eaa75759-5375-4922-8556-4bd1619b1800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"displayName": "Hybrid :: Hernandez, Robbins and Kane :: ATAT Remote Admin"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '77'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/applications
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#applications/$entity",
+        "id": "*****", "deletedDateTime": null, "appId": "*****", "applicationTemplateId":
+        null, "createdDateTime": "2020-04-24T19:56:53.9670113Z", "displayName": "Hybrid
+        :: Hernandez, Robbins and Kane :: ATAT Remote Admin", "groupMembershipClaims":
+        null, "identifierUris": [], "isDeviceOnlyAuthSupported": null, "isFallbackPublicClient":
+        null, "optionalClaims": null, "publisherDomain": "dancorriganpromptworks.onmicrosoft.com",
+        "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": [], "tokenEncryptionKeyId":
+        null, "spa": {"redirectUris": []}, "addIns": [], "api": {"acceptMappedClaims":
+        null, "knownClientApplications": [], "requestedAccessTokenVersion": 2, "oauth2PermissionScopes":
+        [], "preAuthorizedApplications": []}, "appRoles": [], "info": {"logoUrl":
+        null, "marketingUrl": null, "privacyStatementUrl": null, "supportUrl": null,
+        "termsOfServiceUrl": null}, "keyCredentials": [], "parentalControlSettings":
+        {"countriesBlockedForMinors": [], "legalAgeGroupRule": "Allow"}, "passwordCredentials":
+        [], "publicClient": {"redirectUris": []}, "requiredResourceAccess": [], "web":
+        {"homePageUrl": null, "logoutUrl": null, "redirectUris": [], "implicitGrantSettings":
+        {"enableAccessTokenIssuance": false, "enableIdTokenIssuance": false}}}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '1303'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:55 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/09661d5f-679b-47b1-8202-a9888e41597b/Microsoft.DirectoryServices.Application
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - 102769f9-4369-4460-a9a5-462248b2acce
+      request-id:
+      - 102769f9-4369-4460-a9a5-462248b2acce
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_17"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:54 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ArgigYkJkWVEglS0U6MGOW5J34YQAQAAAIc7NdYOAAAA; expires=Sun, 24-May-2020
+        19:56:55 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 8f9cc3ec-379e-41db-86ad-d9eac7691600
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - bfa6b228-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '716'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:55 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 77ae1cc8-6d31-4ef6-a3f1-3232c6397405
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:55 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AjvLU7-w8n1IhiDXl3ARCvA; expires=Sun, 24-May-2020 19:56:56 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 81f84ab9-678d-4639-a04f-85c790bc0d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761816", "not_before":
+        "1587757916", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41h5RCM1fqoz9-mdQnJmmdVIv3D-6yM_cnYKRzp3_IbsCUjCG7O-vejl61JlyNw9iiooedFyoIpWIGzP-8OCD1uDGEy3XFJysMUqy07Fg8bCmJO-dnr18c-YthG6JQaR5nXW2-4uO7U5H8rJ2SCCRXgzxzdmbt60uL-viX_56PnNWU0IcUSQhUCcVnCBrppU7d2LJhwmHZfNg8Zsp53erXU7cdDJ0hZCO6INRVIyTRE6slTLT9qZlFtD_6qloblsh-pJQYCczYeXtK6B9e-p9asA0RoQkltXLNmTfCoR7esJ3s5g9qGieG_SNgRSCYn6M2LgnptHgK-f4C6Ms7vEY7acaJou1ZqQFhdqXyN_xCOGQDU9lWMBRLik2SPr1k7k33ru_zTCU2J44A3j7rEF3NTJTULq63gA_PAA6Ied2T_ISiXMxZxeO84kWKjgDsRYOqlV2rSSA3pb7CP6lfLAh9RlOSxUtHZuW_Jo_oPzPvmC80uh7GmEqwg1rYjoNtKHdwI_oR90yaieZsipdo3bO4IahnosfFApCc94wN25HqCM39ESa2a_Zxc8rqcUwo9sKXkz-khC-uo8Ezz3Nd0q65oMdkvIdSBrNxVpmYAT4mD2bYCMugBra7f-xutFvA8KgaIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTE2LCJuYmYiOjE1ODc3NTc5MTYsImV4cCI6MTU4Nzc2MTgxNiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3551'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:55 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AgnH4owRQUxEn0wVS-sYDkkz3-LjAQAAAIc7NdYOAAAA; expires=Sun, 24-May-2020
+        19:56:56 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - a2c1b613-2f7e-4636-9591-ca53263d4203
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - EUS ProdSlices
+      x-ms-request-id:
+      - faa9525a-448a-4d0c-80dc-b17aafd71c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"appId": "*****"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '49'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/beta/servicePrincipals
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#servicePrincipals/$entity",
+        "id": "*****", "deletedDateTime": null, "accountEnabled": true, "alternativeNames":
+        [], "appDisplayName": "Hybrid :: Hernandez, Robbins and Kane :: ATAT Remote
+        Admin", "appId": "*****", "applicationTemplateId": null, "appOwnerOrganizationId":
+        "*****", "appRoleAssignmentRequired": false, "displayName": "Hybrid :: Hernandez,
+        Robbins and Kane :: ATAT Remote Admin", "errorUrl": null, "homepage": null,
+        "isAuthorizationServiceEnabled": false, "loginUrl": null, "logoutUrl": null,
+        "notificationEmailAddresses": [], "preferredSingleSignOnMode": null, "preferredTokenSigningKeyEndDateTime":
+        null, "preferredTokenSigningKeyThumbprint": null, "publisherName": "Default
+        Directory", "replyUrls": [], "samlMetadataUrl": null, "samlSingleSignOnSettings":
+        null, "servicePrincipalNames": ["*****"], "servicePrincipalType": "Application",
+        "signInAudience": "AzureADandPersonalMicrosoftAccount", "tags": [], "tokenEncryptionKeyId":
+        null, "verifiedPublisher": {"displayName": null, "verifiedPublisherId": null,
+        "addedDateTime": null}, "addIns": [], "api": {"resourceSpecificApplicationPermissions":
+        []}, "appRoles": [], "info": {"termsOfServiceUrl": null, "supportUrl": null,
+        "privacyStatementUrl": null, "marketingUrl": null, "logoUrl": null}, "keyCredentials":
+        [], "publishedPermissionScopes": [], "passwordCredentials": []}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '1437'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:56:56 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/b14032fd-5473-4c2f-aca2-1eb71fba6d43/Microsoft.DirectoryServices.ServicePrincipal
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - c31eab6c-c41c-431c-b45f-e5b5c3011165
+      request-id:
+      - c31eab6c-c41c-431c-b45f-e5b5c3011165
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_26"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:01 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AvyJaV4oE_9DsEyg78QBkaBJ34YQAQAAAI07NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:01 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - EUS ProdSlices
+      x-ms-request-id:
+      - a6ff2930-54bd-410c-b9d3-c1737cb01c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c0a2991c-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '716'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:01 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 8aff5939-242e-4985-a596-55192e078f69
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:01 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Atpn2RpGxA1EpEhMridEcaQ; expires=Sun, 24-May-2020 19:57:02 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - 183e58f3-bc91-407b-b994-ecb988ea1b00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761822", "not_before":
+        "1587757922", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41enoqg8C4s9KmdLR68UoBt5Iiu5qZNXY1tCc0fDP2XQLMVd1PgKB-UdFuz7oxBdKfBy5dihq0h-BODitkUhdLfw_uoySS1tx73vThBdSbu_c19HE0CJhDhhz0MfAdmU0d9nabH1-I01OsbjbUvp_D3IM2r2Kl8LKbWBgo6m-P4GHlAR7glbjP4-7gGeSraFFEEUoKl8xWQLnNxK-9vk5oBESzaVxQudo7eF6U9b-PdtBAJV9aCXf4pJqIS_BSuJh-VwAWstfQSeMzxYWXZ3hOTyN3_ayWCz-zjZaTuoRWVKXtaNi1NMiXLWBt2aMXxTEhH1XUIi1Ip5fsjI3j8DpOCB4plxpAbDMQqF3o4U2fW7ed5svf0jY5akcP6HfU3v2abkYJDyVE2ZszYBsK9LeJn9qcd1ZJEMv2sn1hxxOkmwzGr59P55dJecfd1isnKJb4m3WOq7g4O3eLFOq0zERu5CZCsbyhIQB1gK-tESbXC_-IDhBmyNp_tYbmARCyDBtkkdRhlcdSXpjeIqgSUAPs6bwgLY1Bxz6h9vh1WFpRx9s5P4cHysYHvPVA45LOH2xKoh2KSIeVHbkApccA7ppFgA8XNxoKne-dAEpiOmn424cbicrrPGhmkDhhs2IQwf51IAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTIyLCJuYmYiOjE1ODc3NTc5MjIsImV4cCI6MTU4Nzc2MTgyMiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3551'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:02 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AsNQqfa3zf9DoEJe8FgSobgz3-LjAQAAAI47NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:03 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 948dffa8-708e-4c39-b1ca-9f74cadf19e2
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - a9a74ab1-656e-4978-be41-db9dcf0f0d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"passwordCredentials": [{"displayName": "ATAT Generated Password"}]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '69'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/applications/*****/addPassword
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR79n
+        NcvabDytlm3+rv3o0Ufztl01j+7evaiz1Xy8KKZ11VTnLbVY3L3cHe/c/d0WeZvhpR93X0rjVdY0
+        V1U9O6nzWb5si6z8aPTRdN201eL3yq/P+LPzIq8/erRcl+Xoo1nRrMrs+kW2yM1H+XL2NGvzNwU+
+        +mhvZ29ve2d/e2//ze7DR/cfPNq5N7738GD/3qf3f4pAz4slMN7+7AH98RY90F+z+9N7Dx/m59sP
+        s93J9v6nk3v0W35/e7o3y/Ps3nRv+vCAmjf5tM7bNzJmgnCy/Oze9366+mr5U1+UXz7b2WsWD37P
+        R7Pf/83D/b033L7N6jZEbWcQtV/y/wDRHXOEWAEAAA==
+    headers:
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '373'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:04 GMT
+      Location:
+      - https://graph.microsoft.com
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      client-request-id:
+      - 7baf27d8-89a0-46db-952c-ac0d0010c7c6
+      request-id:
+      - 7baf27d8-89a0-46db-952c-ac0d0010c7c6
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"002","RoleInstance":"AGSFE_IN_20"}}'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:04 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AlbMiVzuExxGrZCEevnMjyZJ34YQAQAAAI87NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:04 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - f797948b-3812-466f-9424-4a9fa0831800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c513e082-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758211, "updated": 1587758211,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '716'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:04 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 6eb90e23-5463-430a-8434-306ebec5b16c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:05 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AphkXkPWEo5Mi4hxyv8593RJ34YQAQAAAJA7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:05 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - 1dd12d1a-a64b-42d8-b9d5-0e7972b21b00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '512'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c5889350-8665-11ea-83d2-acde48001122
+    method: PUT
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:05 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 4f55755a-159a-49f0-a7fa-e8f00d7dddfe
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:05 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AhKgGfUkj_NHgXHsVVVM8IFJ34YQAQAAAJE7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:05 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - 3bd1ac16-0211-4f42-ab03-15ce30451b00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c5d833ec-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:05 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 294fc9ef-b7af-455d-819e-7d6a64d9a861
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:07 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AgiTVqka-AxIqHmLqB47ZuY; expires=Sun, 24-May-2020 19:57:07 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 9e76dd79-8134-4fa4-88f6-66dd5a291800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761827", "not_before":
+        "1587757927", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41WDDX9upJRhXwc3LQ7kJGwPYfUsaZ6rtkwpkwxLGZ5ErnbtarlP1hdcgf4Y58CuBzQoROtVoTn4CzQsOKEBYJbqwmxeeGitoT1oehCcJp7vaI0mGycCV0odo61P4eg0WjfGQ9Gw4HSOWmIFzu4Pl9Lsl7jHQ2XjIsavz1bY7rNkWiGkA9-07iijX7-BsBjknyt2OApISS0lLrcSLr65kZDd_j4GrnOpAuUCNSVmMxK2Xwfvu4cBW3-GO1aL7cPFQl0Zd2GsG-N6A2Nq44GviKkRbqGeZWxDmoMrHwwHpN9ff_scQ5QUumfkZynpvPLBco5CYTYjJpFvEe0jC7LGUvbs3jQZvlVLM0OdBWymMfHKJ_xkMnF0x3N9FR7V8e41KWweHZaCDc2MNAm-KqSbwdd7Lm4JE-ZNq_vmZDMgcdiVD37zvJh_K0soXmpIDQmIxtGmOqowlI2uc9rCJtCG00nrvVGRj_5RZMNG-dcsKjC9sOI1_AUgSaKRHAmJiwht_2isli7S5K51me3pJcE2MJnVODfeuHopa8FfrZKWznSRXcYebXj6yXHCH8KJbyS1N_FsNj-N0EQ3ca0anmWQY8Cgye1JsIKj4iuhj3LQICW23mUjWVpYivziiLGmr957r0IAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTI3LCJuYmYiOjE1ODc3NTc5MjcsImV4cCI6MTU4Nzc2MTgyNywiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3551'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:07 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ApAJruUy3WFAgAUj4Xds1Wcz3-LjAQAAAJM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:07 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 2d69a50b-0b22-467b-9efa-b4409c4d3edc
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 5ea75fa6-dad8-4ffc-9e14-6069bcb40e00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://graph.microsoft.com/beta/roleManagement/directory/roleDefinitions
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR79n
+        NcvabDytlm3+rv3o0Ufztl01j+7evaiz1Xy8KKZ11VTnLbVY3J3kbXb3d1vQv3jpx+uqzL/IltlF
+        vsiX7d1ZUefTtqqv7+KLp/l5sSzaolo2H40+uszKdf7Ro+/94o+KGXXy6V7+cOfew/3tTx+e39/e
+        37v3YPvh7sOd7Z3dvd0HD3b37+e7O/TWLG+mdbECEHrpJFumC+4uzcoyzZoVddek1Xl6/IN1nafH
+        T9NsOUu/MCinTV5fFtO8Sdt51qbrhpqYhsWMMCbs8maMfopmVWbXL7IF4fjRSbVYZcvr9Hi2oBE0
+        bZ3RoKhV0TxZF2V7Rri09TrHB6fLbFLmNCL5oM6bal1P89fTapU3NNyP7n70/dFHbb4g8G1+Rg1v
+        O/TLvG5k2Lv0Fwj6Mq8XRYMPAfkXf0Q0qK7y2Svt83gKMuGrj9ykuSnJ3GCKy/wrmpnmLkF4WROm
+        NeiAv95kzVvMVhTAalUWU3qbOkHbr/XmG6VEc7dYNm1GU0B/DL/2ioZ9TEO+WILBuKP36HY9K9rn
+        1QU39F6r82w28Mq0rNaz49XqdT5d10VLMII36a9NHZIMLfnX5u6UOhkcmNeOIHrw6aVBzMw7n9fV
+        enXbDrTxLC/zWzf+2iiFL65XpCI29NlmJLudd+ivG+hL7Pver81yVgJo9h4vmd/Agtz6a77rOJ7e
+        +howXl8vp2j8Hq9Wi4ykC81u/9JFbA7pr5vfGWcsoNCDbyqMmN/zoGzkhEEYGxl88K2NnM5vvc7b
+        tlj2lAL9deNQ9dWvOaNqca7pjZY+ImWIN+ivW75fVhfF8sv6IlsWP2Bd+qQma0f44MXbg6mO1+18
+        z9mSzwnK+0pU5WGBtrd/c1WRJdB27/FWXVwWZX6Rz86UiJ7XQe96kIhrhvQVbOjXNiZ42fNo0Pz2
+        LzdwB2bg0C/yxYQM+7x4X1lTV0aM/F1SgsUlseBr+fRW75CPA0l5ar5+RvJFztCt3s1ZyL7Wqxd5
+        e3yZFSUAnL5rifL0qRv3Zhgv62I5LVZZyfRxb+GvW1DLe138xi7bP6vq47KEawuHb5t9pCGQxDdn
+        y1f5qqp7vLOB6Zr1BC7sJJ+9frvuvkd/bRoFOaw9F4H+6r+SwasdZ7PLbDnNZ2/mhE9L73hq5pTI
+        ftP7xfK8qhcs1O//MqEKin87z8p2joa3emm9AjnfFNO3uRB181s0T4ucXN3xpChL1Xyb35hdLzP6
+        q7n36X002Nz4nPxpfLO5VbFs18sc321uV52fE0GoY6BNDjDmRtRWjRdu+zKFQG/banW8zMrrlkaC
+        9rd9N383nWfLi/dCtqymbyfVOzS77SuLvGloWCck2zQ2/SsiFUNvNOptfyGfbnxzZTlTXybcbotn
+        k2f1dM5uJL2rKmGwreCEWFDm7uv0914y4b04z+r8ZUWchpa3fuvt9SonjfZk3RRLIiXa3/rd95RE
+        9+YaU+apRfvehkmEYiPCLtZLDQuDF+n3TR1e5ZOX1FlWoqF9CcHkLKtn/W5XFCTXFNMxYNuefu93
+        YpvKb0/O0GzzK1fFclZdNSSm5/lyRm+/lxKm3ABxI4Wp1OKjR8t1Wf6S7/+SkeZIdndmWX5/93x7
+        8ml2vr2/s/vp9sHsU/pnupc9fDh5uPdwco9wIQVBBsbkSMhHydZlm8JfSUmfpxfrvOHcR92MU2RQ
+        CK9ZmqVlsSjafEY5khYZFGt1Us8M9FMjnzO0rwgaffXN5ENuOcxvPB/ikhKbuGfghepqSfjcurl1
+        eze8YMK22+DC4ch7NSV04H/6/u/NLy3YW/3y/NZNbwP0ZtJpQ+JMhFsbmwaRyCRriimJ3DnFCpte
+        Iu6FXva8w4A6JLzVB7x+I3H7799mHvtvCck3z07/rYH47/1g3DiF8XdmX05+mhq855u3ER7Wb5RT
+        vCSdxjpqYzvWiU963EKaqauNSRe/n1qRDm4zodLy/VhH3pG/jc29sXleFhcFaWWJPTfzi7whnlF9
+        i4a3Bvn+bKfvgW2eagbvdq1vwWTSekUWmxTM7elS5xeUQc/r98BIQv9gJeE2Pa2yprmqiIE0eRay
+        5ke/m+HGs+Z1Xp5/5HkNe9n5wf5kN9++tzc9oOWFyYPtg73JdHuWZQd7+zv7O3v3JtR16DUQuLYu
+        pvAHYFl/FhwHrweWz2/Wh7jloH/kQ3htf2Q6Nwti/63312ERGDdOevyd22i1/pshz5DUeErkR/bt
+        Fg1vDfL9eUPfw9ze2ppw61twgrS+hX0LX/j/gn17eD9/8HB35+H2w/vTne392UG+neX5ve3Zzm42
+        nZ7vzfYfQNWH9g3mS5xD36zRR7McRCK2hClr53n6sUx5k047rzQfw+IhIOkbN7FoZ9z6mzNqtxzp
+        N23UmDS3dqX/X6UJfp7I9YCYEv94MsTq3YnNef7w3s4kf7B9P/90b3v/wWyy/XCX8i0PD6b3sv2H
+        2b2DCdinLzZC05R4KM2aFeHRQFQYkZSmPpVgfUSyMi3XcKfJT1RBSY2UN+xQGseRV1mavhTBI0yP
+        p9NqTeIYaBRq+s2I1C2p8E2LVIT1Ny5vR9pvXNiOtGeHzmjX+FvELC0tJN6Ai221EQPb6hb9Csfc
+        Jd4gbJ8T/y6bG5puRFDbbERP28yLGel68RNUaDa2r3NabiD5ahRLR+Cb3mvozxuQeQ9K9af3Nq+J
+        krtdWyigWzZV4b6hMSuIW82xtNw4xdJk4wxLk9taLWqXlQXQp+XfV/k5Tdj8TfWWsNz42nvzg3lt
+        EztIm1twgzR8X2aQt0SL17dpapT2bdriXxtuQI3HXtK1XglObrsYpi997WWp910lcm++J6Lei7dA
+        lgwSqcoBG/1g7+HB3gPy8B5Od/e39x+eP9ieTHbJRH26c3C+e//TyWRyQH33bTQxGCVjzMSJtV1W
+        y222tMaIirn+dl6uCMDb0MBGrHG8ITX7ZizxLcf6TVtiMOzXFv9J0T6n1fG8fpVPK8Ls+vfKryHd
+        HVbqvmbm5UeysRlZYpFh2TinFN757GB3O/v03oPt/cn9TyksOp9tU4SUTXf29j7duYdVQuLYnmxQ
+        1lLxTueMOPmqJCGSqWShEO2YKpJpK1j2ZeK1gnmtDX92ROOWQyUGhBTQCx8iGspLMrDbzqu+JFTY
+        OKf+W44b/r/IgJOd8/v7n366u703e0AKa3p/Zzs7z+5t7+bTg51757t7+TlEu8+Aq7wGt6XTarEg
+        fpsUZUnuU1rnmPBZ2qJrio3e5inrB3y3yq5h2X0+7TPjEwX0s8OEtxzuN8OETmP2k9I/x1oTs5YT
+        3mOdN7Ta/Ibjuf8vsnm2Q1b43v6nlG+6l2/v5wdkkg/OD7Yf3L/38ODBJN9/+GCH+g7Z/Gl+nq3L
+        1q0dSeghWQJ/8QhJBNK3VzV56V97KQl5Avrwm+HzW473m+Zz8uIpM88DNLHPcfMlgjACH3tBg6/b
+        NB1IWcmr7/fOxpBr4J1BqXVv2mWJYVlwjT1SvTTvyVg2k4G4BDJkw5PbvcUse5dSGcUltVWD/7LM
+        lhvbk0NJjCxxJ3FYV7xIuD6APTZOQtCSGJ4+vFXTjHJ1+XIaDdgGX6EEOWkT+fs9XrwFRwTtaZ4o
+        TdMWmLPbv3WbFEbwAhlm5dz3esvw4O1fIeVRkILmv254jWaFYgxKrhC/0HIsoci6mxh3SDxmmgIm
+        HQnlN9BK1cdGVtI2m5lIG91iSrUlUeK98hX62ux6mdHXmqubF6tXa1qZvs2bYntu18tteEabko2C
+        b3arxmOK+Gi0mI83FUZPZAjm8+vB2Dh7li9v1+oWE2jb3oZKpAbBh5623YhHpPlG/u23z5k0t25+
+        kbcviaKIw1/TNJb5ayLul8sTp2puDUqixW8KWiAf+exN9b50hs64WZPH3ru9Ou+/fQv+6b90a8Xe
+        f/Xr8SDJ2+1UfORVw/3v+V6bXdzwCs3z2dKsaYZ6gfV86EB89Lu9XvPC4Jn6Le/lTXCP4qNM59nS
+        sa0i10VOmpI787XyY+AJGs15cZOqlvYFMwMP/BatFxWFYLeC2+RZTaMl9SDro5Smu/m1Mwo5aDpm
+        MxqsTsRNjfNFVpS3a0ozvDzb6Oa6tqt5tcxv2VSJzY27fGN8zbPmdV6ef+QFefuT7N7Daba/fX/v
+        wZSSrw+z7cnDe7Pt2cPJ/sM9ivX39j+lvjtBXkU55RYxXbrNvxXLNl/OKHyjWC29yIk3sxJf9yO2
+        l1nd0tfpmyKvd032jFp9MyHcLUdDXhgUAb3wzYRwRGtZ8iStRqgQzI2tNppD24pFaDOzinuwuVdt
+        8027QjS51CQjkt1uUW/jmKXJ11Q11Iz+2gz6FrSUhoEJvoWLKm+JG/CjJbXBEN69+fX7vMUQSR2Q
+        +Bi1x/G203T5zk5+8Ol+tr37YHp/ez/bp/TOdOfT7fP7k4f3s4PZ/ckMy0w/K5pu7xvXdLcczf9f
+        NN2sIgNLnps0JZxlwuONVY1tRFHbbERQ29B00J83NLqVfr1dStu1b9YTMOMkn71+u94kX+4VYkXC
+        gpQM6a8f6eUf6WW8NMw37s33RNR78RbIkvIiYR/QywcHs4P8Hi3/H5zfhybbzWmN8162/XDy8ODh
+        weTg4MGnE+o71Mt2HYE5aGC5ID2hFZtqWV5DQdPyWpVe1JSX9loziGxKSbMGXxOXUaTHLze8OnGB
+        NG5k9fephfCKIOQ1iPPN6PVbUuOb1uuZWzksLvOvlgVN5TDbbH7PqMJNr3mEvl0//gvqn962uQ3f
+        N7xA7Cm26DbI2MYy0i/Pb2pcc+vbgDYp3PdpexssTNs6v6DZyin5whkEfPAe72C5DX8Pv2J+g7K+
+        5SjMb/JKXhYXBQmNZnvf400hw+Y31Iu4DV5q19+jKTEdMPFt1M0vCdabJy9oehugNwuINrSZ7Jua
+        vjYNb00PfeONKrfbvTmwjnirV33f6r1fIAVNLD47OW6eVbVJjBFXNUBoExSadNIuDMQuSd6md6hs
+        n1Nu+w6tr5PCRXe3e4ckFlJs3ZUOm3KW+eu/Lri/1/tfD2nh/c1i0n9rgJ3eD8aNshR/Z/Ylp2rf
+        883b2Krm60YFt2/5fpMs78jfJpl9Y3Pjm9/c8BZTLy3ff7r1PUyX5Idv2/oWkyutnfEMOiC3jxyD
+        AY/44b1Pd87zyf3t8/3dg23KaWbbB7sP7m/ne9nOziSb7t/bgdc34BHTHKdXddHmm31j0nPiDpOS
+        HnCBR/2MBw9qkz/8XfT8DfrDt6TFN+0PswkjOSAAN8XR2vQ22YY6pyw9KK0QnXxtfo8nMhZk9lrS
+        9HUF9zaviYzdri34/5ZNrXtxc2N1F25DR9t0Y+4ibHoLChJnQ0A9ZdxcL6fzujJOgreke1e019eF
+        9J1q8qEgXk/ntOa0GQgL6614WFp+7UTPe3K1vHaLKZGG78vT8pZQ5la5H/xrKQ2NZl4iZTSspfce
+        7t3bm87Otx/e27u3vb93PtumVMDe9u5s5+GD7Pxevj9Dt30tLZilpJDSrFkRJk1anae0Ap+evqO1
+        SlqZTYmgs/W07Sta2+K1MEh67ALwqqbm34zWveXYfpa07ryYkaDdIgKU9uP1sjgv8tktVIdre7Pu
+        cG3flwE7r9+C0TtvvIc6tu8Mq2VNKgrDDCf4QiHXl26R3PPfcmnBXBkV7W77zjJvKex6e3eV1+Rr
+        kJhMdTk73vw9R+S9+LVHtW5Ico2LS23texvQvE1OluRvWNGc7x1ku+f3d7bPP80fbO/ff7BLLtDB
+        ZPvTbHfvfC87/3Ty6ZT6fh9F83qe1fnLily7VKnYVzVem59dZXPL8f3sKBsrPz9SHtFXVA8IA9xW
+        1PSlry1mPzRFYFkcLW/91tce18+J+nhw/+H+7s7Ow+2Hu/ez7f2DTx9uZxMStE8f7k7Oz3cP9h48
+        xJS/l/p4e73KOR58sm6KJbl+wx7Lc/Jbf5YVyC1H+M0oEOVtGdBtWU5f+tqM857deS9ipijUN/OE
+        9rd+92uj+3PC57P9nfvTT8ln3cnOKVOQ35vQylm+v70/2/k0v7+/t3vAXBDy+VOKXXJKd1B6Yzt9
+        WqUvKOFBqxx9NpbsDb77BpMbt0T5JsZ1NHh4vvPp3s7+bPvBvekugdmfbh8c7GTbn+azycOdT3c+
+        PZ8dEIguDXhogWzGcjyxZtTqmyHFLTG/iRS3k+GOHbRZgpDbfD6NvzG0uEGDG+bTh9Odh/u0pru9
+        //AhrfDuTg+2D/bpn3v5ZPJwQmHXw3vn1Hd3jt6PT79DRo2++4bm5nYY3zQ3jgTTe/vnnx7cO6d5
+        hsLe37m3nZ1TjPnpp7v3852d/F72AAC/Jgm+S64D/UlU+Nkgxi1xvz0xdh/c273/4OGD7d2dvdn2
+        /s5kn6LufGd7/94eicQ0m2a74PyQGLDPYDXO9qqhnlaEZgFniX5dnhcXa5JRas5tKElD2rWhbG56
+        DGOUHj/lz79kBZxCA6OTgJAnDmAg9dTwm6HlLYd+Ey1vJ/Rqg9/PkupLX9sSujn5giepxgu3ffnr
+        xNDvOT7vxa/nC/+c+Bcf7ivsPZzsTXbubx/s7H9KQjyhVYUH9w+2d/O9T8lfPJ+e39ujvkOZ+3JZ
+        XmMBZJZOrp0QnVTLJZmG4TjarY28JlfYS+Gmx9NptaaAkF75ZuTplsP6ZuTJmUQKce2a0eY4Omi5
+        MYoOWmbrWZGTDMUC1MFXKFAhzpC/3+PFWwTcQXsaLyUrZVXg9m8NB9wDL1AobGbofd4yy8kbX7G/
+        gUEhUi9r4rGahYr+6kuifeFuVV9khp8BhyFs7MyiRIS7RauNTGJbhaJ/Q2Ol/W2a8i/XxyBpPntT
+        3eqdWzCQbauo3K4xLcPScu3T/Dxbl+3md1QZ2UWNG6jdb76R7P3mhBnpqls3JwX5Xu0v8vYlLWNR
+        Tmj2mtzuMn9NubQv/QW5W4MSX+mbgkbC5pJ7N3HIDa9LbvC93r8N2/ffkgThl+fv91Z1TBp1zxmK
+        z2tixvfEV9n9vd+ZfTn5aWrwnm9awXmvt4I54Sl9T0m7nbGKvXd7i9V/+xZap/8SKQXD8u/7KqaF
+        pvI93yKrouzz/q+a2XzP99rswrxC7tKwS7g3oeh2Mp1tz7J9ysA8/JSC3Cyfbj84yHc/fbB/nn26
+        DyYKXcJbx6QaiWoQAAXzzXh8t8T6m/b4Zjyc2ykg0/Y2ase0rfMLCjZzYs8vhc/e6x2agdu9cguh
+        MU0ddMXoPd8SnPQlmsVhRnw4OXh4f/Zwb5sW4Cnlsj99sP1wtrO3nX2aTfdm9/Ps/vQedRsyIvIB
+        JM0EnKN6sXLd1D2pNsoDACMK4+m9htuSAsjrVV001H5Fa0KAHfAuuz/E5PTGz1Ie4JZD/qa5mIZr
+        Bsa6kNAhuDe23OgbBS29P8ilfndN/DDIk17byIvKOJte5db9V2G2aYr1ow2AbsLhdVOeICigIJxQ
+        +QBAX9Wl5k+tQNwGyq3MaueVrzn0W+iFoD3xzu3saPDWbUxo8MKtrWf41q0MZ/AKCZpMM/1169dc
+        MrxYwi4QOYZfo8lsn1fEACSxxBQ0Mo42N8gHKUzkWWjNAeQeBu21e3/YnyO5f9sOtPFGddBt/LVR
+        Cl+87Zy8NHO/cUSxFzaOKvYCpvwmVyD2nkrBe77FTH27wDz2+vsJuH1Ncd34Htl52H7PA91I+37z
+        jZSPNH/PWPo9Q/VvMPRuKDfkpT89EHfFX/m6kL5TTT4UxOvpPF9k7wtEmn9T9FFoVslLhE3J9eOy
+        HHvsuJ3BCbs1WHrzRwHtza9+Pdkmhayz9f6vGq3ynu95Ae3AKzTPZ8tXORZXaBYCw0GqKNSTusAl
+        vdx21Uhf+trrN+/ZnffiLbqk4IKMJ/kXNCm94Gp6vju9d5Df37736d4urTju7G9nD6YTWiZ5+One
+        /myazx5Mqe/h4MqJYSeUKpazfJXTP8sWsRaxfvoxB33plF6XtnntA2g+pkUj9oM3x1yUO8hLzCC1
+        +mbirVtSgdxAcDa98LMWbx03HE4T+IEXnOqS/OhtXhtIVd7mVZowcKYnbuFbRMlh5ro/+3Ty6WTy
+        YHuWPyCyfrp3b3uyn51vP/z03sFOdu/+3v2dh9Rvn7moixnxwnRdF+01cdJ5VS+YTBygf52l+9cG
+        2CsCTXiDUb4JzrnlEL9xziET9J7xQgFJJApQ65Y+Iui3f9eq5ts4tZQ6uSzK/CKfnWmXkuUDv96+
+        S3D4z67Sdlp0ZUlyQjjmNdrbd3udufe+dofrhujhjc2+t6GzD17j3324n+X7pNUmu3u0GL4z2due
+        zO5Ptj/debg7IW59+OAB+v6a0jjiP8RlSwmJ8+JiLaaA3vgacvqzk1i7JQ2+cXH1Fb0Vpo1Oy9eQ
+        cJNkneBFcgjqV/m0oqFc/1759cYXP0Q13PjuxlFaWohVuanVxlDQtrqFp2zb3sbLtY3fY8H5G1KC
+        omA862tx2dj7/xeU58b3IqNzb35tVH9O1G5+8OnubjY52J7uHjwkDyE/2H64n++SytnbvZdNds8P
+        dvep777aVV0K7UOLFphSME/g9ojSJcSogV3VIG5R1ksN7+k6G97vq1yvPZzLnyXNe0sykLqCkqUX
+        viHN6wZTXOZfLQuZeU8e6K8+z3gA+i43vXH79+1vgMKtb//uBac6xzL5oPibKgYlIiy3gLFR4w6+
+        tVEDD8QZIbb016Yxv4fipL82QQLzfO1pw8uk6Il3mL3Q/PYvN5CDGQj2Ba/xNvOil7GmvzaCEB1H
+        smk0f8CIXydtRT3rvNzAMv1XRRV1J1YzcdNqscqW15Es3DeoRe9le9NP92aT7fv3dg+29/d2ZtsH
+        swf723v3svPzPKfF0tl96ntQi1K3vo5ENuJs2a6XeUp2aLaeRvSifv9aqPGzpBZvOa5vWi0SoduM
+        aLFZC9hWG6XetrqF32Vc1I3dmkYbezWN3tvZtS/eHluTrMpnnPS4QXz6b3Haa/NLonA300XbbCSL
+        tpkXM9Keqn0Ik0FqaHtiVfrzBqC3oJi2DHSVaN/bvLZQfG/T9jaOuzbVpOINjdc8Sd4YNzd83yHK
+        W6KN6lhTdcNvkdD13ypYSeG7ze2cKn7fHtybH6zEd+8fTHf2H2Tb04c7D7b379//dHvyID/f3t//
+        9P793ezTyf3zB9R3X4mLWLCzKxTs6nOaDUpEQN5IPdN7DbelWclrcigaar9aNWn+bpqv2pRyyeQk
+        V++u+zr/pKzWMzSgKIsB/Syp/VtSgvQZNDxeoL8+XO0TFczAbtA1QcuNGidoiazFzUtjnVfIGBMz
+        yd/v8eItRDVoT+MlnXiLtbDgrdvomeCFW7tZ4Vu3iuuDV4g5ChJN/uvWr71RLmzuFktILpFj+DWa
+        TDKupDiJy0hgaGQs8cQ3Q+bE6+mlGRHRfUMfkRduy272BQzEqaDbv6dz+55v8VRds45gN/w9X38/
+        trWvKa4b3yMTA9fDc9w30r7ffCPlI82LBprv1u0pffY+zS/y9iVFoFdVPXtN9rvMX5Op/XJ54uT4
+        1qCa6+V0XlfL4gdMVQ+EmuSvC+k71eRDQbyezvNF9r5ApPk3RR+FZlVXEOB57BgJ8jaBpTedk8TC
+        8p78CxV0sz2JvXd7o9J/+xYi2n+JRM2Q/X1f/XqyTepYZ+v9XzVa5T3fa7OLG16hef7ZTTzrS1/b
+        iX3P7rwXb9EluXnD3u/96f75w9l0tr3/YDbd3p+eP9g+mD7Mth/mFPY/mE7Opw/h5fW9X5KimkLb
+        9AuDVaq4pHX+i9YUuTVpW6XZlILOJp2uKZJb5HVa1ReZUTFZmdKkZRF/17T+koaIOHpSvUuPBRJZ
+        OHT7zTm9tyQAdQmmphfw19d1et3E3SZsiU95KQQJ3qPfbzHX+/v3Pn2w++m97XyS7ZJXP723/fAg
+        O98+v//ggP57eP7w04w67c+1KOJueEPKLH16vcwIyQbrpsNJq6DVz27q6pZj/GamU8VeBnRb4dWX
+        RFg2Cq7/1kxJSBREg82NHbO8J27ei++Jn3vz52Q9K3uYZwcPH366vbu3RwHrlJKVD+/v7Wwf5CTa
+        uw/3DvY+nVLf78PaL2n66/TJ2TBb2xY/uyx9y7H9f46l3fS/Z3fei1+7y58tLvXfXBG1azJYjfz2
+        5Cx4j34XBGm+hxl7sjvJd6f38u3Jp/fJRp3vPtw+2N97sH3+6Xm2M3v44DyfPKROBxnbQiZra4xx
+        tsomRUmf5k2fqU+8F4zN/Vlh61uO7Jtha+cMegSR4dlglnxlwo06eb/XNoanw68Ns81t3lbn/Gu9
+        y3727VIFw0BuEY0Mv6zYf823W4rYly2tg2brsjVAiLvsGz0h2s/uzw7OP72/vb87y7b3Z/n+9sHD
+        Tw+2851794n77t17OD0nNPpCBNKkCB+2C/J4KXmL0A8eLuuNvvCoQklf0XvfoI+6fzv8v2lR4cG+
+        X6oNtPrZDbWcOv7aL27W/UT8YU568HBnuns+ebj94PwBlNbBwfbBp+Ro5ue75w/vT3fuT3cn1OsA
+        Jy2IjalrWQcQxm3S86qGv1GEwVFKDPclY8xO8xfyZnpCwTz5HNWyjKwTdBp9w0x4y6F/M0zoJut9
+        ja57U6kt1KBlPP7rVpO8//D++Wy6v31vn/7Zn+3e3872Dh5SIPHg4IBgP3x4jj77k6w2lxDtOpPH
+        YHVa3KfJXsj8kmC01AK/DjqYG9/62bHKtxz7NzPLogAKNz43vGC26fe+PMvL76kE9KWv7Ta+Z3fe
+        i7fokuZimCnvHWQPP92/t7u9N5lRFDDZn24fTD7Nt+/P7s0Oskk23c32qe8+U6rXR/Ji+PNp3rxt
+        q5X+iWViStVUpbTREUaMm3ntmEzyNWUxf7Ycw1uO9JtkQR30badVX4pN6Ya3HDN8fZ02kzmwU4Ce
+        NuPqen3PQXov3mKgNInDvLs/+5Rmbf+clMr9e3BidrYn+fnD7exevjO9/+nDBw/uISnT513hUKMg
+        U3IA82VDNpPU35qGIxx7UVdrirEAIODX59L6Z4lLbzmmb4ZLnYMlg71LKyzkaekICfCGpuSs1hUJ
+        dKOtZd0DUj/wHlP2Vj1Iy6/ZAXthlN1lxW/ceP8FlbKvy7VfX8hu0SVxwzC7P/iUUo4PHuxtU8Jx
+        sr2fTQ+2H+7snm9/ujP7dLJD2cjz2R51HbL782JRtDlFGKKuKXeuzD/LgUwDh1D8geOnfV4/Kav1
+        jBQ7mv4sMfwtR/VNM/zXCEKUYvRzQ2RuG21cLjatKOS8udEEiJKOrF/lU6xRXP9e+fVGRCEn/y+K
+        lmjGh5l6uk/O32T2cHt3d2dne//T2T1aJ6GQ9HyySxyQ7ew82EUMGjI1dLhj6MsivxqRg9Gy2iae
+        w2/BmihFSO28mhGvW5eQ46NseZ0uzUIvq/6+CByHkH52hOCWVKDJB7/TC9+MEGDEzd1ieZmVBfQk
+        LYC/ys8J4fmb6i3pXOpk+DWiQbW8CMnzjelbfekWHoL/lmPLn1UtPfDiLZCleR8WhQeTnBaWDjJi
+        R1pZ2s/3Mspczj7dziZ7n+4/zEkX7t6jvn/2RAHzmm6JMNBHVjLu9KWC1skvizK/IMsScsDPkoDc
+        kjY/EpDNbzlu/f+igEyy83sPJvey7U93d/Lt/fuUtHyYf7q3PXs4283v5wcPd/eRKuoLiLo8U+qm
+        WF4Qr1PMmuct/U55MsrOEymb9Kpo58T4NFvpFwb79E2eLRoSKB5yXwzk65NqsVgvdYZ/tsLXWw7+
+        m5EA5S4Z9m1nWl+6xSz7b3n88X7deS++vV7lz6r6yboplqQJ0f7W735tdDnQ8Jws+94G2bmN1NHE
+        D4vA+YOdh5TI2Nk+n+6So7D74AFxwcOd7b3dBwfnBw8+vf/g3gPquy8CpIvWxHLNvKpaWr0LGJa4
+        Y+0EQHgapCRJmV1myykpeU7k3JL/XwtJ09PlBU3HN5gqvuXgfw5FwM3013/xA5j5w9lrev5wd+fh
+        wfbOvRzZh+zh9uT+hHTO+U4+Pdg9IDOLYOybYi9e7ftavPWa0uAFGeUGyYBviLtuN/YfcdfX5q5P
+        H+483N3b/3R7byc/2N7P7pP/lu3Ptnc+/XTnwf3JXvYgO6C++9yl9vtrmObX8vXPkk2+5YC+GZZx
+        7qVm4ObFbJYvv8gXE4Iv5Pcnrtt+TGJ0Tkvzd6fUtOOCDrbdmOvotM1Wq1c0Npeno2Rc39sdfJ2V
+        wXu9sdChv8871dVy4JWvJZL6kmilr+FELPP2qqrf3qX0DEVhxOfTvD+Trvl7Yue9+AFy//VH93Pi
+        IlH6/NN8/95s+8FkjxaUd/Kd7YyWkbf39u+dn9+7/2lGWp367msZgCZ9Ml3XRXtNAYIs7HK0IOxC
+        puyDV88ROGfT6/QbXkW/5aC/GU30fpMVn2Ylr1CFJJn/2sgY2kbfMPOk5NU3iSzDjPFpfp8MPGXV
+        Hk4yotG9fEaZ5vN72/nDfSLTp5/O9s53qO8+Y4jCZEYgCaXeukvxiPfTcyJcxI15sneSfoXvn9H3
+        P1t26HYj+2Zm36nWyd4UI8PAMP9elpn+Er1AmA5PyM75wwe7eZ6Rs5VT6p9Wt7Yz+mD7/oPJ5IAW
+        vM7Pd6GibzMhcA2ytq2LyZq+aKbzfJGl2WVWlCAmuZg8Ze8xTxbWz86M3XLoP0szZkeHiXrvacuy
+        8/17e/c+3d6Z7hC3ze6fbx8cIDHx8P79ewd7pHcOgG1/2nSuSHRrMiScdjzPSQuyb8+zmS+n9TW/
+        AlWLST0jF4fUynV6+o6wLKhBnj6racpgNtOts9Nnkewk5pK+SbFQQhnQn50pvCUZfham8E29blpL
+        BBrk67zF3L33TJKiyM4//fTe9j1iw+39/QekQc4f7m/fn957eJCffzrdeQC90Z9JmkAiA0+ZTirR
+        rWnTc4NUuqpoVZ0w+Ubm8SWAXf8szeMtifCzPo8ySMzce8/jJN8737+f7ZIieUCsuEcp8mzn0wfb
+        n+bT3fPs03uT6f59Qjoyj9XyvLggFzYtzPzQovsl/VGLfJLGxAwK2p609ufq9B2Z5WVWupmmYTCk
+        n6V5u+Wgv+l5oxHx8MzoeI7oj/ebsfzT2W62R9pilu3SCGh1Y/vh/Qc725P8fHrw6YzGkSGV1Zkx
+        ljrxSEXsGppBIkmBuIF+Jc9o2fanhnIops3TrM1+lubjlkP6pudjWlbr2fFq9VodQkxAbDp8p1Ki
+        Nm8JjF5oCR79hhesI0u/D71MVvR9IjF96WtHUm6av+CJr/HCbV/O303n2fKCrf1t3yEjzeR0vKOO
+        N713exjvRSPvxXlW5y+rYslm7dZv/ZzEuLcJgUhUSDgHVMH98z16Jrvk+00p73hAKceDbHZ/e0aW
+        6OH57vks/xRr/zerAjNlaX5JUxVxcY2IpF+SdHyjsn/LMfy/Qfbd26S9MV3Q5J7w01+3fH9Fobys
+        gRuTJ7KJ1Bfe9SDRbIVhregDs7zyZk4NWmrv4WFZiX7vY0GisV6GAk0gwj4cjxrO+BBhvn0u56pY
+        zhBizfLzfEkW8vi9RkmsNSwrD/ZzCpzuT7YpwXqf0hyw+fdne9uTh/fvPZwd3Pv03v17hEtHVsjR
+        ERkhEWl11Zd8G5dK/r2y4gdZmfUlRr/4WbKYtxzNNyM1bia/vlr+uVOS53tEqod70+172TnFy59O
+        aHHmwZTotbv3aZ4/2CdfD8TpTzxAQyHW11h9uqBYJGvTLL0oqwn5qhnmNZ2adhQSp0tawJJ0HylX
+        eanPF5/L65LEw6C/GYa45ShpNJh7egF/fV2GcIqMEvcUerAjRDPp/iBRfXctk+NPq3uR5mvJv9Jr
+        m/Vd5J3POTF/+xclkX/7VQ8TgXbYLN4YSxZnS0+93Q4nCo8ICdIL1fLieE1xLrG20K7/Frlwi5wm
+        YzwpypK4Cr1YUei1drIT9d42tA/zpPrXe7xhjEWYWY2/+Z7LFxRbqu7Xvm45JIPSRvu14f3b2y73
+        zgerrJ2Hn+5PJvdzSsrOSJhnDyaUkt97uH3/IH/wcP/g071sH3mFvsrqJ1cIAz/d7AzX6zyrp3Nr
+        1vqKShv87NivW47wm1FXbmZCdtW/Ns5lk4MKUD0IkO8KVQfb/tCt488Je1Ku8v7ew91s++HuwXR7
+        /3z2YDt7OM23z2kF++H5zvT8wewh9X0b9iS9l+bUTVUXZBSpS1A5bdbEeFmTTqrq7SKr3zaj9Cf4
+        rWP6raxETdKvlI+vamKqSE5JufeUYdO33wzb3nLk/99i258THnr46acPdh7Mdrbv7dECxv6DvQek
+        CvK97YPpvWx353z34eQh+u7zEE0T5eVXWdOQ+ZiJO76sltvsjxk9JdHtS20U6rCIqos3pGbfDNfc
+        cqzfDNd0PQxDqbvimRJk1/YbnM9P9yki2X9wsJ3vHZxv79O/FIvMyB09J5/rYZbtTHYRxvfnU1iz
+        a6coQCbO1XnUP6AexP+LTaG2+dmZwVuO7puZQQnwedDBbNDvYgoIOyLFwETkB1NaeTjf3c73J5Tb
+        zjNCldYhKKt6MHt4f+ecVimQS+1PRJ1fEN2IhCD5emn/ZERynQphIvNZSgzSrjfMxpt8Ol+SK50t
+        qck3MxW3HN83PxVEcuU+EQdfkPx2/C/1futWQuebW7o5uUVbnicQj9Ae4BTiXcqr39/dnny6Qz7Y
+        /j6ZtYP96fbO3qf3987zg/Nsd0o9hZyi0RNklALcJgVlOQoW266WJpWIaxT91PqcaVm8zdNlRhJ7
+        wdyVv1sVJLjUk10EHPEXl0V+Zd7OaKIuyaPnL7I1DY5Yl41Xnw8lUPxZUgq3pN83w4lOrQsZ7pJa
+        p8DzOenvZRNq9V5TmYTNbWZ5md/U5tbxs7anaamrKXkriuUxo4wc503vNfTnDchMsqaYGj7f2HKh
+        CN+mbXW1vG1Tw8WxxiKTZH/fJx7Ql943FrA2/D27c8b/63cJ1/GH7jru7n66f3D/ITlRe5+SEz49
+        v7f9cHrvUzID+WSyM8kOZlPIXai3YOFEDlhvqEIiDHyvw0XHT6+hlqZNShiP0pcknjUtFpDyoXdd
+        q2ckt32lw63Tl6QnyDdd/Cwpn1sS4ZtRPsqZ78df+tJ78tZMCU90R4PNjSn+u8I3m1s51nvPEXgv
+        vuco3Js/WxLiv7miCWT2DNrT74IYsc6wMOX3Hj64N5mRU/vwgJyoh1m+fXDvQbZNHJTv3dudPtg7
+        +JQ66wuTStAxZjl9ml9+SdJR1RfZkpY90EwsuFhpoyr7shK8/rMjKbcc4TcpKTMeD2bgPWfjIJve
+        O59+ur/9aT7Ntvf3cnIpcooZaSV0f/qA/Ix8skfYhbMhNBmls3xVVtfkc1XL8+KC8BjpJNHPaok8
+        CE8GZZzX1L6ZV7RcMS1pGZTc+eqywEBpkrhNFiSkaf5YbiLz9+3rSV3MUrOK+bM0hbckyzczhc7Q
+        e+sZNzhRQcuNrlTQEt5rTinpmAsx+Io/M+/x4i38paA9jZcnNSujHs7AW7fxn4IXKP1vZuh93oJu
+        gVjd9pU3yk7N3WIJRUrjGn6NZqV9XpFnR+xyu8UcFiNqaqWo8yr9JdIff93+9vp6OUXj2796TrNE
+        wpbPOmtI9Nrtgfh6G8gwGhtJa7JK386aObemHm7fH96mJf1qfTH/ELQpybkgRda8bio0fZ8XWZ8h
+        SzEtVuBw4vbhwfabbxTxSPOigc67dfucVeStm4Nhb1YjsfcC2r/n27dQKP2XiM630yr9V2+jWvpv
+        EUfcTr9EXr2Vkum/12YXN7xCUfCtV4zFo9Bebuu56ktf22vVJYb3WnB4LwS9F2+BJPkD5NSQVqZp
+        7PlMe5MH+/fh3+0c7NyjpcSDne0s+/T+9sHe3nR//+G9WZYhEgp9Js+D/ZJRSclYNOoO6Vgo90Rz
+        WpJwkVfEzBB6swoA+QzJUsnflBcjaLRSD3+orah5SfM+opSq/MZNV+SCFc08/fhqnrUfN+kyv/o4
+        PScdRPMGBw6rNng5X862kcenJuRUAqm+D6YDQADws+R/3ZLE34z/pbwrc3BbftKXbsFL/luOC5XF
+        /9/C8PE3v04sCeY5qRaLNaXhRc37L9Lvmzq8TSBKvEL8OiCbs3sPpgeTfLa982B3l1Kkuw8o7LpH
+        Gfv9bJJ/+uk035/CcR+UzWXekpfx1q35svDUJAmUD+a5oox349oRINKtJLb0Y045HUrAeOkaGlL6
+        mn65ykjIaHk5S1/LJEL4Sbyli76AvVDoPzvCdUsafTPC5eZWSXbXkhZzvIkZzAtkqYisNEHkcAxz
+        wPd/yf8DjvWlJhgUAQA=
+    headers:
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '12212'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:07 GMT
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      client-request-id:
+      - 1a8cfa68-3f64-475e-9c2a-520d8d9ce911
+      request-id:
+      - 1a8cfa68-3f64-475e-9c2a-520d8d9ce911
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"003","RoleInstance":"AGSFE_IN_26"}}'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:08 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ar-pP5jdO5tDhdUp7m-8QW9J34YQAQAAAJM7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:08 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 5342f97b-a7cd-4f64-946f-c55f30db0d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c750d508-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:08 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - f07488df-6c49-4c8a-b68e-c9593222c9b1
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:09 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ArLpbKjFoBdMqFyIo5guGME; expires=Sun, 24-May-2020 19:57:09 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - ee1f6ec8-8ea5-453d-9e29-84862e190f00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '222'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761829", "not_before":
+        "1587757929", "resource": "https://graph.microsoft.com", "access_token": "*****",
+        "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41EsrjpNCjj2hsZBGzuDR5ig4LCVvWtOqrMOqBs8ljhrd9Hk44SBx6gr1RvZYioMPlHJ_l-45IA4iMFqZB4VseVMMkb1SzgE80LeNeNCxnUcfl0c5dggOG78M186VdKsZwmnH3aRpj7KLnV5K2YiKwGCf_Yhx-OoPd6irqfRfxVk1KgzlmXQCi7MT23ukPBVpoT1uiERJXKGeUn8gUh259cuh85slOZpSZos699YKXcrz6QrouQDj13dSxNJclM98j5ki2ufGQhQaoF7yGDpaUP-zFd2rHLg3qAxKJWheSo5zTESOmR35lPLrqFOmdaNq80BlAvYcxEAERTKbDCRbkckNxoPTS8JTVQb08c0vc3sePnVrzhJC_ID8VwbDCvzrjidPoHhgXqdViVRppws3U_IGCI9FSTw9diq8T58_AWkwPjOQRph2bnuIHbnNuVxZK26KHs8PhPzkLLiZ305nCeh99zBMLY5tu5s3-O3cQQ1pK9iRRdBTe_c7KzwfPK57r9v3EgXamM3ZDuFPUM1cUyVBkMt3uHhJ8dcD_QbuRu7LtP5WRLhLQR1BEICzrbinv52eZ3v8qIv2SUnUTOp42IhZi_aDzT7tv29a_LRvauktdQEUzwrj9LZHn8VxBeu4YIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTI5LCJuYmYiOjE1ODc3NTc5MjksImV4cCI6MTU4Nzc2MTgyOSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3546'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:08 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AtZX7c6shkdDlJffF907PwUz3-LjAQAAAJU7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:09 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 8e09d5e0-daf0-4905-ad88-dec8109debbc
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - a9a74ab1-656e-4978-be41-db9d92100d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"principalId": "*****", "roleDefinitionId": "*****", "resourceScope":
+      "/"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/beta/roleManagement/directory/roleAssignments
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#roleManagement/directory/roleAssignments/$entity",
+        "id": "lAPpYvVpN0KRkAEhdxReEP0yQLFzVC9MrKIetx-6bUM-1", "principalId": "*****",
+        "resourceScope": "/", "directoryScopeId": "/", "roleDefinitionId": "*****"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '319'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:10 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/roleAssignments/lAPpYvVpN0KRkAEhdxReEP0yQLFzVC9MrKIetx-6bUM-1
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - 2c9f8d57-dced-4a60-974b-5c47dfd53ceb
+      request-id:
+      - 2c9f8d57-dced-4a60-974b-5c47dfd53ceb
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"2","ScaleUnit":"000","RoleInstance":"AGSFE_IN_88"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:10 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AvrhejyiRiVAkvWJt2ay2d5J34YQAQAAAJY7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:10 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - c226a040-1c76-4759-93bc-29c58c7d1c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - c89bc8a0-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:10 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - bc7e3bd4-b64b-497a-8768-fb599c154571
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 66dbd017-a859-4fd0-b367-dc2477007e88
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587761831", "not_before": "1587757931", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1487'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:10 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ak_dr-sHyLFHgIwKabAKtTbZVRABAQAAAJY7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:11 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 66dbd017-a859-4fd0-b367-dc2477007e88
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - 171aad2a-99cb-4c9a-a89b-2bb24e461b00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"name": "*****", "properties": {"displayName": "Hybrid :: Hernandez, Robbins
+      and Kane", "details": {"parent": {}}}}'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '147'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+      x-ms-client-request-id:
+      - c90ef7b2-8665-11ea-83d2-acde48001122
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "NotStarted"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '220'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:12 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/972b3ded-0da4-4a40-a7c9-e869dff56b26?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      request-id:
+      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      x-ba-restapi:
+      - 1.0.3.1566
+      x-ms-correlation-request-id:
+      - 0ad4add2-275c-4b85-971b-91e76ce3653a
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - centralus:0ad4add2-275c-4b85-971b-91e76ce3653a
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195712Z:0ad4add2-275c-4b85-971b-91e76ce3653a
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - c90ef7b2-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
+  response:
+    body:
+      string: '{"id": "/providers/Microsoft.Management/managementGroups/*****", "type":
+        "/providers/Microsoft.Management/managementGroups", "name": "*****", "status":
+        "Running"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '217'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:22 GMT
+      Expires:
+      - '-1'
+      Location:
+      - https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/972b3ded-0da4-4a40-a7c9-e869dff56b26?api-version=2018-03-01-preview
+      Pragma:
+      - no-cache
+      Retry-After:
+      - '10'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      request-id:
+      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      x-ba-restapi:
+      - 1.0.3.1566
+      x-ms-correlation-request-id:
+      - d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195722Z:d0fd04e9-9b7b-41eb-a562-fb74aa9105fa
+    status:
+      code: 202
+      message: Accepted
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      x-ms-client-request-id:
+      - c90ef7b2-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/operationResults/create/managementGroups/*****?api-version=2018-03-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dx8+2Jvcm+Wz7Z1Ztr+9n+3v
+        bGcPpg+384NPH87Oz+9/Otn79KPRR+31Kv8a4OnNZbbAm7fsp2mzdt1Q+9fr6TTP6QX6kDpd5XVb
+        5PTFL/6ozZfZsj3DaCf3s8lOvptv7zw8P9je37t/sJ2dTx5sn092H3x6f38yvT+5R+/PimZVZtcv
+        BJNvX0/qYpY+epR+O68J1Cz/wSh9VU0mxbJJ6c/098qWOd7K26wouctLGnBRLT96tDv6aL2aZW0+
+        e1MwsL2dvZ3tnf3tvf03uw8f3X/waPfe+N6n+w/u7e7+FMHQxk+uqem9B5/uTO/vH2zvzfJzosDe
+        ZPvhp9PZ9oP7hPPe7s5envFgs5rIh16/3oTekiY6LbdsHVLwDc8A0axqU+71o1/yS37JL/l/ABtL
+        eIGCAgAA
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:32 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      request-id:
+      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      x-ba-restapi:
+      - 1.0.3.1566
+      x-ms-correlation-request-id:
+      - 71d95b25-73f0-445d-92d3-a2729d1d0e01
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:71d95b25-73f0-445d-92d3-a2729d1d0e01
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195733Z:71d95b25-73f0-445d-92d3-a2729d1d0e01
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:34 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AiRPjsj5jepJrdMj7TOz4C9J34YQAQAAAK07NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:34 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - e77d5dec-7443-41d6-b78c-eaaa1f7f0e00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - d678b708-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:33 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 00e47acd-8e3a-442a-b013-184bc9e87b58
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - e3732c4a-764d-4f9a-9546-65f6fdf8592a
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587761855", "not_before": "1587757955", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1487'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:34 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Ahf77jhCWh1JgMnPCJAB_QPZVRABAQAAAK47NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:35 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - e3732c4a-764d-4f9a-9546-65f6fdf8592a
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - NCUS ProdSlices
+      x-ms-request-id:
+      - c226a040-1c76-4759-93bc-29c5ad801c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit) msrest/0.6.13 msrest_azure/0.6.3
+        azure-mgmt-managementgroups/0.2.0 Azure-SDK-For-Python
+      accept-language:
+      - en-US
+      x-ms-client-request-id:
+      - d77ce700-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****?api-version=2018-03-01-preview
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR8Xs
+        o0cf3V3V1WUxy+vm7hfFtK6a6rwdf5Ets4t8kS/buwv76+d1tV41dyf3s8lOvptv7zw8P9je37t/
+        sJ2dTx5sn092H3x6f38yvT+599Hoo/Z6lX8N8PTmMlvgzVv2Q/BXed0WefPRo1/8UZsvs2V7hoHd
+        8v1Z0azK7PqFdPqG309fVVWbMkJokbdZUTL4SxpHUS0/erQ7+mi9mmVtPntT8It7O7sPt3f3tncf
+        vNn99NH+w0f3dsZ7u7v3P93f/ymCoY2fXFNT7eNJNn17XpRl+p1q8tEv+SW/5P8Bd7okpZABAAA=
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:35 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      request-id:
+      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      x-ba-restapi:
+      - 1.0.3.1566
+      x-ms-correlation-request-id:
+      - 43830dca-b9d3-48e5-9bb3-db232fac24c7
+      x-ms-ratelimit-remaining-tenant-reads:
+      - '11999'
+      x-ms-request-id:
+      - centralus:43830dca-b9d3-48e5-9bb3-db232fac24c7
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195735Z:43830dca-b9d3-48e5-9bb3-db232fac24c7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:35 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Aktsv0nW6IFDmX8LTVb17GRJ34YQAQAAAK87NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:36 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - EUS ProdSlices
+      x-ms-request-id:
+      - a7ff9419-f74c-48be-876f-80c8cfd51b00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - d7d95db4-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:35 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 8af926db-0124-421b-b240-f5b182633d36
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 0b400214-fca5-4115-8a0a-7a73666da715
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:35 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AqigbENHpTFEtN0wx2jaS-U; expires=Sun, 24-May-2020 19:57:36 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=prod; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=ests; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 0b400214-fca5-4115-8a0a-7a73666da715
+      x-ms-ests-server:
+      - 2.1.10393.22 - EST ProdSlices
+      x-ms-request-id:
+      - 63d79287-8704-4314-870d-754866c04900
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '226'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 0b400214-fca5-4115-8a0a-7a73666da715
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761856", "not_before":
+        "1587757956", "resource": "https://management.azure.com/", "access_token":
+        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41rr6heuxCTOned7TDSbRuXID7P_boxs77OIqyDuuo4AOwL8s8VRlj69zPIEgGeMJzZ31AdECx1FETuME6xnmiMWeRsY5WqLGJ9PrWNo8p6wjpWzCP0RGUwnqJhldECL0ZtwbAdwZUvUteBCmINvTZ_tumzmFE25AQ65r4fl6KoM_ukVap52DYCZ24VpWw4r6N6HgNAIgEFpmPWc00FBZ7RW63IoMG8c3QJ-8NGtw5r3rNDoktv55l8IDt2RckiXzEcWjIjCNo2EvfwyQHRZTRJtTp_W-ffwRE1Sid-PRaX4J4QxOLId-YTomdotM9W7A8ItYxeJEI0HfCJXg4dKHNNaZX0dDEz-wG2TpbyEtzTooi4mhWq8WDW_TWDdqf1JZa_3tzd_ZfpRXCmfTohKx0hUm_FtodsjooEGNSkR0aIN1mRHGe2Ob441_0Haprhr7M5Uq5Tb_ZyEoDdfKqqY6pVTEETmUmJG5vQkv_1Q7VZWA8t-fs_fP9dlVIca4iCh_LFJER5etgIoa3HgXTBLa0jAB5jVf1ef75ePMG5f8Zb8LFHPTmD56hAtmz47nRtnoebdp_704qhtixZiJocsNRucjTHINPHRtCjzFBkA0wAyTgnA8b8izaP0JHxJENM9TmIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTU2LCJuYmYiOjE1ODc3NTc5NTYsImV4cCI6MTU4Nzc2MTg1NiwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3424'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:36 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AiJtBNjsUm9GoIgxuF8Gl6cz99dOAQAAALA7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:36 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 0b400214-fca5-4115-8a0a-7a73666da715
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - EUS ProdSlices
+      x-ms-request-id:
+      - 8fc0f85e-918a-4180-9465-bdf3bbe01c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://management.azure.com//providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 24 Apr 2020 19:57:36 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 3cc4f2fa-ac46-42b8-b38a-22a8bea4c605
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - d1009d6b-a522-477c-93c4-e0672160e650
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195737Z:3cc4f2fa-ac46-42b8-b38a-22a8bea4c605
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleDefinitions/*****",
+      "principalId": "*****"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '267'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
+  response:
+    body:
+      string: '{"error": {"code": "RoleAssignmentExists", "message": "The role assignment
+        already exists."}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '89'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:36 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - d0443cd3-6853-45ca-9bb4-212c6ba13fe5
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - 82a2fd72-6c69-41b0-ab2d-b133807e4797
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195737Z:d0443cd3-6853-45ca-9bb4-212c6ba13fe5
+    status:
+      code: 409
+      message: Conflict
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:37 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AuP7I4AMaYJOuaQ-aUbEQudJ34YQAQAAALE7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:38 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 7246db70-f73f-45af-acec-ccd806fb1700
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - d90b69ac-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:37 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 45d8833c-11d4-4964-bf6f-f732a69eaad7
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: GET
+    uri: https://login.microsoftonline.com/common/UserRealm/atat.hybrid%40dancorriganpromptworks.onmicrosoft.com?api-version=1.0
+  response:
+    body:
+      string: '{"ver": "1.0", "account_type": "Managed", "domain_name": "dancorriganpromptworks.onmicrosoft.com",
+        "cloud_instance_name": "microsoftonline.com", "cloud_audience_urn": "urn:federation:MicrosoftOnline"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Disposition:
+      - inline; filename=userrealm.json
+      Content-Length:
+      - '191'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:38 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AtFsXXwsIrlDi3svtbjPwHo; expires=Sun, 24-May-2020 19:57:38 GMT; path=/;
+        secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - dd9f3d1d-6fb5-498b-b2f6-caee7d4e0d00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '226'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "scope": "user_impersonation", "expires_in":
+        "3599", "ext_expires_in": "3599", "expires_on": "1587761859", "not_before":
+        "1587757959", "resource": "https://management.azure.com/", "access_token":
+        "*****", "refresh_token": "0.ATYAHg6rtfgJWEKvt_sXZUvFs1iiUBl7IjFOqc9xdJWUX8I2AM0.AQABAAAAAAAm-06blBE1TpVMil8KPQ41bwLKtMXEajbPJ12SHCHvNXN-qf6GYs59RuKMnvfckN3-7n6AzR_YQ8ZJkf80A0L7CZ5VvfvxvB7nl9a6HanDV6K4DJ74SvZPhkmBuxUfk-S56I9vTPFEIjmje8DIyI5SzGZJpzrpXvjh6twV7BdXsKtiWQKWiU4RcaQrqtGPYRyBqCvmudjDpxGPfKVOZbfE9vUCDMhjIo9Ku7kWYYLjCrdwwFIpzoL9LzV0fPkpUacFaREQPm9HzzpQFnKHZbmRMYlcXVqC1YD8_GKYLfbBoelk-RbRRP0e8WgVjboP9jFxRvoLGjJakgc6XwQaA8BGKtb4VckGCCi2ao5VILDhc114HwuQckFa6LpCu-dsE6kYYAUf3bQYYXYalLp-5tSBEqcsTaqmacA494HmpULd-X6aut07vPieyXCem3M6o331TufGtm-9PFkeEuyXIiZuj40-voFfN31cC1jLve3_8YdgOVFT8v-OxuvisQIpRjNCs9Dq51Ih3i6hfCG6U2MA-c0Tk39YwblskQwGIcCvVxdPBxx56pbQOAcGGi66vm1J_vj5H1YgGDUJKfulaWkvAtPTzCvU3kioJD8KWAa-McGgU9VwMkLQrTEV5lSN6sDMX-I6LbAYhL5r51nPp2dmIAA",
+        "foci": "1", "id_token": "eyJ0eXAiOiJKV1QiLCJhbGciOiJub25lIn0.eyJhdWQiOiIxOTUwYTI1OC0yMjdiLTRlMzEtYTljZi03MTc0OTU5NDVmYzIiLCJpc3MiOiJodHRwczovL3N0cy53aW5kb3dzLm5ldC9iNWFiMGUxZS0wOWY4LTQyNTgtYWZiNy1mYjE3NjU0YmM1YjMvIiwiaWF0IjoxNTg3NzU3OTU5LCJuYmYiOjE1ODc3NTc5NTksImV4cCI6MTU4Nzc2MTg1OSwiYW1yIjpbInB3ZCJdLCJpcGFkZHIiOiI3Mi4xMy4xMzIuMTUwIiwibmFtZSI6IkFUQVQgSHlicmlkIiwib2lkIjoiYjQ1MDI2OTctYjVlMy00Y2M3LTlmZjAtOWM5OWEyMjkzYzlmIiwicmgiOiIwLkFUWUFIZzZydGZnSldFS3Z0X3NYWlV2RnMxaWlVQmw3SWpGT3FjOXhkSldVWDhJMkFNMC4iLCJzdWIiOiJzajJNNEs3VXR3VGg2c1BRRTgya1VnZmtKMjU3Z3JUeW42RFpuZnUtN08wIiwidGlkIjoiYjVhYjBlMWUtMDlmOC00MjU4LWFmYjctZmIxNzY1NGJjNWIzIiwidW5pcXVlX25hbWUiOiJhdGF0Lmh5YnJpZEBkYW5jb3JyaWdhbnByb21wdHdvcmtzLm9ubWljcm9zb2Z0LmNvbSIsInVwbiI6ImF0YXQuaHlicmlkQGRhbmNvcnJpZ2FucHJvbXB0d29ya3Mub25taWNyb3NvZnQuY29tIiwidmVyIjoiMS4wIn0."}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '3424'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:38 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=ApYP2Oa4LQtGtZaJQ8yB1w4z99dOAQAAALI7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:39 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - c9d42981-aa78-4428-b71b-6f944a4e9ff4
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 8f9cc3ec-379e-41db-86ad-d9ea1a6f1600
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://management.azure.com//providers/Microsoft.Authorization/elevateAccess?api-version=2016-07-01
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '0'
+      Date:
+      - Fri, 24 Apr 2020 19:57:39 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 4028a972-b68e-4916-9657-0d0fd9df9aa5
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - 1b81cd8a-30dc-4d7f-88c5-1b98eeeae063
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195739Z:4028a972-b68e-4916-9657-0d0fd9df9aa5
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleDefinitions/*****",
+      "principalId": "*****"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '267'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****?api-version=2015-07-01
+  response:
+    body:
+      string: '{"properties": {"roleDefinitionId": "/providers/Microsoft.Authorization/roleDefinitions/*****",
+        "principalId": "*****", "scope": "/providers/Microsoft.Management/managementGroups/*****",
+        "createdOn": "2020-04-24T19:57:40.4261798Z", "updatedOn": "2020-04-24T19:57:40.4261798Z",
+        "createdBy": null, "updatedBy": "*****"}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/roleAssignments/*****",
+        "type": "Microsoft.Authorization/roleAssignments", "name": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '703'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:40 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - x-ms-gateway-slice=Production; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 155dd86d-8232-4695-b1da-f3950c989ea7
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - 64528b6f-d664-4546-936a-62dcc7f6fcd1
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195741Z:155dd86d-8232-4695-b1da-f3950c989ea7
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:41 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=Aiwl2DAyQbFCv0a7g6wGvaFJ34YQAQAAALU7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:41 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - EUS ProdSlices
+      x-ms-request-id:
+      - 8fc0f85e-918a-4180-9465-bdf356e11c00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - daff109c-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:41 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - e6f5166a-c6c8-47f9-9f0c-5b52a3d7e28c
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '176'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - f3bb436d-7f78-4129-a194-3d51b366b2d0
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587761862", "not_before": "1587757962", "resource": "https://graph.microsoft.com",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1622'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:42 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AuFbh3_CSABHlpWupt05IvQ8RRv1AQAAALU7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:42 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - f3bb436d-7f78-4129-a194-3d51b366b2d0
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - WUS2 ProdSlices
+      x-ms-request-id:
+      - 6b37aa9f-e751-46ac-975b-ffa9f10a0e00
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '355'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/v1.0/users
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users/$entity",
+        "id": "*****", "businessPhones": [], "displayName": "Hybrid :: Hernandez,
+        Robbins and Kane :: Billing", "givenName": null, "jobTitle": null, "mail":
+        null, "mobilePhone": null, "officeLocation": null, "preferredLanguage": null,
+        "surname": null, "userPrincipalName": "hybrid.hernandez.robbins.and.kane.billing@dancorriganpromptworks.onmicrosoft.com"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '435'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:41 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/directoryObjects/5e938647-664e-42a9-bf4d-3b2b5f3ca215/Microsoft.DirectoryServices.User
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - f7defca6-edee-459d-90aa-32a6f6c51a3d
+      request-id:
+      - f7defca6-edee-459d-90aa-32a6f6c51a3d
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_91"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '46'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PATCH
+    uri: https://graph.microsoft.com/v1.0/users/*****
+  response:
+    body:
+      string: ''
+    headers:
+      Cache-Control:
+      - private
+      Content-Type:
+      - text/plain
+      Date:
+      - Fri, 24 Apr 2020 19:57:42 GMT
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - d544b3f6-be93-4b49-9aa6-81abc3c3ea52
+      request-id:
+      - d544b3f6-be93-4b49-9aa6-81abc3c3ea52
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_48"}}'
+    status:
+      code: 204
+      message: No Content
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.23.0
+    method: GET
+    uri: https://graph.microsoft.com/v1.0/directoryRoles
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR79n
+        NcvabDytlm3+rv3o0Ufztl01j+7evaiz1Xy8KKZ11VTnLbVY3L3cHe/c/d0WeZvhpR+fFXU+bav6
+        +lVV5s1Ho48us3Kdf/Toe7/4o2JGoHbP97Kdew/z7U/3Hmbb+w+zh9sH+59m2wcHBw9n5zv7D3Ye
+        zuitWV7mbT57mrX5m2JB7y/XZYmPm2ldrNqiWhKsk2yZ1nk2S/PLvL5u58XyIm3nWZtm6UVZTbIy
+        zWaLYplOTbvJuk2XVZuuV4RrnmZLeWmMDotmVWbXLzJ09tHn8voreimv6duaBvMmX1CLNj/DMM73
+        8vOHD/em2/ey88n2/qeTh9uTB9Pz7Wx379M8f7A/3b+/+9EvGemg97PdjAZ+b3v3wfmD7f3de/e2
+        s/sP72/P9s+JHA+neZ4fUC+3HvSURgP8V6uymGb4gsZ3UTRtzX80abGc5auc/lm2aXVORMnTj79q
+        8rpRWqBtXvsAmo/TJm/bKDWOXbP0KdG6rFZxqkzPd6f3DvL72/c+3dvd3t/Z2d/OHkwn2wcPHn66
+        tz+b5rMHU0eVB9P7k09n+9l2Njvf395/sHu+/fD+7P42Afj04MH92f7s4CH18t5UWc7SRbbMLujX
+        kligWRFDNiADDVfHbuiEtkSjvF7VRUPtV6tm8/CPwVACoIqS4OHkgAbxcG97bzq7t72/P32w/XC2
+        s7edfZpN92b38+z+9J4jwcF0fyc//zTfJn4iadg9v7892SWRePDw3sHu7l5GDPJe0qDjBlY08Ka4
+        WC5oeOCH9PgH6zpPj5+OeNAdyrysi8uizC/yWXoGpina6/QLhoX3+yTx2kPObyZLfvDp7m42Odie
+        7h48JHnJD7Yf7ue725/u7O3eyya75we7+44s2c7OZC8nedmZ7k+pNQnNw/OD/e3de/mUCDU7f/B+
+        SkLJ0hm0oQgT5Auj1EgM6stimjckNaRK1sQWtmEhtCnyCJecVIsVKZSbSfHpXv6QNOD+9qcPabr3
+        9+7R4HYf7mzv7O7tPniwu38/391xpJgQve7nD4gU+T1qPSUqZPey+9vnO7vn+d7s4f1PZxPq5dak
+        IMk9r+pFSqp7Qfw8KcqSZJ7EAvjN0jZr3jZpWbzNRUniu1V2DS4gJsKb9Fm17A//iQK6cfiTnfP7
+        +59+uru9N3tAUj+9v7OdnWekGvPpwc69811SrLkb/pS4JM8e3N/e2dsjvpnSPw/3qfXBg/39bId4
+        6l6+T73cevikIsgMZE0xTa2lCgaW0jwSYcprzDzRo0rJ6NHgXWsGkU2JQ4hFKugMox1En1ys86aN
+        MMhTC0HMCoxjjzoHB7OD/F5OAzy/T9Od7eakE+9l2w8nDw8eHkwODh58OnHUOd85f3h/9+Gn2we7
+        E1If56R2Dj69N9l+eHD+IL9/7/79hwc59XJr6sTlhAhBhoOHVlfrVTMigk3L9QzTXedqNYhLmuaq
+        qmdNSsQkDloU1KUY4AgxYIzS4+m0WhNtb+SZ8/zhvZ1J/mD7fv7pHlmKGQ1xNyNzcTC9l5EPce9g
+        Qtb2+7/k/wHP+0d7uwgAAA==
+    headers:
+      Cache-Control:
+      - private
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1270'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:43 GMT
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      Vary:
+      - Accept-Encoding
+      client-request-id:
+      - 126df737-8b05-49ac-ac0c-91c9317e62d2
+      request-id:
+      - 126df737-8b05-49ac-ac0c-91c9317e62d2
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_60"}}'
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"roleDefinitionId": "*****", "principalId": "*****", "resourceScope":
+      "/"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '137'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: POST
+    uri: https://graph.microsoft.com/beta/roleManagement/directory/roleAssignments
+  response:
+    body:
+      string: '{"@odata.context": "https://graph.microsoft.com/beta/$metadata#roleManagement/directory/roleAssignments/$entity",
+        "id": "YUb1sHQtUEyvox7IA_Eu_keGk15OZqlCv007K188ohU-1", "principalId": "*****",
+        "resourceScope": "/", "directoryScopeId": "/", "roleDefinitionId": "*****"}'
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '319'
+      Content-Type:
+      - application/json;odata.metadata=minimal;odata.streaming=true;IEEE754Compatible=false;charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:43 GMT
+      Location:
+      - https://graph.microsoft.com/v2/b5ab0e1e-09f8-4258-afb7-fb17654bc5b3/roleAssignments/YUb1sHQtUEyvox7IA_Eu_keGk15OZqlCv007K188ohU-1
+      OData-Version:
+      - '4.0'
+      Strict-Transport-Security:
+      - max-age=31536000
+      client-request-id:
+      - 37d89e7c-8c97-469c-9e43-ecf20c9d4f7e
+      request-id:
+      - 37d89e7c-8c97-469c-9e43-ecf20c9d4f7e
+      x-ms-ags-diagnostic:
+      - '{"ServerInfo":{"DataCenter":"North Central US","Slice":"SliceC","Ring":"3","ScaleUnit":"001","RoleInstance":"AGSFE_IN_8"}}'
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '186'
+      Content-Type:
+      - application/x-www-form-urlencoded
+      User-Agent:
+      - azsdk-python-identity/1.3.1 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/v2.0/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": 3599, "ext_expires_in": 3599,
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1380'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:44 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AlISLHE_F3BKihLdTL6QgT5J34YQAQAAALc7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:44 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 5d1d9321-d914-4c74-bca0-467c02071800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - azsdk-python-keyvault-secrets/4.1.0 Python/3.7.3 (Darwin-19.4.0-x86_64-i386-64bit)
+      x-ms-client-request-id:
+      - dca209ea-8665-11ea-83d2-acde48001122
+    method: GET
+    uri: https://my-vault.vault.azure.net/secret/*****
+  response:
+    body:
+      string: '{"value": "{\"root_sp_client_id\": \"*****\", \"root_sp_key\": \"*****\",
+        \"root_tenant_id\": \"*****\", \"tenant_id\": \"*****\", \"tenant_admin_username\":
+        \"*****\", \"tenant_admin_password\": \"*****\", \"tenant_sp_client_id\":
+        \"*****\", \"tenant_sp_key\": \"*****\"}", "id": "https://my-vault.vault.azure.net/secret/*****",
+        "attributes": {"enabled": true, "created": 1587758225, "updated": 1587758225,
+        "recoveryLevel": "Recoverable+Purgeable"}}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '784'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:44 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Server:
+      - Microsoft-IIS/10.0
+      Strict-Transport-Security:
+      - max-age=31536000;includeSubDomains
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Content-Type-Options:
+      - nosniff
+      X-Powered-By:
+      - ASP.NET
+      x-ms-keyvault-network-info:
+      - addr=72.13.132.150;act_addr_fam=InterNetwork;
+      x-ms-keyvault-region:
+      - eastus
+      x-ms-keyvault-service-version:
+      - 1.1.0.898
+      x-ms-request-id:
+      - 730f5203-72f1-4c8a-8f8b-293f72713e9d
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '*****'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Charset:
+      - utf-8
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '180'
+      User-Agent:
+      - python-requests/2.23.0
+      client-request-id:
+      - 4eec6b4a-3bc2-4da2-bb4e-f8e0060e418a
+      content-type:
+      - application/x-www-form-urlencoded
+      return-client-request-id:
+      - 'true'
+      x-client-CPU:
+      - x64
+      x-client-OS:
+      - darwin
+      x-client-SKU:
+      - Python
+      x-client-Ver:
+      - 1.2.2
+    method: POST
+    uri: https://login.microsoftonline.com/*****/oauth2/token
+  response:
+    body:
+      string: '{"token_type": "Bearer", "expires_in": "3599", "ext_expires_in": "3599",
+        "expires_on": "1587761864", "not_before": "1587757964", "resource": "https://management.azure.com/",
+        "access_token": "*****"}'
+    headers:
+      Cache-Control:
+      - no-cache, no-store
+      Content-Length:
+      - '1487'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:44 GMT
+      Expires:
+      - '-1'
+      P3P:
+      - CP="DSP CUR OTPi IND OTRi ONL FIN"
+      Pragma:
+      - no-cache
+      Set-Cookie:
+      - fpc=AlWvWwcdrVpFsBbgKLWAbwOtcNdbAQAAALg7NdYOAAAA; expires=Sun, 24-May-2020
+        19:57:44 GMT; path=/; secure; HttpOnly; SameSite=None
+      - x-ms-gateway-slice=estsfd; path=/; SameSite=None; secure; HttpOnly
+      - stsservicecookie=estsfd; path=/; SameSite=None; secure; HttpOnly
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      client-request-id:
+      - 4eec6b4a-3bc2-4da2-bb4e-f8e0060e418a
+      x-ms-clitelem:
+      - 1,0,0,,
+      x-ms-ests-server:
+      - 2.1.10433.14 - SCUS ProdSlices
+      x-ms-request-id:
+      - 400e507f-e1a8-4c49-b65e-0fd0991e1800
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"properties": {"displayName": "Allowed resource types", "policyType":
+      "Custom", "mode": "Indexed", "description": "The list of resource types that
+      can be deployed", "parameters": {"listOfResourceTypesAllowed": {"type": "Array",
+      "metadata": {"description": "The list of resource types that can be deployed",
+      "displayName": "Allowed resource types", "strongType": "resourceTypes"}}}, "policyRule":
+      {"if": {"not": {"field": "type", "in": "[parameters(''listOfResourceTypesAllowed'')]"}},
+      "then": {"effect": "deny"}}}, "type": "Microsoft.Authorization/policyDefinitions"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '566'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed%20resource%20types?api-version=2019-09-01
+  response:
+    body:
+      string: '{"properties": {"displayName": "Allowed resource types", "policyType":
+        "Custom", "mode": "Indexed", "description": "The list of resource types that
+        can be deployed", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:45.5003123Z",
+        "updatedBy": null, "updatedOn": null}, "parameters": {"listOfResourceTypesAllowed":
+        {"type": "Array", "metadata": {"description": "The list of resource types
+        that can be deployed", "displayName": "Allowed resource types", "strongType":
+        "resourceTypes"}}}, "policyRule": {"if": {"not": {"field": "type", "in": "[parameters(''listOfResourceTypesAllowed'')]"}},
+        "then": {"effect": "deny"}}}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        resource types", "type": "Microsoft.Authorization/policyDefinitions", "name":
+        "Allowed resource types"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '876'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:44 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - c6aa01e6-4daf-461d-b403-49251c48b9bb
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1199'
+      x-ms-request-id:
+      - centralus:9b4e1d1b-5449-4555-8095-22eef51e7359
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195745Z:c6aa01e6-4daf-461d-b403-49251c48b9bb
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"displayName": "Allowed Regions", "description": "The list
+      of locations that can be specified when deploying resources.", "policyType":
+      "Custom", "mode": "Indexed", "parameters": {"listOfAllowedLocations": {"type":
+      "Array", "metadata": {"displayName": "Allowed Regions", "description": "The
+      list of locations that can be specified when deploying resources.", "strongType":
+      "location"}}}, "policyRule": {"if": {"allOf": [{"field": "location", "notIn":
+      "[parameters(''listOfAllowedLocations'')]"}, {"field": "location", "notEquals":
+      "global"}, {"field": "type", "notEquals": "Microsoft.AzureActiveDirectory/b2cDirectories"}]},
+      "then": {"effect": "Deny"}}}, "type": "Microsoft.Authorization/policyDefinitions"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '721'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed%20Regions?api-version=2019-09-01
+  response:
+    body:
+      string: '{"properties": {"displayName": "Allowed Regions", "policyType": "Custom",
+        "mode": "Indexed", "description": "The list of locations that can be specified
+        when deploying resources.", "metadata": {"createdBy": "*****", "createdOn":
+        "2020-04-24T19:57:45.8077322Z", "updatedBy": null, "updatedOn": null}, "parameters":
+        {"listOfAllowedLocations": {"type": "Array", "metadata": {"displayName": "Allowed
+        Regions", "description": "The list of locations that can be specified when
+        deploying resources.", "strongType": "location"}}}, "policyRule": {"if": {"allOf":
+        [{"field": "location", "notIn": "[parameters(''listOfAllowedLocations'')]"},
+        {"field": "location", "notEquals": "global"}, {"field": "type", "notEquals":
+        "Microsoft.AzureActiveDirectory/b2cDirectories"}]}, "then": {"effect": "Deny"}}},
+        "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        Regions", "type": "Microsoft.Authorization/policyDefinitions", "name": "Allowed
+        Regions"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '1009'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:44 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 351260d5-f443-4a1d-9d2a-948772b0cb5e
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1198'
+      x-ms-request-id:
+      - centralus:e51f1737-d561-43ca-ab55-a58004ddc888
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195745Z:351260d5-f443-4a1d-9d2a-948772b0cb5e
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"displayName": "Allowed VM SKUs", "policyType": "Custom",
+      "mode": "Indexed", "description": "The list of SKUs that can be specified for
+      virtual machines.", "parameters": {"listOfAllowedSKUs": {"type": "array", "metadata":
+      {"description": "The list of SKUs that can be specified for virtual machines.",
+      "displayName": "Allowed SKUs", "strongType": "VMSKUs"}}}, "policyRule": {"if":
+      {"allOf": [{"field": "type", "equals": "Microsoft.Compute/virtualMachines"},
+      {"not": {"field": "Microsoft.Compute/virtualMachines/sku.name", "in": "[parameters(''listOfAllowedSKUs'')]"}}]},
+      "then": {"effect": "Deny"}}}, "type": "Microsoft.Authorization/policyDefinitions"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '667'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed%20VM%20SKUs?api-version=2019-09-01
+  response:
+    body:
+      string: '{"properties": {"displayName": "Allowed VM SKUs", "policyType": "Custom",
+        "mode": "Indexed", "description": "The list of SKUs that can be specified
+        for virtual machines.", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.0116091Z",
+        "updatedBy": null, "updatedOn": null}, "parameters": {"listOfAllowedSKUs":
+        {"type": "Array", "metadata": {"description": "The list of SKUs that can be
+        specified for virtual machines.", "displayName": "Allowed SKUs", "strongType":
+        "VMSKUs"}}}, "policyRule": {"if": {"allOf": [{"field": "type", "equals": "Microsoft.Compute/virtualMachines"},
+        {"not": {"field": "Microsoft.Compute/virtualMachines/sku.name", "in": "[parameters(''listOfAllowedSKUs'')]"}}]},
+        "then": {"effect": "Deny"}}}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        VM SKUs", "type": "Microsoft.Authorization/policyDefinitions", "name": "Allowed
+        VM SKUs"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '958'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:45 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 833d8064-beab-4c8c-bfd6-9cf3c96fbd17
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1197'
+      x-ms-request-id:
+      - centralus:7c50dabf-af60-4fb0-ac02-d0b3489e6578
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195746Z:833d8064-beab-4c8c-bfd6-9cf3c96fbd17
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"displayName": "Default JEDI Policy Set", "policyDefinitions":
+      [{"policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+      resource types", "policyDefinitionReferenceId": "Allowed resource types", "parameters":
+      {"listOfResourceTypesAllowed": {"value": ["microsoft.apimanagement/checkfeedbackrequired",
+      "microsoft.apimanagement/checknameavailability", "microsoft.apimanagement/checkservicenameavailability",
+      "microsoft.apimanagement/operations", "microsoft.apimanagement/reportfeedback",
+      "microsoft.apimanagement/service", "microsoft.apimanagement/service/apis", "microsoft.apimanagement/service/apis/diagnostics",
+      "microsoft.apimanagement/service/apis/issues", "microsoft.apimanagement/service/apis/issues/attachments",
+      "microsoft.apimanagement/service/apis/issues/comments", "microsoft.apimanagement/service/apis/operations",
+      "microsoft.apimanagement/service/apis/operations/policies", "microsoft.apimanagement/service/apis/operations/tags",
+      "microsoft.apimanagement/service/apis/policies", "microsoft.apimanagement/service/apis/releases",
+      "microsoft.apimanagement/service/apis/schemas", "microsoft.apimanagement/service/apis/tagdescriptions",
+      "microsoft.apimanagement/service/apis/tags", "microsoft.apimanagement/service/apiversionsets",
+      "microsoft.apimanagement/service/authorizationservers", "microsoft.apimanagement/service/backends",
+      "microsoft.apimanagement/service/caches", "microsoft.apimanagement/service/diagnostics",
+      "microsoft.apimanagement/service/groups", "microsoft.apimanagement/service/identityproviders",
+      "microsoft.apimanagement/service/loggers", "microsoft.apimanagement/service/notifications",
+      "microsoft.apimanagement/service/openidconnectproviders", "microsoft.apimanagement/service/policies",
+      "microsoft.apimanagement/service/portalsettings", "microsoft.apimanagement/service/products",
+      "microsoft.apimanagement/service/products/policies", "microsoft.apimanagement/service/products/tags",
+      "microsoft.apimanagement/service/properties", "microsoft.apimanagement/service/subscriptions",
+      "microsoft.apimanagement/service/tags", "microsoft.apimanagement/service/templates",
+      "microsoft.apimanagement/service/users", "microsoft.apimanagement/validateservicename",
+      "microsoft.authorization/checkaccess", "microsoft.authorization/classicadministrators",
+      "microsoft.authorization/dataaliases", "microsoft.authorization/denyassignments",
+      "microsoft.authorization/elevateaccess", "microsoft.authorization/findorphanroleassignments",
+      "microsoft.authorization/locks", "microsoft.authorization/operations", "microsoft.authorization/permissions",
+      "microsoft.authorization/policyassignments", "microsoft.authorization/policydefinitions",
+      "microsoft.authorization/policysetdefinitions", "microsoft.authorization/provideroperations",
+      "microsoft.authorization/roleassignments", "microsoft.authorization/roleassignmentsusagemetrics",
+      "microsoft.authorization/roledefinitions", "microsoft.automation/automationaccounts",
+      "microsoft.automation/automationaccounts/certificates", "microsoft.automation/automationaccounts/compilationjobs",
+      "microsoft.automation/automationaccounts/configurations", "microsoft.automation/automationaccounts/connections",
+      "microsoft.automation/automationaccounts/connectiontypes", "microsoft.automation/automationaccounts/credentials",
+      "microsoft.automation/automationaccounts/jobs", "microsoft.automation/automationaccounts/jobschedules",
+      "microsoft.automation/automationaccounts/modules", "microsoft.automation/automationaccounts/nodeconfigurations",
+      "microsoft.automation/automationaccounts/python2packages", "microsoft.automation/automationaccounts/runbooks",
+      "microsoft.automation/automationaccounts/schedules", "microsoft.automation/automationaccounts/softwareupdateconfigurations",
+      "microsoft.automation/automationaccounts/variables", "microsoft.automation/automationaccounts/watchers",
+      "microsoft.automation/automationaccounts/webhooks", "microsoft.automation/operations",
+      "microsoft.batch/batchaccounts", "microsoft.batch/batchaccounts/applications",
+      "microsoft.batch/batchaccounts/applications/versions", "microsoft.batch/batchaccounts/certificates",
+      "microsoft.batch/batchaccounts/pools", "microsoft.batch/locations", "microsoft.batch/locations/accountoperationresults",
+      "microsoft.batch/locations/checknameavailability", "microsoft.batch/locations/quotas",
+      "microsoft.batch/operations", "microsoft.cache/checknameavailability", "microsoft.cache/locations",
+      "microsoft.cache/locations/operationresults", "microsoft.cache/operations",
+      "microsoft.cache/redis", "microsoft.cache/redis/firewallrules", "microsoft.cache/redis/linkedservers",
+      "microsoft.cache/redis/patchschedules", "microsoft.cache/redisconfigdefinition",
+      "microsoft.cdn/cdnwebapplicationfirewallmanagedrulesets", "microsoft.cdn/cdnwebapplicationfirewallpolicies",
+      "microsoft.cdn/checknameavailability", "microsoft.cdn/checkresourceusage", "microsoft.cdn/edgenodes",
+      "microsoft.cdn/operationresults", "microsoft.cdn/operationresults/profileresults",
+      "microsoft.cdn/operationresults/profileresults/endpointresults", "microsoft.cdn/operationresults/profileresults/endpointresults/customdomainresults",
+      "microsoft.cdn/operationresults/profileresults/endpointresults/originresults",
+      "microsoft.cdn/operations", "microsoft.cdn/profiles", "microsoft.cdn/profiles/endpoints",
+      "microsoft.cdn/profiles/endpoints/customdomains", "microsoft.cdn/profiles/endpoints/origins",
+      "microsoft.cdn/validateprobe", "microsoft.compute/availabilitysets", "microsoft.compute/diskencryptionsets",
+      "microsoft.compute/disks", "microsoft.compute/galleries", "microsoft.compute/galleries/applications",
+      "microsoft.compute/galleries/applications/versions", "microsoft.compute/galleries/images",
+      "microsoft.compute/galleries/images/versions", "microsoft.compute/hostgroups",
+      "microsoft.compute/hostgroups/hosts", "microsoft.compute/images", "microsoft.compute/locations",
+      "microsoft.compute/locations/artifactpublishers", "microsoft.compute/locations/capsoperations",
+      "microsoft.compute/locations/diskoperations", "microsoft.compute/locations/loganalytics",
+      "microsoft.compute/locations/operations", "microsoft.compute/locations/publishers",
+      "microsoft.compute/locations/runcommands", "microsoft.compute/locations/systeminfo",
+      "microsoft.compute/locations/usages", "microsoft.compute/locations/virtualmachines",
+      "microsoft.compute/locations/vmsizes", "microsoft.compute/locations/vsmoperations",
+      "microsoft.compute/operations", "microsoft.compute/proximityplacementgroups",
+      "microsoft.compute/restorepointcollections", "microsoft.compute/restorepointcollections/restorepoints",
+      "microsoft.compute/sharedvmimages", "microsoft.compute/sharedvmimages/versions",
+      "microsoft.compute/snapshots", "microsoft.compute/virtualmachines", "microsoft.compute/virtualmachines/extensions",
+      "microsoft.compute/virtualmachines/metricdefinitions", "microsoft.compute/virtualmachinescalesets",
+      "microsoft.compute/virtualmachinescalesets/extensions", "microsoft.compute/virtualmachinescalesets/networkinterfaces",
+      "microsoft.compute/virtualmachinescalesets/publicipaddresses", "microsoft.compute/virtualmachinescalesets/virtualmachines",
+      "microsoft.compute/virtualmachinescalesets/virtualmachines/networkinterfaces",
+      "microsoft.containerregistry/checknameavailability", "microsoft.containerregistry/locations",
+      "microsoft.containerregistry/locations/authorize", "microsoft.containerregistry/locations/deletevirtualnetworkorsubnets",
+      "microsoft.containerregistry/locations/operationresults", "microsoft.containerregistry/locations/setupauth",
+      "microsoft.containerregistry/operations", "microsoft.containerregistry/registries",
+      "microsoft.containerregistry/registries/builds", "microsoft.containerregistry/registries/builds/cancel",
+      "microsoft.containerregistry/registries/builds/getloglink", "microsoft.containerregistry/registries/buildtasks",
+      "microsoft.containerregistry/registries/buildtasks/listsourcerepositoryproperties",
+      "microsoft.containerregistry/registries/buildtasks/steps", "microsoft.containerregistry/registries/buildtasks/steps/listbuildarguments",
+      "microsoft.containerregistry/registries/eventgridfilters", "microsoft.containerregistry/registries/generatecredentials",
+      "microsoft.containerregistry/registries/getbuildsourceuploadurl", "microsoft.containerregistry/registries/getcredentials",
+      "microsoft.containerregistry/registries/importimage", "microsoft.containerregistry/registries/listbuildsourceuploadurl",
+      "microsoft.containerregistry/registries/listcredentials", "microsoft.containerregistry/registries/listpolicies",
+      "microsoft.containerregistry/registries/listusages", "microsoft.containerregistry/registries/queuebuild",
+      "microsoft.containerregistry/registries/regeneratecredential", "microsoft.containerregistry/registries/regeneratecredentials",
+      "microsoft.containerregistry/registries/replications", "microsoft.containerregistry/registries/runs",
+      "microsoft.containerregistry/registries/runs/cancel", "microsoft.containerregistry/registries/runs/listlogsasurl",
+      "microsoft.containerregistry/registries/schedulerun", "microsoft.containerregistry/registries/scopemaps",
+      "microsoft.containerregistry/registries/taskruns", "microsoft.containerregistry/registries/tasks",
+      "microsoft.containerregistry/registries/tasks/listdetails", "microsoft.containerregistry/registries/tokens",
+      "microsoft.containerregistry/registries/updatepolicies", "microsoft.containerregistry/registries/webhooks",
+      "microsoft.containerregistry/registries/webhooks/getcallbackconfig", "microsoft.containerregistry/registries/webhooks/listevents",
+      "microsoft.containerregistry/registries/webhooks/ping", "microsoft.containerregistry/swagger",
+      "microsoft.containerservice/containerservices", "microsoft.containerservice/locations",
+      "microsoft.containerservice/locations/openshiftclusters", "microsoft.containerservice/locations/operationresults",
+      "microsoft.containerservice/locations/operations", "microsoft.containerservice/locations/orchestrators",
+      "microsoft.containerservice/managedclusters", "microsoft.containerservice/managedclusters/agentpools",
+      "microsoft.containerservice/openshiftmanagedclusters", "microsoft.containerservice/operations",
+      "microsoft.costmanagement/alerts", "microsoft.costmanagement/billingaccounts",
+      "microsoft.costmanagement/budgets", "microsoft.costmanagement/cloudconnectors",
+      "microsoft.costmanagement/connectors", "microsoft.costmanagement/departments",
+      "microsoft.costmanagement/dimensions", "microsoft.costmanagement/enrollmentaccounts",
+      "microsoft.costmanagement/exports", "microsoft.costmanagement/externalbillingaccounts",
+      "microsoft.costmanagement/externalbillingaccounts/alerts", "microsoft.costmanagement/externalbillingaccounts/dimensions",
+      "microsoft.costmanagement/externalbillingaccounts/forecast", "microsoft.costmanagement/externalbillingaccounts/query",
+      "microsoft.costmanagement/externalsubscriptions", "microsoft.costmanagement/externalsubscriptions/alerts",
+      "microsoft.costmanagement/externalsubscriptions/dimensions", "microsoft.costmanagement/externalsubscriptions/forecast",
+      "microsoft.costmanagement/externalsubscriptions/query", "microsoft.costmanagement/forecast",
+      "microsoft.costmanagement/operations", "microsoft.costmanagement/query", "microsoft.costmanagement/register",
+      "microsoft.costmanagement/reportconfigs", "microsoft.costmanagement/reports",
+      "microsoft.costmanagement/settings", "microsoft.costmanagement/showbackrules",
+      "microsoft.costmanagement/views", "microsoft.databoxedge/databoxedgedevices",
+      "microsoft.databoxedge/databoxedgedevices/checknameavailability", "microsoft.databoxedge/operations",
+      "microsoft.databricks/locations", "microsoft.databricks/locations/getnetworkpolicies",
+      "microsoft.databricks/locations/operationstatuses", "microsoft.databricks/operations",
+      "microsoft.databricks/workspaces", "microsoft.databricks/workspaces/storageencryption",
+      "microsoft.databricks/workspaces/virtualnetworkpeerings", "microsoft.dbformysql/checknameavailability",
+      "microsoft.dbformysql/locations", "microsoft.dbformysql/locations/administratorazureasyncoperation",
+      "microsoft.dbformysql/locations/administratoroperationresults", "microsoft.dbformysql/locations/azureasyncoperation",
+      "microsoft.dbformysql/locations/operationresults", "microsoft.dbformysql/locations/performancetiers",
+      "microsoft.dbformysql/locations/privateendpointconnectionazureasyncoperation",
+      "microsoft.dbformysql/locations/privateendpointconnectionoperationresults",
+      "microsoft.dbformysql/locations/privateendpointconnectionproxyazureasyncoperation",
+      "microsoft.dbformysql/locations/privateendpointconnectionproxyoperationresults",
+      "microsoft.dbformysql/locations/recommendedactionsessionsazureasyncoperation",
+      "microsoft.dbformysql/locations/recommendedactionsessionsoperationresults",
+      "microsoft.dbformysql/locations/securityalertpoliciesazureasyncoperation", "microsoft.dbformysql/locations/securityalertpoliciesoperationresults",
+      "microsoft.dbformysql/locations/serverkeyazureasyncoperation", "microsoft.dbformysql/locations/serverkeyoperationresults",
+      "microsoft.dbformysql/operations", "microsoft.dbformysql/servers", "microsoft.dbformysql/servers/advisors",
+      "microsoft.dbformysql/servers/configurations", "microsoft.dbformysql/servers/databases",
+      "microsoft.dbformysql/servers/firewallrules", "microsoft.dbformysql/servers/keys",
+      "microsoft.dbformysql/servers/privateendpointconnectionproxies", "microsoft.dbformysql/servers/privateendpointconnections",
+      "microsoft.dbformysql/servers/privatelinkresources", "microsoft.dbformysql/servers/querytexts",
+      "microsoft.dbformysql/servers/recoverableservers", "microsoft.dbformysql/servers/securityalertpolicies",
+      "microsoft.dbformysql/servers/topquerystatistics", "microsoft.dbformysql/servers/virtualnetworkrules",
+      "microsoft.dbformysql/servers/waitstatistics", "microsoft.dbforpostgresql/checknameavailability",
+      "microsoft.dbforpostgresql/locations", "microsoft.dbforpostgresql/locations/administratorazureasyncoperation",
+      "microsoft.dbforpostgresql/locations/administratoroperationresults", "microsoft.dbforpostgresql/locations/azureasyncoperation",
+      "microsoft.dbforpostgresql/locations/operationresults", "microsoft.dbforpostgresql/locations/performancetiers",
+      "microsoft.dbforpostgresql/locations/privateendpointconnectionazureasyncoperation",
+      "microsoft.dbforpostgresql/locations/privateendpointconnectionoperationresults",
+      "microsoft.dbforpostgresql/locations/privateendpointconnectionproxyazureasyncoperation",
+      "microsoft.dbforpostgresql/locations/privateendpointconnectionproxyoperationresults",
+      "microsoft.dbforpostgresql/locations/recommendedactionsessionsazureasyncoperation",
+      "microsoft.dbforpostgresql/locations/recommendedactionsessionsoperationresults",
+      "microsoft.dbforpostgresql/locations/securityalertpoliciesazureasyncoperation",
+      "microsoft.dbforpostgresql/locations/securityalertpoliciesoperationresults",
+      "microsoft.dbforpostgresql/locations/serverkeyazureasyncoperation", "microsoft.dbforpostgresql/locations/serverkeyoperationresults",
+      "microsoft.dbforpostgresql/operations", "microsoft.dbforpostgresql/servergroups",
+      "microsoft.dbforpostgresql/servers", "microsoft.dbforpostgresql/servers/advisors",
+      "microsoft.dbforpostgresql/servers/configurations", "microsoft.dbforpostgresql/servers/databases",
+      "microsoft.dbforpostgresql/servers/firewallrules", "microsoft.dbforpostgresql/servers/keys",
+      "microsoft.dbforpostgresql/servers/privateendpointconnectionproxies", "microsoft.dbforpostgresql/servers/privateendpointconnections",
+      "microsoft.dbforpostgresql/servers/privatelinkresources", "microsoft.dbforpostgresql/servers/querytexts",
+      "microsoft.dbforpostgresql/servers/recoverableservers", "microsoft.dbforpostgresql/servers/securityalertpolicies",
+      "microsoft.dbforpostgresql/servers/topquerystatistics", "microsoft.dbforpostgresql/servers/virtualnetworkrules",
+      "microsoft.dbforpostgresql/servers/waitstatistics", "microsoft.dbforpostgresql/serversv2",
+      "microsoft.devices/checknameavailability", "microsoft.devices/checkprovisioningservicenameavailability",
+      "microsoft.devices/elasticpools", "microsoft.devices/elasticpools/iothubtenants",
+      "microsoft.devices/elasticpools/iothubtenants/securitysettings", "microsoft.devices/iothubs",
+      "microsoft.devices/iothubs/certificates", "microsoft.devices/iothubs/eventgridfilters",
+      "microsoft.devices/iothubs/securitysettings", "microsoft.devices/operationresults",
+      "microsoft.devices/operations", "microsoft.devices/provisioningservices", "microsoft.devices/usages",
+      "microsoft.documentdb/databaseaccountnames", "microsoft.documentdb/databaseaccounts",
+      "microsoft.documentdb/locations", "microsoft.documentdb/locations/deletevirtualnetworkorsubnets",
+      "microsoft.documentdb/locations/operationsstatus", "microsoft.documentdb/operationresults",
+      "microsoft.documentdb/operations", "microsoft.eventhub/availableclusterregions",
+      "microsoft.eventhub/checknameavailability", "microsoft.eventhub/checknamespaceavailability",
+      "microsoft.eventhub/clusters", "microsoft.eventhub/locations", "microsoft.eventhub/locations/deletevirtualnetworkorsubnets",
+      "microsoft.eventhub/namespaces", "microsoft.eventhub/namespaces/authorizationrules",
+      "microsoft.eventhub/namespaces/disasterrecoveryconfigs", "microsoft.eventhub/namespaces/disasterrecoveryconfigs/checknameavailability",
+      "microsoft.eventhub/namespaces/eventhubs", "microsoft.eventhub/namespaces/eventhubs/authorizationrules",
+      "microsoft.eventhub/namespaces/eventhubs/consumergroups", "microsoft.eventhub/namespaces/ipfilterrules",
+      "microsoft.eventhub/namespaces/networkrulesets", "microsoft.eventhub/namespaces/virtualnetworkrules",
+      "microsoft.eventhub/operations", "microsoft.eventhub/sku", "microsoft.hdinsight/clusters",
+      "microsoft.hdinsight/clusters/applications", "microsoft.hdinsight/clusters/operationresults",
+      "microsoft.hdinsight/locations", "microsoft.hdinsight/locations/azureasyncoperations",
+      "microsoft.hdinsight/locations/billingspecs", "microsoft.hdinsight/locations/capabilities",
+      "microsoft.hdinsight/locations/operationresults", "microsoft.hdinsight/locations/usages",
+      "microsoft.hdinsight/locations/validatecreaterequest", "microsoft.hdinsight/operations",
+      "microsoft.insights/accounts", "microsoft.insights/actiongroups", "microsoft.insights/activitylogalerts",
+      "microsoft.insights/alertrules", "microsoft.insights/automatedexportsettings",
+      "microsoft.insights/autoscalesettings", "microsoft.insights/baseline", "microsoft.insights/calculatebaseline",
+      "microsoft.insights/components", "microsoft.insights/components/events", "microsoft.insights/components/metrics",
+      "microsoft.insights/components/pricingplans", "microsoft.insights/components/proactivedetectionconfigs",
+      "microsoft.insights/components/query", "microsoft.insights/datacollectionruleassociations",
+      "microsoft.insights/datacollectionrules", "microsoft.insights/diagnosticsettings",
+      "microsoft.insights/diagnosticsettingscategories", "microsoft.insights/eventcategories",
+      "microsoft.insights/eventtypes", "microsoft.insights/extendeddiagnosticsettings",
+      "microsoft.insights/guestdiagnosticsettings", "microsoft.insights/guestdiagnosticsettingsassociation",
+      "microsoft.insights/listmigrationdate", "microsoft.insights/locations", "microsoft.insights/locations/operationresults",
+      "microsoft.insights/logdefinitions", "microsoft.insights/logprofiles", "microsoft.insights/logs",
+      "microsoft.insights/metricalerts", "microsoft.insights/metricbaselines", "microsoft.insights/metricbatch",
+      "microsoft.insights/metricdefinitions", "microsoft.insights/metricnamespaces",
+      "microsoft.insights/metrics", "microsoft.insights/migratealertrules", "microsoft.insights/migratetonewpricingmodel",
+      "microsoft.insights/myworkbooks", "microsoft.insights/notificationgroups", "microsoft.insights/notificationrules",
+      "microsoft.insights/notifications", "microsoft.insights/operations", "microsoft.insights/queries",
+      "microsoft.insights/rollbacktolegacypricingmodel", "microsoft.insights/scheduledqueryrules",
+      "microsoft.insights/topology", "microsoft.insights/transactions", "microsoft.insights/vminsightsonboardingstatuses",
+      "microsoft.insights/webtests", "microsoft.insights/workbooks", "microsoft.insights/workbooktemplates",
+      "microsoft.keyvault/checknameavailability", "microsoft.keyvault/deletedvaults",
+      "microsoft.keyvault/hsmpools", "microsoft.keyvault/locations", "microsoft.keyvault/locations/deletedvaults",
+      "microsoft.keyvault/locations/deletevirtualnetworkorsubnets", "microsoft.keyvault/locations/operationresults",
+      "microsoft.keyvault/operations", "microsoft.keyvault/vaults", "microsoft.keyvault/vaults/accesspolicies",
+      "microsoft.keyvault/vaults/eventgridfilters", "microsoft.keyvault/vaults/secrets",
+      "microsoft.machinelearning/commitmentplans", "microsoft.machinelearning/locations",
+      "microsoft.machinelearning/locations/operations", "microsoft.machinelearning/locations/operationsstatus",
+      "microsoft.machinelearning/operations", "microsoft.machinelearning/webservices",
+      "microsoft.machinelearning/workspaces", "microsoft.network/applicationgatewayavailablerequestheaders",
+      "microsoft.network/applicationgatewayavailableresponseheaders", "microsoft.network/applicationgatewayavailableservervariables",
+      "microsoft.network/applicationgatewayavailablessloptions", "microsoft.network/applicationgatewayavailablewafrulesets",
+      "microsoft.network/applicationgateways", "microsoft.network/applicationgatewaywebapplicationfirewallpolicies",
+      "microsoft.network/applicationsecuritygroups", "microsoft.network/azurefirewallfqdntags",
+      "microsoft.network/azurefirewalls", "microsoft.network/bastionhosts", "microsoft.network/bgpservicecommunities",
+      "microsoft.network/checkfrontdoornameavailability", "microsoft.network/checktrafficmanagernameavailability",
+      "microsoft.network/connections", "microsoft.network/ddoscustompolicies", "microsoft.network/ddosprotectionplans",
+      "microsoft.network/dnsoperationresults", "microsoft.network/dnsoperationstatuses",
+      "microsoft.network/dnszones", "microsoft.network/dnszones/a", "microsoft.network/dnszones/aaaa",
+      "microsoft.network/dnszones/all", "microsoft.network/dnszones/caa", "microsoft.network/dnszones/cname",
+      "microsoft.network/dnszones/mx", "microsoft.network/dnszones/ns", "microsoft.network/dnszones/ptr",
+      "microsoft.network/dnszones/recordsets", "microsoft.network/dnszones/soa", "microsoft.network/dnszones/srv",
+      "microsoft.network/dnszones/txt", "microsoft.network/expressroutecircuits",
+      "microsoft.network/expressroutecircuits/authorizations", "microsoft.network/expressroutecircuits/peerings",
+      "microsoft.network/expressroutecircuits/peerings/connections", "microsoft.network/expressroutecrossconnections",
+      "microsoft.network/expressroutecrossconnections/peerings", "microsoft.network/expressroutegateways",
+      "microsoft.network/expressroutegateways/expressrouteconnections", "microsoft.network/expressrouteports",
+      "microsoft.network/expressrouteportslocations", "microsoft.network/expressrouteserviceproviders",
+      "microsoft.network/firewallpolicies", "microsoft.network/firewallpolicies/rulegroups",
+      "microsoft.network/frontdooroperationresults", "microsoft.network/frontdoors",
+      "microsoft.network/frontdoors/backendpools", "microsoft.network/frontdoorwebapplicationfirewallmanagedrulesets",
+      "microsoft.network/frontdoorwebapplicationfirewallpolicies", "microsoft.network/getdnsresourcereference",
+      "microsoft.network/internalnotify", "microsoft.network/ipgroups", "microsoft.network/loadbalancers",
+      "microsoft.network/loadbalancers/inboundnatrules", "microsoft.network/localnetworkgateways",
+      "microsoft.network/locations", "microsoft.network/locations/autoapprovedprivatelinkservices",
+      "microsoft.network/locations/availabledelegations", "microsoft.network/locations/availableprivateendpointtypes",
+      "microsoft.network/locations/availableservicealiases", "microsoft.network/locations/baremetaltenants",
+      "microsoft.network/locations/checkacceleratednetworkingsupport", "microsoft.network/locations/checkdnsnameavailability",
+      "microsoft.network/locations/checkprivatelinkservicevisibility", "microsoft.network/locations/effectiveresourceownership",
+      "microsoft.network/locations/nfvoperationresults", "microsoft.network/locations/nfvoperations",
+      "microsoft.network/locations/operationresults", "microsoft.network/locations/operations",
+      "microsoft.network/locations/servicetags", "microsoft.network/locations/setresourceownership",
+      "microsoft.network/locations/supportedvirtualmachinesizes", "microsoft.network/locations/usages",
+      "microsoft.network/locations/validateresourceownership", "microsoft.network/locations/virtualnetworkavailableendpointservices",
+      "microsoft.network/natgateways", "microsoft.network/networkexperimentprofiles",
+      "microsoft.network/networkintentpolicies", "microsoft.network/networkinterfaces",
+      "microsoft.network/networkinterfaces/tapconfigurations", "microsoft.network/networkprofiles",
+      "microsoft.network/networksecuritygroups", "microsoft.network/networksecuritygroups/securityrules",
+      "microsoft.network/networkwatchers", "microsoft.network/networkwatchers/connectionmonitors",
+      "microsoft.network/networkwatchers/flowlogs", "microsoft.network/networkwatchers/lenses",
+      "microsoft.network/networkwatchers/packetcaptures", "microsoft.network/networkwatchers/pingmeshes",
+      "microsoft.network/operations", "microsoft.network/p2svpngateways", "microsoft.network/privatednsoperationresults",
+      "microsoft.network/privatednsoperationstatuses", "microsoft.network/privatednszones",
+      "microsoft.network/privatednszones/a", "microsoft.network/privatednszones/aaaa",
+      "microsoft.network/privatednszones/all", "microsoft.network/privatednszones/cname",
+      "microsoft.network/privatednszones/mx", "microsoft.network/privatednszones/ptr",
+      "microsoft.network/privatednszones/soa", "microsoft.network/privatednszones/srv",
+      "microsoft.network/privatednszones/txt", "microsoft.network/privatednszones/virtualnetworklinks",
+      "microsoft.network/privateendpointredirectmaps", "microsoft.network/privateendpoints",
+      "microsoft.network/privatelinkservices", "microsoft.network/privatelinkservices/privateendpointconnections",
+      "microsoft.network/publicipaddresses", "microsoft.network/publicipprefixes",
+      "microsoft.network/routefilters", "microsoft.network/routefilters/routefilterrules",
+      "microsoft.network/routetables", "microsoft.network/routetables/routes", "microsoft.network/serviceendpointpolicies",
+      "microsoft.network/serviceendpointpolicies/serviceendpointpolicydefinitions",
+      "microsoft.network/trafficmanagergeographichierarchies", "microsoft.network/trafficmanagerprofiles",
+      "microsoft.network/trafficmanagerprofiles/heatmaps", "microsoft.network/trafficmanagerusermetricskeys",
+      "microsoft.network/virtualhubs", "microsoft.network/virtualhubs/routetables",
+      "microsoft.network/virtualnetworkgateways", "microsoft.network/virtualnetworks",
+      "microsoft.network/virtualnetworks/subnets", "microsoft.network/virtualnetworks/taggedtrafficconsumers",
+      "microsoft.network/virtualnetworks/virtualnetworkpeerings", "microsoft.network/virtualnetworktaps",
+      "microsoft.network/virtualrouters", "microsoft.network/virtualrouters/peerings",
+      "microsoft.network/virtualwans", "microsoft.network/virtualwans/p2svpnserverconfigurations",
+      "microsoft.network/vpngateways", "microsoft.network/vpngateways/vpnconnections",
+      "microsoft.network/vpnserverconfigurations", "microsoft.network/vpnsites", "microsoft.network/webapplicationfirewallpolicies",
+      "microsoft.operationalinsights/clusters", "microsoft.operationalinsights/devices",
+      "microsoft.operationalinsights/linktargets", "microsoft.operationalinsights/operations",
+      "microsoft.operationalinsights/storageinsightconfigs", "microsoft.operationalinsights/workspaces",
+      "microsoft.operationalinsights/workspaces/datasources", "microsoft.operationalinsights/workspaces/linkedservices",
+      "microsoft.operationalinsights/workspaces/query", "microsoft.operationalinsights/workspaces/savedsearches",
+      "microsoft.operationalinsights/workspaces/storageinsightconfigs", "microsoft.operationalinsights/workspaces/views",
+      "microsoft.recoveryservices/backupprotecteditems", "microsoft.recoveryservices/locations",
+      "microsoft.recoveryservices/locations/allocatedstamp", "microsoft.recoveryservices/locations/allocatestamp",
+      "microsoft.recoveryservices/locations/backupaadproperties", "microsoft.recoveryservices/locations/backupcrossregionrestore",
+      "microsoft.recoveryservices/locations/backupcrrjob", "microsoft.recoveryservices/locations/backupcrrjobs",
+      "microsoft.recoveryservices/locations/backupcrroperationresults", "microsoft.recoveryservices/locations/backupcrroperationsstatus",
+      "microsoft.recoveryservices/locations/backupprevalidateprotection", "microsoft.recoveryservices/locations/backupstatus",
+      "microsoft.recoveryservices/locations/backupvalidatefeatures", "microsoft.recoveryservices/locations/checknameavailability",
+      "microsoft.recoveryservices/operations", "microsoft.recoveryservices/replicationeligibilityresults",
+      "microsoft.recoveryservices/vaults", "microsoft.recoveryservices/vaults/backupfabrics/backupprotectionintent",
+      "microsoft.recoveryservices/vaults/backupfabrics/protectioncontainers", "microsoft.recoveryservices/vaults/backupfabrics/protectioncontainers/protecteditems",
+      "microsoft.recoveryservices/vaults/backuppolicies", "microsoft.recoveryservices/vaults/backupstorageconfig",
+      "microsoft.recoveryservices/vaults/extendedinformation", "microsoft.recoveryservices/vaults/replicationalertsettings",
+      "microsoft.recoveryservices/vaults/replicationfabrics", "microsoft.recoveryservices/vaults/replicationfabrics/replicationnetworks/replicationnetworkmappings",
+      "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationmigrationitems",
+      "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationprotecteditems",
+      "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationprotectioncontainermappings",
+      "microsoft.recoveryservices/vaults/replicationfabrics/replicationstorageclassifications/replicationstorageclassificationmappings",
+      "microsoft.recoveryservices/vaults/replicationfabrics/replicationvcenters",
+      "microsoft.recoveryservices/vaults/replicationrecoveryplans", "microsoft.recoveryservices/vaults/replicationvaultsettings",
+      "microsoft.security/adaptivenetworkhardenings", "microsoft.security/advancedthreatprotectionsettings",
+      "microsoft.security/alerts", "microsoft.security/allowedconnections", "microsoft.security/applicationwhitelistings",
+      "microsoft.security/assessmentmetadata", "microsoft.security/assessments", "microsoft.security/autodismissalertsrules",
+      "microsoft.security/automations", "microsoft.security/autoprovisioningsettings",
+      "microsoft.security/complianceresults", "microsoft.security/compliances", "microsoft.security/datacollectionagents",
+      "microsoft.security/datacollectionresults", "microsoft.security/devicesecuritygroups",
+      "microsoft.security/discoveredsecuritysolutions", "microsoft.security/externalsecuritysolutions",
+      "microsoft.security/informationprotectionpolicies", "microsoft.security/iotsecuritysolutions",
+      "microsoft.security/iotsecuritysolutions/analyticsmodels", "microsoft.security/iotsecuritysolutions/analyticsmodels/aggregatedalerts",
+      "microsoft.security/iotsecuritysolutions/analyticsmodels/aggregatedrecommendations",
+      "microsoft.security/jitnetworkaccesspolicies", "microsoft.security/locations",
+      "microsoft.security/locations/alerts", "microsoft.security/locations/allowedconnections",
+      "microsoft.security/locations/applicationwhitelistings", "microsoft.security/locations/discoveredsecuritysolutions",
+      "microsoft.security/locations/externalsecuritysolutions", "microsoft.security/locations/jitnetworkaccesspolicies",
+      "microsoft.security/locations/securitysolutions", "microsoft.security/locations/securitysolutionsreferencedata",
+      "microsoft.security/locations/tasks", "microsoft.security/locations/topologies",
+      "microsoft.security/networkdata", "microsoft.security/operations", "microsoft.security/policies",
+      "microsoft.security/pricings", "microsoft.security/regulatorycompliancestandards",
+      "microsoft.security/regulatorycompliancestandards/regulatorycompliancecontrols",
+      "microsoft.security/regulatorycompliancestandards/regulatorycompliancecontrols/regulatorycomplianceassessments",
+      "microsoft.security/securitycontacts", "microsoft.security/securitysolutions",
+      "microsoft.security/securitysolutionsreferencedata", "microsoft.security/securitystatuses",
+      "microsoft.security/securitystatusessummaries", "microsoft.security/servervulnerabilityassessments",
+      "microsoft.security/settings", "microsoft.security/subassessments", "microsoft.security/tasks",
+      "microsoft.security/topologies", "microsoft.security/workspacesettings", "microsoft.servicebus/checknameavailability",
+      "microsoft.servicebus/checknamespaceavailability", "microsoft.servicebus/locations",
+      "microsoft.servicebus/locations/deletevirtualnetworkorsubnets", "microsoft.servicebus/namespaces",
+      "microsoft.servicebus/namespaces/authorizationrules", "microsoft.servicebus/namespaces/disasterrecoveryconfigs",
+      "microsoft.servicebus/namespaces/disasterrecoveryconfigs/checknameavailability",
+      "microsoft.servicebus/namespaces/eventgridfilters", "microsoft.servicebus/namespaces/ipfilterrules",
+      "microsoft.servicebus/namespaces/messagingplan", "microsoft.servicebus/namespaces/migrationconfigurations",
+      "microsoft.servicebus/namespaces/networkrulesets", "microsoft.servicebus/namespaces/queues",
+      "microsoft.servicebus/namespaces/queues/authorizationrules", "microsoft.servicebus/namespaces/topics",
+      "microsoft.servicebus/namespaces/topics/authorizationrules", "microsoft.servicebus/namespaces/topics/subscriptions",
+      "microsoft.servicebus/namespaces/topics/subscriptions/rules", "microsoft.servicebus/namespaces/virtualnetworkrules",
+      "microsoft.servicebus/operations", "microsoft.servicebus/premiummessagingregions",
+      "microsoft.servicebus/sku", "microsoft.solutions/applicationdefinitions", "microsoft.solutions/applications",
+      "microsoft.solutions/jitrequests", "microsoft.solutions/locations", "microsoft.solutions/locations/operationstatuses",
+      "microsoft.solutions/operations", "microsoft.sql/checknameavailability", "microsoft.sql/instancepools",
+      "microsoft.sql/locations", "microsoft.sql/locations/administratorazureasyncoperation",
+      "microsoft.sql/locations/administratoroperationresults", "microsoft.sql/locations/auditingsettingsazureasyncoperation",
+      "microsoft.sql/locations/auditingsettingsoperationresults", "microsoft.sql/locations/capabilities",
+      "microsoft.sql/locations/databaseazureasyncoperation", "microsoft.sql/locations/databaseoperationresults",
+      "microsoft.sql/locations/databaserestoreazureasyncoperation", "microsoft.sql/locations/deletedserverasyncoperation",
+      "microsoft.sql/locations/deletedserveroperationresults", "microsoft.sql/locations/deletedservers",
+      "microsoft.sql/locations/deletevirtualnetworkorsubnets", "microsoft.sql/locations/deletevirtualnetworkorsubnetsazureasyncoperation",
+      "microsoft.sql/locations/deletevirtualnetworkorsubnetsoperationresults", "microsoft.sql/locations/dnsaliasasyncoperation",
+      "microsoft.sql/locations/dnsaliasoperationresults", "microsoft.sql/locations/elasticpoolazureasyncoperation",
+      "microsoft.sql/locations/elasticpooloperationresults", "microsoft.sql/locations/encryptionprotectorazureasyncoperation",
+      "microsoft.sql/locations/encryptionprotectoroperationresults", "microsoft.sql/locations/extendedauditingsettingsazureasyncoperation",
+      "microsoft.sql/locations/extendedauditingsettingsoperationresults", "microsoft.sql/locations/failovergroupazureasyncoperation",
+      "microsoft.sql/locations/failovergroupoperationresults", "microsoft.sql/locations/firewallrulesazureasyncoperation",
+      "microsoft.sql/locations/firewallrulesoperationresults", "microsoft.sql/locations/instancefailovergroupazureasyncoperation",
+      "microsoft.sql/locations/instancefailovergroupoperationresults", "microsoft.sql/locations/instancefailovergroups",
+      "microsoft.sql/locations/instancepoolazureasyncoperation", "microsoft.sql/locations/instancepooloperationresults",
+      "microsoft.sql/locations/interfaceendpointprofileazureasyncoperation", "microsoft.sql/locations/interfaceendpointprofileoperationresults",
+      "microsoft.sql/locations/jobagentazureasyncoperation", "microsoft.sql/locations/jobagentoperationresults",
+      "microsoft.sql/locations/longtermretentionbackupazureasyncoperation", "microsoft.sql/locations/longtermretentionbackupoperationresults",
+      "microsoft.sql/locations/longtermretentionbackups", "microsoft.sql/locations/longtermretentionpolicyazureasyncoperation",
+      "microsoft.sql/locations/longtermretentionpolicyoperationresults", "microsoft.sql/locations/longtermretentionservers",
+      "microsoft.sql/locations/manageddatabaseazureasyncoperation", "microsoft.sql/locations/manageddatabasecompleterestoreazureasyncoperation",
+      "microsoft.sql/locations/manageddatabasecompleterestoreoperationresults", "microsoft.sql/locations/manageddatabaseoperationresults",
+      "microsoft.sql/locations/manageddatabaserestoreazureasyncoperation", "microsoft.sql/locations/manageddatabaserestoreoperationresults",
+      "microsoft.sql/locations/managedinstanceazureasyncoperation", "microsoft.sql/locations/managedinstanceencryptionprotectorazureasyncoperation",
+      "microsoft.sql/locations/managedinstanceencryptionprotectoroperationresults",
+      "microsoft.sql/locations/managedinstancekeyazureasyncoperation", "microsoft.sql/locations/managedinstancekeyoperationresults",
+      "microsoft.sql/locations/managedinstanceoperationresults", "microsoft.sql/locations/managedinstancetdecertazureasyncoperation",
+      "microsoft.sql/locations/managedinstancetdecertoperationresults", "microsoft.sql/locations/managedserversecurityalertpoliciesazureasyncoperation",
+      "microsoft.sql/locations/managedserversecurityalertpoliciesoperationresults",
+      "microsoft.sql/locations/managedshorttermretentionpolicyazureasyncoperation",
+      "microsoft.sql/locations/managedshorttermretentionpolicyoperationresults", "microsoft.sql/locations/privateendpointconnectionazureasyncoperation",
+      "microsoft.sql/locations/privateendpointconnectionoperationresults", "microsoft.sql/locations/privateendpointconnectionproxyazureasyncoperation",
+      "microsoft.sql/locations/privateendpointconnectionproxyoperationresults", "microsoft.sql/locations/securityalertpoliciesazureasyncoperation",
+      "microsoft.sql/locations/securityalertpoliciesoperationresults", "microsoft.sql/locations/serveradministratorazureasyncoperation",
+      "microsoft.sql/locations/serveradministratoroperationresults", "microsoft.sql/locations/serverazureasyncoperation",
+      "microsoft.sql/locations/serverkeyazureasyncoperation", "microsoft.sql/locations/serverkeyoperationresults",
+      "microsoft.sql/locations/serveroperationresults", "microsoft.sql/locations/shorttermretentionpolicyazureasyncoperation",
+      "microsoft.sql/locations/shorttermretentionpolicyoperationresults", "microsoft.sql/locations/syncagentoperationresults",
+      "microsoft.sql/locations/syncdatabaseids", "microsoft.sql/locations/syncgroupoperationresults",
+      "microsoft.sql/locations/syncmemberoperationresults", "microsoft.sql/locations/tdecertazureasyncoperation",
+      "microsoft.sql/locations/tdecertoperationresults", "microsoft.sql/locations/usages",
+      "microsoft.sql/locations/virtualclusterazureasyncoperation", "microsoft.sql/locations/virtualclusteroperationresults",
+      "microsoft.sql/locations/virtualnetworkrulesazureasyncoperation", "microsoft.sql/locations/virtualnetworkrulesoperationresults",
+      "microsoft.sql/locations/vulnerabilityassessmentscanazureasyncoperation", "microsoft.sql/locations/vulnerabilityassessmentscanoperationresults",
+      "microsoft.sql/managedinstances", "microsoft.sql/managedinstances/administrators",
+      "microsoft.sql/managedinstances/databases", "microsoft.sql/managedinstances/databases/backupshorttermretentionpolicies",
+      "microsoft.sql/managedinstances/databases/schemas/tables/columns/sensitivitylabels",
+      "microsoft.sql/managedinstances/databases/securityalertpolicies", "microsoft.sql/managedinstances/databases/vulnerabilityassessments",
+      "microsoft.sql/managedinstances/databases/vulnerabilityassessments/rules/baselines",
+      "microsoft.sql/managedinstances/encryptionprotector", "microsoft.sql/managedinstances/keys",
+      "microsoft.sql/managedinstances/metricdefinitions", "microsoft.sql/managedinstances/metrics",
+      "microsoft.sql/managedinstances/recoverabledatabases", "microsoft.sql/managedinstances/restorabledroppeddatabases/backupshorttermretentionpolicies",
+      "microsoft.sql/managedinstances/securityalertpolicies", "microsoft.sql/managedinstances/tdecertificates",
+      "microsoft.sql/managedinstances/vulnerabilityassessments", "microsoft.sql/operations",
+      "microsoft.sql/servers", "microsoft.sql/servers/administratoroperationresults",
+      "microsoft.sql/servers/administrators", "microsoft.sql/servers/advisors", "microsoft.sql/servers/aggregateddatabasemetrics",
+      "microsoft.sql/servers/auditingpolicies", "microsoft.sql/servers/auditingsettings",
+      "microsoft.sql/servers/automatictuning", "microsoft.sql/servers/backuplongtermretentionvaults",
+      "microsoft.sql/servers/communicationlinks", "microsoft.sql/servers/connectionpolicies",
+      "microsoft.sql/servers/databases", "microsoft.sql/servers/databases/activate",
+      "microsoft.sql/servers/databases/activatedatabase", "microsoft.sql/servers/databases/advisors",
+      "microsoft.sql/servers/databases/auditingpolicies", "microsoft.sql/servers/databases/auditingsettings",
+      "microsoft.sql/servers/databases/auditrecords", "microsoft.sql/servers/databases/automatictuning",
+      "microsoft.sql/servers/databases/backuplongtermretentionpolicies", "microsoft.sql/servers/databases/backupshorttermretentionpolicies",
+      "microsoft.sql/servers/databases/connectionpolicies", "microsoft.sql/servers/databases/databasestate",
+      "microsoft.sql/servers/databases/datamaskingpolicies", "microsoft.sql/servers/databases/datamaskingpolicies/rules",
+      "microsoft.sql/servers/databases/deactivate", "microsoft.sql/servers/databases/deactivatedatabase",
+      "microsoft.sql/servers/databases/extendedauditingsettings", "microsoft.sql/servers/databases/extensions",
+      "microsoft.sql/servers/databases/geobackuppolicies", "microsoft.sql/servers/databases/metricdefinitions",
+      "microsoft.sql/servers/databases/metrics", "microsoft.sql/servers/databases/recommendedsensitivitylabels",
+      "microsoft.sql/servers/databases/schemas/tables/columns/sensitivitylabels",
+      "microsoft.sql/servers/databases/securityalertpolicies", "microsoft.sql/servers/databases/syncgroups",
+      "microsoft.sql/servers/databases/syncgroups/syncmembers", "microsoft.sql/servers/databases/topqueries",
+      "microsoft.sql/servers/databases/topqueries/querytext", "microsoft.sql/servers/databases/transparentdataencryption",
+      "microsoft.sql/servers/databases/vulnerabilityassessment", "microsoft.sql/servers/databases/vulnerabilityassessments",
+      "microsoft.sql/servers/databases/vulnerabilityassessments/rules/baselines",
+      "microsoft.sql/servers/databases/vulnerabilityassessmentscans", "microsoft.sql/servers/databases/vulnerabilityassessmentsettings",
+      "microsoft.sql/servers/databases/workloadgroups", "microsoft.sql/servers/databasesecuritypolicies",
+      "microsoft.sql/servers/disasterrecoveryconfiguration", "microsoft.sql/servers/dnsaliases",
+      "microsoft.sql/servers/elasticpoolestimates", "microsoft.sql/servers/elasticpools",
+      "microsoft.sql/servers/elasticpools/advisors", "microsoft.sql/servers/elasticpools/metricdefinitions",
+      "microsoft.sql/servers/elasticpools/metrics", "microsoft.sql/servers/encryptionprotector",
+      "microsoft.sql/servers/extendedauditingsettings", "microsoft.sql/servers/failovergroups",
+      "microsoft.sql/servers/firewallrules", "microsoft.sql/servers/import", "microsoft.sql/servers/importexportoperationresults",
+      "microsoft.sql/servers/interfaceendpointprofiles", "microsoft.sql/servers/jobaccounts",
+      "microsoft.sql/servers/jobagents", "microsoft.sql/servers/jobagents/jobs", "microsoft.sql/servers/jobagents/jobs/executions",
+      "microsoft.sql/servers/jobagents/jobs/steps", "microsoft.sql/servers/keys",
+      "microsoft.sql/servers/operationresults", "microsoft.sql/servers/recommendedelasticpools",
+      "microsoft.sql/servers/recoverabledatabases", "microsoft.sql/servers/restorabledroppeddatabases",
+      "microsoft.sql/servers/securityalertpolicies", "microsoft.sql/servers/serviceobjectives",
+      "microsoft.sql/servers/syncagents", "microsoft.sql/servers/tdecertificates",
+      "microsoft.sql/servers/usages", "microsoft.sql/servers/virtualnetworkrules",
+      "microsoft.sql/servers/vulnerabilityassessments", "microsoft.sql/virtualclusters",
+      "microsoft.storage/checknameavailability", "microsoft.storage/locations", "microsoft.storage/locations/asyncoperations",
+      "microsoft.storage/locations/checknameavailability", "microsoft.storage/locations/deletevirtualnetworkorsubnets",
+      "microsoft.storage/locations/usages", "microsoft.storage/operations", "microsoft.storage/storageaccounts",
+      "microsoft.storage/storageaccounts/blobservices", "microsoft.storage/storageaccounts/fileservices",
+      "microsoft.storage/storageaccounts/fileservices/shares", "microsoft.storage/storageaccounts/listaccountsas",
+      "microsoft.storage/storageaccounts/listservicesas", "microsoft.storage/storageaccounts/managementpolicies",
+      "microsoft.storage/storageaccounts/queueservices", "microsoft.storage/storageaccounts/services",
+      "microsoft.storage/storageaccounts/services/metricdefinitions", "microsoft.storage/storageaccounts/tableservices",
+      "microsoft.storage/usages", "microsoft.web/apimanagementaccounts", "microsoft.web/apimanagementaccounts/apiacls",
+      "microsoft.web/apimanagementaccounts/apis", "microsoft.web/apimanagementaccounts/apis/apiacls",
+      "microsoft.web/apimanagementaccounts/apis/connectionacls", "microsoft.web/apimanagementaccounts/apis/connections",
+      "microsoft.web/apimanagementaccounts/apis/connections/connectionacls", "microsoft.web/apimanagementaccounts/apis/localizeddefinitions",
+      "microsoft.web/apimanagementaccounts/connectionacls", "microsoft.web/apimanagementaccounts/connections",
+      "microsoft.web/availablestacks", "microsoft.web/billingmeters", "microsoft.web/certificates",
+      "microsoft.web/checknameavailability", "microsoft.web/connectiongateways", "microsoft.web/connections",
+      "microsoft.web/customapis", "microsoft.web/deletedsites", "microsoft.web/deploymentlocations",
+      "microsoft.web/functions", "microsoft.web/georegions", "microsoft.web/hostingenvironments",
+      "microsoft.web/hostingenvironments/eventgridfilters", "microsoft.web/hostingenvironments/metricdefinitions",
+      "microsoft.web/hostingenvironments/metrics", "microsoft.web/hostingenvironments/multirolepools",
+      "microsoft.web/hostingenvironments/multirolepools/instances", "microsoft.web/hostingenvironments/multirolepools/instances/metricdefinitions",
+      "microsoft.web/hostingenvironments/multirolepools/instances/metrics", "microsoft.web/hostingenvironments/multirolepools/metricdefinitions",
+      "microsoft.web/hostingenvironments/multirolepools/metrics", "microsoft.web/hostingenvironments/workerpools",
+      "microsoft.web/hostingenvironments/workerpools/instances", "microsoft.web/hostingenvironments/workerpools/instances/metricdefinitions",
+      "microsoft.web/hostingenvironments/workerpools/instances/metrics", "microsoft.web/hostingenvironments/workerpools/metricdefinitions",
+      "microsoft.web/hostingenvironments/workerpools/metrics", "microsoft.web/ishostingenvironmentnameavailable",
+      "microsoft.web/ishostnameavailable", "microsoft.web/isusernameavailable", "microsoft.web/listsitesassignedtohostname",
+      "microsoft.web/locations", "microsoft.web/locations/apioperations", "microsoft.web/locations/connectiongatewayinstallations",
+      "microsoft.web/locations/deletedsites", "microsoft.web/locations/deletevirtualnetworkorsubnets",
+      "microsoft.web/locations/extractapidefinitionfromwsdl", "microsoft.web/locations/getnetworkpolicies",
+      "microsoft.web/locations/listwsdlinterfaces", "microsoft.web/locations/managedapis",
+      "microsoft.web/locations/operationresults", "microsoft.web/locations/operations",
+      "microsoft.web/locations/runtimes", "microsoft.web/operations", "microsoft.web/publishingusers",
+      "microsoft.web/recommendations", "microsoft.web/resourcehealthmetadata", "microsoft.web/runtimes",
+      "microsoft.web/serverfarms", "microsoft.web/serverfarms/eventgridfilters", "microsoft.web/serverfarms/metricdefinitions",
+      "microsoft.web/serverfarms/metrics", "microsoft.web/serverfarms/virtualnetworkconnections/gateways",
+      "microsoft.web/serverfarms/virtualnetworkconnections/routes", "microsoft.web/serverfarms/workers",
+      "microsoft.web/sites", "microsoft.web/sites/config", "microsoft.web/sites/domainownershipidentifiers",
+      "microsoft.web/sites/eventgridfilters", "microsoft.web/sites/extensions", "microsoft.web/sites/hostnamebindings",
+      "microsoft.web/sites/hybridconnection", "microsoft.web/sites/hybridconnectionnamespaces/relays",
+      "microsoft.web/sites/instances", "microsoft.web/sites/metricdefinitions", "microsoft.web/sites/metrics",
+      "microsoft.web/sites/networkconfig", "microsoft.web/sites/premieraddons", "microsoft.web/sites/privateaccess",
+      "microsoft.web/sites/publiccertificates", "microsoft.web/sites/recommendations",
+      "microsoft.web/sites/resourcehealthmetadata", "microsoft.web/sites/slots", "microsoft.web/sites/slots/config",
+      "microsoft.web/sites/slots/domainownershipidentifiers", "microsoft.web/sites/slots/eventgridfilters",
+      "microsoft.web/sites/slots/extensions", "microsoft.web/sites/slots/hostnamebindings",
+      "microsoft.web/sites/slots/hybridconnection", "microsoft.web/sites/slots/hybridconnectionnamespaces/relays",
+      "microsoft.web/sites/slots/instances", "microsoft.web/sites/slots/metricdefinitions",
+      "microsoft.web/sites/slots/metrics", "microsoft.web/sites/slots/networkconfig",
+      "microsoft.web/sites/slots/premieraddons", "microsoft.web/sites/slots/publiccertificates",
+      "microsoft.web/sites/slots/sourcecontrols", "microsoft.web/sites/slots/virtualnetworkconnections",
+      "microsoft.web/sites/slots/virtualnetworkconnections/gateways", "microsoft.web/sites/sourcecontrols",
+      "microsoft.web/sites/virtualnetworkconnections", "microsoft.web/sites/virtualnetworkconnections/gateways",
+      "microsoft.web/sourcecontrols", "microsoft.web/validate", "microsoft.web/verifyhostingenvironmentvnet"]}}},
+      {"policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+      Regions", "policyDefinitionReferenceId": "Allowed Regions", "parameters": {"listOfAllowedLocations":
+      {"value": ["eastus", "southcentralus", "westus"]}}}, {"policyDefinitionId":
+      "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+      VM SKUs", "policyDefinitionReferenceId": "Allowed VM SKUs", "parameters": {"listOfAllowedSKUs":
+      {"value": ["standard_a1_v2", "standard_a2_v2", "standard_a2m_v2", "standard_a4_v2",
+      "standard_a4m_v2", "standard_a8m_v2", "standard_a8_v2", "standard_b12ms", "standard_b16ms",
+      "standard_b1ls", "standard_b1ms", "standard_b1s", "standard_b20ms", "standard_b2ms",
+      "standard_b2s", "standard_b4ms", "standard_b8ms", "standard_d16_v3", "standard_d16s_v3",
+      "standard_d2_v3", "standard_d2s_v3", "standard_d32_v3", "standard_d32s_v3",
+      "standard_d4_v3", "standard_d48_v3", "standard_d48s_v3", "standard_d4s_v3",
+      "standard_d64_v3", "standard_d64s_v3", "standard_d8_v3", "standard_d8s_v3",
+      "standard_e16_v3", "standard_e16-4s_v3", "standard_e16-8s_v3", "standard_e16s_v3",
+      "standard_e2_v3", "standard_e20_v3", "standard_e20s_v3", "standard_e2s_v3",
+      "standard_e32_v3", "standard_e32-16s_v3", "standard_e32-8s_v3", "standard_e4_v3",
+      "standard_e32s_v3", "standard_e4-2s_v3", "standard_e48_v3", "standard_e48s_v3",
+      "standard_e4s_v3", "standard_e64_v3", "standard_e64-16s_v3", "standard_e64-32s_v3",
+      "standard_e64i_v3", "standard_e64is_v3", "standard_e64s_v3", "standard_e8_v3",
+      "standard_e8-2s_v3", "standard_e8-4s_v3", "standard_e8s_v3", "standard_f16s_v2",
+      "standard_f2s_v2", "standard_f32s_v2", "standard_f48s_v2", "standard_f4s_v2",
+      "standard_f64s_v2", "standard_f72s_v2", "standard_f8s_v2", "standard_m128",
+      "standard_m128-32ms", "standard_m128-64ms", "standard_m128m", "standard_m128ms",
+      "standard_m128s", "standard_m16-4ms", "standard_m16-8ms", "standard_m16ms",
+      "standard_m32-16ms", "standard_m32-8ms", "standard_m32ls", "standard_m32ms",
+      "standard_m32ts", "standard_m64", "standard_m64-16ms", "standard_m64-32ms",
+      "standard_m64ls", "standard_m64m", "standard_m64ms", "standard_m64s", "standard_m8-2ms",
+      "standard_m8-4ms", "standard_m8ms", "standard_nc12s_v3", "standard_nc24rs_v3",
+      "standard_nc24s_v3", "standard_nc6s_v3", "standard_l16s_v2", "standard_l32s_v2",
+      "standard_l48s_v2", "standard_l64s_v2", "standard_l80s_v2", "standard_l8s_v2",
+      "standard_dc2s", "standard_dc4s", "standard_nv12s_v3", "standard_nv24s_v3",
+      "standard_nv48s_v3", "standard_hb120rs_v2", "standard_m208ms_v2", "standard_m208s_v2",
+      "standard_m416ms_v2", "standard_m416s_v2"]}}}], "policyType": "Custom"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '52743'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policySetDefinitions/Default%20JEDI%20Policy%20Set?api-version=2019-09-01
+  response:
+    body:
+      string: '{"properties": {"displayName": "Default JEDI Policy Set", "policyType":
+        "Custom", "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.608718Z",
+        "updatedBy": null, "updatedOn": null}, "policyDefinitions": [{"policyDefinitionReferenceId":
+        "Allowed resource types", "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        resource types", "parameters": {"listOfResourceTypesAllowed": {"value": ["microsoft.apimanagement/checkfeedbackrequired",
+        "microsoft.apimanagement/checknameavailability", "microsoft.apimanagement/checkservicenameavailability",
+        "microsoft.apimanagement/operations", "microsoft.apimanagement/reportfeedback",
+        "microsoft.apimanagement/service", "microsoft.apimanagement/service/apis",
+        "microsoft.apimanagement/service/apis/diagnostics", "microsoft.apimanagement/service/apis/issues",
+        "microsoft.apimanagement/service/apis/issues/attachments", "microsoft.apimanagement/service/apis/issues/comments",
+        "microsoft.apimanagement/service/apis/operations", "microsoft.apimanagement/service/apis/operations/policies",
+        "microsoft.apimanagement/service/apis/operations/tags", "microsoft.apimanagement/service/apis/policies",
+        "microsoft.apimanagement/service/apis/releases", "microsoft.apimanagement/service/apis/schemas",
+        "microsoft.apimanagement/service/apis/tagdescriptions", "microsoft.apimanagement/service/apis/tags",
+        "microsoft.apimanagement/service/apiversionsets", "microsoft.apimanagement/service/authorizationservers",
+        "microsoft.apimanagement/service/backends", "microsoft.apimanagement/service/caches",
+        "microsoft.apimanagement/service/diagnostics", "microsoft.apimanagement/service/groups",
+        "microsoft.apimanagement/service/identityproviders", "microsoft.apimanagement/service/loggers",
+        "microsoft.apimanagement/service/notifications", "microsoft.apimanagement/service/openidconnectproviders",
+        "microsoft.apimanagement/service/policies", "microsoft.apimanagement/service/portalsettings",
+        "microsoft.apimanagement/service/products", "microsoft.apimanagement/service/products/policies",
+        "microsoft.apimanagement/service/products/tags", "microsoft.apimanagement/service/properties",
+        "microsoft.apimanagement/service/subscriptions", "microsoft.apimanagement/service/tags",
+        "microsoft.apimanagement/service/templates", "microsoft.apimanagement/service/users",
+        "microsoft.apimanagement/validateservicename", "microsoft.authorization/checkaccess",
+        "microsoft.authorization/classicadministrators", "microsoft.authorization/dataaliases",
+        "microsoft.authorization/denyassignments", "microsoft.authorization/elevateaccess",
+        "microsoft.authorization/findorphanroleassignments", "microsoft.authorization/locks",
+        "microsoft.authorization/operations", "microsoft.authorization/permissions",
+        "microsoft.authorization/policyassignments", "microsoft.authorization/policydefinitions",
+        "microsoft.authorization/policysetdefinitions", "microsoft.authorization/provideroperations",
+        "microsoft.authorization/roleassignments", "microsoft.authorization/roleassignmentsusagemetrics",
+        "microsoft.authorization/roledefinitions", "microsoft.automation/automationaccounts",
+        "microsoft.automation/automationaccounts/certificates", "microsoft.automation/automationaccounts/compilationjobs",
+        "microsoft.automation/automationaccounts/configurations", "microsoft.automation/automationaccounts/connections",
+        "microsoft.automation/automationaccounts/connectiontypes", "microsoft.automation/automationaccounts/credentials",
+        "microsoft.automation/automationaccounts/jobs", "microsoft.automation/automationaccounts/jobschedules",
+        "microsoft.automation/automationaccounts/modules", "microsoft.automation/automationaccounts/nodeconfigurations",
+        "microsoft.automation/automationaccounts/python2packages", "microsoft.automation/automationaccounts/runbooks",
+        "microsoft.automation/automationaccounts/schedules", "microsoft.automation/automationaccounts/softwareupdateconfigurations",
+        "microsoft.automation/automationaccounts/variables", "microsoft.automation/automationaccounts/watchers",
+        "microsoft.automation/automationaccounts/webhooks", "microsoft.automation/operations",
+        "microsoft.batch/batchaccounts", "microsoft.batch/batchaccounts/applications",
+        "microsoft.batch/batchaccounts/applications/versions", "microsoft.batch/batchaccounts/certificates",
+        "microsoft.batch/batchaccounts/pools", "microsoft.batch/locations", "microsoft.batch/locations/accountoperationresults",
+        "microsoft.batch/locations/checknameavailability", "microsoft.batch/locations/quotas",
+        "microsoft.batch/operations", "microsoft.cache/checknameavailability", "microsoft.cache/locations",
+        "microsoft.cache/locations/operationresults", "microsoft.cache/operations",
+        "microsoft.cache/redis", "microsoft.cache/redis/firewallrules", "microsoft.cache/redis/linkedservers",
+        "microsoft.cache/redis/patchschedules", "microsoft.cache/redisconfigdefinition",
+        "microsoft.cdn/cdnwebapplicationfirewallmanagedrulesets", "microsoft.cdn/cdnwebapplicationfirewallpolicies",
+        "microsoft.cdn/checknameavailability", "microsoft.cdn/checkresourceusage",
+        "microsoft.cdn/edgenodes", "microsoft.cdn/operationresults", "microsoft.cdn/operationresults/profileresults",
+        "microsoft.cdn/operationresults/profileresults/endpointresults", "microsoft.cdn/operationresults/profileresults/endpointresults/customdomainresults",
+        "microsoft.cdn/operationresults/profileresults/endpointresults/originresults",
+        "microsoft.cdn/operations", "microsoft.cdn/profiles", "microsoft.cdn/profiles/endpoints",
+        "microsoft.cdn/profiles/endpoints/customdomains", "microsoft.cdn/profiles/endpoints/origins",
+        "microsoft.cdn/validateprobe", "microsoft.compute/availabilitysets", "microsoft.compute/diskencryptionsets",
+        "microsoft.compute/disks", "microsoft.compute/galleries", "microsoft.compute/galleries/applications",
+        "microsoft.compute/galleries/applications/versions", "microsoft.compute/galleries/images",
+        "microsoft.compute/galleries/images/versions", "microsoft.compute/hostgroups",
+        "microsoft.compute/hostgroups/hosts", "microsoft.compute/images", "microsoft.compute/locations",
+        "microsoft.compute/locations/artifactpublishers", "microsoft.compute/locations/capsoperations",
+        "microsoft.compute/locations/diskoperations", "microsoft.compute/locations/loganalytics",
+        "microsoft.compute/locations/operations", "microsoft.compute/locations/publishers",
+        "microsoft.compute/locations/runcommands", "microsoft.compute/locations/systeminfo",
+        "microsoft.compute/locations/usages", "microsoft.compute/locations/virtualmachines",
+        "microsoft.compute/locations/vmsizes", "microsoft.compute/locations/vsmoperations",
+        "microsoft.compute/operations", "microsoft.compute/proximityplacementgroups",
+        "microsoft.compute/restorepointcollections", "microsoft.compute/restorepointcollections/restorepoints",
+        "microsoft.compute/sharedvmimages", "microsoft.compute/sharedvmimages/versions",
+        "microsoft.compute/snapshots", "microsoft.compute/virtualmachines", "microsoft.compute/virtualmachines/extensions",
+        "microsoft.compute/virtualmachines/metricdefinitions", "microsoft.compute/virtualmachinescalesets",
+        "microsoft.compute/virtualmachinescalesets/extensions", "microsoft.compute/virtualmachinescalesets/networkinterfaces",
+        "microsoft.compute/virtualmachinescalesets/publicipaddresses", "microsoft.compute/virtualmachinescalesets/virtualmachines",
+        "microsoft.compute/virtualmachinescalesets/virtualmachines/networkinterfaces",
+        "microsoft.containerregistry/checknameavailability", "microsoft.containerregistry/locations",
+        "microsoft.containerregistry/locations/authorize", "microsoft.containerregistry/locations/deletevirtualnetworkorsubnets",
+        "microsoft.containerregistry/locations/operationresults", "microsoft.containerregistry/locations/setupauth",
+        "microsoft.containerregistry/operations", "microsoft.containerregistry/registries",
+        "microsoft.containerregistry/registries/builds", "microsoft.containerregistry/registries/builds/cancel",
+        "microsoft.containerregistry/registries/builds/getloglink", "microsoft.containerregistry/registries/buildtasks",
+        "microsoft.containerregistry/registries/buildtasks/listsourcerepositoryproperties",
+        "microsoft.containerregistry/registries/buildtasks/steps", "microsoft.containerregistry/registries/buildtasks/steps/listbuildarguments",
+        "microsoft.containerregistry/registries/eventgridfilters", "microsoft.containerregistry/registries/generatecredentials",
+        "microsoft.containerregistry/registries/getbuildsourceuploadurl", "microsoft.containerregistry/registries/getcredentials",
+        "microsoft.containerregistry/registries/importimage", "microsoft.containerregistry/registries/listbuildsourceuploadurl",
+        "microsoft.containerregistry/registries/listcredentials", "microsoft.containerregistry/registries/listpolicies",
+        "microsoft.containerregistry/registries/listusages", "microsoft.containerregistry/registries/queuebuild",
+        "microsoft.containerregistry/registries/regeneratecredential", "microsoft.containerregistry/registries/regeneratecredentials",
+        "microsoft.containerregistry/registries/replications", "microsoft.containerregistry/registries/runs",
+        "microsoft.containerregistry/registries/runs/cancel", "microsoft.containerregistry/registries/runs/listlogsasurl",
+        "microsoft.containerregistry/registries/schedulerun", "microsoft.containerregistry/registries/scopemaps",
+        "microsoft.containerregistry/registries/taskruns", "microsoft.containerregistry/registries/tasks",
+        "microsoft.containerregistry/registries/tasks/listdetails", "microsoft.containerregistry/registries/tokens",
+        "microsoft.containerregistry/registries/updatepolicies", "microsoft.containerregistry/registries/webhooks",
+        "microsoft.containerregistry/registries/webhooks/getcallbackconfig", "microsoft.containerregistry/registries/webhooks/listevents",
+        "microsoft.containerregistry/registries/webhooks/ping", "microsoft.containerregistry/swagger",
+        "microsoft.containerservice/containerservices", "microsoft.containerservice/locations",
+        "microsoft.containerservice/locations/openshiftclusters", "microsoft.containerservice/locations/operationresults",
+        "microsoft.containerservice/locations/operations", "microsoft.containerservice/locations/orchestrators",
+        "microsoft.containerservice/managedclusters", "microsoft.containerservice/managedclusters/agentpools",
+        "microsoft.containerservice/openshiftmanagedclusters", "microsoft.containerservice/operations",
+        "microsoft.costmanagement/alerts", "microsoft.costmanagement/billingaccounts",
+        "microsoft.costmanagement/budgets", "microsoft.costmanagement/cloudconnectors",
+        "microsoft.costmanagement/connectors", "microsoft.costmanagement/departments",
+        "microsoft.costmanagement/dimensions", "microsoft.costmanagement/enrollmentaccounts",
+        "microsoft.costmanagement/exports", "microsoft.costmanagement/externalbillingaccounts",
+        "microsoft.costmanagement/externalbillingaccounts/alerts", "microsoft.costmanagement/externalbillingaccounts/dimensions",
+        "microsoft.costmanagement/externalbillingaccounts/forecast", "microsoft.costmanagement/externalbillingaccounts/query",
+        "microsoft.costmanagement/externalsubscriptions", "microsoft.costmanagement/externalsubscriptions/alerts",
+        "microsoft.costmanagement/externalsubscriptions/dimensions", "microsoft.costmanagement/externalsubscriptions/forecast",
+        "microsoft.costmanagement/externalsubscriptions/query", "microsoft.costmanagement/forecast",
+        "microsoft.costmanagement/operations", "microsoft.costmanagement/query", "microsoft.costmanagement/register",
+        "microsoft.costmanagement/reportconfigs", "microsoft.costmanagement/reports",
+        "microsoft.costmanagement/settings", "microsoft.costmanagement/showbackrules",
+        "microsoft.costmanagement/views", "microsoft.databoxedge/databoxedgedevices",
+        "microsoft.databoxedge/databoxedgedevices/checknameavailability", "microsoft.databoxedge/operations",
+        "microsoft.databricks/locations", "microsoft.databricks/locations/getnetworkpolicies",
+        "microsoft.databricks/locations/operationstatuses", "microsoft.databricks/operations",
+        "microsoft.databricks/workspaces", "microsoft.databricks/workspaces/storageencryption",
+        "microsoft.databricks/workspaces/virtualnetworkpeerings", "microsoft.dbformysql/checknameavailability",
+        "microsoft.dbformysql/locations", "microsoft.dbformysql/locations/administratorazureasyncoperation",
+        "microsoft.dbformysql/locations/administratoroperationresults", "microsoft.dbformysql/locations/azureasyncoperation",
+        "microsoft.dbformysql/locations/operationresults", "microsoft.dbformysql/locations/performancetiers",
+        "microsoft.dbformysql/locations/privateendpointconnectionazureasyncoperation",
+        "microsoft.dbformysql/locations/privateendpointconnectionoperationresults",
+        "microsoft.dbformysql/locations/privateendpointconnectionproxyazureasyncoperation",
+        "microsoft.dbformysql/locations/privateendpointconnectionproxyoperationresults",
+        "microsoft.dbformysql/locations/recommendedactionsessionsazureasyncoperation",
+        "microsoft.dbformysql/locations/recommendedactionsessionsoperationresults",
+        "microsoft.dbformysql/locations/securityalertpoliciesazureasyncoperation",
+        "microsoft.dbformysql/locations/securityalertpoliciesoperationresults", "microsoft.dbformysql/locations/serverkeyazureasyncoperation",
+        "microsoft.dbformysql/locations/serverkeyoperationresults", "microsoft.dbformysql/operations",
+        "microsoft.dbformysql/servers", "microsoft.dbformysql/servers/advisors", "microsoft.dbformysql/servers/configurations",
+        "microsoft.dbformysql/servers/databases", "microsoft.dbformysql/servers/firewallrules",
+        "microsoft.dbformysql/servers/keys", "microsoft.dbformysql/servers/privateendpointconnectionproxies",
+        "microsoft.dbformysql/servers/privateendpointconnections", "microsoft.dbformysql/servers/privatelinkresources",
+        "microsoft.dbformysql/servers/querytexts", "microsoft.dbformysql/servers/recoverableservers",
+        "microsoft.dbformysql/servers/securityalertpolicies", "microsoft.dbformysql/servers/topquerystatistics",
+        "microsoft.dbformysql/servers/virtualnetworkrules", "microsoft.dbformysql/servers/waitstatistics",
+        "microsoft.dbforpostgresql/checknameavailability", "microsoft.dbforpostgresql/locations",
+        "microsoft.dbforpostgresql/locations/administratorazureasyncoperation", "microsoft.dbforpostgresql/locations/administratoroperationresults",
+        "microsoft.dbforpostgresql/locations/azureasyncoperation", "microsoft.dbforpostgresql/locations/operationresults",
+        "microsoft.dbforpostgresql/locations/performancetiers", "microsoft.dbforpostgresql/locations/privateendpointconnectionazureasyncoperation",
+        "microsoft.dbforpostgresql/locations/privateendpointconnectionoperationresults",
+        "microsoft.dbforpostgresql/locations/privateendpointconnectionproxyazureasyncoperation",
+        "microsoft.dbforpostgresql/locations/privateendpointconnectionproxyoperationresults",
+        "microsoft.dbforpostgresql/locations/recommendedactionsessionsazureasyncoperation",
+        "microsoft.dbforpostgresql/locations/recommendedactionsessionsoperationresults",
+        "microsoft.dbforpostgresql/locations/securityalertpoliciesazureasyncoperation",
+        "microsoft.dbforpostgresql/locations/securityalertpoliciesoperationresults",
+        "microsoft.dbforpostgresql/locations/serverkeyazureasyncoperation", "microsoft.dbforpostgresql/locations/serverkeyoperationresults",
+        "microsoft.dbforpostgresql/operations", "microsoft.dbforpostgresql/servergroups",
+        "microsoft.dbforpostgresql/servers", "microsoft.dbforpostgresql/servers/advisors",
+        "microsoft.dbforpostgresql/servers/configurations", "microsoft.dbforpostgresql/servers/databases",
+        "microsoft.dbforpostgresql/servers/firewallrules", "microsoft.dbforpostgresql/servers/keys",
+        "microsoft.dbforpostgresql/servers/privateendpointconnectionproxies", "microsoft.dbforpostgresql/servers/privateendpointconnections",
+        "microsoft.dbforpostgresql/servers/privatelinkresources", "microsoft.dbforpostgresql/servers/querytexts",
+        "microsoft.dbforpostgresql/servers/recoverableservers", "microsoft.dbforpostgresql/servers/securityalertpolicies",
+        "microsoft.dbforpostgresql/servers/topquerystatistics", "microsoft.dbforpostgresql/servers/virtualnetworkrules",
+        "microsoft.dbforpostgresql/servers/waitstatistics", "microsoft.dbforpostgresql/serversv2",
+        "microsoft.devices/checknameavailability", "microsoft.devices/checkprovisioningservicenameavailability",
+        "microsoft.devices/elasticpools", "microsoft.devices/elasticpools/iothubtenants",
+        "microsoft.devices/elasticpools/iothubtenants/securitysettings", "microsoft.devices/iothubs",
+        "microsoft.devices/iothubs/certificates", "microsoft.devices/iothubs/eventgridfilters",
+        "microsoft.devices/iothubs/securitysettings", "microsoft.devices/operationresults",
+        "microsoft.devices/operations", "microsoft.devices/provisioningservices",
+        "microsoft.devices/usages", "microsoft.documentdb/databaseaccountnames", "microsoft.documentdb/databaseaccounts",
+        "microsoft.documentdb/locations", "microsoft.documentdb/locations/deletevirtualnetworkorsubnets",
+        "microsoft.documentdb/locations/operationsstatus", "microsoft.documentdb/operationresults",
+        "microsoft.documentdb/operations", "microsoft.eventhub/availableclusterregions",
+        "microsoft.eventhub/checknameavailability", "microsoft.eventhub/checknamespaceavailability",
+        "microsoft.eventhub/clusters", "microsoft.eventhub/locations", "microsoft.eventhub/locations/deletevirtualnetworkorsubnets",
+        "microsoft.eventhub/namespaces", "microsoft.eventhub/namespaces/authorizationrules",
+        "microsoft.eventhub/namespaces/disasterrecoveryconfigs", "microsoft.eventhub/namespaces/disasterrecoveryconfigs/checknameavailability",
+        "microsoft.eventhub/namespaces/eventhubs", "microsoft.eventhub/namespaces/eventhubs/authorizationrules",
+        "microsoft.eventhub/namespaces/eventhubs/consumergroups", "microsoft.eventhub/namespaces/ipfilterrules",
+        "microsoft.eventhub/namespaces/networkrulesets", "microsoft.eventhub/namespaces/virtualnetworkrules",
+        "microsoft.eventhub/operations", "microsoft.eventhub/sku", "microsoft.hdinsight/clusters",
+        "microsoft.hdinsight/clusters/applications", "microsoft.hdinsight/clusters/operationresults",
+        "microsoft.hdinsight/locations", "microsoft.hdinsight/locations/azureasyncoperations",
+        "microsoft.hdinsight/locations/billingspecs", "microsoft.hdinsight/locations/capabilities",
+        "microsoft.hdinsight/locations/operationresults", "microsoft.hdinsight/locations/usages",
+        "microsoft.hdinsight/locations/validatecreaterequest", "microsoft.hdinsight/operations",
+        "microsoft.insights/accounts", "microsoft.insights/actiongroups", "microsoft.insights/activitylogalerts",
+        "microsoft.insights/alertrules", "microsoft.insights/automatedexportsettings",
+        "microsoft.insights/autoscalesettings", "microsoft.insights/baseline", "microsoft.insights/calculatebaseline",
+        "microsoft.insights/components", "microsoft.insights/components/events", "microsoft.insights/components/metrics",
+        "microsoft.insights/components/pricingplans", "microsoft.insights/components/proactivedetectionconfigs",
+        "microsoft.insights/components/query", "microsoft.insights/datacollectionruleassociations",
+        "microsoft.insights/datacollectionrules", "microsoft.insights/diagnosticsettings",
+        "microsoft.insights/diagnosticsettingscategories", "microsoft.insights/eventcategories",
+        "microsoft.insights/eventtypes", "microsoft.insights/extendeddiagnosticsettings",
+        "microsoft.insights/guestdiagnosticsettings", "microsoft.insights/guestdiagnosticsettingsassociation",
+        "microsoft.insights/listmigrationdate", "microsoft.insights/locations", "microsoft.insights/locations/operationresults",
+        "microsoft.insights/logdefinitions", "microsoft.insights/logprofiles", "microsoft.insights/logs",
+        "microsoft.insights/metricalerts", "microsoft.insights/metricbaselines", "microsoft.insights/metricbatch",
+        "microsoft.insights/metricdefinitions", "microsoft.insights/metricnamespaces",
+        "microsoft.insights/metrics", "microsoft.insights/migratealertrules", "microsoft.insights/migratetonewpricingmodel",
+        "microsoft.insights/myworkbooks", "microsoft.insights/notificationgroups",
+        "microsoft.insights/notificationrules", "microsoft.insights/notifications",
+        "microsoft.insights/operations", "microsoft.insights/queries", "microsoft.insights/rollbacktolegacypricingmodel",
+        "microsoft.insights/scheduledqueryrules", "microsoft.insights/topology", "microsoft.insights/transactions",
+        "microsoft.insights/vminsightsonboardingstatuses", "microsoft.insights/webtests",
+        "microsoft.insights/workbooks", "microsoft.insights/workbooktemplates", "microsoft.keyvault/checknameavailability",
+        "microsoft.keyvault/deletedvaults", "microsoft.keyvault/hsmpools", "microsoft.keyvault/locations",
+        "microsoft.keyvault/locations/deletedvaults", "microsoft.keyvault/locations/deletevirtualnetworkorsubnets",
+        "microsoft.keyvault/locations/operationresults", "microsoft.keyvault/operations",
+        "microsoft.keyvault/vaults", "microsoft.keyvault/vaults/accesspolicies", "microsoft.keyvault/vaults/eventgridfilters",
+        "microsoft.keyvault/vaults/secrets", "microsoft.machinelearning/commitmentplans",
+        "microsoft.machinelearning/locations", "microsoft.machinelearning/locations/operations",
+        "microsoft.machinelearning/locations/operationsstatus", "microsoft.machinelearning/operations",
+        "microsoft.machinelearning/webservices", "microsoft.machinelearning/workspaces",
+        "microsoft.network/applicationgatewayavailablerequestheaders", "microsoft.network/applicationgatewayavailableresponseheaders",
+        "microsoft.network/applicationgatewayavailableservervariables", "microsoft.network/applicationgatewayavailablessloptions",
+        "microsoft.network/applicationgatewayavailablewafrulesets", "microsoft.network/applicationgateways",
+        "microsoft.network/applicationgatewaywebapplicationfirewallpolicies", "microsoft.network/applicationsecuritygroups",
+        "microsoft.network/azurefirewallfqdntags", "microsoft.network/azurefirewalls",
+        "microsoft.network/bastionhosts", "microsoft.network/bgpservicecommunities",
+        "microsoft.network/checkfrontdoornameavailability", "microsoft.network/checktrafficmanagernameavailability",
+        "microsoft.network/connections", "microsoft.network/ddoscustompolicies", "microsoft.network/ddosprotectionplans",
+        "microsoft.network/dnsoperationresults", "microsoft.network/dnsoperationstatuses",
+        "microsoft.network/dnszones", "microsoft.network/dnszones/a", "microsoft.network/dnszones/aaaa",
+        "microsoft.network/dnszones/all", "microsoft.network/dnszones/caa", "microsoft.network/dnszones/cname",
+        "microsoft.network/dnszones/mx", "microsoft.network/dnszones/ns", "microsoft.network/dnszones/ptr",
+        "microsoft.network/dnszones/recordsets", "microsoft.network/dnszones/soa",
+        "microsoft.network/dnszones/srv", "microsoft.network/dnszones/txt", "microsoft.network/expressroutecircuits",
+        "microsoft.network/expressroutecircuits/authorizations", "microsoft.network/expressroutecircuits/peerings",
+        "microsoft.network/expressroutecircuits/peerings/connections", "microsoft.network/expressroutecrossconnections",
+        "microsoft.network/expressroutecrossconnections/peerings", "microsoft.network/expressroutegateways",
+        "microsoft.network/expressroutegateways/expressrouteconnections", "microsoft.network/expressrouteports",
+        "microsoft.network/expressrouteportslocations", "microsoft.network/expressrouteserviceproviders",
+        "microsoft.network/firewallpolicies", "microsoft.network/firewallpolicies/rulegroups",
+        "microsoft.network/frontdooroperationresults", "microsoft.network/frontdoors",
+        "microsoft.network/frontdoors/backendpools", "microsoft.network/frontdoorwebapplicationfirewallmanagedrulesets",
+        "microsoft.network/frontdoorwebapplicationfirewallpolicies", "microsoft.network/getdnsresourcereference",
+        "microsoft.network/internalnotify", "microsoft.network/ipgroups", "microsoft.network/loadbalancers",
+        "microsoft.network/loadbalancers/inboundnatrules", "microsoft.network/localnetworkgateways",
+        "microsoft.network/locations", "microsoft.network/locations/autoapprovedprivatelinkservices",
+        "microsoft.network/locations/availabledelegations", "microsoft.network/locations/availableprivateendpointtypes",
+        "microsoft.network/locations/availableservicealiases", "microsoft.network/locations/baremetaltenants",
+        "microsoft.network/locations/checkacceleratednetworkingsupport", "microsoft.network/locations/checkdnsnameavailability",
+        "microsoft.network/locations/checkprivatelinkservicevisibility", "microsoft.network/locations/effectiveresourceownership",
+        "microsoft.network/locations/nfvoperationresults", "microsoft.network/locations/nfvoperations",
+        "microsoft.network/locations/operationresults", "microsoft.network/locations/operations",
+        "microsoft.network/locations/servicetags", "microsoft.network/locations/setresourceownership",
+        "microsoft.network/locations/supportedvirtualmachinesizes", "microsoft.network/locations/usages",
+        "microsoft.network/locations/validateresourceownership", "microsoft.network/locations/virtualnetworkavailableendpointservices",
+        "microsoft.network/natgateways", "microsoft.network/networkexperimentprofiles",
+        "microsoft.network/networkintentpolicies", "microsoft.network/networkinterfaces",
+        "microsoft.network/networkinterfaces/tapconfigurations", "microsoft.network/networkprofiles",
+        "microsoft.network/networksecuritygroups", "microsoft.network/networksecuritygroups/securityrules",
+        "microsoft.network/networkwatchers", "microsoft.network/networkwatchers/connectionmonitors",
+        "microsoft.network/networkwatchers/flowlogs", "microsoft.network/networkwatchers/lenses",
+        "microsoft.network/networkwatchers/packetcaptures", "microsoft.network/networkwatchers/pingmeshes",
+        "microsoft.network/operations", "microsoft.network/p2svpngateways", "microsoft.network/privatednsoperationresults",
+        "microsoft.network/privatednsoperationstatuses", "microsoft.network/privatednszones",
+        "microsoft.network/privatednszones/a", "microsoft.network/privatednszones/aaaa",
+        "microsoft.network/privatednszones/all", "microsoft.network/privatednszones/cname",
+        "microsoft.network/privatednszones/mx", "microsoft.network/privatednszones/ptr",
+        "microsoft.network/privatednszones/soa", "microsoft.network/privatednszones/srv",
+        "microsoft.network/privatednszones/txt", "microsoft.network/privatednszones/virtualnetworklinks",
+        "microsoft.network/privateendpointredirectmaps", "microsoft.network/privateendpoints",
+        "microsoft.network/privatelinkservices", "microsoft.network/privatelinkservices/privateendpointconnections",
+        "microsoft.network/publicipaddresses", "microsoft.network/publicipprefixes",
+        "microsoft.network/routefilters", "microsoft.network/routefilters/routefilterrules",
+        "microsoft.network/routetables", "microsoft.network/routetables/routes", "microsoft.network/serviceendpointpolicies",
+        "microsoft.network/serviceendpointpolicies/serviceendpointpolicydefinitions",
+        "microsoft.network/trafficmanagergeographichierarchies", "microsoft.network/trafficmanagerprofiles",
+        "microsoft.network/trafficmanagerprofiles/heatmaps", "microsoft.network/trafficmanagerusermetricskeys",
+        "microsoft.network/virtualhubs", "microsoft.network/virtualhubs/routetables",
+        "microsoft.network/virtualnetworkgateways", "microsoft.network/virtualnetworks",
+        "microsoft.network/virtualnetworks/subnets", "microsoft.network/virtualnetworks/taggedtrafficconsumers",
+        "microsoft.network/virtualnetworks/virtualnetworkpeerings", "microsoft.network/virtualnetworktaps",
+        "microsoft.network/virtualrouters", "microsoft.network/virtualrouters/peerings",
+        "microsoft.network/virtualwans", "microsoft.network/virtualwans/p2svpnserverconfigurations",
+        "microsoft.network/vpngateways", "microsoft.network/vpngateways/vpnconnections",
+        "microsoft.network/vpnserverconfigurations", "microsoft.network/vpnsites",
+        "microsoft.network/webapplicationfirewallpolicies", "microsoft.operationalinsights/clusters",
+        "microsoft.operationalinsights/devices", "microsoft.operationalinsights/linktargets",
+        "microsoft.operationalinsights/operations", "microsoft.operationalinsights/storageinsightconfigs",
+        "microsoft.operationalinsights/workspaces", "microsoft.operationalinsights/workspaces/datasources",
+        "microsoft.operationalinsights/workspaces/linkedservices", "microsoft.operationalinsights/workspaces/query",
+        "microsoft.operationalinsights/workspaces/savedsearches", "microsoft.operationalinsights/workspaces/storageinsightconfigs",
+        "microsoft.operationalinsights/workspaces/views", "microsoft.recoveryservices/backupprotecteditems",
+        "microsoft.recoveryservices/locations", "microsoft.recoveryservices/locations/allocatedstamp",
+        "microsoft.recoveryservices/locations/allocatestamp", "microsoft.recoveryservices/locations/backupaadproperties",
+        "microsoft.recoveryservices/locations/backupcrossregionrestore", "microsoft.recoveryservices/locations/backupcrrjob",
+        "microsoft.recoveryservices/locations/backupcrrjobs", "microsoft.recoveryservices/locations/backupcrroperationresults",
+        "microsoft.recoveryservices/locations/backupcrroperationsstatus", "microsoft.recoveryservices/locations/backupprevalidateprotection",
+        "microsoft.recoveryservices/locations/backupstatus", "microsoft.recoveryservices/locations/backupvalidatefeatures",
+        "microsoft.recoveryservices/locations/checknameavailability", "microsoft.recoveryservices/operations",
+        "microsoft.recoveryservices/replicationeligibilityresults", "microsoft.recoveryservices/vaults",
+        "microsoft.recoveryservices/vaults/backupfabrics/backupprotectionintent",
+        "microsoft.recoveryservices/vaults/backupfabrics/protectioncontainers", "microsoft.recoveryservices/vaults/backupfabrics/protectioncontainers/protecteditems",
+        "microsoft.recoveryservices/vaults/backuppolicies", "microsoft.recoveryservices/vaults/backupstorageconfig",
+        "microsoft.recoveryservices/vaults/extendedinformation", "microsoft.recoveryservices/vaults/replicationalertsettings",
+        "microsoft.recoveryservices/vaults/replicationfabrics", "microsoft.recoveryservices/vaults/replicationfabrics/replicationnetworks/replicationnetworkmappings",
+        "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationmigrationitems",
+        "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationprotecteditems",
+        "microsoft.recoveryservices/vaults/replicationfabrics/replicationprotectioncontainers/replicationprotectioncontainermappings",
+        "microsoft.recoveryservices/vaults/replicationfabrics/replicationstorageclassifications/replicationstorageclassificationmappings",
+        "microsoft.recoveryservices/vaults/replicationfabrics/replicationvcenters",
+        "microsoft.recoveryservices/vaults/replicationrecoveryplans", "microsoft.recoveryservices/vaults/replicationvaultsettings",
+        "microsoft.security/adaptivenetworkhardenings", "microsoft.security/advancedthreatprotectionsettings",
+        "microsoft.security/alerts", "microsoft.security/allowedconnections", "microsoft.security/applicationwhitelistings",
+        "microsoft.security/assessmentmetadata", "microsoft.security/assessments",
+        "microsoft.security/autodismissalertsrules", "microsoft.security/automations",
+        "microsoft.security/autoprovisioningsettings", "microsoft.security/complianceresults",
+        "microsoft.security/compliances", "microsoft.security/datacollectionagents",
+        "microsoft.security/datacollectionresults", "microsoft.security/devicesecuritygroups",
+        "microsoft.security/discoveredsecuritysolutions", "microsoft.security/externalsecuritysolutions",
+        "microsoft.security/informationprotectionpolicies", "microsoft.security/iotsecuritysolutions",
+        "microsoft.security/iotsecuritysolutions/analyticsmodels", "microsoft.security/iotsecuritysolutions/analyticsmodels/aggregatedalerts",
+        "microsoft.security/iotsecuritysolutions/analyticsmodels/aggregatedrecommendations",
+        "microsoft.security/jitnetworkaccesspolicies", "microsoft.security/locations",
+        "microsoft.security/locations/alerts", "microsoft.security/locations/allowedconnections",
+        "microsoft.security/locations/applicationwhitelistings", "microsoft.security/locations/discoveredsecuritysolutions",
+        "microsoft.security/locations/externalsecuritysolutions", "microsoft.security/locations/jitnetworkaccesspolicies",
+        "microsoft.security/locations/securitysolutions", "microsoft.security/locations/securitysolutionsreferencedata",
+        "microsoft.security/locations/tasks", "microsoft.security/locations/topologies",
+        "microsoft.security/networkdata", "microsoft.security/operations", "microsoft.security/policies",
+        "microsoft.security/pricings", "microsoft.security/regulatorycompliancestandards",
+        "microsoft.security/regulatorycompliancestandards/regulatorycompliancecontrols",
+        "microsoft.security/regulatorycompliancestandards/regulatorycompliancecontrols/regulatorycomplianceassessments",
+        "microsoft.security/securitycontacts", "microsoft.security/securitysolutions",
+        "microsoft.security/securitysolutionsreferencedata", "microsoft.security/securitystatuses",
+        "microsoft.security/securitystatusessummaries", "microsoft.security/servervulnerabilityassessments",
+        "microsoft.security/settings", "microsoft.security/subassessments", "microsoft.security/tasks",
+        "microsoft.security/topologies", "microsoft.security/workspacesettings", "microsoft.servicebus/checknameavailability",
+        "microsoft.servicebus/checknamespaceavailability", "microsoft.servicebus/locations",
+        "microsoft.servicebus/locations/deletevirtualnetworkorsubnets", "microsoft.servicebus/namespaces",
+        "microsoft.servicebus/namespaces/authorizationrules", "microsoft.servicebus/namespaces/disasterrecoveryconfigs",
+        "microsoft.servicebus/namespaces/disasterrecoveryconfigs/checknameavailability",
+        "microsoft.servicebus/namespaces/eventgridfilters", "microsoft.servicebus/namespaces/ipfilterrules",
+        "microsoft.servicebus/namespaces/messagingplan", "microsoft.servicebus/namespaces/migrationconfigurations",
+        "microsoft.servicebus/namespaces/networkrulesets", "microsoft.servicebus/namespaces/queues",
+        "microsoft.servicebus/namespaces/queues/authorizationrules", "microsoft.servicebus/namespaces/topics",
+        "microsoft.servicebus/namespaces/topics/authorizationrules", "microsoft.servicebus/namespaces/topics/subscriptions",
+        "microsoft.servicebus/namespaces/topics/subscriptions/rules", "microsoft.servicebus/namespaces/virtualnetworkrules",
+        "microsoft.servicebus/operations", "microsoft.servicebus/premiummessagingregions",
+        "microsoft.servicebus/sku", "microsoft.solutions/applicationdefinitions",
+        "microsoft.solutions/applications", "microsoft.solutions/jitrequests", "microsoft.solutions/locations",
+        "microsoft.solutions/locations/operationstatuses", "microsoft.solutions/operations",
+        "microsoft.sql/checknameavailability", "microsoft.sql/instancepools", "microsoft.sql/locations",
+        "microsoft.sql/locations/administratorazureasyncoperation", "microsoft.sql/locations/administratoroperationresults",
+        "microsoft.sql/locations/auditingsettingsazureasyncoperation", "microsoft.sql/locations/auditingsettingsoperationresults",
+        "microsoft.sql/locations/capabilities", "microsoft.sql/locations/databaseazureasyncoperation",
+        "microsoft.sql/locations/databaseoperationresults", "microsoft.sql/locations/databaserestoreazureasyncoperation",
+        "microsoft.sql/locations/deletedserverasyncoperation", "microsoft.sql/locations/deletedserveroperationresults",
+        "microsoft.sql/locations/deletedservers", "microsoft.sql/locations/deletevirtualnetworkorsubnets",
+        "microsoft.sql/locations/deletevirtualnetworkorsubnetsazureasyncoperation",
+        "microsoft.sql/locations/deletevirtualnetworkorsubnetsoperationresults", "microsoft.sql/locations/dnsaliasasyncoperation",
+        "microsoft.sql/locations/dnsaliasoperationresults", "microsoft.sql/locations/elasticpoolazureasyncoperation",
+        "microsoft.sql/locations/elasticpooloperationresults", "microsoft.sql/locations/encryptionprotectorazureasyncoperation",
+        "microsoft.sql/locations/encryptionprotectoroperationresults", "microsoft.sql/locations/extendedauditingsettingsazureasyncoperation",
+        "microsoft.sql/locations/extendedauditingsettingsoperationresults", "microsoft.sql/locations/failovergroupazureasyncoperation",
+        "microsoft.sql/locations/failovergroupoperationresults", "microsoft.sql/locations/firewallrulesazureasyncoperation",
+        "microsoft.sql/locations/firewallrulesoperationresults", "microsoft.sql/locations/instancefailovergroupazureasyncoperation",
+        "microsoft.sql/locations/instancefailovergroupoperationresults", "microsoft.sql/locations/instancefailovergroups",
+        "microsoft.sql/locations/instancepoolazureasyncoperation", "microsoft.sql/locations/instancepooloperationresults",
+        "microsoft.sql/locations/interfaceendpointprofileazureasyncoperation", "microsoft.sql/locations/interfaceendpointprofileoperationresults",
+        "microsoft.sql/locations/jobagentazureasyncoperation", "microsoft.sql/locations/jobagentoperationresults",
+        "microsoft.sql/locations/longtermretentionbackupazureasyncoperation", "microsoft.sql/locations/longtermretentionbackupoperationresults",
+        "microsoft.sql/locations/longtermretentionbackups", "microsoft.sql/locations/longtermretentionpolicyazureasyncoperation",
+        "microsoft.sql/locations/longtermretentionpolicyoperationresults", "microsoft.sql/locations/longtermretentionservers",
+        "microsoft.sql/locations/manageddatabaseazureasyncoperation", "microsoft.sql/locations/manageddatabasecompleterestoreazureasyncoperation",
+        "microsoft.sql/locations/manageddatabasecompleterestoreoperationresults",
+        "microsoft.sql/locations/manageddatabaseoperationresults", "microsoft.sql/locations/manageddatabaserestoreazureasyncoperation",
+        "microsoft.sql/locations/manageddatabaserestoreoperationresults", "microsoft.sql/locations/managedinstanceazureasyncoperation",
+        "microsoft.sql/locations/managedinstanceencryptionprotectorazureasyncoperation",
+        "microsoft.sql/locations/managedinstanceencryptionprotectoroperationresults",
+        "microsoft.sql/locations/managedinstancekeyazureasyncoperation", "microsoft.sql/locations/managedinstancekeyoperationresults",
+        "microsoft.sql/locations/managedinstanceoperationresults", "microsoft.sql/locations/managedinstancetdecertazureasyncoperation",
+        "microsoft.sql/locations/managedinstancetdecertoperationresults", "microsoft.sql/locations/managedserversecurityalertpoliciesazureasyncoperation",
+        "microsoft.sql/locations/managedserversecurityalertpoliciesoperationresults",
+        "microsoft.sql/locations/managedshorttermretentionpolicyazureasyncoperation",
+        "microsoft.sql/locations/managedshorttermretentionpolicyoperationresults",
+        "microsoft.sql/locations/privateendpointconnectionazureasyncoperation", "microsoft.sql/locations/privateendpointconnectionoperationresults",
+        "microsoft.sql/locations/privateendpointconnectionproxyazureasyncoperation",
+        "microsoft.sql/locations/privateendpointconnectionproxyoperationresults",
+        "microsoft.sql/locations/securityalertpoliciesazureasyncoperation", "microsoft.sql/locations/securityalertpoliciesoperationresults",
+        "microsoft.sql/locations/serveradministratorazureasyncoperation", "microsoft.sql/locations/serveradministratoroperationresults",
+        "microsoft.sql/locations/serverazureasyncoperation", "microsoft.sql/locations/serverkeyazureasyncoperation",
+        "microsoft.sql/locations/serverkeyoperationresults", "microsoft.sql/locations/serveroperationresults",
+        "microsoft.sql/locations/shorttermretentionpolicyazureasyncoperation", "microsoft.sql/locations/shorttermretentionpolicyoperationresults",
+        "microsoft.sql/locations/syncagentoperationresults", "microsoft.sql/locations/syncdatabaseids",
+        "microsoft.sql/locations/syncgroupoperationresults", "microsoft.sql/locations/syncmemberoperationresults",
+        "microsoft.sql/locations/tdecertazureasyncoperation", "microsoft.sql/locations/tdecertoperationresults",
+        "microsoft.sql/locations/usages", "microsoft.sql/locations/virtualclusterazureasyncoperation",
+        "microsoft.sql/locations/virtualclusteroperationresults", "microsoft.sql/locations/virtualnetworkrulesazureasyncoperation",
+        "microsoft.sql/locations/virtualnetworkrulesoperationresults", "microsoft.sql/locations/vulnerabilityassessmentscanazureasyncoperation",
+        "microsoft.sql/locations/vulnerabilityassessmentscanoperationresults", "microsoft.sql/managedinstances",
+        "microsoft.sql/managedinstances/administrators", "microsoft.sql/managedinstances/databases",
+        "microsoft.sql/managedinstances/databases/backupshorttermretentionpolicies",
+        "microsoft.sql/managedinstances/databases/schemas/tables/columns/sensitivitylabels",
+        "microsoft.sql/managedinstances/databases/securityalertpolicies", "microsoft.sql/managedinstances/databases/vulnerabilityassessments",
+        "microsoft.sql/managedinstances/databases/vulnerabilityassessments/rules/baselines",
+        "microsoft.sql/managedinstances/encryptionprotector", "microsoft.sql/managedinstances/keys",
+        "microsoft.sql/managedinstances/metricdefinitions", "microsoft.sql/managedinstances/metrics",
+        "microsoft.sql/managedinstances/recoverabledatabases", "microsoft.sql/managedinstances/restorabledroppeddatabases/backupshorttermretentionpolicies",
+        "microsoft.sql/managedinstances/securityalertpolicies", "microsoft.sql/managedinstances/tdecertificates",
+        "microsoft.sql/managedinstances/vulnerabilityassessments", "microsoft.sql/operations",
+        "microsoft.sql/servers", "microsoft.sql/servers/administratoroperationresults",
+        "microsoft.sql/servers/administrators", "microsoft.sql/servers/advisors",
+        "microsoft.sql/servers/aggregateddatabasemetrics", "microsoft.sql/servers/auditingpolicies",
+        "microsoft.sql/servers/auditingsettings", "microsoft.sql/servers/automatictuning",
+        "microsoft.sql/servers/backuplongtermretentionvaults", "microsoft.sql/servers/communicationlinks",
+        "microsoft.sql/servers/connectionpolicies", "microsoft.sql/servers/databases",
+        "microsoft.sql/servers/databases/activate", "microsoft.sql/servers/databases/activatedatabase",
+        "microsoft.sql/servers/databases/advisors", "microsoft.sql/servers/databases/auditingpolicies",
+        "microsoft.sql/servers/databases/auditingsettings", "microsoft.sql/servers/databases/auditrecords",
+        "microsoft.sql/servers/databases/automatictuning", "microsoft.sql/servers/databases/backuplongtermretentionpolicies",
+        "microsoft.sql/servers/databases/backupshorttermretentionpolicies", "microsoft.sql/servers/databases/connectionpolicies",
+        "microsoft.sql/servers/databases/databasestate", "microsoft.sql/servers/databases/datamaskingpolicies",
+        "microsoft.sql/servers/databases/datamaskingpolicies/rules", "microsoft.sql/servers/databases/deactivate",
+        "microsoft.sql/servers/databases/deactivatedatabase", "microsoft.sql/servers/databases/extendedauditingsettings",
+        "microsoft.sql/servers/databases/extensions", "microsoft.sql/servers/databases/geobackuppolicies",
+        "microsoft.sql/servers/databases/metricdefinitions", "microsoft.sql/servers/databases/metrics",
+        "microsoft.sql/servers/databases/recommendedsensitivitylabels", "microsoft.sql/servers/databases/schemas/tables/columns/sensitivitylabels",
+        "microsoft.sql/servers/databases/securityalertpolicies", "microsoft.sql/servers/databases/syncgroups",
+        "microsoft.sql/servers/databases/syncgroups/syncmembers", "microsoft.sql/servers/databases/topqueries",
+        "microsoft.sql/servers/databases/topqueries/querytext", "microsoft.sql/servers/databases/transparentdataencryption",
+        "microsoft.sql/servers/databases/vulnerabilityassessment", "microsoft.sql/servers/databases/vulnerabilityassessments",
+        "microsoft.sql/servers/databases/vulnerabilityassessments/rules/baselines",
+        "microsoft.sql/servers/databases/vulnerabilityassessmentscans", "microsoft.sql/servers/databases/vulnerabilityassessmentsettings",
+        "microsoft.sql/servers/databases/workloadgroups", "microsoft.sql/servers/databasesecuritypolicies",
+        "microsoft.sql/servers/disasterrecoveryconfiguration", "microsoft.sql/servers/dnsaliases",
+        "microsoft.sql/servers/elasticpoolestimates", "microsoft.sql/servers/elasticpools",
+        "microsoft.sql/servers/elasticpools/advisors", "microsoft.sql/servers/elasticpools/metricdefinitions",
+        "microsoft.sql/servers/elasticpools/metrics", "microsoft.sql/servers/encryptionprotector",
+        "microsoft.sql/servers/extendedauditingsettings", "microsoft.sql/servers/failovergroups",
+        "microsoft.sql/servers/firewallrules", "microsoft.sql/servers/import", "microsoft.sql/servers/importexportoperationresults",
+        "microsoft.sql/servers/interfaceendpointprofiles", "microsoft.sql/servers/jobaccounts",
+        "microsoft.sql/servers/jobagents", "microsoft.sql/servers/jobagents/jobs",
+        "microsoft.sql/servers/jobagents/jobs/executions", "microsoft.sql/servers/jobagents/jobs/steps",
+        "microsoft.sql/servers/keys", "microsoft.sql/servers/operationresults", "microsoft.sql/servers/recommendedelasticpools",
+        "microsoft.sql/servers/recoverabledatabases", "microsoft.sql/servers/restorabledroppeddatabases",
+        "microsoft.sql/servers/securityalertpolicies", "microsoft.sql/servers/serviceobjectives",
+        "microsoft.sql/servers/syncagents", "microsoft.sql/servers/tdecertificates",
+        "microsoft.sql/servers/usages", "microsoft.sql/servers/virtualnetworkrules",
+        "microsoft.sql/servers/vulnerabilityassessments", "microsoft.sql/virtualclusters",
+        "microsoft.storage/checknameavailability", "microsoft.storage/locations",
+        "microsoft.storage/locations/asyncoperations", "microsoft.storage/locations/checknameavailability",
+        "microsoft.storage/locations/deletevirtualnetworkorsubnets", "microsoft.storage/locations/usages",
+        "microsoft.storage/operations", "microsoft.storage/storageaccounts", "microsoft.storage/storageaccounts/blobservices",
+        "microsoft.storage/storageaccounts/fileservices", "microsoft.storage/storageaccounts/fileservices/shares",
+        "microsoft.storage/storageaccounts/listaccountsas", "microsoft.storage/storageaccounts/listservicesas",
+        "microsoft.storage/storageaccounts/managementpolicies", "microsoft.storage/storageaccounts/queueservices",
+        "microsoft.storage/storageaccounts/services", "microsoft.storage/storageaccounts/services/metricdefinitions",
+        "microsoft.storage/storageaccounts/tableservices", "microsoft.storage/usages",
+        "microsoft.web/apimanagementaccounts", "microsoft.web/apimanagementaccounts/apiacls",
+        "microsoft.web/apimanagementaccounts/apis", "microsoft.web/apimanagementaccounts/apis/apiacls",
+        "microsoft.web/apimanagementaccounts/apis/connectionacls", "microsoft.web/apimanagementaccounts/apis/connections",
+        "microsoft.web/apimanagementaccounts/apis/connections/connectionacls", "microsoft.web/apimanagementaccounts/apis/localizeddefinitions",
+        "microsoft.web/apimanagementaccounts/connectionacls", "microsoft.web/apimanagementaccounts/connections",
+        "microsoft.web/availablestacks", "microsoft.web/billingmeters", "microsoft.web/certificates",
+        "microsoft.web/checknameavailability", "microsoft.web/connectiongateways",
+        "microsoft.web/connections", "microsoft.web/customapis", "microsoft.web/deletedsites",
+        "microsoft.web/deploymentlocations", "microsoft.web/functions", "microsoft.web/georegions",
+        "microsoft.web/hostingenvironments", "microsoft.web/hostingenvironments/eventgridfilters",
+        "microsoft.web/hostingenvironments/metricdefinitions", "microsoft.web/hostingenvironments/metrics",
+        "microsoft.web/hostingenvironments/multirolepools", "microsoft.web/hostingenvironments/multirolepools/instances",
+        "microsoft.web/hostingenvironments/multirolepools/instances/metricdefinitions",
+        "microsoft.web/hostingenvironments/multirolepools/instances/metrics", "microsoft.web/hostingenvironments/multirolepools/metricdefinitions",
+        "microsoft.web/hostingenvironments/multirolepools/metrics", "microsoft.web/hostingenvironments/workerpools",
+        "microsoft.web/hostingenvironments/workerpools/instances", "microsoft.web/hostingenvironments/workerpools/instances/metricdefinitions",
+        "microsoft.web/hostingenvironments/workerpools/instances/metrics", "microsoft.web/hostingenvironments/workerpools/metricdefinitions",
+        "microsoft.web/hostingenvironments/workerpools/metrics", "microsoft.web/ishostingenvironmentnameavailable",
+        "microsoft.web/ishostnameavailable", "microsoft.web/isusernameavailable",
+        "microsoft.web/listsitesassignedtohostname", "microsoft.web/locations", "microsoft.web/locations/apioperations",
+        "microsoft.web/locations/connectiongatewayinstallations", "microsoft.web/locations/deletedsites",
+        "microsoft.web/locations/deletevirtualnetworkorsubnets", "microsoft.web/locations/extractapidefinitionfromwsdl",
+        "microsoft.web/locations/getnetworkpolicies", "microsoft.web/locations/listwsdlinterfaces",
+        "microsoft.web/locations/managedapis", "microsoft.web/locations/operationresults",
+        "microsoft.web/locations/operations", "microsoft.web/locations/runtimes",
+        "microsoft.web/operations", "microsoft.web/publishingusers", "microsoft.web/recommendations",
+        "microsoft.web/resourcehealthmetadata", "microsoft.web/runtimes", "microsoft.web/serverfarms",
+        "microsoft.web/serverfarms/eventgridfilters", "microsoft.web/serverfarms/metricdefinitions",
+        "microsoft.web/serverfarms/metrics", "microsoft.web/serverfarms/virtualnetworkconnections/gateways",
+        "microsoft.web/serverfarms/virtualnetworkconnections/routes", "microsoft.web/serverfarms/workers",
+        "microsoft.web/sites", "microsoft.web/sites/config", "microsoft.web/sites/domainownershipidentifiers",
+        "microsoft.web/sites/eventgridfilters", "microsoft.web/sites/extensions",
+        "microsoft.web/sites/hostnamebindings", "microsoft.web/sites/hybridconnection",
+        "microsoft.web/sites/hybridconnectionnamespaces/relays", "microsoft.web/sites/instances",
+        "microsoft.web/sites/metricdefinitions", "microsoft.web/sites/metrics", "microsoft.web/sites/networkconfig",
+        "microsoft.web/sites/premieraddons", "microsoft.web/sites/privateaccess",
+        "microsoft.web/sites/publiccertificates", "microsoft.web/sites/recommendations",
+        "microsoft.web/sites/resourcehealthmetadata", "microsoft.web/sites/slots",
+        "microsoft.web/sites/slots/config", "microsoft.web/sites/slots/domainownershipidentifiers",
+        "microsoft.web/sites/slots/eventgridfilters", "microsoft.web/sites/slots/extensions",
+        "microsoft.web/sites/slots/hostnamebindings", "microsoft.web/sites/slots/hybridconnection",
+        "microsoft.web/sites/slots/hybridconnectionnamespaces/relays", "microsoft.web/sites/slots/instances",
+        "microsoft.web/sites/slots/metricdefinitions", "microsoft.web/sites/slots/metrics",
+        "microsoft.web/sites/slots/networkconfig", "microsoft.web/sites/slots/premieraddons",
+        "microsoft.web/sites/slots/publiccertificates", "microsoft.web/sites/slots/sourcecontrols",
+        "microsoft.web/sites/slots/virtualnetworkconnections", "microsoft.web/sites/slots/virtualnetworkconnections/gateways",
+        "microsoft.web/sites/sourcecontrols", "microsoft.web/sites/virtualnetworkconnections",
+        "microsoft.web/sites/virtualnetworkconnections/gateways", "microsoft.web/sourcecontrols",
+        "microsoft.web/validate", "microsoft.web/verifyhostingenvironmentvnet"]}}},
+        {"policyDefinitionReferenceId": "Allowed Regions", "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        Regions", "parameters": {"listOfAllowedLocations": {"value": ["eastus", "southcentralus",
+        "westus"]}}}, {"policyDefinitionReferenceId": "Allowed VM SKUs", "policyDefinitionId":
+        "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyDefinitions/Allowed
+        VM SKUs", "parameters": {"listOfAllowedSKUs": {"value": ["standard_a1_v2",
+        "standard_a2_v2", "standard_a2m_v2", "standard_a4_v2", "standard_a4m_v2",
+        "standard_a8m_v2", "standard_a8_v2", "standard_b12ms", "standard_b16ms", "standard_b1ls",
+        "standard_b1ms", "standard_b1s", "standard_b20ms", "standard_b2ms", "standard_b2s",
+        "standard_b4ms", "standard_b8ms", "standard_d16_v3", "standard_d16s_v3", "standard_d2_v3",
+        "standard_d2s_v3", "standard_d32_v3", "standard_d32s_v3", "standard_d4_v3",
+        "standard_d48_v3", "standard_d48s_v3", "standard_d4s_v3", "standard_d64_v3",
+        "standard_d64s_v3", "standard_d8_v3", "standard_d8s_v3", "standard_e16_v3",
+        "standard_e16-4s_v3", "standard_e16-8s_v3", "standard_e16s_v3", "standard_e2_v3",
+        "standard_e20_v3", "standard_e20s_v3", "standard_e2s_v3", "standard_e32_v3",
+        "standard_e32-16s_v3", "standard_e32-8s_v3", "standard_e4_v3", "standard_e32s_v3",
+        "standard_e4-2s_v3", "standard_e48_v3", "standard_e48s_v3", "standard_e4s_v3",
+        "standard_e64_v3", "standard_e64-16s_v3", "standard_e64-32s_v3", "standard_e64i_v3",
+        "standard_e64is_v3", "standard_e64s_v3", "standard_e8_v3", "standard_e8-2s_v3",
+        "standard_e8-4s_v3", "standard_e8s_v3", "standard_f16s_v2", "standard_f2s_v2",
+        "standard_f32s_v2", "standard_f48s_v2", "standard_f4s_v2", "standard_f64s_v2",
+        "standard_f72s_v2", "standard_f8s_v2", "standard_m128", "standard_m128-32ms",
+        "standard_m128-64ms", "standard_m128m", "standard_m128ms", "standard_m128s",
+        "standard_m16-4ms", "standard_m16-8ms", "standard_m16ms", "standard_m32-16ms",
+        "standard_m32-8ms", "standard_m32ls", "standard_m32ms", "standard_m32ts",
+        "standard_m64", "standard_m64-16ms", "standard_m64-32ms", "standard_m64ls",
+        "standard_m64m", "standard_m64ms", "standard_m64s", "standard_m8-2ms", "standard_m8-4ms",
+        "standard_m8ms", "standard_nc12s_v3", "standard_nc24rs_v3", "standard_nc24s_v3",
+        "standard_nc6s_v3", "standard_l16s_v2", "standard_l32s_v2", "standard_l48s_v2",
+        "standard_l64s_v2", "standard_l80s_v2", "standard_l8s_v2", "standard_dc2s",
+        "standard_dc4s", "standard_nv12s_v3", "standard_nv24s_v3", "standard_nv48s_v3",
+        "standard_hb120rs_v2", "standard_m208ms_v2", "standard_m208s_v2", "standard_m416ms_v2",
+        "standard_m416s_v2"]}}}]}, "id": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policySetDefinitions/Default
+        JEDI Policy Set", "type": "Microsoft.Authorization/policySetDefinitions",
+        "name": "Default JEDI Policy Set"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '52001'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:45 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - 45a4d7a8-f9ca-442d-af9b-9c53b6295d13
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1196'
+      x-ms-request-id:
+      - centralus:52022b29-04e0-42f7-a52f-e6a854839540
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195746Z:45a4d7a8-f9ca-442d-af9b-9c53b6295d13
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"properties": {"displayName": "Default JEDI Policy Set", "policyDefinitionId":
+      "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policySetDefinitions/Default
+      JEDI Policy Set"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '248'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.23.0
+    method: PUT
+    uri: https://management.azure.com/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyAssignments/Default%20JEDI%20Policy%20Set?api-version=2019-09-01
+  response:
+    body:
+      string: '{"sku": {"name": "A0", "tier": "Free"}, "properties": {"displayName":
+        "Default JEDI Policy Set", "policyDefinitionId": "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policySetDefinitions/Default
+        JEDI Policy Set", "scope": "/providers/Microsoft.Management/managementGroups/*****",
+        "metadata": {"createdBy": "*****", "createdOn": "2020-04-24T19:57:46.8546562Z",
+        "updatedBy": null, "updatedOn": null}, "enforcementMode": "Default"}, "id":
+        "/providers/Microsoft.Management/managementGroups/*****/providers/Microsoft.Authorization/policyAssignments/Default
+        JEDI Policy Set", "type": "Microsoft.Authorization/policyAssignments", "name":
+        "Default JEDI Policy Set"}'
+    headers:
+      Cache-Control:
+      - no-cache
+      Content-Length:
+      - '796'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 24 Apr 2020 19:57:45 GMT
+      Expires:
+      - '-1'
+      Pragma:
+      - no-cache
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      X-Content-Type-Options:
+      - nosniff
+      x-ms-correlation-request-id:
+      - f94b9fba-0fb8-477b-820d-b23e189c8b3c
+      x-ms-ratelimit-remaining-tenant-writes:
+      - '1195'
+      x-ms-request-id:
+      - centralus:d87ac137-42cd-49ab-a49c-39a3eff3a5ce
+      x-ms-routing-request-id:
+      - CENTRALUS:20200424T195746Z:f94b9fba-0fb8-477b-820d-b23e189c8b3c
+    status:
+      code: 201
+      message: Created
+version: 1


### PR DESCRIPTION
Caches most HTTP interactions performed by the hybrid tests as "cassette" (yaml) files. When the tests are run with the cassettes present, instead of issuing real requests, the VCR library instead serves the cached response. 

https://ccpo.atlassian.net/browse/AT-5208

Co-authored by @carleton-dds 

## Issues

@carleton-dds and I found that the management group SDK was using two different versions of the SDK at the same time. `2015` and `2018-preview`. We probably should investigate this in other places and standardize the API version used.