### PR TITLE
[ATAT-5320] Update create database script

### DIFF
--- a/script/create_db_extension.sh
+++ b/script/create_db_extension.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+create_db_extension() {
+  local database_name="${1}"
+  local extension_name="${2}"
+
+  if [ -z "${database_name}"  ]; then
+    local database_name="atat"
+  fi
+
+  if [ -z "${extension_name}"  ]; then
+    local extension_name="uuid-ossp"
+  fi
+
+	echo "Creating ${extension_name} in ${database_name}"
+  psql "${database_name}" -c "CREATE EXTENSION IF NOT EXISTS \"${extension_name}\""
+}
+
+if [  "$(caller)" = "0 NULL"  ]; then
+  # will only run if you actually call this script rather than source it
+  create_db_extension "${1}" "${2}"
+fi
+
+

--- a/script/include/helper_functions.inc.sh
+++ b/script/include/helper_functions.inc.sh
@@ -1,5 +1,8 @@
 # helper_functions.inc.sh: General helper functions
 
+# source create_db_extension
+source ./script/create_db_extension.sh
+
 # Check pip to see if the given package is installed
 # (returns 0 if installed, 2 if not installed)
 check_system_pip_for () {
@@ -44,6 +47,9 @@ reset_db() {
 
   # Create a fresh DB
   createdb "${database_name}"
+
+  # create uuid extension
+  create_db_extension "${database_name}"
 
   # Run migrations
   migrate_db


### PR DESCRIPTION
[ATAT-5320](https://ccpo.atlassian.net/browse/AT-5320)

While performing [database bootstrap testing](https://ccpo.atlassian.net/browse/AT-5320) for the upcoming go live dry run I encountered an error with the `script/reset_database.py` script. 

One of the migrations attempts to create the DB extension `uuid-ossp`, however extensions can only be created by admin users in postgres and the script is usual run by a non-admin user. To resolve this I updated `script/create_database.py` to also create that extension after creating the database, as that script runs as the admin user. I also had to update the `helper_functions.inc.sh` script to create the extension as well, so that `script/setup` continued to work properly for developers. It's not great that the name of the extension exists in two scripts rather than a single place (the migration), but it seemed to be the only way to make everything work properly for the moment