### PR TITLE
[AT-5352] Enforce nesting of application and environment management groups.

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -316,12 +316,11 @@ class AzureCloudProvider(CloudProviderInterface):
         session.headers = {
             "Authorization": f"Bearer {sp_token}",
         }
-        if parent_id is None:
-            parent_id = f"/providers/Microsoft.Management/managementGroups/{tenant_id}"
+        request_body = {"properties": {"displayName": display_name}}
 
-        request_body = {
-            "properties": {"displayName": display_name, "parent": {"id": parent_id},}
-        }
+        if parent_id:
+            request_body["properties"]["parent"] = {"id": parent_id}
+
         response = session.put(
             f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Management/managementGroups/{management_group_id}?api-version=2020-02-01",
             json=request_body,
@@ -329,9 +328,31 @@ class AzureCloudProvider(CloudProviderInterface):
         response.raise_for_status()
         if response.status_code == 202:
             status_url = response.headers["Azure-AsyncOperation"]
-            return self._poll_management_group_creation_job(status_url, session)
+            poll_resp = self._poll_management_group_creation_job(status_url, session)
+            if parent_id:
+                self._force_apply_mgmt_grp_parent(
+                    session, parent_id, display_name, management_group_id
+                )
+            return poll_resp
         else:
-            return response.json()
+            resp = response.json()
+            if parent_id:
+                self._force_apply_mgmt_grp_parent(
+                    session, parent_id, display_name, management_group_id
+                )
+            return resp
+
+    @log_and_raise_exceptions
+    def _force_apply_mgmt_grp_parent(
+        self, session, parent_id, display_name, management_group_id
+    ):
+        request_body = {"displayName": display_name, "parentId": parent_id}
+        response = session.patch(
+            f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Management/managementGroups/{management_group_id}?api-version=2020-02-01",
+            json=request_body,
+        )
+        response.raise_for_status()
+        return True
 
     @log_and_raise_exceptions
     def _poll_management_group_creation_job(self, url: str, session) -> Dict:

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -351,16 +351,12 @@ class AzureCloudProvider(CloudProviderInterface):
             # This should not be necessary, but Azure is currently not
             # respecting the specified parent in the request body of the
             # initial call, so we update it here.
-            self._force_apply_mgmt_grp_parent(
-                session, parent_id, display_name, management_group_id
-            )
+            self._force_apply_mgmt_grp_parent(session, parent_id, management_group_id)
 
         return resp
 
     @log_and_raise_exceptions
-    def _force_apply_mgmt_grp_parent(
-        self, session, parent_id, display_name, management_group_id
-    ):
+    def _force_apply_mgmt_grp_parent(self, session, parent_id, management_group_id):
         """
         Update an existing management group to specify its parent.
 
@@ -368,12 +364,11 @@ class AzureCloudProvider(CloudProviderInterface):
         Args:
             session: a requests session object
             parent_id: the ID of the parent for the management group
-            display_name: a display name for the management group
             management_group_id: a simple ID for the management group, like a GUID (i.e., not fully qualified)
         Returns:
             True
         """
-        request_body = {"displayName": display_name, "parentId": parent_id}
+        request_body = {"parentId": parent_id}
         response = session.patch(
             f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Management/managementGroups/{management_group_id}?api-version=2020-02-01",
             json=request_body,

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -175,7 +175,9 @@ def do_create_environment(csp: CloudProviderInterface, environment_id=None):
             tenant_id=tenant_id, display_name=environment.name, parent_id=parent_id
         )
         env_result = csp.create_environment(payload)
-        environment.cloud_id = env_result.id
+        environment.cloud_id = (
+            f"/providers/Microsoft.Management/managementGroups/{env_result.name}"
+        )
         db.session.add(environment)
         db.session.commit()
 

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -115,8 +115,8 @@ class PortfolioStateMachine(
 
     @property
     def current_stage(self) -> str:
-        """Returns the current stage of the CSP provisioning process       
-        
+        """Returns the current stage of the CSP provisioning process
+
         E.g. TENANT_IN_PROGRESS -> tenant
         """
         for stage_state in StageStates:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -115,7 +115,14 @@ def db(app, request):
     _db.drop_all()
 
 
-@pytest.fixture(scope="function", autouse=True)
+def determine_session_scope(fixture_name, config):
+    if config.getoption("--hybrid", None):
+        return "session"
+    else:
+        return "function"
+
+
+@pytest.fixture(scope=determine_session_scope, autouse=True)
 def session(db, request):
     """Creates a new database session for a test."""
     connection = db.engine.connect()

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -16,6 +16,7 @@ from atat.domain.csp.cloud.models import (
 )
 from atat.jobs import do_create_application, do_create_environment_role, do_create_user
 from atat.models import PortfolioStates, PortfolioStateMachine
+import tests.factories as factories
 from tests.factories import (
     ApplicationFactory,
     ApplicationRoleFactory,
@@ -30,12 +31,28 @@ from tests.factories import (
 )
 
 
-@pytest.fixture(scope="function")
-def portfolio(csp, app):
+def _create_active_taskorder(factory: TaskOrderFactory, portfolio):
+    """
+    Since some of the fixtures in this module are scoped to the test session
+    and others to the function, they cannot easily share fixtures in common.
+    In order to DRY up some of the code, this method takes the
+    TaskOrderFactory as an argument. That way pytest does not object about
+    whether the SQLAlchemy session fixture underlying the factory is session
+    or function-scoped.
+    """
     today = pendulum.today()
     yesterday = today.subtract(days=1)
     future = today.add(days=100)
 
+    return factory.create(
+        portfolio=portfolio,
+        signed_at=yesterday,
+        clins=[CLINFactory.create(start_date=yesterday, end_date=future)],
+    )
+
+
+@pytest.fixture(scope="function")
+def portfolio(csp, app):
     owner = UserFactory.create()
     portfolio = PortfolioFactory.create(
         owner=owner,
@@ -46,11 +63,7 @@ def portfolio(csp, app):
         },
     )
 
-    TaskOrderFactory.create(
-        portfolio=portfolio,
-        signed_at=yesterday,
-        clins=[CLINFactory.create(start_date=yesterday, end_date=future)],
-    )
+    _create_active_taskorder(TaskOrderFactory, portfolio)
 
     return portfolio
 
@@ -81,45 +94,116 @@ def csp(app):
     return csp
 
 
-@pytest.fixture(scope="function")
-def state_machine(app, csp, portfolio):
-    return PortfolioStateMachineFactory.create(portfolio=portfolio, cloud=csp)
-
-
 @pytest.mark.hybrid
-def test_hybrid_provision_portfolio(state_machine: PortfolioStateMachine):
-    csp_data = {}
-    config = {"billing_account_name": "billing_account_name"}
+class TestIntegration:
+    @pytest.fixture(scope="session", autouse=True)
+    def session(self, db, request):
+        """Creates a new database session for a test."""
+        connection = db.engine.connect()
+        transaction = connection.begin()
 
-    while state_machine.state != PortfolioStates.COMPLETED:
-        collected_data = dict(
-            list(csp_data.items())
-            + list(state_machine.portfolio.to_dictionary().items())
-            + list(config.items())
+        options = dict(bind=connection, binds={})
+        session = db.create_scoped_session(options=options)
+
+        db.session = session
+
+        factory_list = [
+            cls
+            for _name, cls in factories.__dict__.items()
+            if isinstance(cls, type) and cls.__module__ == "tests.factories"
+        ]
+        for factory in factory_list:
+            factory._meta.sqlalchemy_session = session
+            factory._meta.sqlalchemy_session_persistence = "commit"
+
+        yield session
+
+        transaction.rollback()
+        connection.close()
+        session.remove()
+
+    @pytest.fixture(scope="session")
+    def portfolio(self, csp, app):
+        owner = UserFactory.create()
+        portfolio = PortfolioFactory.create(owner=owner,)
+
+        _create_active_taskorder(TaskOrderFactory, portfolio)
+
+        return portfolio
+
+    @pytest.fixture(scope="session")
+    def csp(self, app):
+        csp = CSP(
+            "hybrid",
+            app.config,
+            with_delay=False,
+            with_failure=False,
+            with_authorization=False,
+        ).cloud
+
+        return csp
+
+    @pytest.fixture(scope="session")
+    def state_machine(self, app, csp, portfolio):
+        return PortfolioStateMachineFactory.create(portfolio=portfolio, cloud=csp)
+
+    def test_hybrid_provision_portfolio(self, state_machine: PortfolioStateMachine):
+        csp_data = {}
+        config = {"billing_account_name": "billing_account_name"}
+
+        self.portfolio = state_machine.portfolio
+        self.csp = state_machine.cloud
+
+        while state_machine.state != PortfolioStates.COMPLETED:
+            collected_data = dict(
+                list(csp_data.items())
+                + list(state_machine.portfolio.to_dictionary().items())
+                + list(config.items())
+            )
+
+            state_machine.trigger_next_transition(csp_data=collected_data)
+            # TODO: The _get_service_principal_token method call within
+            # create_initial_mgmt_group fails periodically. There must be some kind
+            # of race condition on the Azure side we're not accounting for. This
+            # sleep is temporary and we should solve the race condition.
+            sleep(1)
+            assert (
+                "created" in state_machine.state.value
+                or state_machine.state == PortfolioStates.COMPLETED
+            )
+
+            csp_data = state_machine.portfolio.csp_data
+
+    def _get_management_group(self, csp, tenant_id, management_group_id):
+        sp_token = csp.azure._get_tenant_principal_token(tenant_id)
+        headers = {
+            "Authorization": f"Bearer {sp_token}",
+        }
+        response = csp.azure.sdk.requests.get(
+            f"{csp.azure.sdk.cloud.endpoints.resource_manager}{management_group_id}?api-version=2020-02-01",
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def test_hybrid_create_application_job(self, csp, portfolio, session):
+        application = ApplicationFactory.create(portfolio=portfolio, cloud_id=None)
+
+        do_create_application(csp, application.id)
+        session.refresh(application)
+
+        assert application.cloud_id
+
+        mgmt_grp_resp = self._get_management_group(
+            csp, portfolio.csp_data["tenant_id"], application.cloud_id
         )
 
-        state_machine.trigger_next_transition(csp_data=collected_data)
-        # TODO: The _get_service_principal_token method call within
-        # create_initial_mgmt_group fails periodically. There must be some kind
-        # of race condition on the Azure side we're not accounting for. This
-        # sleep is temporary and we should solve the race condition.
-        sleep(1)
+        # the root management group should be the parent of the management
+        # group we just created for the application
         assert (
-            "created" in state_machine.state.value
-            or state_machine.state == PortfolioStates.COMPLETED
+            portfolio.csp_data["root_management_group_name"]
+            in mgmt_grp_resp["properties"]["details"]["parent"]["id"]
         )
-
-        csp_data = state_machine.portfolio.csp_data
-
-
-@pytest.mark.hybrid
-def test_hybrid_create_application_job(csp, portfolio, session):
-    application = ApplicationFactory.create(portfolio=portfolio, cloud_id=None)
-
-    do_create_application(csp, application.id)
-    session.refresh(application)
-
-    assert application.cloud_id
 
 
 @pytest.mark.hybrid

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -101,32 +101,6 @@ def csp(app):
 
 @pytest.mark.hybrid
 class TestIntegration:
-    @pytest.fixture(scope="session", autouse=True)
-    def session(self, db, request):
-        """Creates a new database session for a test."""
-        connection = db.engine.connect()
-        transaction = connection.begin()
-
-        options = dict(bind=connection, binds={})
-        session = db.create_scoped_session(options=options)
-
-        db.session = session
-
-        factory_list = [
-            cls
-            for _name, cls in factories.__dict__.items()
-            if isinstance(cls, type) and cls.__module__ == "tests.factories"
-        ]
-        for factory in factory_list:
-            factory._meta.sqlalchemy_session = session
-            factory._meta.sqlalchemy_session_persistence = "commit"
-
-        yield session
-
-        transaction.rollback()
-        connection.close()
-        session.remove()
-
     @pytest.fixture(scope="session")
     def portfolio(self, csp, app):
         owner = UserFactory.create()


### PR DESCRIPTION
When we create management group, we transmit information about what management group should be its parent. For an application management group, its parent should be the portfolio management group. These parameters in the request body do not seem to be respected by Azure at the moment.  It is creating application management groups as children of the tenant's root management group, which is not the hierarchy we want for our Hybrid implementation.

Making a subsequent PATCH request on the management group to update its parent fixes the issue, but we should not have to do this. I think that we should use this as a temporary fix and investigate why the Azure resource management API doesn't seem to respect the initial set of parameters we give it.

This PR introduces a new test class for the hybrid suite, `TestIntegration`. The tests are highly dependent on their order here. The first test provisions a portfolio in Azure. Subsequent tests add an application and environment, provisioning their management groups and ensuring they are nested correctly.

Notes

- The TestIntegration class implements its own version of the database session fixture. Since database entities implemented as fixtures need to be shared between tests in the class, the database session needs to be scoped to the test run session.
- The commit de4c8662d9a912b2ca45151b397518f98701fd69 introduces a parallel change to what was previously done in 60aef421e7. We save the fully qualified ID of the new environment management group as the `cloud_id` for that environment.

https://ccpo.atlassian.net/browse/AT-5352
https://ccpo.atlassian.net/browse/AT-5353
