### PR TITLE
Use variable $CA_CERTS

### DIFF
--- a/script/sync-dod-certs
+++ b/script/sync-dod-certs
@@ -9,12 +9,6 @@ echo "Resetting CA bundle..."
 rm $CA_CHAIN &> /dev/null || true
 touch $CA_CHAIN
 
-if [[ $FLASK_ENV != "prod" ]]; then
-  # only for testing and development
-  echo "Copy in testing client CA..."
-  cat ssl/client-certs/client-ca.crt >> $CA_CHAIN
-fi
-
 # dod intermediate certs
 echo "Adding DoD root certs"
 rm -rf tmp || true

--- a/script/sync-dod-certs
+++ b/script/sync-dod-certs
@@ -6,7 +6,7 @@ CAS_FILE_NAME="Certificates_PKCS7_v5.3_DoD"
 CA_CHAIN="ssl/server-certs/ca-chain.pem"
 
 echo "Resetting CA bundle..."
-rm ssl/server-certs/ca-chain.pem &> /dev/null || true
+rm $CA_CHAIN &> /dev/null || true
 touch $CA_CHAIN
 
 if [[ $FLASK_ENV != "prod" ]]; then


### PR DESCRIPTION
Use variable instead of writing path out so there's one less thing to miss in case this variable needs to be updated.