### PR TITLE
[AT-5367] Use pytest-depends for integration test order

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -333,7 +333,6 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or python_version >= \"3.4\" and sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -514,6 +513,17 @@ name = "future"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "0.18.2"
+
+[[package]]
+category = "dev"
+description = "A backport of fstrings to python<3.6"
+name = "future-fstrings"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "1.2.0"
+
+[package.extras]
+rewrite = ["tokenize-rt (>=3)"]
 
 [[package]]
 category = "dev"
@@ -832,6 +842,30 @@ python-versions = "*"
 version = "0.4.3"
 
 [[package]]
+category = "dev"
+description = "Python package for creating and manipulating graphs and networks"
+name = "networkx"
+optional = false
+python-versions = ">=3.5"
+version = "2.4"
+
+[package.dependencies]
+decorator = ">=4.3.0"
+
+[package.extras]
+all = ["numpy", "scipy", "pandas", "matplotlib", "pygraphviz", "pydot", "pyyaml", "gdal", "lxml", "pytest"]
+gdal = ["gdal"]
+lxml = ["lxml"]
+matplotlib = ["matplotlib"]
+numpy = ["numpy"]
+pandas = ["pandas"]
+pydot = ["pydot"]
+pygraphviz = ["pygraphviz"]
+pytest = ["pytest"]
+pyyaml = ["pyyaml"]
+scipy = ["scipy"]
+
+[[package]]
 category = "main"
 description = "A generic, spec-compliant, thorough implementation of the OAuth request-signing logic"
 name = "oauthlib"
@@ -1088,6 +1122,20 @@ pytest = ">=4.6"
 
 [package.extras]
 testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
+category = "dev"
+description = "Tests that depend on other tests"
+name = "pytest-depends"
+optional = false
+python-versions = "*"
+version = "1.0.1"
+
+[package.dependencies]
+colorama = "*"
+future-fstrings = "*"
+networkx = "*"
+pytest = ">=3"
 
 [[package]]
 category = "dev"
@@ -1473,7 +1521,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "eb70cd67cae3f16b5ffc01afd8336503318aadd0550e5fa63ec9a58b3457560a"
+content-hash = "95be599be1a570546f0efe8c16a7b29ebc7676c82d47983025ad38a1607c629e"
 python-versions = "3.7.3"
 
 [metadata.files]
