### PR TITLE
[AT-5282] Add missing usage of @log_and_raise_exceptions

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1139,6 +1139,7 @@ class AzureCloudProvider(CloudProviderInterface):
             if role["displayName"] == "Billing Administrator":
                 return role["id"]
 
+    @log_and_raise_exceptions
     def create_user(self, payload: UserCSPPayload) -> UserCSPResult:
         """Create a user in an Azure Active Directory instance.
         Unlike most of the methods on this interface, this requires
@@ -1243,6 +1244,7 @@ class AzureCloudProvider(CloudProviderInterface):
         result.raise_for_status()
         return True
 
+    @log_and_raise_exceptions
     def create_user_role(self, payload: UserRoleCSPPayload):
         graph_token = self._get_tenant_principal_token(payload.tenant_id)
 


### PR DESCRIPTION
Addresses https://ccpo.atlassian.net/browse/AT-5282

Handle exceptions / logging for `create_user` and `create_user_role` in Azure cloud provider.