### PR TITLE
Update README with more details about hybrid tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,11 @@ To run only the Python unit tests:
 
     poetry run python -m pytest
 
-Integration tests that use the hybrid cloud provider are skipped by default. To run these tests, add a `--hybrid` flag when running pytest:
+Integration tests that use the hybrid cloud provider are skipped by default. To run these tests, add a `--hybrid` flag and run the hybrid test file:
 
-    poetry run python -m pytest --hybrid
+    poetry run python -m pytest --hybrid tests/domain/cloud/test_hybrid_csp.py
+
+Note that running the hybrid tests requires that additional config values be set, outlined in the [Hybrid Configuration](#hybrid-configuration) section.
 
 This project also runs Javascript tests using jest. To run the Javascript tests:
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ To run only the Python unit tests:
     poetry run python -m pytest
 **Integration tests with the Hybrid Interface**
 
-Integration tests that use the hybrid cloud provider are skipped by default and should be run on their own, as some of the required hybrid configuration values may cause certain non-hybrid tests to fail. As a result, it's recommended that you do not `EXPORT` these hybrid config values into your shell environmental, but instead load them only for that command with something like the following:
+Integration tests that use the hybrid cloud provider are skipped by default and should be run on their own, as some of the required hybrid configuration values may cause certain non-hybrid tests to fail. As a result, it's recommended that you do not `EXPORT` these hybrid config values into your shell environment, but instead load them only for that command with something like the following:
 
 ```
 env $(cat .env.hybrid | xargs) poetry run pytest --no-cov --hybrid tests/domain/cloud/test_hybrid_csp.py

--- a/README.md
+++ b/README.md
@@ -215,12 +215,14 @@ To run lint, static analysis, and Python unit tests:
 To run only the Python unit tests:
 
     poetry run python -m pytest
+**Integration tests with the Hybrid Interface**
 
-Integration tests that use the hybrid cloud provider are skipped by default. To run these tests, add a `--hybrid` flag and run the hybrid test file:
+Integration tests that use the hybrid cloud provider are skipped by default and should be run on their own, as some of the required hybrid configuration values may cause certain non-hybrid tests to fail. As a result, it's recommended that you do not `EXPORT` these hybrid config values into your shell environmental, but instead load them only for that command with something like the following:
 
-    poetry run python -m pytest --hybrid tests/domain/cloud/test_hybrid_csp.py
-
-Note that running the hybrid tests requires that additional config values be set, outlined in the [Hybrid Configuration](#hybrid-configuration) section.
+```
+env $(cat .env.hybrid | xargs) poetry run pytest --no-cov --hybrid tests/domain/cloud/test_hybrid_csp.py
+```
+The config values required by the hybrid tests are outlined in the [Hybrid Configuration](#hybrid-configuration) section. Note that the `--hybrid` parameter is also required for hybrid tests to run. 
 
 This project also runs Javascript tests using jest. To run the Javascript tests:
 


### PR DESCRIPTION
The README should specify that only the hybrid test file should be run
with the `--hybrid` flag. Other tests are not written to work against
live Azure APIs and would require additional config be supplied.