### PR TITLE
[AT-5185] Use printf style formatting for log messages

### DIFF
--- a/atat/domain/auth.py
+++ b/atat/domain/auth.py
@@ -82,7 +82,7 @@ def logout():
     _nullify_session(session)
 
     if dod_id:
-        app.logger.info(f"user with EDIPI {dod_id} has logged out")
+        app.logger.info("user with EDIPI %s has logged out", dod_id)
     else:
         app.logger.info("unauthenticated user has logged out")
 

--- a/atat/domain/authnid/crl/util.py
+++ b/atat/domain/authnid/crl/util.py
@@ -310,18 +310,20 @@ def remove_bad_crl(out_dir, crl_location):
 def log_error(logger, error_string, crl_location):
     if logger:
         logger.error(
-            f"{error_string}: Error downloading {crl_location}, removing file and continuing anyway"
+            "%s: Error downloading , removing file and continuing anyway",
+            error_string,
+            crl_location,
         )
 
 
 def refresh_crl(out_dir, target_dir, crl_uri, logger):
-    logger.info("updating CRL from {}".format(crl_uri))
+    logger.info("updating CRL from %s", crl_uri)
     try:
         was_updated, crl_path = write_crl(out_dir, target_dir, crl_uri)
         if was_updated:
-            logger.info("successfully synced CRL from {}".format(crl_uri))
+            logger.info("successfully synced CRL from %s", crl_uri)
         else:
-            logger.info("no updates for CRL from {}".format(crl_uri))
+            logger.info("no updates for CRL from %s")
 
         return crl_path
     except requests.exceptions.ChunkedEncodingError:

--- a/atat/domain/authz/decorator.py
+++ b/atat/domain/authz/decorator.py
@@ -28,18 +28,20 @@ def user_can_access_decorator(permission, message=None, override=None):
             try:
                 check_access(permission, message, override, *args, **kwargs)
                 app.logger.info(
-                    "User {} accessed {} {}".format(
-                        g.current_user.id, request.method, request.path
-                    ),
+                    "User %s accessed %s %s",
+                    g.current_user.id,
+                    request.method,
+                    request.path,
                     extra={"tags": ["access", "success"]},
                 )
 
                 return f(*args, **kwargs)
             except UnauthorizedError as err:
                 app.logger.warning(
-                    "User {} denied access {} {}".format(
-                        g.current_user.id, request.method, request.path
-                    ),
+                    "User %s denied access %s %s",
+                    g.current_user.id,
+                    request.method,
+                    request.path,
                     extra={"tags": ["access", "failure"]},
                 )
 

--- a/atat/domain/csp/__init__.py
+++ b/atat/domain/csp/__init__.py
@@ -26,7 +26,7 @@ class CSP:
 
 def make_csp_provider(app, csp=None):
     simulate_failures = app.config.get("SIMULATE_API_FAILURE", False)
-    app.logger.info(f"Created a cloud service provider in '{csp}' mode!")
+    app.logger.info("Created a cloud service provider in '%s' mode!", csp)
     app.csp = CSP(
         csp,
         app.config,

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -61,9 +61,10 @@ def send_mail(recipients, subject, body, attachments=[]):
 @celery.task(ignore_result=True)
 def send_notification_mail(recipients, subject, body):
     app.logger.info(
-        "Sending a notification to these recipients: {}\n\nSubject: {}\n\n{}".format(
-            recipients, subject, body
-        )
+        "Sending a notification to these recipients: %s\n\nSubject: %s\n\n%s",
+        recipients,
+        subject,
+        body,
     )
     app.mailer.send(recipients, subject, body)
 
@@ -75,7 +76,8 @@ def do_create_application(csp: CloudProviderInterface, application_id=None):
 
         if application.cloud_id:
             app.logger.warning(
-                f"Attempted to create application {application.cloud_id} when it already exists."
+                "Attempted to create application %s when it already exists.",
+                application.cloud_id,
             )
             return
 
@@ -83,10 +85,10 @@ def do_create_application(csp: CloudProviderInterface, application_id=None):
         parent_id = f"/providers/Microsoft.Management/managementGroups/{csp_details['root_management_group_name']}"
         tenant_id = csp_details["tenant_id"]
 
-        app.logger.debug(f"application.id = {application.id}")
-        app.logger.debug(f"application.portfolio.id = {application.portfolio.id}")
-        app.logger.debug(f"tenant_id = {tenant_id}")
-        app.logger.debug(f"parent_id = {parent_id}")
+        app.logger.debug("application.id = %s", application.id)
+        app.logger.debug("application.portfolio.id = %s", application.portfolio.id)
+        app.logger.debug("tenant_id = %s", tenant_id)
+        app.logger.debug("parent_id = %s", parent_id)
 
         payload = ApplicationCSPPayload(
             tenant_id=tenant_id, display_name=application.name, parent_id=parent_id
@@ -110,7 +112,7 @@ def do_create_user(csp: CloudProviderInterface, application_role_ids=None):
 
         if any([ar.cloud_id for ar in app_roles]):
             app.logger.warning(
-                f"Application role cloud ID {ar.cloud_id} already present."
+                "Application role cloud ID %s already present.", ar.cloud_id
             )
             return
 
@@ -146,7 +148,7 @@ def do_create_user(csp: CloudProviderInterface, application_role_ids=None):
             ),
         )
         app.logger.info(
-            f"Application role created notification email sent. User id: {user.id}"
+            "Application role created notification email sent. User id: %s", user.id
         )
 
 
