### PR TITLE
Fix cluster_migration script for sh.

### DIFF
--- a/script/cluster_migration
+++ b/script/cluster_migration
@@ -17,27 +17,12 @@ if [ -z "${K8S_NAMESPACE+is_set}" ]; then
 fi
 
 # Expected settings. Script will error if these are not provided.
-SETTINGS=(
-  VMSS_CLIENT_ID
-  KEYVAULT_NAME
-  TENANT_ID
-  CONTAINER_IMAGE
-)
-
-# Loop all expected settings. Track ones that are missing and build
-# concatenated list for envsubst. If any are missing, exit.
-MISSING_SETTINGS=()
-for envvar in "${SETTINGS[@]}"; do
-  if [ -z "${!envvar}" ]; then
-    MISSING_SETTINGS+=(${envvar})
-  fi
-done
-
-if [[ ${#MISSING_SETTINGS[@]} > 0 ]]; then
+if [ -z "${VMSS_CLIENT_ID+is_set}" ] ||
+   [ -z "${KEYVAULT_NAME+is_set}" ] ||
+   [ -z "${TENANT_ID+is_set}" ] ||
+   [ -z "${CONTAINER_IMAGE+is_set}" ]; then
   >&2 echo "The following variables need to be set:"
-  for missing in "${MISSING_SETTINGS[@]}"; do
-    >&2 echo $missing
-  done
+  >&2 echo "VMSS_CLIENT_ID, KEYVAULT_NAME, TENANT_ID, CONTAINER_IMAGE"
   exit 1
 fi
 


### PR DESCRIPTION
script/cluster_migration has to run with /bin/sh for CI and is currently
failing. I was using an array to check all of the variables that need to
be defined. It seems that sh doesn't natively support arrays and it
requires some fancy footwork to do anything similar with strings. Rather
than complicate the script or burn too much time on it, I've decided to
just use a conditional test for each of the variables we expect to be
defined.