### PR TITLE
[AT-5242] Expand available space for total TO value

### DIFF
--- a/templates/task_orders/fragments/task_order_view.html
+++ b/templates/task_orders/fragments/task_order_view.html
@@ -9,7 +9,7 @@
 
   <div>
     <section class="usa-grid">
-      <div class='usa-width-one-third summary-item'>
+      <div class='usa-width-one-half summary-item'>
         <h4 class="summary-item__header">
           <span class="summary-item__header-text">{{ 'task_orders.summary.total' | translate }}</span>
           {{ Tooltip(("task_orders.review.tooltip.total_value" | translate), title="", classes="icon-tooltip--tight") }}

--- a/templates/task_orders/fragments/task_order_view.html
+++ b/templates/task_orders/fragments/task_order_view.html
@@ -7,9 +7,9 @@
   {% set contract_amount = task_order.total_contract_amount %}
   {% set expended_funds = task_order.invoiced_funds %}
 
-  <div>
+  <div class="task-order">
     <section class="usa-grid">
-      <div class='usa-width-one-half summary-item'>
+      <div class='usa-width-one-third summary-item'>
         <h4 class="summary-item__header">
           <span class="summary-item__header-text">{{ 'task_orders.summary.total' | translate }}</span>
           {{ Tooltip(("task_orders.review.tooltip.total_value" | translate), title="", classes="icon-tooltip--tight") }}

--- a/templates/task_orders/view.html
+++ b/templates/task_orders/view.html
@@ -11,7 +11,5 @@
     {% endif %}
   {% endcall %}
 
-  <div class="task-order">
-    {{ TaskOrderView(task_order, portfolio) }}
-  </div>
+  {{ TaskOrderView(task_order, portfolio) }}
 {% endblock %}


### PR DESCRIPTION
Addresses UI issue that makes large TO values overlap with borders/each other. This fixes displaying large numbers on the step_4 page by adding a class to override the width set by the `form-container` class on all TO steps. This same component is used for displaying the completed task order summary as well, and once we add the Total Expended field to the component, we'll have to revisit the layout as the current styling (`summary-item` in particular) does not play nice with the layout classes.

## Before
<img width="767" alt="Screen Shot 2020-06-10 at 12 48 35 PM" src="https://user-images.githubusercontent.com/52750307/84298317-eb19ec00-ab1c-11ea-9914-2f6c2b076981.png">

## After
<img width="939" alt="Screen Shot 2020-06-12 at 1 15 05 PM" src="https://user-images.githubusercontent.com/52750307/84529052-c81f4180-acae-11ea-9a0e-bf8748779736.png">
