### PR TITLE
[AT-5338] Change resourceScope to directoryScopeId

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ js/test_templates
 
 # mac indexing
 **/*.DS_Store
+
+# sonar cube files
+.scannerwork

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1154,7 +1154,7 @@ class AzureCloudProvider(CloudProviderInterface):
         request_body = {
             "principalId": payload.principal_id,
             "roleDefinitionId": payload.admin_role_def_id,
-            "resourceScope": "/",
+            "directoryScopeId": "/",
         }
 
         auth_header = {
@@ -1261,7 +1261,7 @@ class AzureCloudProvider(CloudProviderInterface):
         request_body = {
             "roleDefinitionId": billing_admin_role_id,
             "principalId": user_id,
-            "resourceScope": "/",
+            "directoryScopeId": "/",
         }
 
         auth_header = {


### PR DESCRIPTION
Per [documentation](https://docs.microsoft.com/en-us/graph/api/resources/unifiedroleassignment?view=graph-rest-beta#properties), replace `resourceScope` with `directoryScopeId`.  From [this example](https://docs.microsoft.com/en-us/graph/api/rbacapplication-post-roleassignments?view=graph-rest-beta&tabs=http#example-1-create-a-role-assignment-at-tenant-scope), The value should remain "/". 