### PR TITLE
Alleviate 502 error

### DIFF
--- a/atat/domain/authnid/crl/__init__.py
+++ b/atat/domain/authnid/crl/__init__.py
@@ -146,14 +146,19 @@ class CRLCache(CRLInterface):
 
     def _add_certificate_chain_to_store(self, store, issuer):
         ca = self.certificate_authorities.get(issuer.der())
+        store.add_cert(ca)
+
         while issuer != ca.get_issuer():
+            issuer = ca.get_issuer()
+            ca = self.certificate_authorities.get(issuer.der())
             store.add_cert(ca)
+
             self._log(
                 "STORE ID: {}. Adding CA with subject {}".format(
                     id(store), ca.get_subject()
                 )
             )
-            ca = self.certificate_authorities.get(issuer.der())
+
         return store
 
     def crl_check(self, cert):

--- a/atat/domain/authnid/crl/__init__.py
+++ b/atat/domain/authnid/crl/__init__.py
@@ -7,6 +7,7 @@ import logging
 from OpenSSL import crypto, SSL
 from flask import current_app as app
 
+from atat.utils.processify import processify
 from .util import load_crl_locations_cache, serialize_crl_locations_cache, CRL_LIST
 
 # error codes from OpenSSL: https://github.com/openssl/openssl/blob/2c75f03b39de2fa7d006bc0f0d7c58235a54d9bb/include/openssl/x509_vfy.h#L111
@@ -161,6 +162,7 @@ class CRLCache(CRLInterface):
 
         return store
 
+    @processify
     def crl_check(self, cert):
         parsed = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
         store = self._get_store(parsed)
@@ -187,9 +189,3 @@ class CRLCache(CRLInterface):
                     type(err), err.args
                 )
             )
-
-        finally:
-            del context
-            del store
-            del parsed
-            gc.collect()

--- a/atat/domain/authnid/crl/__init__.py
+++ b/atat/domain/authnid/crl/__init__.py
@@ -145,19 +145,15 @@ class CRLCache(CRLInterface):
 
     def _add_certificate_chain_to_store(self, store, issuer):
         ca = self.certificate_authorities.get(issuer.der())
-        store.add_cert(ca)
-        self._log(
-            "STORE ID: {}. Adding CA with subject {}".format(
-                id(store), ca.get_subject()
+        while issuer != ca.get_issuer():
+            store.add_cert(ca)
+            self._log(
+                "STORE ID: {}. Adding CA with subject {}".format(
+                    id(store), ca.get_subject()
+                )
             )
-        )
-
-        if issuer == ca.get_issuer():
-            # i.e., it is the root CA and we are at the end of the chain
-            return store
-
-        else:
-            return self._add_certificate_chain_to_store(store, ca.get_issuer())
+            ca = self.certificate_authorities.get(issuer.der())
+        return store
 
     def crl_check(self, cert):
         parsed = crypto.load_certificate(crypto.FILETYPE_PEM, cert)

--- a/atat/domain/authnid/crl/__init__.py
+++ b/atat/domain/authnid/crl/__init__.py
@@ -1,4 +1,3 @@
-import gc
 import os
 import re
 import hashlib

--- a/atat/domain/authnid/crl/__init__.py
+++ b/atat/domain/authnid/crl/__init__.py
@@ -1,3 +1,4 @@
+import gc
 import os
 import re
 import hashlib
@@ -159,6 +160,7 @@ class CRLCache(CRLInterface):
         parsed = crypto.load_certificate(crypto.FILETYPE_PEM, cert)
         store = self._get_store(parsed)
         context = crypto.X509StoreContext(store, parsed)
+
         try:
             context.verify_certificate()
             return True
@@ -180,3 +182,9 @@ class CRLCache(CRLInterface):
                     type(err), err.args
                 )
             )
+
+        finally:
+            del context
+            del store
+            del parsed
+            gc.collect()

--- a/atat/utils/processify.py
+++ b/atat/utils/processify.py
@@ -10,6 +10,8 @@ def processify(func):
     is *pickable*.
     The created process is joined, so the code does not
     run in parallel.
+
+    https://gist.github.com/schlamar/2311116
     """
 
     def process_func(q, *args, **kwargs):

--- a/atat/utils/processify.py
+++ b/atat/utils/processify.py
@@ -1,0 +1,47 @@
+import sys
+import traceback
+from functools import wraps
+from multiprocessing import Process, Queue
+
+
+def processify(func):
+    """Decorator to run a function as a process.
+    Be sure that every argument and the return value
+    is *pickable*.
+    The created process is joined, so the code does not
+    run in parallel.
+    """
+
+    def process_func(q, *args, **kwargs):
+        try:
+            ret = func(*args, **kwargs)
+        except Exception:
+            ex_type, ex_value, tb = sys.exc_info()
+            error = ex_type, ex_value, "".join(traceback.format_tb(tb))
+            ret = None
+        else:
+            error = None
+
+        q.put((ret, error))
+
+    # register original function with different name
+    # in sys.modules so it is pickable
+    process_func.__name__ = func.__name__ + "processify_func"
+    setattr(sys.modules[__name__], process_func.__name__, process_func)
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        q = Queue()
+        p = Process(target=process_func, args=[q] + list(args), kwargs=kwargs)
+        p.start()
+        ret, error = q.get()
+        p.join()
+
+        if error:
+            ex_type, ex_value, tb_str = error
+            message = "%s (in subprocess)\n%s" % (str(ex_value), tb_str)
+            raise ex_type(message)
+
+        return ret
+
+    return wrapper

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -59,10 +59,10 @@ spec:
               mountPath: "/config"
           resources:
             requests:
-              memory: 400Mi
+              memory: 800Mi
               cpu: 940m
             limits:
-              memory: 400Mi
+              memory: 800Mi
               cpu: 940m
         - name: nginx
           image: $NGINX_CONTAINER_IMAGE


### PR DESCRIPTION
We are able to definitively say that a source of the 502 errors during CAC logins is due to containers exceeding their memory thresholds and trigger the OOMKiller. There is an observable leak that occurs where memory allocated to the server process is not reclaimed after multiple CAC login attempts. This is potentially due to leaks in the underlying OpenSSL crypto library.

We alleviate this issue by moving the CRL checking functionality into a separate process. This allows the operating system to reclaim the memory after the process has finished. 

However, this does not fix the overall issue, that individual login requests (depending on the CAC card) take a disproportionally large amount of resources to serve. OOMKiller will likely still be triggered if multiple people attempt to log in at once, meaning there's more investigating that needs to be done.

https://ccpo.atlassian.net/browse/AT-5331