### PR TITLE
[AT-5373] Subscription integration test

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,8 @@ Values where "[Testing only]" is mentioned are only required for running the Hyb
 Configuration variables that are needed solely to run Hybrid tests are in the `[hybrid]` section of the base configuration file.
 - `AZURE_ADMIN_ROLE_ASSIGNMENT_ID`: The fully pathed role assignment ID that associates a user with admin privileges to the root tenant of the Hybrid Cloud
 - `AZURE_BILLING_PROFILE_ID`: ID of the billing profile used for Cost Management queries with the Hybrid interface.
+- `AZURE_SUBSCRIPTION_CREATION_CLIENT_ID`: [Testing only] Client ID of an app registration in the root tenant used for subscription integration tests
+- `AZURE_SUBSCRIPTION_CREATION_SECRET`: [Testing only] Secret key for the app registration associated with the `AZURE_SUBSCRIPTION_CREATION_CLIENT_ID`
 - `AZURE_HYBRID_REPORTING_CLIENT_ID`: Client ID of an app registration with an "Invoice Section Reader" role for the invoice section defined by AZURE_INVOICE_SECTION_ID
 - `AZURE_HYBRID_REPORTING_SECRET`: Secret key for the app registration associated with the `AZURE_HYBRID_REPORTING_CLIENT_ID`
 - `AZURE_HYBRID_TENANT_DOMAIN`: The domain of the hybrid tenant

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -55,8 +55,6 @@ from .models import (
     ProductPurchaseVerificationCSPResult,
     SubscriptionCreationCSPPayload,
     SubscriptionCreationCSPResult,
-    SubscriptionVerificationCSPPayload,
-    SuscriptionVerificationCSPResult,
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingCreationCSPResult,
     TaskOrderBillingVerificationCSPPayload,

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -746,21 +746,19 @@ class AzureCloudProvider(CloudProviderInterface):
         return BillingInstructionCSPResult(**result.json())
 
     @log_and_raise_exceptions
-    def create_subscription(self, payload: SubscriptionCreationCSPPayload):
-        sp_token = self._get_tenant_principal_token(payload.tenant_id)
+    def create_subscription(self, payload: SubscriptionCreationCSPPayload, token=None):
+        if token is None:
+            token = self._get_tenant_principal_token(payload.tenant_id)
 
         request_body = {
             "displayName": payload.display_name,
             "skuId": AZURE_SKU_ID,
             "managementGroupId": payload.parent_group_id,
         }
-
         url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/invoiceSections/{payload.invoice_section_name}/providers/Microsoft.Subscription/createSubscription?api-version=2019-10-01-preview"
-
         auth_header = {
-            "Authorization": f"Bearer {sp_token}",
+            "Authorization": f"Bearer {token}",
         }
-
         result = self.sdk.requests.post(
             url, headers=auth_header, json=request_body, timeout=30
         )

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -755,13 +755,13 @@ class AzureCloudProvider(CloudProviderInterface):
             "managementGroupId": payload.parent_group_id,
         }
 
-        url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/invoiceSections/{payload.invoice_section_name}/providers/Microsoft.Subscription/createSubscription?api-version=2018-11-01-preview"
+        url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/invoiceSections/{payload.invoice_section_name}/providers/Microsoft.Subscription/createSubscription?api-version=2019-10-01-preview"
 
         auth_header = {
             "Authorization": f"Bearer {sp_token}",
         }
 
