### PR TITLE
[AT-5354] Make the fully pathed `id` derivable for `cloud_id`

### DIFF
--- a/atat/domain/csp/cloud/mock_cloud_provider.py
+++ b/atat/domain/csp/cloud/mock_cloud_provider.py
@@ -483,14 +483,16 @@ class MockCloudProvider(CloudProviderInterface):
         self._maybe_raise(self.UNAUTHORIZED_RATE, GeneralCSPException)
 
         return ApplicationCSPResult(
-            id=f"{AZURE_MGMNT_PATH}{payload.management_group_name}"
+            id=f"{AZURE_MGMNT_PATH}{payload.management_group_name}",
+            name=payload.management_group_name,
         )
 
     def create_environment(self, payload: EnvironmentCSPPayload):
         self._maybe_raise(self.UNAUTHORIZED_RATE, GeneralCSPException)
 
         return EnvironmentCSPResult(
-            id=f"{AZURE_MGMNT_PATH}{payload.management_group_name}"
+            id=f"{AZURE_MGMNT_PATH}{payload.management_group_name}",
+            name=payload.management_group_name,
         )
 
     def create_user(self, payload: UserCSPPayload):

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -372,6 +372,7 @@ class ManagementGroupCSPPayload(AliasModel):
 
 class ManagementGroupCSPResponse(AliasModel):
     id: str
+    name: str
 
 
 class ManagementGroupGetCSPPayload(BaseCSPPayload):
@@ -395,14 +396,16 @@ class InitialMgmtGroupCSPPayload(ManagementGroupCSPPayload):
 
 
 class InitialMgmtGroupCSPResult(AliasModel):
-    root_management_group_id: str
     root_management_group_name: str
 
     class Config:
         fields = {
-            "root_management_group_id": "id",
             "root_management_group_name": "name",
         }
+
+    @property
+    def root_management_group_id(self):
+        return f"/providers/Microsoft.Management/managementGroups/{self.root_management_group_name}"
 
 
 class InitialMgmtGroupVerificationCSPPayload(ManagementGroupGetCSPPayload):

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -80,7 +80,7 @@ def do_create_application(csp: CloudProviderInterface, application_id=None):
             return
 
         csp_details = application.portfolio.csp_data
-        parent_id = csp_details["root_management_group_id"]
+        parent_id = f"/providers/Microsoft.Management/managementGroups/{csp_details['root_management_group_name']}"
         tenant_id = csp_details["tenant_id"]
 
         app.logger.debug(f"application.id = {application.id}")
@@ -93,7 +93,9 @@ def do_create_application(csp: CloudProviderInterface, application_id=None):
         )
 
         app_result = csp.create_application(payload)
-        application.cloud_id = app_result.id
+        application.cloud_id = (
+            f"/providers/Microsoft.Management/managementGroups/{app_result.name}"
+        )
         db.session.add(application)
         db.session.commit()
 

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -120,7 +120,12 @@ def test_create_environment_succeeds(mock_azure: AzureCloudProvider, monkeypatch
     monkeypatch.setattr(
         mock_azure,
         "_create_management_group",
-        Mock(return_value={"id": "management/group/path/TestName"}),
+        Mock(
+            return_value={
+                "id": "management/group/path/TestName",
+                "name": "0000000-0000-0000-0000-000000000000",
+            }
+        ),
     )
     payload = EnvironmentCSPPayload(
         tenant_id="1234",
@@ -142,7 +147,12 @@ def test_create_application_succeeds(mock_azure: AzureCloudProvider, monkeypatch
     monkeypatch.setattr(
         mock_azure,
         "_create_management_group",
-        Mock(return_value={"id": management_group_id}),
+        Mock(
+            return_value={
+                "id": management_group_id,
+                "name": "0000000-0000-0000-0000-000000000000",
+            }
+        ),
     )
 
     result: ApplicationCSPResult = mock_azure.create_application(payload)
@@ -155,7 +165,7 @@ def test_create_initial_mgmt_group_succeeds(
     payload = InitialMgmtGroupCSPPayload(
         tenant_id="123", display_name="A Management Group"
     )
-    management_group_id = f"management/group/path/{payload.management_group_name}"
+    management_group_id = f"/providers/Microsoft.Management/managementGroups/{payload.management_group_name}"
     monkeypatch.setattr(
         mock_azure,
         "_create_management_group",

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -42,7 +42,7 @@ def portfolio(csp, app):
         csp_data={
             "tenant_id": csp.mock_tenant_id,
             "domain_name": app.config["AZURE_HYBRID_TENANT_DOMAIN"],
-            "root_management_group_id": csp.hybrid_tenant_id,
+            "root_management_group_name": csp.hybrid_tenant_id,
         },
     )
 

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -71,7 +71,7 @@ def test_ManagementGroupCSPPayload_parent_id():
 def test_ManagementGroupCSPResponse_id():
     full_id = "/path/to/naboo-123"
     response = ManagementGroupCSPResponse(
-        **{"id": "/path/to/naboo-123", "other": "stuff"}
+        **{"id": "/path/to/naboo-123", "other": "stuff", "name": "foo"}
     )
     assert response.id == full_id
 

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -135,7 +135,7 @@ def test_create_environment_job_is_idempotent(csp, session):
 
 def test_create_application_job(session, csp):
     portfolio = PortfolioFactory.create(
-        csp_data={"tenant_id": str(uuid4()), "root_management_group_id": str(uuid4())}
+        csp_data={"tenant_id": str(uuid4()), "root_management_group_name": str(uuid4())}
     )
     application = ApplicationFactory.create(portfolio=portfolio, cloud_id=None)
     do_create_application(csp, application.id)


### PR DESCRIPTION
https://ccpo.atlassian.net/browse/AT-5354

Co-authored By: @okaycj-atat @graham-dds 

Fixes the cloud id by deriving the management group id from a `name` rather than just using the splatted id from the polling response.

This highlights ongoing issues around standardizing our usage of names and ids. We should be working towards this:

> Only store UUIDs or simple string identifiers in a portfolio's CSP data dictionary, and use these identifiers to build the path for "fully pathed" resources

https://github.com/dod-ccpo/atst/blob/staging/atat/domain/csp/cloud/README.md#best-practices-for-integrating-with-the-azure-rest-api