### PR TITLE
Remove ADAL library

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1371,26 +1371,11 @@ class AzureCloudProvider(CloudProviderInterface):
         if result.ok:
             return CostManagementQueryCSPResult(**result.json())
 
-    @log_and_raise_exceptions
-    def _get_calculator_creds(self):
-        url = f"{self.sdk.cloud.endpoints.active_directory}/{self.root_tenant_id}/oauth2/token"
-        resource = self.config.get("AZURE_CALC_RESOURCE")
-        payload = {
-            "grant_type": "client_credentials",
-            "client_id": self.config.get("AZURE_CALC_CLIENT_ID"),
-            "client_secret": self.config.get("AZURE_CALC_SECRET"),
-            "resource": resource,
-        }
-        token_response = self.sdk.requests.get(url, data=payload, timeout=30)
-        token_response.raise_for_status()
-        token = token_response.json().get("access_token")
-        if token is None:
-            message = f"Failed to get token for resource '{resource}' in tenant '{self.root_tenant_id}'"
-            app.logger.error(message, exc_info=1)
-            raise AuthenticationException(message)
-        else:
-            return token
-
     def get_calculator_url(self):
-        calc_access_token = self._get_calculator_creds()
+        calc_access_token = self._get_service_principal_token(
+            self.root_tenant_id,
+            self.config.get("AZURE_CALC_CLIENT_ID"),
+            self.config.get("AZURE_CALC_SECRET"),
+            scope=self.config.get("AZURE_CALC_RESOURCE"),
+        )
         return f"{self.config.get('AZURE_CALC_URL')}?access_token={calc_access_token}"

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 from flask import current_app as app
 
 from atat.utils import sha256_hex
+from atat.domain.csp.cloud.utils import get_user_principal_token_for_scope
 
 from .cloud_provider_interface import CloudProviderInterface
 from .exceptions import (
@@ -1253,25 +1254,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     @log_and_raise_exceptions
     def _get_user_principal_token_for_scope(self, username, password, tenant_id, scope):
-        url = (
-            f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}/oauth2/v2.0/token"
-        )
-        payload = {
-            "client_id": self.ps_client_id,
-            "grant_type": "password",
-            "username": username,
-            "password": password,
-            "scope": scope,
-        }
-        token_response = self.sdk.requests.post(url, data=payload, timeout=30)
-        token_response.raise_for_status()
-        token = token_response.json().get("access_token")
-        if token is None:
-            message = f"Failed to get user principal token for scope '{scope}' in tenant '{tenant_id}'"
-            app.logger.error(message, exc_info=1)
-            raise AuthenticationException(message)
-        else:
-            return token
+        return get_user_principal_token_for_scope(username, password, tenant_id, scope)
 
     @property
     def _root_creds(self):

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -116,11 +116,6 @@ def log_and_raise_exceptions(func):
             app.logger.error(status_code, message, exc_info=1)
             raise UnknownServerException(status_code, f"{message}. {str(exc)}")
 
-        except cloud.sdk.adal.AdalError as exc:
-            message = f"ADAL error calling {func.__name__}"
-            app.logger.error(message, exc_info=1)
-            raise AuthenticationException(message)
-
     return wrapped_func
 
 
@@ -129,11 +124,9 @@ class AzureSDKProvider(object):
         from msrestazure.azure_cloud import (
             AZURE_PUBLIC_CLOUD,
         )  # TODO: choose cloud type from config
-        import adal
         import requests
 
         self.cloud = AZURE_PUBLIC_CLOUD
-        self.adal = adal
         self.requests = requests
 
 

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1249,15 +1249,17 @@ class AzureCloudProvider(CloudProviderInterface):
     def _get_service_principal_token(
         self, tenant_id, client_id, secret_key, resource=None
     ):
-        context = self.sdk.adal.AuthenticationContext(
-            f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}"
-        )
+        url = f"{self.sdk.cloud.endpoints.active_directory}/{tenant_id}/oauth2/token"
         resource = resource or self.sdk.cloud.endpoints.resource_manager
