### PR TITLE
[AT-5195] Raise AuthenticationExceptions for Adal errors and DRY token getting

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1343,29 +1343,27 @@ class AzureCloudProvider(CloudProviderInterface):
             creds.root_tenant_id, creds.root_sp_client_id, creds.root_sp_key
         )
 
+    @log_and_raise_exceptions
     def _get_service_principal_token(
         self, tenant_id, client_id, secret_key, resource=None
     ):
         context = self.sdk.adal.AuthenticationContext(
             f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}"
         )
-
         resource = resource or self.sdk.cloud.endpoints.resource_manager
-        # TODO: handle failure states here
         token_response = context.acquire_token_with_client_credentials(
             resource, client_id, secret_key
         )
 
         return token_response.get("accessToken", None)
 
+    @log_and_raise_exceptions
     def _get_user_principal_token_for_resource(
         self, username, password, tenant_id, resource
     ):
         context = self.sdk.adal.AuthenticationContext(
             f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}"
         )
-
-        # TODO: handle failure states here
         token_response = context.acquire_token_with_username_password(
             resource, username, password, self.ps_client_id
         )
@@ -1497,6 +1495,7 @@ class AzureCloudProvider(CloudProviderInterface):
         if result.ok:
             return CostManagementQueryCSPResult(**result.json())
 
+    @log_and_raise_exceptions
     def _get_calculator_creds(self):
         authority = f"{self.sdk.cloud.endpoints.active_directory}/{self.tenant_id}"
         context = self.sdk.adal.AuthenticationContext(authority=authority)

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1276,9 +1276,9 @@ class AzureCloudProvider(CloudProviderInterface):
 
         token = token_response.get("accessToken")
         if token is None:
-            raise AuthenticationException(
-                f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
-            )
+            message = f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
+            app.logger.error(message, exc_info=1)
+            raise AuthenticationException(message)
         else:
             return token
 
@@ -1295,9 +1295,9 @@ class AzureCloudProvider(CloudProviderInterface):
 
         token = token_response.get("accessToken")
         if token is None:
-            raise AuthenticationException(
-                f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
-            )
+            message = f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
+            app.logger.error(message, exc_info=1)
+            raise AuthenticationException(message)
         else:
             return token
 
@@ -1431,9 +1431,9 @@ class AzureCloudProvider(CloudProviderInterface):
         )
         token = token_response.get("accessToken")
         if token is None:
-            raise AuthenticationException(
-                f"Failed to get token for resource '{calc_resource}' in tenant '{tenant_id}'"
-            )
+            message = f"Failed to get token for resource '{calc_resource}' in tenant '{tenant_id}'"
+            app.logger.error(message, exc_info=1)
+            raise AuthenticationException(message)
         else:
             return token
 

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -394,8 +394,6 @@ class AzureCloudProvider(CloudProviderInterface):
         """
 
         sp_token = self._get_tenant_principal_token(payload.tenant_id)
-        if sp_token is None:
-            raise AuthenticationException("Could not resolve token in disable user")
         headers = {
             "Authorization": f"Bearer {sp_token}",
         }
@@ -429,8 +427,6 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def disable_user(self, tenant_id, role_assignment_cloud_id):
         sp_token = self._get_tenant_principal_token(tenant_id)
-        if sp_token is None:
-            raise AuthenticationException("Could not resolve token in disable user")
         headers = {
             "Authorization": f"Bearer {sp_token}",
         }
@@ -467,8 +463,6 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def create_tenant(self, payload: TenantCSPPayload):
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException("Could not resolve token for tenant creation")
 
         payload.password = token_urlsafe(16)
         payload.domain_name = self.generate_valid_domain_name(payload.domain_name)
@@ -519,10 +513,6 @@ class AzureCloudProvider(CloudProviderInterface):
             https://docs.microsoft.com/en-us/microsoft-store/billing-profile
             """
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for billing profile creation"
-            )
 
         create_billing_account_body = payload.dict(by_alias=True)
 
