### PR TITLE
[AT-5330] revert MAIL_SENDER domain to atat.code.mil

### DIFF
--- a/deploy/azure/atst-worker-envvars-configmap.yml
+++ b/deploy/azure/atst-worker-envvars-configmap.yml
@@ -12,7 +12,7 @@ data:
   DEBUG: "0"
   DISABLE_CRL_CHECK: "true"
   MAIL_PORT: "587"
-  MAIL_SENDER: postmaster@atat.dev
+  MAIL_SENDER: postmaster@atat.code.mil
   MAIL_SERVER: smtp.mailgun.org
   MAIL_TLS: "true"
   OVERRIDE_CONFIG_DIRECTORY: /config


### PR DESCRIPTION
This is a one line fix to resolve the [SMTP bug](https://ccpo.atlassian.net/browse/AT-5330) we've been having. The culprit was updating our MAIL_SENDER to have the atat.dev domain when it needs to remain atat.code.mil [Here’s the change](https://github.com/dod-ccpo/atst/commit/c13a701a7fdf3e09054066b64824f0caab9a0785#diff-1874bc335d72441f94e97e2f52f6eea9R15) in question that caused the problem.  I will also open a ticket to fix it the mail sender domain with Mail Gun.