-        result = self.sdk.requests.put(
+        result = self.sdk.requests.post(
             url, headers=auth_header, json=request_body, timeout=30
         )
         result.raise_for_status()

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -769,27 +769,6 @@ class AzureCloudProvider(CloudProviderInterface):
             # 202 has location/retry after headers
             return SubscriptionCreationCSPResult(**result.headers, **result.json())
 
-    def create_subscription_creation(self, payload: SubscriptionCreationCSPPayload):
-        return self.create_subscription(payload)
-
-    @log_and_raise_exceptions
-    def create_subscription_verification(
-        self, payload: SubscriptionVerificationCSPPayload
-    ):
-        sp_token = self._get_tenant_principal_token(payload.tenant_id)
-
-        auth_header = {
-            "Authorization": f"Bearer {sp_token}",
-        }
-
-        result = self.sdk.requests.get(
-            payload.subscription_verify_url, headers=auth_header, timeout=30
-        )
-        result.raise_for_status()
-
-        # 202 has location/retry after headers
-        return SuscriptionVerificationCSPResult(**result.json())
-
     @log_and_raise_exceptions
     def create_product_purchase(self, payload: ProductPurchaseCSPPayload):
         sp_token = self._get_root_provisioning_token()

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -289,19 +289,10 @@ class HybridCloudProvider(object):
         return self.azure.get_reporting_data(payload, token=hybrid_reporting_token)
 
     def create_subscription(self, payload: SubscriptionCreationCSPPayload):
-        # TODO: This will need to be updated to use the azure function.  The same with
-        # "create_subscription_creation" and "create_subscription_verification".  Additionally,
+        # TODO: This will need to be updated to use the azure function. Additionally,
         # the payload display_name will have to be prepended with the hybrid prefix.
         #
         # Example code:
         # payload.display_name = f"{HYBRID_PREFIX} {payload.display_name}"
         # return self.azure.create_subscription(payload)
         return self.mock.create_subscription(payload)
-
-    def create_subscription_creation(self, payload: SubscriptionCreationCSPPayload):
-        return self.mock.create_subscription_creation(payload)
-
-    def create_subscription_verification(
-        self, payload: SubscriptionVerificationCSPPayload
-    ):
-        return self.mock.create_subscription_verification(payload)

--- a/atat/domain/csp/cloud/mock_cloud_provider.py
+++ b/atat/domain/csp/cloud/mock_cloud_provider.py
@@ -109,26 +109,12 @@ class MockCloudProvider(CloudProviderInterface):
         return default
 
     def create_subscription(self, payload: SubscriptionCreationCSPPayload):
-        return self.create_subscription_creation(payload)
-
-    def create_subscription_creation(self, payload: SubscriptionCreationCSPPayload):
         self._maybe_raise(self.NETWORK_FAILURE_PCT, self.NETWORK_EXCEPTION)
         self._maybe_raise(self.SERVER_FAILURE_PCT, self.SERVER_EXCEPTION)
         self._maybe_raise(self.UNAUTHORIZED_RATE, self.AUTHORIZATION_EXCEPTION)
 
         return SubscriptionCreationCSPResult(
             subscription_verify_url="https://zombo.com", subscription_retry_after=10
-        )
-
-    def create_subscription_verification(
-        self, payload: SubscriptionVerificationCSPPayload
-    ):
-        self._maybe_raise(self.NETWORK_FAILURE_PCT, self.NETWORK_EXCEPTION)
-        self._maybe_raise(self.SERVER_FAILURE_PCT, self.SERVER_EXCEPTION)
-        self._maybe_raise(self.UNAUTHORIZED_RATE, self.AUTHORIZATION_EXCEPTION)
-
-        return SuscriptionVerificationCSPResult(
-            subscription_id="subscriptions/60fbbb72-0516-4253-ab18-c92432ba3230"
         )
 
     def create_tenant(self, payload: TenantCSPPayload):

--- a/atat/domain/csp/cloud/mock_cloud_provider.py
+++ b/atat/domain/csp/cloud/mock_cloud_provider.py
@@ -46,8 +46,6 @@ from .models import (
     ProductPurchaseVerificationCSPResult,
     SubscriptionCreationCSPPayload,
     SubscriptionCreationCSPResult,
-    SubscriptionVerificationCSPPayload,
-    SuscriptionVerificationCSPResult,
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingCreationCSPResult,
     TaskOrderBillingVerificationCSPPayload,

--- a/pytest.ini
+++ b/pytest.ini
@@ -8,4 +8,5 @@ markers =
   audit_log: Tests for the audit log, which is behind a feature flag at the moment. Enable these tests by setting `USE_AUDIT_LOG = true`
   state_machine: Tests related to state machines
   hybrid: Integration tests for the Hybrid Cloud Provider. These tests are skipped by default -- enable them by adding a `--hybrid` flag 
+  subscriptions: Integration tests related to subscription creation. These tests are skipped by default -- enable them by adding a `--subscriptions` flag 
   access_check: An access check test

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ dictConfig({"version": 1, "handlers": {"wsgi": {"class": "logging.NullHandler"}}
 
 def pytest_addoption(parser):
     parser.addoption("--hybrid", action="store_true", default=False)
+    parser.addoption("--subscriptions", action="store_true", default=False)
     parser.addoption(
         "--repeat", action="store", help="Number of times to repeat each test"
     )
@@ -41,13 +42,18 @@ def pytest_generate_tests(metafunc):
         metafunc.parametrize("tmp_ct", range(count))
 
 
-def pytest_collection_modifyitems(config, items):
-    if config.getoption("--hybrid"):
+def set_skip_mark_for_option(option, config, items):
+    if config.getoption(f"--{option}"):
         return
-    skip_hybrid = pytest.mark.skip(reason="need --hybrid option to run")
+    skip_option_mark = pytest.mark.skip(reason=f"need --{option} option to run")
     for item in items:
-        if "hybrid" in item.keywords:
-            item.add_marker(skip_hybrid)
+        if option in item.keywords:
+            item.add_marker(skip_option_mark)
+
+
+def pytest_collection_modifyitems(config, items):
+    set_skip_mark_for_option("hybrid", config, items)
+    set_skip_mark_for_option("subscriptions", config, items)
 
 
 @pytest.fixture(scope="session")

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -970,9 +970,7 @@ def test_create_principal_admin_role(
     assert result.principal_assignment_id == "id"
 
 
-def test_create_subscription_creation(
-    mock_azure: AzureCloudProvider, mock_http_error_response
-):
+def test_create_subscription(mock_azure: AzureCloudProvider, mock_http_error_response):
 
     mock_result = mock_requests_response(
         status=202, headers={"Location": "https://verify.me", "Retry-After": 10}
@@ -997,53 +995,15 @@ def test_create_subscription_creation(
         )
     )
     with pytest.raises(ConnectionException):
-        mock_azure.create_subscription_creation(payload)
+        mock_azure.create_subscription(payload)
     with pytest.raises(ConnectionException):
-        mock_azure.create_subscription_creation(payload)
+        mock_azure.create_subscription(payload)
     with pytest.raises(UnknownServerException, match=r".*500 Server Error.*"):
-        mock_azure.create_subscription_creation(payload)
+        mock_azure.create_subscription(payload)
 
-    result: SubscriptionCreationCSPResult = mock_azure.create_subscription_creation(
-        payload
-    )
+    result: SubscriptionCreationCSPResult = mock_azure.create_subscription(payload)
 
     assert result.subscription_verify_url == "https://verify.me"
-
-
-def test_create_subscription_verification(
-    mock_azure: AzureCloudProvider, mock_http_error_response
-):
-
-    mock_result = mock_requests_response(
-        json_data={
-            "subscriptionLink": "/subscriptions/60fbbb72-0516-4253-ab18-c92432ba3230"
-        }
-    )
-
-    mock_azure.sdk.requests.get.side_effect = [
-        mock_azure.sdk.requests.exceptions.ConnectionError,
-        mock_azure.sdk.requests.exceptions.Timeout,
-        mock_http_error_response,
-        mock_result,
-    ]
-
-    payload = SubscriptionVerificationCSPPayload(
-        **dict(
-            tenant_id="60ff9d34-82bf-4f21-b565-308ef0533435",
-            subscription_verify_url="https://verify.me",
-        )
-    )
-    with pytest.raises(ConnectionException):
-        mock_azure.create_subscription_verification(payload)
-    with pytest.raises(ConnectionException):
-        mock_azure.create_subscription_verification(payload)
-    with pytest.raises(UnknownServerException, match=r".*500 Server Error.*"):
-        mock_azure.create_subscription_verification(payload)
-
-    result: SuscriptionVerificationCSPResult = mock_azure.create_subscription_verification(
-        payload
-    )
-    assert result.subscription_id == "60fbbb72-0516-4253-ab18-c92432ba3230"
 
 
 def test_get_reporting_data(mock_azure: AzureCloudProvider, mock_http_error_response):

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -978,7 +978,7 @@ def test_create_subscription_creation(
         status=202, headers={"Location": "https://verify.me", "Retry-After": 10}
     )
 
-    mock_azure.sdk.requests.put.side_effect = [
+    mock_azure.sdk.requests.post.side_effect = [
         mock_azure.sdk.requests.exceptions.ConnectionError,
         mock_azure.sdk.requests.exceptions.Timeout,
         mock_http_error_response,

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -232,52 +232,59 @@ def test_get_reporting_data(csp, app):
 
 
 @pytest.mark.hybrid
-@pytest.mark.skip(
-    reason="We are using the mock cloud provider's subscription method right now"
-)
-def test_create_subscription(csp):
-    environment = EnvironmentFactory.create()
-
-    payload = SubscriptionCreationCSPPayload(
-        display_name=environment.name,
-        tenant_id=csp.mock_tenant_id,
-        parent_group_id=csp.hybrid_tenant_id,
-        billing_account_name=csp.azure.config["AZURE_BILLING_ACCOUNT_NAME"],
-        billing_profile_name=csp.azure.config["AZURE_BILLING_PROFILE_ID"],
-        invoice_section_name=csp.azure.config["AZURE_INVOICE_SECTION_ID"],
-    )
-
-    csp.create_subscription_creation(payload)
-
-
-@pytest.mark.hybrid
-def test_create_subscription_mocked(csp):
-    # TODO: When we finally move over to azure, this mocked test should
-    # probably be removed in favor of the above "test_create_subscription"
-    # test.
-    payload = SubscriptionCreationCSPPayload(
-        tenant_id="tenant id",
-        displayName="display name",
-        parentGroupId="parent group id",
-        billingAccountName="billing account name",
-        billingProfileName="billing profile name",
-        invoiceSectionName="invoice section name",
-    )
-
-    sub = csp.create_subscription(payload)
-    sub_creation = csp.create_subscription_creation(payload)
-
-    assert (
-        sub.subscription_verify_url
-        == sub_creation.subscription_verify_url
-        == "https://zombo.com"
-    )
-    assert sub.subscription_retry_after == sub_creation.subscription_retry_after == 10
-
-
-@pytest.mark.hybrid
 def test_create_subscription_verification(csp):
     payload = SubscriptionVerificationCSPPayload(
         tenantId="tenant id", subscriptionVerifyUrl="subscription verify url"
     )
     assert csp.create_subscription_verification(payload).subscription_id
+
+
+@pytest.mark.subscriptions
+class TestSubscriptions:
+    @pytest.mark.skip(
+        reason="We are using the mock cloud provider's subscription method right now"
+    )
+    def test_create_subscription(self, csp):
+        environment = EnvironmentFactory.create()
+
+        payload = SubscriptionCreationCSPPayload(
+            display_name=environment.name,
+            tenant_id=csp.mock_tenant_id,
+            parent_group_id=csp.hybrid_tenant_id,
+            billing_account_name=csp.azure.config["AZURE_BILLING_ACCOUNT_NAME"],
+            billing_profile_name=csp.azure.config["AZURE_BILLING_PROFILE_ID"],
+            invoice_section_name=csp.azure.config["AZURE_INVOICE_SECTION_ID"],
+        )
+
+        csp.create_subscription_creation(payload)
+
+    def test_create_subscription_mocked(self, csp):
+        # TODO: When we finally move over to azure, this mocked test should
+        # probably be removed in favor of the above "test_create_subscription"
+        # test.
+        payload = SubscriptionCreationCSPPayload(
+            tenant_id="tenant id",
+            displayName="display name",
+            parentGroupId="parent group id",
+            billingAccountName="billing account name",
+            billingProfileName="billing profile name",
+            invoiceSectionName="invoice section name",
+        )
+
+        sub = csp.create_subscription(payload)
+        sub_creation = csp.create_subscription_creation(payload)
+
+        assert (
+            sub.subscription_verify_url
+            == sub_creation.subscription_verify_url
+            == "https://zombo.com"
+        )
+        assert (
+            sub.subscription_retry_after == sub_creation.subscription_retry_after == 10
+        )
+
+    def test_create_subscription_verification(self, csp):
+        payload = SubscriptionVerificationCSPPayload(
+            tenantId="tenant id", subscriptionVerifyUrl="subscription verify url"
+        )
+        assert csp.create_subscription_verification(payload).subscription_id

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -6,7 +6,12 @@ import pendulum
 import pytest
 
 from atat.domain.csp import CSP
-from atat.domain.csp.cloud.models import CostManagementQueryCSPPayload
+from atat.domain.csp.cloud.hybrid_cloud_provider import HYBRID_PREFIX
+
+from atat.domain.csp.cloud.models import (
+    CostManagementQueryCSPPayload,
+    SubscriptionCreationCSPPayload,
+)
 from atat.jobs import (
     do_create_application,
     do_create_environment,
@@ -226,14 +231,6 @@ def test_get_reporting_data(csp, app):
 
     result = csp.get_reporting_data(payload)
     assert result.name
-
-
-@pytest.mark.hybrid
-def test_create_subscription_verification(csp):
-    payload = SubscriptionVerificationCSPPayload(
-        tenantId="tenant id", subscriptionVerifyUrl="subscription verify url"
-    )
-    assert csp.create_subscription_verification(payload).subscription_id
 
 
 @pytest.mark.subscriptions

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -240,51 +240,17 @@ def test_create_subscription_verification(csp):
 
 
 @pytest.mark.subscriptions
-class TestSubscriptions:
-    @pytest.mark.skip(
-        reason="We are using the mock cloud provider's subscription method right now"
+@pytest.mark.skip(
+    reason="We are using the mock cloud provider's subscription method right now"
+)
+def test_create_subscription(self, csp, environment, tenant_id):
+    payload = SubscriptionCreationCSPPayload(
+        display_name=f"{environment.name}",
+        tenant_id=tenant_id,
+        parent_group_id=environment.cloud_id,
+        billing_account_name=csp.azure.config["AZURE_BILLING_ACCOUNT_NAME"],
+        billing_profile_name=csp.azure.config["AZURE_BILLING_PROFILE_ID"],
+        invoice_section_name=csp.azure.config["AZURE_INVOICE_SECTION_ID"],
     )
-    def test_create_subscription(self, csp):
-        environment = EnvironmentFactory.create()
 
-        payload = SubscriptionCreationCSPPayload(
-            display_name=environment.name,
-            tenant_id=csp.mock_tenant_id,
-            parent_group_id=csp.hybrid_tenant_id,
-            billing_account_name=csp.azure.config["AZURE_BILLING_ACCOUNT_NAME"],
-            billing_profile_name=csp.azure.config["AZURE_BILLING_PROFILE_ID"],
-            invoice_section_name=csp.azure.config["AZURE_INVOICE_SECTION_ID"],
-        )
-
-        csp.create_subscription_creation(payload)
-
-    def test_create_subscription_mocked(self, csp):
-        # TODO: When we finally move over to azure, this mocked test should
-        # probably be removed in favor of the above "test_create_subscription"
-        # test.
-        payload = SubscriptionCreationCSPPayload(
-            tenant_id="tenant id",
-            displayName="display name",
-            parentGroupId="parent group id",
-            billingAccountName="billing account name",
-            billingProfileName="billing profile name",
-            invoiceSectionName="invoice section name",
-        )
-
-        sub = csp.create_subscription(payload)
-        sub_creation = csp.create_subscription_creation(payload)
-
-        assert (
-            sub.subscription_verify_url
-            == sub_creation.subscription_verify_url
-            == "https://zombo.com"
-        )
-        assert (
-            sub.subscription_retry_after == sub_creation.subscription_retry_after == 10
-        )
-
-    def test_create_subscription_verification(self, csp):
-        payload = SubscriptionVerificationCSPPayload(
-            tenantId="tenant id", subscriptionVerifyUrl="subscription verify url"
-        )
-        assert csp.create_subscription_verification(payload).subscription_id
+    subscription_creation_result = csp.azure.create_subscription(payload)


### PR DESCRIPTION
Adds an integration test for creating subscriptions
Closes [AT-5373](https://ccpo.atlassian.net/browse/AT-5373)

Like hybrid tests, tests marked with `subscriptions` are not run by default. To run them, one must add a `--subscriptions` flag when running `pytest`.

This PR introduces a new app registration (named `hybrid-subscription-creation`) and management group (named `subscription-creation-test`) in our root tenant specifically for this subscription creation test. This app registration was given permissions to create subscriptions on our billing invoice section, which we don't want to grant to app registrations created during our hybrid portfolio provisioning tests. Credentials for this app registration can be found in the creds doc / 1Password. It was also made an `owner` of the `subscription-creation-test` management group.

This PR also changes the behavior of subscription creation:
- instead of the `_creation`, ` _verification` pattern, we just have one method `create_subscription`. For now, we don't keep track of subscription creation -- it's just "fire and forget". This behavior may be changed in [AT-5377](https://ccpo.atlassian.net/browse/AT-5377)
- Updates the API version of the subscription creation endpoint, and changes the REST verb to POST