@@ -561,10 +551,6 @@ class AzureCloudProvider(CloudProviderInterface):
             https://docs.microsoft.com/en-us/microsoft-store/billing-profile
             """
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for billing profile validation"
-            )
 
         auth_header = {
             "Authorization": f"Bearer {sp_token}",
@@ -641,10 +627,6 @@ class AzureCloudProvider(CloudProviderInterface):
         self, payload: TaskOrderBillingVerificationCSPPayload
     ):
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for task order billing validation"
-            )
 
         auth_header = {
             "Authorization": f"Bearer {sp_token}",
@@ -664,10 +646,6 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def create_billing_instruction(self, payload: BillingInstructionCSPPayload):
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for task order billing validation"
-            )
 
         request_body = {
             "properties": {
@@ -692,10 +670,6 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def create_subscription(self, payload: SubscriptionCreationCSPPayload):
         sp_token = self._get_tenant_principal_token(payload.tenant_id)
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for subscription creation"
-            )
 
         request_body = {
             "displayName": payload.display_name,
@@ -725,10 +699,6 @@ class AzureCloudProvider(CloudProviderInterface):
         self, payload: SubscriptionVerificationCSPPayload
     ):
         sp_token = self._get_tenant_principal_token(payload.tenant_id)
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for subscription verification"
-            )
 
         auth_header = {
             "Authorization": f"Bearer {sp_token}",
@@ -745,10 +715,6 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def create_product_purchase(self, payload: ProductPurchaseCSPPayload):
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for aad premium product purchase"
-            )
 
         create_product_purchase_body = {
             "type": "AADPremium",
@@ -782,10 +748,6 @@ class AzureCloudProvider(CloudProviderInterface):
         self, payload: ProductPurchaseVerificationCSPPayload
     ):
         sp_token = self._get_root_provisioning_token()
-        if sp_token is None:
-            raise AuthenticationException(
-                "Could not resolve token for aad premium product purchase validation"
-            )
 
         auth_header = {
             "Authorization": f"Bearer {sp_token}",
@@ -818,11 +780,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
         self._update_active_directory_user_password_profile(graph_token, payload)
 
         return TenantAdminCredentialResetCSPResult()
@@ -910,11 +867,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
         request_body = {"displayName": self.tenant_principal_app_display_name}
 
         auth_header = {
@@ -941,16 +893,10 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
-        request_body = {"appId": payload.principal_app_id}
-
         auth_header = {
             "Authorization": f"Bearer {graph_token}",
         }
+        request_body = {"appId": payload.principal_app_id}
 
         url = f"{self.graph_resource}/beta/servicePrincipals"
 
@@ -967,11 +913,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
         request_body = {
             "passwordCredentials": [{"displayName": "ATAT Generated Password"}]
         }
@@ -1007,11 +948,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
         auth_header = {
             "Authorization": f"Bearer {graph_token}",
         }
@@ -1045,11 +981,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_admin_token(
             payload.tenant_id, self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
-
         request_body = {
             "principalId": payload.principal_id,
             "roleDefinitionId": payload.admin_role_def_id,
@@ -1078,10 +1009,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_principal_token(
             payload.tenant_id, resource=self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
 
         # Step 1: Create an AAD identity for the user
         user_result = self._create_active_directory_user(graph_token, payload)
@@ -1202,10 +1129,6 @@ class AzureCloudProvider(CloudProviderInterface):
         graph_token = self._get_tenant_principal_token(
             payload.tenant_id, resource=self.graph_resource
         )
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
 
         result = self._create_active_directory_user(graph_token, payload)
         self._update_active_directory_user_email(graph_token, result.id, payload)
@@ -1290,10 +1213,6 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def create_user_role(self, payload: UserRoleCSPPayload):
         graph_token = self._get_tenant_principal_token(payload.tenant_id)
-        if graph_token is None:
-            raise AuthenticationException(
-                "Could not resolve graph token for tenant admin"
-            )
 
         role_guid = self.roles[payload.role]
         role_definition_id = f"{payload.management_group_id}/providers/Microsoft.Authorization/roleDefinitions/{role_guid}"
@@ -1355,7 +1274,13 @@ class AzureCloudProvider(CloudProviderInterface):
             resource, client_id, secret_key
         )
 
-        return token_response.get("accessToken", None)
+        token = token_response.get("accessToken")
+        if token is None:
+            raise AuthenticationException(
+                f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
+            )
+        else:
+            return token
 
     @log_and_raise_exceptions
     def _get_user_principal_token_for_resource(
@@ -1368,7 +1293,13 @@ class AzureCloudProvider(CloudProviderInterface):
             resource, username, password, self.ps_client_id
         )
 
-        return token_response.get("accessToken", None)
+        token = token_response.get("accessToken")
+        if token is None:
+            raise AuthenticationException(
+                f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
+            )
+        else:
+            return token
 
     def _get_credential_obj(self, creds, resource=None):
         return self.sdk.credentials.ServicePrincipalCredentials(
@@ -1409,10 +1340,6 @@ class AzureCloudProvider(CloudProviderInterface):
         mgmt_token = self._get_tenant_admin_token(
             tenant_id, self.sdk.cloud.endpoints.resource_manager
         )
-        if mgmt_token is None:
-            raise AuthenticationException(
-                "Failed to resolve management token for tenant admin"
-            )
 
         auth_header = {
             "Authorization": f"Bearer {mgmt_token}",
@@ -1467,9 +1394,6 @@ class AzureCloudProvider(CloudProviderInterface):
             payload.tenant_id, creds.tenant_sp_client_id, creds.tenant_sp_key
         )
 
-        if not token:
-            raise AuthenticationException("Could not retrieve tenant access token")
-
         headers = {"Authorization": f"Bearer {token}"}
 
         request_body = {
@@ -1499,12 +1423,19 @@ class AzureCloudProvider(CloudProviderInterface):
     def _get_calculator_creds(self):
         authority = f"{self.sdk.cloud.endpoints.active_directory}/{self.tenant_id}"
         context = self.sdk.adal.AuthenticationContext(authority=authority)
-        response = context.acquire_token_with_client_credentials(
-            self.config.get("AZURE_CALC_RESOURCE"),
+        calc_resource = self.config.get("AZURE_CALC_RESOURCE")
+        token_response = context.acquire_token_with_client_credentials(
+            calc_resource,
             self.config.get("AZURE_CALC_CLIENT_ID"),
             self.config.get("AZURE_CALC_SECRET"),
         )
-        return response.get("accessToken")
+        token = token_response.get("accessToken")
+        if token is None:
+            raise AuthenticationException(
+                f"Failed to get token for resource '{calc_resource}' in tenant '{tenant_id}'"
+            )
+        else:
+            return token
 
     def get_calculator_url(self):
         calc_access_token = self._get_calculator_creds()

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1167,7 +1167,7 @@ class AzureCloudProvider(CloudProviderInterface):
             app_create_param
         )
 
-        # create a new service principle for the new application, which should be scoped
+        # create a new service principal for the new application, which should be scoped
         # to the new subscription
         app_id = app.app_id
         sp_create_params = self.sdk.graphrbac.models.ServicePrincipalCreateParameters(
@@ -1325,7 +1325,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def _get_tenant_admin_token(self, tenant_id, resource):
         creds = self._source_tenant_creds(tenant_id)
-        return self._get_up_token_for_resource(
+        return self._get_user_principal_token_for_resource(
             creds.tenant_admin_username,
             creds.tenant_admin_password,
             creds.tenant_id,
@@ -1334,11 +1334,13 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def _get_root_provisioning_token(self):
         creds = self._source_root_creds()
-        return self._get_sp_token(
+        return self._get_service_principal_token(
             creds.root_tenant_id, creds.root_sp_client_id, creds.root_sp_key
         )
 
-    def _get_sp_token(self, tenant_id, client_id, secret_key, resource=None):
+    def _get_service_principal_token(
+        self, tenant_id, client_id, secret_key, resource=None
+    ):
         context = self.sdk.adal.AuthenticationContext(
             f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}"
         )
@@ -1351,8 +1353,9 @@ class AzureCloudProvider(CloudProviderInterface):
 
         return token_response.get("accessToken", None)
 
-    def _get_up_token_for_resource(self, username, password, tenant_id, resource):
-
+    def _get_user_principal_token_for_resource(
+        self, username, password, tenant_id, resource
+    ):
         context = self.sdk.adal.AuthenticationContext(
             f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}"
         )
@@ -1391,7 +1394,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def _get_tenant_principal_token(self, tenant_id, resource=None):
         creds = self._source_tenant_creds(tenant_id)
-        return self._get_sp_token(
+        return self._get_service_principal_token(
             creds.tenant_id,
             creds.tenant_sp_client_id,
             creds.tenant_sp_key,
@@ -1457,7 +1460,7 @@ class AzureCloudProvider(CloudProviderInterface):
         with the payload at the `invoice_section_id` key.
         """
         creds = self._source_tenant_creds(payload.tenant_id)