@@ -157,7 +159,7 @@ def do_create_environment(csp: CloudProviderInterface, environment_id=None):
 
         if environment.cloud_id is not None:
             app.logger.warning(
-                f"Environment cloud ID {environment.cloud_id} already present."
+                "Environment cloud ID %s already present.", environment.cloud_id
             )
             return
 
@@ -165,9 +167,9 @@ def do_create_environment(csp: CloudProviderInterface, environment_id=None):
         parent_id = environment.application.cloud_id
         tenant_id = csp_details.get("tenant_id")
 
-        app.logger.debug(f"environment.portfolio.id = {environment.portfolio.id}")
-        app.logger.debug(f"parent_id = {parent_id}")
-        app.logger.debug(f"tenant_id = {tenant_id}")
+        app.logger.debug("environment.portfolio.id = %s", environment.portfolio.id)
+        app.logger.debug("parent_id = %s", parent_id)
+        app.logger.debug("tenant_id = %s", tenant_id)
 
         payload = EnvironmentCSPPayload(
             tenant_id=tenant_id, display_name=environment.name, parent_id=parent_id
@@ -185,7 +187,8 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
 
         if env_role.cloud_id is not None:
             app.logger.warning(
-                f"Attempting to create an environment role {env_role.cloud_id} that already exists."
+                "Attempting to create an environment role %s that already exists.",
+                env_role.cloud_id,
             )
             return
 
@@ -214,7 +217,7 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
         db.session.add(env_role)
         db.session.commit()
 
-        app.logger.info(f"Created environment role {env_role.cloud_id}")
+        app.logger.info("Created environment role %s", env_role.cloud_id)
 
         user = env_role.application_role.user
         domain_name = csp_details.get("domain_name")
@@ -228,7 +231,8 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
             ),
         )
         app.logger.info(
-            f"Notification email sent for environment role creation. User id: {user.id}"
+            "Notification email sent for environment role creation. User id: %s",
+            user.id,
         )
 
 
@@ -266,7 +270,7 @@ def make_initial_csp_data(portfolio):
 def do_provision_portfolio(csp: CloudProviderInterface, portfolio_id=None):
     portfolio = Portfolios.get_for_update(portfolio_id)
     fsm = Portfolios.get_or_create_state_machine(portfolio)
-    app.logger.info(f"Triggering next transition for portfolio {portfolio.id}")
+    app.logger.info("Triggering next transition for portfolio %s", portfolio.id)
     fsm.trigger_next_transition(csp_data=make_initial_csp_data(portfolio))
     if fsm.current_state == PortfolioStates.COMPLETED:
         send_PPOC_email(portfolio.to_dictionary())

--- a/atat/models/mixins/auditable.py
+++ b/atat/models/mixins/auditable.py
@@ -30,7 +30,8 @@ class AuditableMixin(object):
         }
 
         app.logger.info(
-            "Audit Event {}".format(action),
+            "Audit Event %s",
+            action,
             extra={
                 "audit_event": {key: str(value) for key, value in log_data.items()},
                 "tags": ["audit_event", action],

--- a/atat/routes/__init__.py
+++ b/atat/routes/__init__.py
@@ -97,7 +97,7 @@ def current_user_setup(user):
     session["user_id"] = user.id
     session["last_login"] = user.last_login
     app.session_limiter.on_login(user)
-    app.logger.info(f"authentication succeeded for user with EDIPI {user.dod_id}")
+    app.logger.info("authentication succeeded for user with EDIPI %s", user.dod_id)
     Users.update_last_login(user)
 
 
@@ -111,7 +111,7 @@ def login_redirect():
         current_user_setup(user)
     except UnauthenticatedError as err:
         app.logger.info(
-            f"authentication failed for subject distinguished name {_client_s_dn()}"
+            "authentication failed for subject distinguished name %s", _client_s_dn()
         )
         raise err
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -50,8 +50,7 @@ class FakeLogger:
         self._log("exception", msg, *args, **kwargs)
 
     def _log(self, _lvl, msg, *args, **kwargs):
-        msg = msg % (args)
-        self.messages.append(msg)
+        self.messages.append(msg % args)
         if "extra" in kwargs:
             self.extras.append(kwargs["extra"])
 


### PR DESCRIPTION
This PR "enhances" logging by using the suggested method of interpolating values into messages. This will encourage consistency, follow suggested practices, and potentially add a small performance boost.

We were relying on modern string formatting methods like f-strings and .format() to interpolate values in our log messages. The logging module suggests to use printf style formatting, though. Now, we pass a templated message for the message arg of some `logger.method()` and use positional arguments as values to be interpolated. This way, "formatting of message arguments is deferred until it cannot be avoided."

https://docs.python.org/3/howto/logging-cookbook.html#formatting-styles
https://docs.python.org/3/howto/logging.html#optimization