### PR TITLE
Add dependabot config

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,18 @@
+version: 1
+update_configs:
+  - directory: .
+    package_manager: python
+    update_schedule: live
+    default_labels: [dependencies, python]
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:patch"
+  - directory: .
+    package_manager: javascript
+    update_schedule: live
+    default_labels: [dependencies, javascript]
+    automerged_updates:
+      - match:
+          dependency_type: "all"
+          update_type: "semver:patch"


### PR DESCRIPTION
Github's dependabot integration can help with upgrading dependencies. It
examines known dependency files and determines which, if any,
dependencies can be upgraded. It opens pull requests for updates.

This configuration specifies that dependabot should open PRs for both
Python and Javascript. It also allows dependabot to auto-merge patch
releases for dependencies that use semantic versioning. If this is too
aggressive we can adjust the settings.

There doesn't seem to be a way to test what this config will do to our repo (i.e., get a list of dependencies it would bump) but it does pass the Dependabot linter: https://dependabot.com/docs/config-file/validator/