@@ -1712,6 +1760,10 @@ flask-wtf = [
 future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
+future-fstrings = [
+    {file = "future_fstrings-1.2.0-py2.py3-none-any.whl", hash = "sha256:90e49598b553d8746c4dc7d9442e0359d038c3039d802c91c0a55505da318c63"},
+    {file = "future_fstrings-1.2.0.tar.gz", hash = "sha256:6cf41cbe97c398ab5a81168ce0dbb8ad95862d3caf23c21e4430627b90844089"},
+]
 gitdb = [
     {file = "gitdb-4.0.4-py3-none-any.whl", hash = "sha256:ba1132c0912e8c917aa8aa990bee26315064c7b7f171ceaaac0afeb1dc656c6a"},
     {file = "gitdb-4.0.4.tar.gz", hash = "sha256:6f0ecd46f99bb4874e5678d628c3a198e2b4ef38daea2756a2bfd8df7dd5c1a5"},
@@ -1869,6 +1921,10 @@ mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
+networkx = [
+    {file = "networkx-2.4-py3-none-any.whl", hash = "sha256:cdfbf698749a5014bf2ed9db4a07a5295df1d3a53bf80bf3cbd61edf9df05fa1"},
+    {file = "networkx-2.4.tar.gz", hash = "sha256:f8f4ff0b6f96e4f9b16af6b84622597b5334bf9cae8cf9b2e42e7985d5c95c64"},
+]
 oauthlib = [
     {file = "oauthlib-3.1.0-py2.py3-none-any.whl", hash = "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"},
     {file = "oauthlib-3.1.0.tar.gz", hash = "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889"},
@@ -2016,6 +2072,10 @@ pytest = [
 pytest-cov = [
     {file = "pytest-cov-2.10.0.tar.gz", hash = "sha256:1a629dc9f48e53512fcbfda6b07de490c374b0c83c55ff7a1720b3fccff0ac87"},
     {file = "pytest_cov-2.10.0-py2.py3-none-any.whl", hash = "sha256:6e6d18092dce6fad667cd7020deed816f858ad3b49d5b5e2b1cc1c97a4dba65c"},
+]
+pytest-depends = [
+    {file = "pytest-depends-1.0.1.tar.gz", hash = "sha256:90a28e2b87b75b18abd128c94015248544acac20e4392e9921e5a86f93319dfe"},
+    {file = "pytest_depends-1.0.1-py3-none-any.whl", hash = "sha256:a1df072bcc93d77aca3f0946903f5fed8af2d9b0056db1dfc9ed5ac164ab0642"},
 ]
 pytest-env = [
     {file = "pytest-env-0.6.2.tar.gz", hash = "sha256:7e94956aef7f2764f3c147d216ce066bf6c42948bb9e293169b1b1c880a580c2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ beautifulsoup4 = "*"
 mypy = "*"
 rope = "*"
 black = "^19.10b0"
+pytest-depends = "^1.0.1"
 
 
 [tool.black]

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1386,8 +1386,7 @@ def test_create_user_role(mock_azure: AzureCloudProvider):
 
 def test_create_user_role_failure(mock_azure: AzureCloudProvider):
 
-    mock_result_create = mock_requests_response(ok=False)
-    mock_azure.sdk.requests.put.return_value = mock_result_create
+    mock_azure.sdk.requests.put.side_effect = [mock_requests_response(ok=False)]
 
     payload = UserRoleCSPPayload(
         tenant_id=uuid4().hex,

--- a/tests/domain/cloud/test_azure_file_service.py
+++ b/tests/domain/cloud/test_azure_file_service.py
@@ -4,51 +4,61 @@ from atat.domain.csp.files import AzureFileService
 from azure.storage.blob.models import Blob
 
 
-class MockBlockBlobService(object):
-    blob_name = "1s4lsd45"
-    content = b"mock content"
-    metadata = {"filename": "test.pdf"}
+@pytest.fixture
+def mock_block_blob_service():
+    class MockBlockBlobService(object):
+        blob_name = "1s4lsd45"
+        content = b"mock content"
+        metadata = {"filename": "test.pdf"}
 
-    def __init__(self, exception=None, **kwargs):
-        self.exception = exception
+        def __init__(self, exception=None, **kwargs):
+            self.exception = exception
 
-    def get_blob_to_bytes(self, blob_name, **kwargs):
-        if self.exception:
-            raise self.exception
-        else:
-            return Blob(
-                name=MockBlockBlobService.blob_name,
-                content=MockBlockBlobService.content,
-                metadata=MockBlockBlobService.metadata,
-            )
+        def get_blob_to_bytes(self, blob_name, **kwargs):
+            if self.exception:
+                raise self.exception
+            else:
+                return Blob(
+                    name=self.blob_name, content=self.content, metadata=self.metadata,
+                )
+
+    return MockBlockBlobService
+
+
+@pytest.fixture
+def file_service(app, mock_block_blob_service):
+    file_service = AzureFileService(config=app.config)
+    file_service.BlockBlobService = mock_block_blob_service
+    return file_service
+
+
+@pytest.fixture
+def task_order(file_service):
+    return file_service.download_task_order(file_service.BlockBlobService.blob_name)
 
 
 class Test_download_task_order:
-    @pytest.fixture
-    def file_service(self, app):
-        file_service = AzureFileService(config=app.config)
-        file_service.BlockBlobService = MockBlockBlobService
-        return file_service
+    def test_name(self, task_order, file_service):
+        assert task_order["name"] == file_service.BlockBlobService.blob_name
 
-    @pytest.fixture
-    def task_order(self, file_service):
-        return file_service.download_task_order(MockBlockBlobService.blob_name)
+    def test_content(self, task_order, file_service):
+        assert task_order["content"] == file_service.BlockBlobService.content
 
-    def test_name(self, task_order):
-        assert task_order["name"] == MockBlockBlobService.blob_name
-
-    def test_content(self, task_order):
-        assert task_order["content"] == MockBlockBlobService.content
-
-    def test_filename(self, task_order):
-        assert task_order["filename"] == MockBlockBlobService.metadata["filename"]
+    def test_filename(self, task_order, file_service):
+        assert (
+            task_order["filename"] == file_service.BlockBlobService.metadata["filename"]
+        )
 
     def test_no_metadata(self, file_service):
-        MockBlockBlobService.metadata = None
-        task_order = file_service.download_task_order(MockBlockBlobService.blob_name)
+        file_service.BlockBlobService.metadata = None
+        task_order = file_service.download_task_order(
+            file_service.BlockBlobService.blob_name
+        )
         assert task_order["filename"] == AzureFileService.DEFAULT_FILENAME
 
     def test_no_filename_in_metadata(self, file_service):
-        MockBlockBlobService.metadata = {}
-        task_order = file_service.download_task_order(MockBlockBlobService.blob_name)
+        file_service.BlockBlobService.metadata = {}
+        task_order = file_service.download_task_order(
+            file_service.BlockBlobService.blob_name
+        )
         assert task_order["filename"] == AzureFileService.DEFAULT_FILENAME

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -154,6 +154,7 @@ class TestIntegration:
     def state_machine(self, app, csp, portfolio):
         return PortfolioStateMachineFactory.create(portfolio=portfolio, cloud=csp)
 
+    @pytest.mark.depends(name="portfolio")
     def test_hybrid_provision_portfolio(self, state_machine: PortfolioStateMachine):
         csp_data = {}
         config = {"billing_account_name": "billing_account_name"}
@@ -193,6 +194,7 @@ class TestIntegration:
         response.raise_for_status()
         return response.json()
 
+    @pytest.mark.depends(name="application", on=["portfolio"])
     def test_hybrid_create_application_job(self, csp, application, tenant_id, session):
         do_create_application(csp, application.id)
         session.refresh(application)
@@ -208,6 +210,7 @@ class TestIntegration:
             in mgmt_grp_resp["properties"]["details"]["parent"]["id"]
         )
 
+    @pytest.mark.depends(on=["application"])
     def test_hybrid_create_environment_job(self, csp, environment, tenant_id, session):
         do_create_environment(csp, environment.id)
         session.refresh(environment)
@@ -223,6 +226,7 @@ class TestIntegration:
             in mgmt_grp_resp["properties"]["details"]["parent"]["id"]
         )
 
+    @pytest.mark.depends(on=["application"])
     def test_hybrid_create_user_job(self, session, csp, app_role, portfolio):
         assert not app_role.cloud_id
 
@@ -264,7 +268,9 @@ def test_get_reporting_data(csp, app, monkeypatch):
 
 
 @pytest.mark.hybrid
-@pytest.mark.xfail(reason="This test cannot complete due to permission issues.")
+@pytest.mark.skip(
+    reason="We are using the mock cloud provider's subscription method right now"
+)
 def test_create_subscription(csp):
     environment = EnvironmentFactory.create()
 

--- a/tests/test_manual_provisioning.py
+++ b/tests/test_manual_provisioning.py
@@ -11,56 +11,67 @@ import json
 import pytest
 
 
-class TestManualProvisioning:
-    def _helper(self, prov_func, input_path, output_path):
-        csp, inputs = get_provider_and_inputs(input_path, "mock-test")
-        result = prov_func(csp, inputs)
-        update_and_write(inputs, result, output_path, verbose=False)
-        with open(output_path) as json_file:
-            assert json.load(json_file)
+def _helper(prov_func, input_path, output_path):
+    csp, inputs = get_provider_and_inputs(input_path, "mock-test")
+    result = prov_func(csp, inputs)
+    update_and_write(inputs, result, output_path, verbose=False)
+    with open(output_path) as json_file:
+        assert json.load(json_file)
 
-    @pytest.fixture(scope="session")
-    def output_dir(self, tmp_path_factory):
-        return tmp_path_factory.getbasetemp()
 
-    def test_create_tenant(self, output_dir):
-        self._helper(
-            a_create_tenant.create_tenant,
-            "script/provision/sample.json",
-            output_dir / "create_tenant.json",
-        )
+@pytest.fixture(scope="session")
+def output_dir(tmp_path_factory):
+    return tmp_path_factory.getbasetemp()
 
-    def test_setup_billing(self, output_dir):
-        self._helper(
-            b_setup_billing.setup_billing,
-            output_dir / "create_tenant.json",
-            output_dir / "setup_billing.json",
-        )
 
-    def test_grant_access(self, output_dir):
-        self._helper(
-            c_billing_profile_tenant_access.grant_access,
-            output_dir / "setup_billing.json",
-            output_dir / "grant_access.json",
-        )
+def test_create_tenant(output_dir):
+    _helper(
+        a_create_tenant.create_tenant,
+        "script/provision/sample.json",
+        output_dir / "create_tenant.json",
+    )
 
-    def test_setup_to_billing(self, output_dir):
-        self._helper(
-            d_setup_to_billing.setup_to_billing,
-            output_dir / "grant_access.json",
-            output_dir / "setup_to_billing.json",
-        )
 
-    def test_report_clin(self, output_dir):
-        self._helper(
-            e_report_clin.report_clin,
-            output_dir / "setup_to_billing.json",
-            output_dir / "report_clin.json",
-        )
+@pytest.mark.depends(on=["test_create_tenant"])
+def test_setup_billing(output_dir):
+    _helper(
+        b_setup_billing.setup_billing,
+        output_dir / "create_tenant.json",
+        output_dir / "setup_billing.json",
+    )
 
-    def test_purchase_aadp(self, output_dir):
-        self._helper(
-            f_purchase_aadp.purchase_aadp,
-            output_dir / "report_clin.json",
-            output_dir / "purchase_aadp.json",
-        )
+
+@pytest.mark.depends(on=["test_setup_billing"])
+def test_grant_access(output_dir):
+    _helper(
+        c_billing_profile_tenant_access.grant_access,
+        output_dir / "setup_billing.json",
+        output_dir / "grant_access.json",
+    )
+
+
+@pytest.mark.depends(on=["test_grant_access"])
+def test_setup_to_billing(output_dir):
+    _helper(
+        d_setup_to_billing.setup_to_billing,
+        output_dir / "grant_access.json",
+        output_dir / "setup_to_billing.json",
+    )
+
+
+@pytest.mark.depends(on=["test_setup_to_billing"])
+def test_report_clin(output_dir):
+    _helper(
+        e_report_clin.report_clin,
+        output_dir / "setup_to_billing.json",
+        output_dir / "report_clin.json",
+    )
+
+
+@pytest.mark.depends(on=["test_report_clin"])
+def test_purchase_aadp(output_dir):
+    _helper(
+        f_purchase_aadp.purchase_aadp,
+        output_dir / "report_clin.json",
+        output_dir / "purchase_aadp.json",
+    )


### PR DESCRIPTION
In a few integration tests, we rely on execution order to test multi-stage processes. These include:
- hybrid tests where we provision a portfolio and then use that portfolio to create other Azure resources 
- manual provisioning tests where the output of one test is needed by the next test

In this PR, we add the dev dependency [`pytest-depends`](https://pypi.org/project/pytest-depends/) where we can explicity call out and enforce this test order. We use it only for integration tests, and that should be its only use going forward.

Adding these dependency appears to change the default order that `pytest` discovers tests. This had the side-effect of making tests fail which also relied on state mutated in other tests. This PR also addresses these failing tests.