### PR TITLE
[AT-5324] Add management groups to hybrid test teardown

### DIFF
--- a/script/teardown_hybrid.py
+++ b/script/teardown_hybrid.py
@@ -8,6 +8,7 @@ sys.path.append(parent_dir)
 from atat.app import make_config
 from atat.domain.csp.cloud.hybrid_cloud_provider import HYBRID_PREFIX
 from atat.domain.csp.cloud.utils import get_user_principal_token_for_scope
+from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
 
 GRAPH_API = "https://graph.microsoft.com"
@@ -42,6 +43,57 @@ def list_app_registrations(token):
     ]
 
 
+def delete_app_registrations(token):
+    apps = list_app_registrations(token)
+    if len(apps) > 0:
+        print("Deleting Hybrid-managed applications...")
+        for app_name, app_id in apps:
+            delete_tenant_principal_app(token, app_id)
+            print(f"  deleted {app_name}")
+    else:
+        print("No matching applications found in tenant.")
+
+
+def list_management_groups(token):
+    auth_header = {
+        "Authorization": f"Bearer {token}",
+    }
+    response = requests.get(
+        "https://management.azure.com/providers/Microsoft.Management/managementGroups?api-version=2020-02-01",
+        headers=auth_header,
+    )
+    response.raise_for_status()
+    mgmt_groups = response.json()["value"]
+
+    return [
+        (mgmt_group["properties"]["displayName"], mgmt_group["name"])
+        for mgmt_group in mgmt_groups
+        if mgmt_group["properties"]["displayName"].startswith(HYBRID_PREFIX)
+    ]
+
+
+def delete_management_group(token, mgmt_group_id):
+    auth_header = {
+        "Authorization": f"Bearer {token}",
+    }
+    response = requests.delete(
+        f"https://management.azure.com/providers/Microsoft.Management/managementGroups/{mgmt_group_id}?api-version=2020-02-01",
+        headers=auth_header,
+    )
+    response.raise_for_status()
+
+
+def delete_management_groups(token):
+    mgmt_groups = list_management_groups(token)
+    if len(mgmt_groups) > 0:
+        print("Deleting Hybrid-managed management groups...")
+        for display_name, mgmt_group_id in mgmt_groups:
+            delete_management_group(token, mgmt_group_id)
+            print(f"  deleting {display_name}")
+    else:
+        print("No matching management groups found in tenant.")
+
+
 if __name__ == "__main__":
     """
     This script deletes applications created by the HybridCloudProvider
@@ -65,14 +117,17 @@ if __name__ == "__main__":
 
     tenant_id, username, password, ps_client_id = [config[s] for s in required_config]
 
-    token = get_user_principal_token_for_scope(
+    # Delete App registations (which also deletes connected service principals)
+    graph_token = get_user_principal_token_for_scope(
         username, password, tenant_id, GRAPH_API + "/.default"
     )
-    apps = list_app_registrations(token)
-    if len(apps) > 0:
-        print("Deleting Hybrid-managed applications...")
-        for app_name, app_id in apps:
-            delete_tenant_principal_app(token, app_id)
-            print(f"  deleted {app_name}")
-    else:
-        print("No matching applications found in tenant.")
+    delete_app_registrations(graph_token)
+
+    # Delete management_groups
+    resource_token = get_user_principal_token_for_scope(
+        username,
+        password,
+        tenant_id,
+        AZURE_PUBLIC_CLOUD.endpoints.resource_manager + "/.default",
+    )
+    delete_management_groups(resource_token)


### PR DESCRIPTION
This PR extends the hybrid teardown script by deleting management groups in addition to app registrations.

I ran this script on our tenant. It appeared to work as expected. Some management groups couldn't be deleted automatically, [because](https://docs.microsoft.com/en-us/rest/api/resources/managementgroups/delete):
> If a management group contains child resources, the request will fail.

Though I suspect some management groups with child resources were able to be deleted based on ordering after GETing all management groups. If an "application" management group was listed before it's associated "portfolio" management group, both might be able to be deleted. If the portfolio was first though, it would fail. Also, DELETEing a management groups actually kicks off an async job, so there could be race condition issues at play.

I felt that the script was safe to run on our current "hybrid" setup because we'll be switching over all hybrid operations to the new tenant by the end of [AT-5324](https://ccpo.atlassian.net/browse/AT-5324). In the new tenant though, since management groups represent portfolios, applications, and environments, deleting a management groups would be like "deleting" one of these ATAT entities from the Azure side, so to speak.

This poses an interesting question though: what happens in the ATAT UI when I try to say, add a subscription to an environment whose management group I've deleted in the Azure Portal?