### PR TITLE
[AT-5282] Include detailed Azure error messages in logs

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1202,13 +1202,7 @@ class AzureCloudProvider(CloudProviderInterface):
             url, headers=auth_header, json=request_body, timeout=30
         )
         result.raise_for_status()
-
-        if result.ok:
-            return True
-        else:
-            raise UserProvisioningException(
-                f"Failed update user email: {response.json()}"
-            )
+        return True
 
     @log_and_raise_exceptions
     def _update_active_directory_user_password_profile(self, graph_token, payload):
@@ -1230,13 +1224,7 @@ class AzureCloudProvider(CloudProviderInterface):
             url, headers=auth_header, json=request_body, timeout=30
         )
         result.raise_for_status()
-
-        if result.ok:
-            return True
-        else:
-            raise UserProvisioningException(
-                f"Failed update user password profile: {response.json()}"
-            )
+        return True
 
     def create_user_role(self, payload: UserRoleCSPPayload):
         graph_token = self._get_tenant_principal_token(payload.tenant_id)
@@ -1347,8 +1335,6 @@ class AzureCloudProvider(CloudProviderInterface):
 
         result = self.sdk.requests.post(url, headers=auth_header, timeout=30)
         result.raise_for_status()
-        if not result.ok:
-            raise AuthenticationException("Failed to elevate access")
 
         return mgmt_token
 
@@ -1412,8 +1398,7 @@ class AzureCloudProvider(CloudProviderInterface):
             timeout=30,
         )
         result.raise_for_status()
-        if result.ok:
-            return CostManagementQueryCSPResult(**result.json())
+        return CostManagementQueryCSPResult(**result.json())
 
     def get_calculator_url(self):
         calc_access_token = self._get_service_principal_token(

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -119,10 +119,14 @@ def log_and_raise_exceptions(func):
             log_format = "%s %s"
             log_values = [status_code, message]
 
-            if exc.response and exc.response.json():
-                response_body = json.dumps(exc.response.json())
-                log_format += "\n\nResponse Body:\n%s"
-                log_values.append(response_body)
+            try:
+                response_body = exc.response.json()
+                if response_body:
+                    log_format += "\n\nResponse Body:\n%s"
+                    log_values.append(json.dumps(response_body))
+            # No response or body is not parsable to JSON
+            except (AttributeError, json.decoder.JSONDecodeError):
+                pass
 
             app.logger.error(
                 log_format, *log_values, exc_info=1,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,6 +50,7 @@ class FakeLogger:
         self._log("exception", msg, *args, **kwargs)
 
     def _log(self, _lvl, msg, *args, **kwargs):
+        msg = msg % (args)
         self.messages.append(msg)
         if "extra" in kwargs:
             self.extras.append(kwargs["extra"])


### PR DESCRIPTION
Closes [AT-5282](https://ccpo.atlassian.net/browse/AT-5282).

Includes the response body if it's present when logging HTTP errors from Azure.