-        token_response = context.acquire_token_with_client_credentials(
-            resource, client_id, secret_key
-        )
-
-        token = token_response.get("accessToken")
+        payload = {
+            "grant_type": "client_credentials",
+            "client_id": client_id,
+            "client_secret": secret_key,
+            "resource": resource,
+        }
+        token_response = self.sdk.requests.get(url, data=payload, timeout=30)
+        token_response.raise_for_status()
+        token = token_response.json().get("access_token")
         if token is None:
             message = f"Failed to get service principal token for resource '{resource}' in tenant '{tenant_id}'"
             app.logger.error(message, exc_info=1)

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -134,7 +134,7 @@ class HybridCloudProvider(object):
         self, payload: TenantPrincipalCredentialCSPPayload
     ) -> TenantPrincipalCredentialCSPResult:
         token = self.azure._get_tenant_admin_token(
-            payload.tenant_id, self.azure.graph_resource
+            payload.tenant_id, self.azure.graph_resource + "/.default"
         )
 
         original_update_tenant_creds = self.azure.update_tenant_creds

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -215,7 +215,7 @@ class HybridCloudProvider(object):
         self, payload: BillingOwnerCSPPayload
     ) -> BillingOwnerCSPResult:
         token = self.azure._get_tenant_principal_token(
-            payload.tenant_id, resource=self.azure.graph_resource
+            payload.tenant_id, scope=self.azure.graph_resource + "/.default"
         )
         payload.tenant_id = self.azure.root_tenant_id
         with monkeypatched(

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -1,7 +1,11 @@
+import os
 import string
 import re
+import requests
+from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
 from flask import current_app as app
+from atat.domain.csp.cloud.exceptions import AuthenticationException
 
 
 def generate_user_principal_name(name, domain_name):
@@ -14,3 +18,24 @@ ESCAPED_PUNCTUATION = re.escape(string.punctuation)
 
 def generate_mail_nickname(name):
     return re.sub(f"[{ESCAPED_PUNCTUATION} ]+", ".", name).lower()
+
+
+def get_user_principal_token_for_scope(username, password, tenant_id, scope):
+    cloud = AZURE_PUBLIC_CLOUD
+    url = f"{cloud.endpoints.active_directory}/{tenant_id}/oauth2/v2.0/token"
+    payload = {
+        "client_id": os.environ["AZURE_POWERSHELL_CLIENT_ID"],
+        "grant_type": "password",
+        "username": username,
+        "password": password,
+        "scope": scope,
+    }
+    token_response = requests.post(url, data=payload, timeout=30)
+    token_response.raise_for_status()
+    token = token_response.json().get("access_token")
+    if token is None:
+        message = f"Failed to get user principal token for scope '{scope}' in tenant '{tenant_id}'"
+        app.logger.error(message, exc_info=1)
+        raise AuthenticationException(message)
+    else:
+        return token

--- a/poetry.lock
+++ b/poetry.lock
@@ -4,7 +4,7 @@ description = "The ADAL for Python library makes it easy for python application 
 name = "adal"
 optional = false
 python-versions = "*"
-version = "1.2.2"
+version = "1.2.3"
 
 [package.dependencies]
 PyJWT = ">=1.0.0"
@@ -1455,13 +1455,13 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "1c436fcdc3ebc86e5b6df60b85e785b1b92101cab6d16456689dd7d0d52eb531"
+content-hash = "9a2e1a5ce59dc502c7a62f28abc796a5cadb0bc0e793605c8b8cca8c02f4a95c"
 python-versions = "3.7.3"
 
 [metadata.files]
 adal = [
-    {file = "adal-1.2.2-py2.py3-none-any.whl", hash = "sha256:fd17e5661f60634ddf96a569b95d34ccb8a98de60593d729c28bdcfe360eaad1"},
-    {file = "adal-1.2.2.tar.gz", hash = "sha256:5a7f1e037c6290c6d7609cab33a9e5e988c2fbec5c51d1c4c649ee3faff37eaf"},
+    {file = "adal-1.2.3-py2.py3-none-any.whl", hash = "sha256:a74ff45b88db18d3d3d0c50d0d2d6d411866648f457bef4be714ba0b8e30d515"},
+    {file = "adal-1.2.3.tar.gz", hash = "sha256:2ae7e02cea4552349fed6d8c9912da400f7e643fc30098defe0dcd01945e7c54"},
 ]
 alembic = [
     {file = "alembic-1.4.2.tar.gz", hash = "sha256:035ab00497217628bf5d0be82d664d8713ab13d37b630084da8e1f98facf4dbf"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ homepage = "https://github.com/dod-ccpo/atst"
 
 [tool.poetry.dependencies]
 python = "3.7.3"
-adal = "*"
 alembic = "*"
 azure-storage = "*"
 azure-storage-blob = "*"

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1462,12 +1462,16 @@ def test_create_policies(mock_azure: AzureCloudProvider, monkeypatch):
     assert result.policy_assignment_id == final_assignment_id
 
 
-def test_get_service_principal_token_fails(mock_azure: AzureCloudProvider):
-    mock_azure.sdk.adal.AuthenticationContext.return_value.acquire_token_with_client_credentials.side_effect = AdalError(
-        "Adal Error"
+def test_get_service_principal_token_fails(unmocked_cloud_provider):
+    cloud_provider = unmocked_cloud_provider
+    mock_result = mock_requests_response(
+        status=401, json_data={"error": "invalid request"},
     )
+    cloud_provider.sdk.requests.get = Mock()
+    cloud_provider.sdk.requests.get.side_effect = [mock_result]
+
     with pytest.raises(AuthenticationException):
-        mock_azure._get_service_principal_token("resource", "client", "secret")
+        cloud_provider._get_service_principal_token("resource", "client", "secret")
 
 
 def test_get_user_principal_token_for_resource_fails(mock_azure: AzureCloudProvider):

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1476,18 +1476,6 @@ def test_get_service_principal_token_fails(unmocked_cloud_provider):
         cloud_provider._get_service_principal_token("resource", "client", "secret")
 
 
-def test_get_user_principal_token_for_scope_fails(mock_azure):
-    mock_result = mock_requests_response(
-        status=401, json_data={"error": "invalid request"},
-    )
-    mock_azure.sdk.requests.post.return_value = mock_result
-
-    with pytest.raises(AuthenticationException):
-        mock_azure._get_user_principal_token_for_scope(
-            "username", "password", "tenant_id", "my_resource"
-        )
-
-
 class TestCreateManagementGroup:
     def test_status_code_200(self, mock_azure: AzureCloudProvider, monkeypatch):
         mock_session_object = Mock()

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1383,12 +1383,16 @@ class TestGetCalculatorCreds:
     def test_get_calculator_creds_succeeds(self, mock_azure: AzureCloudProvider):
         assert mock_azure._get_calculator_creds() == MOCK_ACCESS_TOKEN
 
-    def test_get_calculator_creds_fails(self, mock_azure: AzureCloudProvider):
-        mock_azure.sdk.adal.AuthenticationContext.return_value.acquire_token_with_client_credentials.side_effect = AdalError(
-            "Adal Error"
+    def test_get_calculator_creds_fails(self, unmocked_cloud_provider):
+        cloud_provider = unmocked_cloud_provider
+        mock_result = mock_requests_response(
+            status=401, json_data={"error": "invalid request"},
         )
+        cloud_provider.sdk.requests.get = Mock()
+        cloud_provider.sdk.requests.get.side_effect = [mock_result]
+
         with pytest.raises(AuthenticationException):
-            mock_azure._get_calculator_creds()
+            cloud_provider._get_calculator_creds()
 
 
 def test_get_calculator_url(mock_azure: AzureCloudProvider):

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1380,8 +1380,14 @@ def test_update_tenant_creds(mock_azure: AzureCloudProvider, monkeypatch):
 
 
 class TestGetCalculatorCreds:
-    def test_get_calculator_creds_succeeds(self, mock_azure: AzureCloudProvider):
-        assert mock_azure._get_calculator_creds() == MOCK_ACCESS_TOKEN
+    def test_get_calculator_creds_succeeds(self, unmocked_cloud_provider):
+        cloud_provider = unmocked_cloud_provider
+        mock_result = mock_requests_response(
+            status=200, json_data={"access_token": MOCK_ACCESS_TOKEN},
+        )
+        cloud_provider.sdk.requests.get = Mock()
+        cloud_provider.sdk.requests.get.side_effect = [mock_result]
+        assert unmocked_cloud_provider._get_calculator_creds() == MOCK_ACCESS_TOKEN
 
     def test_get_calculator_creds_fails(self, unmocked_cloud_provider):
         cloud_provider = unmocked_cloud_provider

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1380,28 +1380,28 @@ def test_update_tenant_creds(mock_azure: AzureCloudProvider, monkeypatch):
 
 
 class TestGetCalculatorCreds:
-    def test_get_calculator_creds_succeeds(self, unmocked_cloud_provider):
-        cloud_provider = unmocked_cloud_provider
+    def test_get_calculator_creds_succeeds(self, mock_azure):
         mock_result = mock_requests_response(
             status=200, json_data={"access_token": MOCK_ACCESS_TOKEN},
         )
-        cloud_provider.sdk.requests.get = Mock()
-        cloud_provider.sdk.requests.get.side_effect = [mock_result]
-        assert unmocked_cloud_provider._get_calculator_creds() == MOCK_ACCESS_TOKEN
+        mock_azure.sdk.requests.get.return_value = mock_result
+        assert mock_azure._get_calculator_creds() == MOCK_ACCESS_TOKEN
 
-    def test_get_calculator_creds_fails(self, unmocked_cloud_provider):
-        cloud_provider = unmocked_cloud_provider
+    def test_get_calculator_creds_fails(self, mock_azure):
         mock_result = mock_requests_response(
             status=401, json_data={"error": "invalid request"},
         )
-        cloud_provider.sdk.requests.get = Mock()
-        cloud_provider.sdk.requests.get.side_effect = [mock_result]
+        mock_azure.sdk.requests.get.return_value = mock_result
 
         with pytest.raises(AuthenticationException):
-            cloud_provider._get_calculator_creds()
+            mock_azure._get_calculator_creds()
 
 
 def test_get_calculator_url(mock_azure: AzureCloudProvider):
+    mock_result = mock_requests_response(
+        status=200, json_data={"access_token": MOCK_ACCESS_TOKEN},
+    )
+    mock_azure.sdk.requests.get.return_value = mock_result
     assert (
         mock_azure.get_calculator_url()
         == f"{mock_azure.config.get('AZURE_CALC_URL')}?access_token={MOCK_ACCESS_TOKEN}"

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1477,8 +1477,8 @@ def test_get_service_principal_token_fails(unmocked_cloud_provider):
     mock_result = mock_requests_response(
         status=401, json_data={"error": "invalid request"},
     )
-    cloud_provider.sdk.requests.get = Mock()
-    cloud_provider.sdk.requests.get.side_effect = [mock_result]
+    cloud_provider.sdk.requests.post = Mock()
+    cloud_provider.sdk.requests.post.side_effect = [mock_result]
 
     with pytest.raises(AuthenticationException):
         cloud_provider._get_service_principal_token("resource", "client", "secret")

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1399,24 +1399,6 @@ def test_update_tenant_creds(mock_azure: AzureCloudProvider, monkeypatch):
     assert updated_secret == KeyVaultCredentials(**{**existing_secrets, **new_secrets})
 
 
-class TestGetCalculatorCreds:
-    def test_get_calculator_creds_succeeds(self, mock_azure):
-        mock_result = mock_requests_response(
-            status=200, json_data={"access_token": MOCK_ACCESS_TOKEN},
-        )
-        mock_azure.sdk.requests.get.return_value = mock_result
-        assert mock_azure._get_calculator_creds() == MOCK_ACCESS_TOKEN
-
-    def test_get_calculator_creds_fails(self, mock_azure):
-        mock_result = mock_requests_response(
-            status=401, json_data={"error": "invalid request"},
-        )
-        mock_azure.sdk.requests.get.return_value = mock_result
-
-        with pytest.raises(AuthenticationException):
-            mock_azure._get_calculator_creds()
-
-
 def test_get_calculator_url(mock_azure: AzureCloudProvider):
     mock_result = mock_requests_response(
         status=200, json_data={"access_token": MOCK_ACCESS_TOKEN},

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -692,15 +692,13 @@ def test_create_tenant_principal_app(
     mock_azure: AzureCloudProvider, mock_http_error_response
 ):
     mock_result = mock_requests_response(json_data={"appId": "appId", "id": "id"})
-    mock_token_response = mock_requests_response(
-        json_data={"access_token": MOCK_ACCESS_TOKEN}
-    )
+    mock_azure._get_user_principal_token_for_scope = Mock()
+    mock_azure._get_user_principal_token_for_scope.return_value = MOCK_ACCESS_TOKEN
 
     mock_azure.sdk.requests.post.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
         mock_azure.sdk.requests.exceptions.Timeout,
         mock_http_error_response,
-        mock_token_response,
         mock_result,
     ]
 
@@ -728,15 +726,13 @@ def test_create_tenant_principal(
     mock_azure: AzureCloudProvider, mock_http_error_response
 ):
     mock_result = mock_requests_response(json_data={"id": "principal_id"})
-    mock_token_response = mock_requests_response(
-        json_data={"access_token": MOCK_ACCESS_TOKEN}
-    )
+    mock_azure._get_user_principal_token_for_scope = Mock()
+    mock_azure._get_user_principal_token_for_scope.return_value = MOCK_ACCESS_TOKEN
 
     mock_azure.sdk.requests.post.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
         mock_azure.sdk.requests.exceptions.Timeout,
         mock_http_error_response,
-        mock_token_response,
         mock_result,
     ]
 
@@ -762,15 +758,13 @@ def test_create_tenant_principal_credential(
     mock_azure: AzureCloudProvider, mock_http_error_response
 ):
     mock_result = mock_requests_response(json_data={"secretText": "new secret key"})
-    mock_token_response = mock_requests_response(
-        json_data={"access_token": MOCK_ACCESS_TOKEN}
-    )
+    mock_azure._get_user_principal_token_for_scope = Mock()
+    mock_azure._get_user_principal_token_for_scope.return_value = MOCK_ACCESS_TOKEN
 
     mock_azure.sdk.requests.post.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
         mock_azure.sdk.requests.exceptions.Timeout,
         mock_http_error_response,
-        mock_token_response,
         mock_result,
     ]
 
@@ -807,9 +801,8 @@ def test_create_admin_role_definition(
             ]
         }
     )
-    mock_token_response = mock_requests_response(
-        json_data={"access_token": MOCK_ACCESS_TOKEN}
-    )
+    mock_azure._get_user_principal_token_for_scope = Mock()
+    mock_azure._get_user_principal_token_for_scope.return_value = MOCK_ACCESS_TOKEN
 
     mock_azure.sdk.requests.get.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
@@ -817,7 +810,6 @@ def test_create_admin_role_definition(
         mock_http_error_response,
         mock_result,
     ]
-    mock_azure.sdk.requests.post.return_value = mock_token_response
 
     payload = AdminRoleDefinitionCSPPayload(
         **{"tenant_id": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4"}
@@ -905,15 +897,13 @@ def test_create_principal_admin_role(
 ):
 
     mock_result = mock_requests_response(json_data={"id": "id"})
-    mock_token_response = mock_requests_response(
-        json_data={"access_token": MOCK_ACCESS_TOKEN}
-    )
+    mock_azure._get_user_principal_token_for_scope = Mock()
+    mock_azure._get_user_principal_token_for_scope.return_value = MOCK_ACCESS_TOKEN
 
     mock_azure.sdk.requests.post.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
         mock_azure.sdk.requests.exceptions.Timeout,
         mock_http_error_response,
-        mock_token_response,
         mock_result,
     ]
 

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -96,4 +96,7 @@ def mock_azure(monkeypatch):
     monkeypatch.setattr(
         azure_cloud_provider, "_get_keyvault_token", Mock(return_value="TOKEN")
     )
+    monkeypatch.setattr(
+        azure_cloud_provider, "_get_service_principal_token", Mock(return_value="TOKEN")
+    )
     return azure_cloud_provider

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -92,9 +92,4 @@ def mock_azure(monkeypatch):
         "_get_user_principal_token_for_resource",
         Mock(return_value=MOCK_ACCESS_TOKEN),
     )
-    monkeypatch.setattr(
-        azure_cloud_provider,
-        "_get_calculator_creds",
-        Mock(return_value=MOCK_ACCESS_TOKEN),
-    )
     return azure_cloud_provider

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -78,14 +78,23 @@ def mock_azure(monkeypatch):
     )
     monkeypatch.setattr(azure_cloud_provider, "set_secret", Mock(return_value=None))
     monkeypatch.setattr(
-        azure_cloud_provider, "_get_keyvault_token", Mock(return_value="TOKEN")
+        azure_cloud_provider,
+        "_get_keyvault_token",
+        Mock(return_value=MOCK_ACCESS_TOKEN),
     )
     monkeypatch.setattr(
-        azure_cloud_provider, "_get_service_principal_token", Mock(return_value="TOKEN")
+        azure_cloud_provider,
+        "_get_service_principal_token",
+        Mock(return_value=MOCK_ACCESS_TOKEN),
     )
     monkeypatch.setattr(
         azure_cloud_provider,
         "_get_user_principal_token_for_resource",
-        Mock(return_value="TOKEN"),
+        Mock(return_value=MOCK_ACCESS_TOKEN),
+    )
+    monkeypatch.setattr(
+        azure_cloud_provider,
+        "_get_calculator_creds",
+        Mock(return_value=MOCK_ACCESS_TOKEN),
     )
     return azure_cloud_provider

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -87,9 +87,4 @@ def mock_azure(monkeypatch):
         "_get_service_principal_token",
         Mock(return_value=MOCK_ACCESS_TOKEN),
     )