-        token = self._get_sp_token(
+        token = self._get_service_principal_token(
             payload.tenant_id, creds.tenant_sp_client_id, creds.tenant_sp_key
         )
 

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -113,6 +113,11 @@ def log_and_raise_exceptions(func):
             app.logger.error(status_code, message, exc_info=1)
             raise UnknownServerException(status_code, f"{message}. {str(exc)}")
 
+        except cloud.sdk.adal.AdalError as exc:
+            message = f"ADAL error calling {func.__name__}"
+            app.logger.error(message, exc_info=1)
+            raise AuthenticationException(message)
+
     return wrapped_func
 
 


### PR DESCRIPTION
Closes: [AT-5195](https://ccpo.atlassian.net/browse/AT-5195)

I discovered that this bug might have been squashed by https://github.com/dod-ccpo/atst/pull/1497.  That catches all exceptions raised during `after_in_progress_callback` and fails the stage. This PR:
- catches ADAL errors and re-raises them as our `AuthenticationException` error
- DRYs token checking. We would do something like:
```python
token = self.fn_that_gets_a_token()
if not token:
    raise AuthenticationException()
```

in each cloud method that needed some authentication token. Now, that logic lives in `fn_that_gets_a_token()`. This makes it so you don't have to remember to check for a token or raise an exception in each method.