### PR TITLE
Make hybrid csp fixture work again

### DIFF
--- a/atat/domain/csp/__init__.py
+++ b/atat/domain/csp/__init__.py
@@ -25,7 +25,7 @@ class CSP:
 
 
 def make_csp_provider(app, csp=None):
-    simulate_failures = app.config.get("SIMULATE_API_FAILURE")
+    simulate_failures = app.config.get("SIMULATE_API_FAILURE", False)
     app.logger.info(f"Created a cloud service provider in '{csp}' mode!")
     app.csp = CSP(
         csp,

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -57,7 +57,13 @@ def portfolio(csp, app):
 
 @pytest.fixture(scope="function")
 def csp(app):
-    csp = CSP("hybrid", app, simulate_failures=False).cloud
+    csp = CSP(
+        "hybrid",
+        app.config,
+        with_delay=False,
+        with_failure=False,
+        with_authorization=False,
+    ).cloud
     csp.mock_tenant_id = str(uuid4())
 
     csp.azure.create_tenant_creds(

--- a/tests/domain/cloud/test_mock_csp.py
+++ b/tests/domain/cloud/test_mock_csp.py
@@ -17,7 +17,9 @@ CREDENTIALS = MockCloudProvider(config={})._auth_credentials
 
 @pytest.fixture
 def mock_csp():
-    return MockCloudProvider(config={}, with_delay=False, with_failure=False)
+    return MockCloudProvider(
+        config={}, with_delay=False, with_failure=False, with_authorization=False
+    )
 
 
 def test_create_environment(mock_csp: MockCloudProvider):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -53,7 +53,11 @@ from atat.utils.localization import translate
 
 @pytest.fixture(autouse=True, scope="function")
 def csp():
-    return Mock(wraps=MockCloudProvider({}, with_delay=False, with_failure=False))
+    return Mock(
+        wraps=MockCloudProvider(
+            {}, with_delay=False, with_failure=False, with_authorization=False
+        )
+    )
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
The hybrid CSP fixture used in hybrid tests was broken, so this PR gets it working again.

It also:
- Adds `with_authorization=False` to all instances of the mock CSP where we don't want to simulate failures 
- Makes it more explicit that when the `SIMULATE_API_FAILURE` environment variable isn't set, we want it to default to `False`

Hybrid tests are passing again, except for `test_get_reporting_data`. This seems like it's outside the scope of this bugfix, though.