### PR TITLE
Fix tenant keyvault service principal

### DIFF
--- a/terraform/modules/azure_ad/ad_application.tf
+++ b/terraform/modules/azure_ad/ad_application.tf
@@ -6,3 +6,11 @@ resource "azuread_application" "app" {
   name = var.name
 
 }
+
+
+resource "azuread_service_principal" "principal" {
+  application_id               = "${azuread_application.app.application_id}"
+  app_role_assignment_required = false
+
+
+}

--- a/terraform/modules/azure_ad/outputs.tf
+++ b/terraform/modules/azure_ad/outputs.tf
@@ -13,6 +13,10 @@ output "oauth2_permissions" {
   value = azuread_application.app.oauth2_permissions
 }
 
+output "sp_object_id" {
+value = azuread_service_principal.principal.object_id
+
+}
 output "name" {
   value = var.name
 }

--- a/terraform/modules/azure_ad/outputs.tf
+++ b/terraform/modules/azure_ad/outputs.tf
@@ -14,7 +14,7 @@ output "oauth2_permissions" {
 }
 
 output "sp_object_id" {
-value = azuread_service_principal.principal.object_id
+  value = azuread_service_principal.principal.object_id
 
 }
 output "name" {

--- a/terraform/providers/pwdev/keyvault.tf
+++ b/terraform/providers/pwdev/keyvault.tf
@@ -23,7 +23,7 @@ module "tenant_keyvault" {
   environment       = var.environment
   tenant_id         = var.tenant_id
   principal_id      = ""
-  tenant_principals = { "${module.tenant_keyvault_app.name}" = "${module.tenant_keyvault_app.application_id}" }
+  tenant_principals = { "${module.tenant_keyvault_app.name}" = "${module.tenant_keyvault_app.sp_object_id}" }
   admin_principals  = {}
   policy            = "Deny"
   subnet_ids        = [module.vpc.subnet_list["aks"].id]


### PR DESCRIPTION
Corrects an issue w/ the associated registered app and service principal configured in tenant keyvault's access policy.

The issue was, Terraform should take the registered app name and service principal object id when specifying the access policy instead of the registered app name and its own object id.  