### PR TITLE
Remove seprate pendulum install and poetry env use command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,12 +38,7 @@ RUN dnf install yarn -y
 COPY . .
 
 # Install app dependencies
-RUN pip3 install uwsgi poetry \
-      # TODO: Remove this when this issue is resolved:
-      # https://github.com/sdispater/pendulum/issues/454#issuecomment-605519477
-      && pip3 install pendulum
-
-RUN poetry env use python3.7
+RUN pip3 install uwsgi poetry
 
 RUN poetry install --no-root --no-dev
 


### PR DESCRIPTION
`poetry env use python3.7`: Removing this was the fix that allowed the container to build. In `rhel-py` we explicitly remove the default `python3` and install `python 3.7.3`, so we don't need to tell poetry to use a specific version of python 3 when creating the new virtual environment.

`pip3 install pendulum`: This was an issue specific to Alpine builds, which was our old base image. This step doesn't seem to be necessary anymore now that we've switched over to a RHEL-based image.