-    monkeypatch.setattr(
-        azure_cloud_provider,
-        "_get_user_principal_token_for_resource",
-        Mock(return_value=MOCK_ACCESS_TOKEN),
-    )
     return azure_cloud_provider

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -44,21 +44,6 @@ def mock_cloud_details():
     return AZURE_PUBLIC_CLOUD
 
 
-def mock_adal():
-    import adal
-    from adal.adal_error import AdalError
-
-    mock_adal = Mock(spec=adal)
-    mock_adal.AdalError = AdalError
-    mock_adal.AuthenticationContext.return_value.acquire_token_with_client_credentials.return_value = {
-        "accessToken": MOCK_ACCESS_TOKEN
-    }
-    mock_adal.AuthenticationContext.return_value.acquire_token_with_username_password.return_value = {
-        "accessToken": MOCK_ACCESS_TOKEN
-    }
-    return mock_adal
-
-
 def mock_requests():
     import requests
 
@@ -70,7 +55,6 @@ def mock_requests():
 class MockAzureSDK(object):
     def __init__(self):
         self.cloud = mock_cloud_details()
-        self.adal = mock_adal()
         self.requests = mock_requests()
 
 
@@ -98,5 +82,10 @@ def mock_azure(monkeypatch):
     )
     monkeypatch.setattr(
         azure_cloud_provider, "_get_service_principal_token", Mock(return_value="TOKEN")
+    )
+    monkeypatch.setattr(
+        azure_cloud_provider,
+        "_get_user_principal_token_for_resource",
+        Mock(return_value="TOKEN"),
     )
     return azure_cloud_provider


### PR DESCRIPTION
[AT-5265](https://ccpo.atlassian.net/browse/AT-5265)

This story was originally intended to replace the ADAL library for obtaining tokens with the MSAL library, as the ADAL library is being phased out. However, after discussing it with Dan we decided to just rely on direct API calls instead of any library, to keep within the larger trend we've been following favoring removal of sdk libraries. I also updated the teardown script appropriately.

This change means we using very similar code to obtain a `client_credentials` token for different resources twice, and I briefly considered abstracting that up into a new method, but decided to leave it as is for the time being, less we become too tightly coupled, but I'm open to updating it if that's what's best.