### PR TITLE
[AT-5241] Resolve changes pending bug

### DIFF
--- a/alembic/versions/ed7fb0017f7d_rename_env_role_status_enum.py
+++ b/alembic/versions/ed7fb0017f7d_rename_env_role_status_enum.py
@@ -1,0 +1,59 @@
+"""rename env role status enum
+
+Change state that represents a successfull creation of an environment role from
+"COMPLETED" to "ACTIVE" to match the wording of other status roles.
+
+Revision ID: ed7fb0017f7d
+Revises: ce9983b781fa
+Create Date: 2020-07-07 11:38:08.238693
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "ed7fb0017f7d"  # pragma: allowlist secret
+down_revision = "ce9983b781fa"  # pragma: allowlist secret
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.alter_column(
+        "environment_roles",
+        "status",
+        type_=sa.Enum(
+            "ACTIVE", "PENDING", "DISABLED", name="status", native_enum=False,
+        ),
+        existing_type=sa.Enum(
+            "PENDING", "COMPLETED", "DISABLED", name="status", native_enum=False
+        ),
+    )
+    conn = op.get_bind()
+    conn.execute(
+        """
+        UPDATE environment_roles
+        SET status = (CASE WHEN status = 'COMPLETED' THEN 'ACTIVE' ELSE status END)
+        """
+    )
+
+
+def downgrade():
+    conn = op.get_bind()
+    conn.execute(
+        """
+        UPDATE environment_roles
+        SET status = (CASE WHEN status = 'ACTIVE' THEN 'COMPLETED' ELSE status END)
+        """
+    )
+    op.alter_column(
+        "environment_roles",
+        "status",
+        type_=sa.Enum(
+            "PENDING", "COMPLETED", "DISABLED", name="status", native_enum=False
+        ),
+        existing_type=sa.Enum(
+            "ACTIVE", "PENDING", "DISABLED", name="status", native_enum=False,
+        ),
+    )

--- a/atat/domain/environment_roles.py
+++ b/atat/domain/environment_roles.py
@@ -6,6 +6,7 @@ from atat.database import db
 from atat.models import (
     Environment,
     EnvironmentRole,
+    EnvironmentRoleStatus,
     Application,
     ApplicationRole,
     ApplicationRoleStatus,
@@ -31,7 +32,7 @@ class EnvironmentRoles(object):
                 EnvironmentRole.application_role_id == application_role_id,
                 EnvironmentRole.environment_id == environment_id,
                 EnvironmentRole.deleted == False,
-                EnvironmentRole.status != EnvironmentRole.Status.DISABLED,
+                EnvironmentRole.status != EnvironmentRoleStatus.DISABLED,
             )
             .one_or_none()
         )
@@ -103,7 +104,7 @@ class EnvironmentRoles(object):
                     ApplicationRole.deleted == False,
                     ApplicationRole.cloud_id != None,
                     ApplicationRole.status != ApplicationRoleStatus.DISABLED,
-                    EnvironmentRole.status != EnvironmentRole.Status.DISABLED,
+                    EnvironmentRole.status != EnvironmentRoleStatus.DISABLED,
                     EnvironmentRole.cloud_id.is_(None),
                     or_(
                         EnvironmentRole.claimed_until.is_(None),
@@ -123,7 +124,7 @@ class EnvironmentRoles(object):
             tenant_id = environment_role.environment.portfolio.tenant_id
             app.csp.cloud.disable_user(tenant_id, environment_role.cloud_id)
 
-        environment_role.status = EnvironmentRole.Status.DISABLED
+        environment_role.status = EnvironmentRoleStatus.DISABLED
         db.session.add(environment_role)
         db.session.commit()
 

--- a/atat/domain/environment_roles.py
+++ b/atat/domain/environment_roles.py
@@ -117,6 +117,16 @@ class EnvironmentRoles(object):
         return [id_ for id_, in results]
 
     @classmethod
+    def activate(cls, role, cloud_id):
+        """Assign a cloud id to an environment role and marks it as completed"""
+
+        role.status = EnvironmentRoleStatus.COMPLETED
+        role.cloud_id = cloud_id
+
+        db.session.add(role)
+        db.session.commit()
+
+    @classmethod
     def disable(cls, environment_role_id):
         environment_role = EnvironmentRoles.get_by_id(environment_role_id)
 

--- a/atat/domain/environment_roles.py
+++ b/atat/domain/environment_roles.py
@@ -118,9 +118,9 @@ class EnvironmentRoles(object):
 
     @classmethod
     def activate(cls, role, cloud_id):
-        """Assign a cloud id to an environment role and marks it as completed"""
+        """Assign a cloud id to an environment role and marks it as active"""
 
-        role.status = EnvironmentRoleStatus.COMPLETED
+        role.status = EnvironmentRoleStatus.ACTIVE
         role.cloud_id = cloud_id
 
         db.session.add(role)

--- a/atat/domain/environments.py
+++ b/atat/domain/environments.py
@@ -63,10 +63,10 @@ class Environments(object):
     def update_env_role(cls, environment, application_role, new_role):
         env_role = EnvironmentRoles.get_for_update(application_role.id, environment.id)
 
-        if env_role and new_role and (env_role.disabled or env_role.deleted):
+        if env_role and new_role and (env_role.is_disabled or env_role.deleted):
             raise DisabledError("environment_role", env_role.id)
 
-        if env_role and env_role.role != new_role and not env_role.disabled:
+        if env_role and env_role.role != new_role and not env_role.is_disabled:
             env_role.role = new_role
             db.session.add(env_role)
         elif not env_role and new_role:
@@ -77,7 +77,7 @@ class Environments(object):
             )
             db.session.add(env_role)
 
-        if env_role and not new_role and not env_role.disabled:
+        if env_role and not new_role and not env_role.is_disabled:
             EnvironmentRoles.disable(env_role.id)
 
         db.session.commit()

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -8,6 +8,7 @@ from flask import current_app as app
 from atat.database import db
 from atat.domain.application_roles import ApplicationRoles
 from atat.domain.applications import Applications
+from atat.domain.environment_roles import EnvironmentRoles
 from atat.domain.csp.cloud import CloudProviderInterface
 from atat.domain.csp.cloud.exceptions import GeneralCSPException
 from atat.domain.csp.cloud.models import (
@@ -18,7 +19,6 @@ from atat.domain.csp.cloud.models import (
     UserRoleCSPPayload,
 )
 from atat.domain.csp.cloud.utils import generate_user_principal_name
-from atat.domain.environment_roles import EnvironmentRoles
 from atat.domain.environments import Environments
 from atat.domain.portfolios import Portfolios
 from atat.domain.task_orders import TaskOrders
@@ -213,11 +213,7 @@ def do_create_environment_role(csp: CloudProviderInterface, environment_role_id=
             role=role,
         )
         result = csp.create_user_role(payload)
-
-        env_role.cloud_id = result.id
-
-        db.session.add(env_role)
-        db.session.commit()
+        EnvironmentRoles.activate(env_role, result.id)
 
         app.logger.info("Created environment role %s", env_role.cloud_id)
 

--- a/atat/models/__init__.py
+++ b/atat/models/__init__.py
@@ -6,7 +6,7 @@ from .attachment import Attachment
 from .audit_event import AuditEvent
 from .clin import CLIN, JEDICLINType
 from .environment import Environment
-from .environment_role import EnvironmentRole, CSPRole
+from .environment_role import EnvironmentRole, CSPRole, Status as EnvironmentRoleStatus
 from .job_failure import JobFailure
 from .notification_recipient import NotificationRecipient
 from .permissions import Permissions

--- a/atat/models/application_role.py
+++ b/atat/models/application_role.py
@@ -12,9 +12,9 @@ from atat.models.mixins.auditable import record_permission_sets_updates
 
 
 class Status(Enum):
+    PENDING = "pending"
     ACTIVE = "active"
     DISABLED = "disabled"
-    PENDING = "pending"
 
 
 application_roles_permission_sets = Table(

--- a/atat/models/environment_role.py
+++ b/atat/models/environment_role.py
@@ -15,8 +15,8 @@ class CSPRole(Enum):
 
 
 class Status(Enum):
-    COMPLETED = "completed"
     PENDING = "pending"
+    ACTIVE = "active"
     DISABLED = "disabled"
 
 

--- a/atat/models/environment_role.py
+++ b/atat/models/environment_role.py
@@ -70,7 +70,7 @@ class EnvironmentRole(
         return self.role
 
     @property
-    def disabled(self):
+    def is_disabled(self):
         return self.status == Status.DISABLED
 
     @property

--- a/atat/models/environment_role.py
+++ b/atat/models/environment_role.py
@@ -14,6 +14,12 @@ class CSPRole(Enum):
     CONTRIBUTOR = "Contributor"
 
 
+class Status(Enum):
+    COMPLETED = "completed"
+    PENDING = "pending"
+    DISABLED = "disabled"
+
+
 class EnvironmentRole(
     Base,
     mixins.TimestampsMixin,
@@ -37,13 +43,6 @@ class EnvironmentRole(
     application_role = relationship("ApplicationRole")
 
     cloud_id = Column(String())
-
-    # TODO: Why is this implemented as a status enum? Seems like we only use
-    # the DISABLED state.
-    class Status(Enum):
-        PENDING = "pending"
-        COMPLETED = "completed"
-        DISABLED = "disabled"
 
     status = Column(
         SQLAEnum(Status, native_enum=False), default=Status.PENDING, nullable=False
@@ -72,11 +71,11 @@ class EnvironmentRole(
 
     @property
     def disabled(self):
-        return self.status == EnvironmentRole.Status.DISABLED
+        return self.status == Status.DISABLED
 
     @property
     def is_pending(self):
-        return self.status == EnvironmentRole.Status.PENDING
+        return self.status == Status.PENDING
 
     @property
     def event_details(self):

--- a/atat/models/portfolio_role.py
+++ b/atat/models/portfolio_role.py
@@ -13,9 +13,9 @@ from atat.models.mixins.auditable import record_permission_sets_updates
 
 
 class Status(Enum):
+    PENDING = "pending"
     ACTIVE = "active"
     DISABLED = "disabled"
-    PENDING = "pending"
 
 
 portfolio_roles_permission_sets = Table(

--- a/atat/routes/applications/settings.py
+++ b/atat/routes/applications/settings.py
@@ -99,7 +99,7 @@ def filter_env_roles_form_data(member, environments):
 
         if len(env_roles_set) == 1:
             (env_role,) = env_roles_set
-            env_data["disabled"] = env_role.disabled
+            env_data["disabled"] = env_role.is_disabled
             if env_role.role:
                 env_data["role"] = env_role.role.name
 

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 import pytest
 
 from atat.domain.environment_roles import EnvironmentRoles
-from atat.models import EnvironmentRole, ApplicationRoleStatus
+from atat.models import EnvironmentRole, ApplicationRoleStatus, EnvironmentRoleStatus
 
 from tests.factories import *
 
@@ -39,6 +39,19 @@ def test_get(application_role, environment):
     assert environment_role
     assert environment_role.application_role == application_role
     assert environment_role.environment == environment
+
+
+def test_activate(application_role, environment):
+    role = EnvironmentRoleFactory.create(
+        application_role=application_role, environment=environment
+    )
+    assert role.cloud_id is None
+    assert role.status == EnvironmentRoleStatus.PENDING
+
+    EnvironmentRoles.activate(role, "123")
+
+    assert role.cloud_id == "123"
+    assert role.status == EnvironmentRoleStatus.COMPLETED
 
 
 def test_get_by_user_and_environment(application_role, environment):

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -51,7 +51,7 @@ def test_activate(application_role, environment):
     EnvironmentRoles.activate(role, "123")
 
     assert role.cloud_id == "123"
-    assert role.status == EnvironmentRoleStatus.COMPLETED
+    assert role.status == EnvironmentRoleStatus.ACTIVE
 
 
 def test_get_by_user_and_environment(application_role, environment):
@@ -99,7 +99,7 @@ class Test_disable:
         environment_role = EnvironmentRoleFactory.create(
             application_role=application_role,
             environment=environment,
-            status=EnvironmentRoleStatus.COMPLETED,
+            status=EnvironmentRoleStatus.ACTIVE,
         )
         EnvironmentRoles.disable(environment_role.id)
         assert environment_role.is_disabled

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -89,7 +89,7 @@ class Test_disable:
             status=EnvironmentRoleStatus.COMPLETED,
         )
         EnvironmentRoles.disable(environment_role.id)
-        assert environment_role.disabled
+        assert environment_role.is_disabled
 
     @patch("atat.domain.environment_roles.app.csp.cloud.disable_user")
     def test_has_cloud_id(self, disable_user, app):

--- a/tests/domain/test_environment_roles.py
+++ b/tests/domain/test_environment_roles.py
@@ -86,7 +86,7 @@ class Test_disable:
         environment_role = EnvironmentRoleFactory.create(
             application_role=application_role,
             environment=environment,
-            status=EnvironmentRole.Status.COMPLETED,
+            status=EnvironmentRoleStatus.COMPLETED,
         )
         EnvironmentRoles.disable(environment_role.id)
         assert environment_role.disabled
@@ -167,6 +167,6 @@ class TestPendingCreation:
     def test_disabled_env_role(self):
         appr = ApplicationRoleFactory.create(cloud_id="123")
         envr = EnvironmentRoleFactory.create(
-            application_role=appr, status=EnvironmentRole.Status.DISABLED
+            application_role=appr, status=EnvironmentRoleStatus.DISABLED
         )
         assert EnvironmentRoles.get_pending_creation() == []

--- a/tests/domain/test_environments.py
+++ b/tests/domain/test_environments.py
@@ -42,7 +42,7 @@ def test_update_env_role_no_access():
         env_role.application_role.id, env_role.environment.id
     )
     assert env_role.role is None
-    assert env_role.disabled
+    assert env_role.is_disabled
 
 
 def test_update_env_role_disabled_role():
@@ -56,7 +56,7 @@ def test_update_env_role_disabled_role():
         )
 
     assert env_role.role is None
-    assert env_role.disabled
+    assert env_role.is_disabled
 
     # An exception should not be raised when no new role is passed
     Environments.update_env_role(env_role.environment, env_role.application_role, None)

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -74,12 +74,6 @@ class Test_display_status:
         )
         assert app_role_pending.display_status == "invite_pending"
 
-    def test_invite_accepted(self):
-        app_role_active = ApplicationRoleFactory.create(
-            status=ApplicationRoleStatus.ACTIVE
-        )
-        assert app_role_active.display_status == None
-
     def test_changes_pending(self):
         app_role_active = ApplicationRoleFactory.create(
             status=ApplicationRoleStatus.ACTIVE
@@ -88,3 +82,33 @@ class Test_display_status:
             application_role=app_role_active
         )
         assert env_role_pending.application_role.display_status == "changes_pending"
+
+    def test_invite_accepted_no_environments(self):
+        app_role_active = ApplicationRoleFactory.create(
+            status=ApplicationRoleStatus.ACTIVE
+        )
+        assert app_role_active.display_status is None
+
+    def test_invite_accepted_some_environments_pending(self):
+        app_role_active = ApplicationRoleFactory.create(
+            status=ApplicationRoleStatus.ACTIVE
+        )
+        EnvironmentRoleFactory.create(
+            application_role=app_role_active, status=EnvironmentRoleStatus.PENDING
+        )
+        EnvironmentRoleFactory.create(
+            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+        )
+        assert app_role_active.display_status == "changes_pending"
+
+    def test_invite_accepted_all_environments_completed(self):
+        app_role_active = ApplicationRoleFactory.create(
+            status=ApplicationRoleStatus.ACTIVE
+        )
+        EnvironmentRoleFactory.create(
+            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+        )
+        EnvironmentRoleFactory.create(
+            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+        )
+        assert app_role_active.display_status is None

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -61,19 +61,30 @@ def test_environment_roles():
     assert not EnvironmentRoles.get_by_user_and_environment(user.id, environment2.id)
 
 
-def test_display_status():
-    yesterday = pendulum.today().subtract(days=1)
-    expired_invite = ApplicationInvitationFactory.create(expiration_time=yesterday)
-    assert expired_invite.role.display_status == "invite_expired"
+class Test_display_status:
+    def test_expired_invite(self):
+        yesterday = pendulum.today().subtract(days=1)
+        expired_invite = ApplicationInvitationFactory.create(expiration_time=yesterday)
+        assert expired_invite.role.display_status == "invite_expired"
 
-    app_role_pending = ApplicationRoleFactory.create()
-    invite = ApplicationInvitationFactory.create(
-        role=app_role_pending, user=app_role_pending.user
-    )
-    assert app_role_pending.display_status == "invite_pending"
+    def test_invite_pending(self):
+        app_role_pending = ApplicationRoleFactory.create()
+        ApplicationInvitationFactory.create(
+            role=app_role_pending, user=app_role_pending.user
+        )
+        assert app_role_pending.display_status == "invite_pending"
 
-    app_role_active = ApplicationRoleFactory.create(status=ApplicationRoleStatus.ACTIVE)
-    assert app_role_active.display_status == None
+    def test_invite_accepted(self):
+        app_role_active = ApplicationRoleFactory.create(
+            status=ApplicationRoleStatus.ACTIVE
+        )
+        assert app_role_active.display_status == None
 
-    env_role_pending = EnvironmentRoleFactory.create(application_role=app_role_active)
-    assert env_role_pending.application_role.display_status == "changes_pending"
+    def test_changes_pending(self):
+        app_role_active = ApplicationRoleFactory.create(
+            status=ApplicationRoleStatus.ACTIVE
+        )
+        env_role_pending = EnvironmentRoleFactory.create(
+            application_role=app_role_active
+        )
+        assert env_role_pending.application_role.display_status == "changes_pending"

--- a/tests/models/test_application_role.py
+++ b/tests/models/test_application_role.py
@@ -97,7 +97,7 @@ class Test_display_status:
             application_role=app_role_active, status=EnvironmentRoleStatus.PENDING
         )
         EnvironmentRoleFactory.create(
-            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+            application_role=app_role_active, status=EnvironmentRoleStatus.ACTIVE
         )
         assert app_role_active.display_status == "changes_pending"
 
@@ -106,9 +106,9 @@ class Test_display_status:
             status=ApplicationRoleStatus.ACTIVE
         )
         EnvironmentRoleFactory.create(
-            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+            application_role=app_role_active, status=EnvironmentRoleStatus.ACTIVE
         )
         EnvironmentRoleFactory.create(
-            application_role=app_role_active, status=EnvironmentRoleStatus.COMPLETED
+            application_role=app_role_active, status=EnvironmentRoleStatus.ACTIVE
         )
         assert app_role_active.display_status is None

--- a/tests/routes/applications/test_settings.py
+++ b/tests/routes/applications/test_settings.py
@@ -567,7 +567,7 @@ def test_update_member(client, user_session, session):
     # check that the user has roles in the correct envs
     assert len(environment_roles) == 3
     assert updated_role.role == CSPRole.CONTRIBUTOR
-    assert suspended_role.disabled
+    assert suspended_role.is_disabled
 
 
 def test_revoke_invite(client, user_session):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -432,7 +432,7 @@ class TestCreateEnvironmentRole:
         do_create_environment_role(csp, environment_role_id=env_role.id)
         session.rollback()
         assert env_role.cloud_id == "a-cloud-id"
-        assert env_role.status == EnvironmentRoleStatus.COMPLETED
+        assert env_role.status == EnvironmentRoleStatus.ACTIVE
 
     def test_sends_email(self, monkeypatch, env_role, csp):
         send_mail = Mock()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -5,8 +5,6 @@ from uuid import uuid4
 import pendulum
 import pytest
 from azure.core.exceptions import AzureError
-from celery.exceptions import Retry
-from pytest import raises
 from tests.factories import (
     ApplicationFactory,
     ApplicationRoleFactory,
@@ -43,6 +41,7 @@ from atat.jobs import (
 )
 from atat.models import (
     ApplicationRoleStatus,
+    EnvironmentRoleStatus,
     PortfolioStates,
     JobFailure,
     Portfolio,
@@ -424,14 +423,16 @@ class TestCreateEnvironmentRole:
 
     @pytest.fixture
     def csp(self):
-        csp = Mock()
-        result = UserRoleCSPResult(id="a-cloud-id")
-        csp.create_user_role = MagicMock(return_value=result)
+        csp = MagicMock()
+        csp.create_user_role.return_value = UserRoleCSPResult(id="a-cloud-id")
         return csp
 
-    def test_success(self, env_role, csp):
+    def test_success(self, env_role, csp, session):
+        session.begin_nested()
         do_create_environment_role(csp, environment_role_id=env_role.id)
+        session.rollback()
         assert env_role.cloud_id == "a-cloud-id"
+        assert env_role.status == EnvironmentRoleStatus.COMPLETED
 
     def test_sends_email(self, monkeypatch, env_role, csp):
         send_mail = Mock()


### PR DESCRIPTION
Closes https://ccpo.atlassian.net/browse/AT-5241

<img width="737" alt="image" src="https://user-images.githubusercontent.com/54586407/86400355-7565f380-bc76-11ea-8158-bbbecefd6d84.png">

On the applications screen, there is a chip to display the status of an application role. 

The status of this chip is controlled by the `display_status` property on the `ApplicationRole` model. A lack of chip means that there are no issues with the application role and nothing is being changed.

Part of the branching logic in the `display_status` property reads:
```python
elif self.is_active and any(
    env_role.is_pending for env_role in self.environment_roles
):
    return "changes_pending"
```

When an environment role is created in the database, its status is `PENDING` by default. After the environment role is successfully provisioned, the role should be marked as `COMPLETED`. This isn't happening, so all environment roles are returning their `is_pending` property to be `True`, which causes the `changes pending` chip to appear even after the invite to the application is accepted and all environment roles are successfully provisioned.

The solution to this bug is to change an environment role's status to `COMPLETED` after the environment role is successfully  provisioned.

This PR also includes a few minor tweaks to naming and organization so that the `EnvironmentRole` model more closely resembles the `ApplicationRole` model.