### PR TITLE
Hybrid switch

### DIFF
--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -24,6 +24,7 @@ def get_user_principal_token_for_scope(username, password, tenant_id, scope):
     cloud = AZURE_PUBLIC_CLOUD
     url = f"{cloud.endpoints.active_directory}/{tenant_id}/oauth2/v2.0/token"
     payload = {
+        # TODO: client_id should be parameterized
         "client_id": os.environ["AZURE_POWERSHELL_CLIENT_ID"],
         "grant_type": "password",
         "username": username,

--- a/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
+++ b/deploy/overlays/cloudzero-pwdev-staging/envvars.yml
@@ -5,7 +5,11 @@ metadata:
   name: atst-worker-envvars
 data:
   AZURE_ACCOUNT_NAME: pwdevtasks
+  AZURE_POWERSHELL_CLIENT_ID: 1950a258-227b-4e31-a9cf-717495945fc2
+  AZURE_TENANT_ADMIN_USERNAME: hybrid.admin@atathybrid.onmicrosoft.com
+  AZURE_VAULT_URL: "https://tenants-pwdev-keyvault.vault.azure.net/"
   CELERY_DEFAULT_QUEUE: celery-staging
+  CSP: hybrid
   FLASK_ENV: staging
   PGDATABASE: cloudzero_pwdev_atat
   PGHOST: 191.238.6.43
@@ -21,10 +25,14 @@ metadata:
 data:
   ASSETS_URL: ""
   AZURE_ACCOUNT_NAME: pwdevtasks
+  AZURE_POWERSHELL_CLIENT_ID: 1950a258-227b-4e31-a9cf-717495945fc2
+  AZURE_TENANT_ADMIN_USERNAME: hybrid.admin@atathybrid.onmicrosoft.com
+  AZURE_VAULT_URL: "https://tenants-pwdev-keyvault.vault.azure.net/"
   BLOB_STORAGE_URL: https://pwdevtasks.blob.core.windows.net/
   CAC_URL: https://auth-staging.atat.dev/login-redirect
   CDN_ORIGIN: https://staging.atat.dev
   CELERY_DEFAULT_QUEUE: celery-staging
+  CSP: hybrid
   FLASK_ENV: staging
   PGDATABASE: cloudzero_pwdev_atat
   PGHOST: 191.238.6.43

--- a/deploy/overlays/cloudzero-pwdev-staging/flex_vol.yml
+++ b/deploy/overlays/cloudzero-pwdev-staging/flex_vol.yml
@@ -21,7 +21,9 @@ spec:
               usevmmanagedidentity: "true"
               vmmanagedidentityclientid: $VMSS_CLIENT_ID
               keyvaultname: "cz-pwdev-keyvault"
-              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -38,7 +40,9 @@ spec:
               usevmmanagedidentity: "true"
               vmmanagedidentityclientid: $VMSS_CLIENT_ID
               keyvaultname: "cz-pwdev-keyvault"
-              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment
@@ -55,7 +59,9 @@ spec:
               usevmmanagedidentity: "true"
               vmmanagedidentityclientid: $VMSS_CLIENT_ID
               keyvaultname: "cz-pwdev-keyvault"
-              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
 ---
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -74,4 +80,6 @@ spec:
                   usevmmanagedidentity: "true"
                   vmmanagedidentityclientid: $VMSS_CLIENT_ID
                   keyvaultname: "cz-pwdev-keyvault"
-                  keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY"
+                  keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+                  keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+                  keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"


### PR DESCRIPTION
Updating some envvars for the switch to the new hybrid tenant. Including adding  `AZURE_POWERSHELL_CLIENT_ID` so that the utils/get_user_principal_token_for_scope works with `os.environ`, but eventually that should be updated with some dependency injection

created with @graham-dds and @dandds 

Dependent on the merging of https://github.com/dod-ccpo/atst/pull/1594 first