### PR TITLE
Updates to tests that had specific TO dates

### DIFF
--- a/uitests/Add_future_TO_to_Portfolio.html
+++ b/uitests/Add_future_TO_to_Portfolio.html
@@ -215,7 +215,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>7</td>
+<td>10</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_New_TO.html
+++ b/uitests/Create_New_TO.html
@@ -410,7 +410,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_New_TO_(Base).html
+++ b/uitests/Create_New_TO_(Base).html
@@ -410,7 +410,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_TO_after_other_steps.html
+++ b/uitests/Create_TO_after_other_steps.html
@@ -260,7 +260,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_future_TO.html
+++ b/uitests/Create_future_TO.html
@@ -215,7 +215,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>7</td>
+<td>10</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_Basics.html
+++ b/uitests/Reports_-_Basics.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -665,7 +665,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - June 30, 2020*</td>
+<td>*October 01, 2019 - September 30, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_Follow_TO_link.html
+++ b/uitests/Reports_-_Follow_TO_link.html
@@ -475,7 +475,7 @@ Imported from: AT-AT CI - Create New TO
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -705,7 +705,7 @@ Funding Duration-->
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - June 30, 2020*</td>
+<td>*October 01, 2019 - September 30, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_TO,_App,_and_Environments.html
+++ b/uitests/Reports_-_with_TO,_App,_and_Environments.html
@@ -840,7 +840,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
+++ b/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1239,7 +1239,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>7</td>
+<td>10</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1520,9 +1520,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019
-        -
-        June 30, 2020*</td>
+<td>*October 01, 2019 - September 30, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_active_and_expired_TOs.html
+++ b/uitests/Reports_-_with_active_and_expired_TOs.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1098,9 +1098,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019
-        -
-        June 30, 2020*</td>
+<td>*October 01, 2019 - September 30, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_future_TO.html
+++ b/uitests/Reports_-_with_future_TO.html
@@ -390,7 +390,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>7</td>
+<td>10</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_Draft_TO.html
+++ b/uitests/TO_Index_with_Draft_TO.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_TO.html
+++ b/uitests/TO_Index_with_TO.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_Unconfirmed_TO.html
+++ b/uitests/TO_Index_with_Unconfirmed_TO.html
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>9</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_future_TO.html
+++ b/uitests/TO_Index_with_future_TO.html
@@ -390,7 +390,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>7</td>
+<td>10</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -789,9 +789,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=#Upcoming > .accordion__content--list-item > .usa-grid > .usa-width-one-fourth:nth-of-type(1) > p</td>
-<td>*Jul 01, 2020
-                    -
-                    Dec 31, 2020*</td>
+<td>*Oct 01, 2020 - Dec 31, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>


### PR DESCRIPTION
This PR addresses a number of tests that failed because I had some TOs ending on 6/30/2020 that need to be Active and others that started 7/1/2020 that need to be Future. Dates changed to accommodate the arrival and passage of those two dates and the impact that had on tests.