### PR TITLE
[AT-5316] Remove User Access Admin role assignment after elevated access is no longer needed

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1614,3 +1614,9 @@ class AzureCloudProvider(CloudProviderInterface):
         )
         response.raise_for_status()
         return response.json()
+
+    def _get_role_definition_id(self, token, role_definition_name):
+        definitions = self._list_role_definitions(
+            token, params={"$filter": f"roleName eq '{role_definition_name}'"}
+        )
+        return next((d["name"] for d in definitions), None)

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1583,3 +1583,19 @@ class AzureCloudProvider(CloudProviderInterface):
         )
         response.raise_for_status()
         return response.json()["value"]
+
+    @log_and_raise_exceptions
+    def _list_role_definitions(self, token, params=None):
+        api_version_param = {"api-version": "2015-07-01"}
+        if params is None:
+            params = api_version_param
+        else:
+            params.update(api_version_param)
+        auth_header = {"Authorization": f"Bearer {token}"}
+        response = self.sdk.requests.get(
+            url=f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Authorization/roleDefinitions",
+            headers=auth_header,
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["value"]

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1620,3 +1620,13 @@ class AzureCloudProvider(CloudProviderInterface):
             token, params={"$filter": f"roleName eq '{role_definition_name}'"}
         )
         return next((d["name"] for d in definitions), None)
+
+    def _filter_role_assignments(self, assignments, role_definition_id):
+        """Find a role assignment in a list of role assignments with a given role definition id"""
+
+        for assignment in assignments:
+            if assignment["properties"]["roleDefinitionId"].endswith(
+                role_definition_id
+            ):
+                return assignment
+        return None

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1567,3 +1567,19 @@ class AzureCloudProvider(CloudProviderInterface):
             scope=self.config.get("AZURE_CALC_RESOURCE"),
         )
         return f"{self.config.get('AZURE_CALC_URL')}?access_token={calc_access_token}"
+
+    @log_and_raise_exceptions
+    def _list_role_assignments(self, token, params=None):
+        api_version_param = {"api-version": "2015-07-01"}
+        if params is None:
+            params = api_version_param
+        else:
+            params.update(api_version_param)
+        auth_header = {"Authorization": f"Bearer {token}"}
+        response = self.sdk.requests.get(
+            url=f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Authorization/roleAssignments",
+            headers=auth_header,
+            params=params,
+        )
+        response.raise_for_status()
+        return response.json()["value"]

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -189,12 +189,10 @@ class HybridCloudProvider(object):
         request with the root credentials.
         """
 
-        token = self.azure._get_elevated_management_token(payload.tenant_id)
+        token = self.azure._elevate_tenant_admin_access(payload.tenant_id)
         payload.tenant_id = self.hybrid_tenant_id
 
-        with monkeypatched(
-            self.azure, "_get_elevated_management_token", lambda _: token
-        ):
+        with monkeypatched(self.azure, "_elevate_tenant_admin_access", lambda _: token):
             try:
                 return self.azure.create_tenant_admin_ownership(payload)
             except UnknownServerException:
@@ -211,11 +209,9 @@ class HybridCloudProvider(object):
         the tenant principal ownership request with the root credentials.
         """
 
-        token = self.azure._get_elevated_management_token(payload.tenant_id)
+        token = self.azure._elevate_tenant_admin_access(payload.tenant_id)
         payload.tenant_id = self.hybrid_tenant_id
-        with monkeypatched(
-            self.azure, "_get_elevated_management_token", lambda _: token
-        ):
+        with monkeypatched(self.azure, "_elevate_tenant_admin_access", lambda _: token):
             return self.azure.create_tenant_principal_ownership(payload)
 
     def create_billing_owner(

--- a/atat/domain/csp/cloud/hybrid_cloud_provider.py
+++ b/atat/domain/csp/cloud/hybrid_cloud_provider.py
@@ -121,12 +121,12 @@ class HybridCloudProvider(object):
     def create_tenant_principal_app(
         self, payload: TenantPrincipalAppCSPPayload
     ) -> TenantPrincipalAppCSPResult:
-        with monkeypatched(
-            self.azure,
-            "tenant_principal_app_display_name",
-            f"{HYBRID_PREFIX} {payload.display_name} :: ATAT Remote Admin",
-        ):
-            return self.azure.create_tenant_principal_app(payload)
+        payload.tenant_principal_app_display_name = "{} {} :: {}".format(
+            HYBRID_PREFIX,
+            payload.display_name,
+            payload.tenant_principal_app_display_name,
+        )
+        return self.azure.create_tenant_principal_app(payload)
 
     def create_tenant_principal(
         self, payload: TenantPrincipalCSPPayload
@@ -149,11 +149,12 @@ class HybridCloudProvider(object):
             creds.tenant_id = self.hybrid_tenant_id
             original_update_tenant_creds(tenant_id, creds)
 
-        with monkeypatched(self.azure, "_get_tenant_admin_token", lambda *_a: token):
-            with monkeypatched(
-                self.azure, "update_tenant_creds", mocked_update_tenant_creds
-            ):
-                return self.azure.create_tenant_principal_credential(payload)
+        with monkeypatched(
+            self.azure, "update_tenant_creds", mocked_update_tenant_creds
+        ):
+            return self.azure.create_tenant_principal_credential(
+                payload, graph_token=token
+            )
 
     def create_admin_role_definition(
         self, payload: AdminRoleDefinitionCSPPayload
@@ -188,17 +189,13 @@ class HybridCloudProvider(object):
         token from KeyVault with the original tenant id, but make the role assignment
         request with the root credentials.
         """
-
-        token = self.azure._elevate_tenant_admin_access(payload.tenant_id)
-        payload.tenant_id = self.hybrid_tenant_id
-
-        with monkeypatched(self.azure, "_elevate_tenant_admin_access", lambda _: token):
-            try:
-                return self.azure.create_tenant_admin_ownership(payload)
-            except UnknownServerException:
-                return TenantAdminOwnershipCSPResult(
-                    id=self.azure.config["AZURE_ADMIN_ROLE_ASSIGNMENT_ID"]
-                )
+        payload.root_management_group_name = self.hybrid_tenant_id
+        try:
+            return self.azure.create_tenant_admin_ownership(payload)
+        except UnknownServerException:
+            return TenantAdminOwnershipCSPResult(
+                id=self.azure.config["AZURE_ADMIN_ROLE_ASSIGNMENT_ID"]
+            )
 
     def create_tenant_principal_ownership(
         self, payload: TenantPrincipalOwnershipCSPPayload
@@ -209,10 +206,8 @@ class HybridCloudProvider(object):
         the tenant principal ownership request with the root credentials.
         """
 
-        token = self.azure._elevate_tenant_admin_access(payload.tenant_id)
-        payload.tenant_id = self.hybrid_tenant_id
-        with monkeypatched(self.azure, "_elevate_tenant_admin_access", lambda _: token):
-            return self.azure.create_tenant_principal_ownership(payload)
+        payload.root_management_group_name = self.hybrid_tenant_id
+        return self.azure.create_tenant_principal_ownership(payload)
 
     def create_billing_owner(
         self, payload: BillingOwnerCSPPayload
@@ -221,11 +216,8 @@ class HybridCloudProvider(object):
             payload.tenant_id, scope=self.azure.graph_resource + "/.default"
         )
         payload.tenant_id = self.hybrid_tenant_id
-        with monkeypatched(
-            self.azure, "_get_tenant_principal_token", lambda *a, **kw: token
-        ):
-            payload.display_name = f"{HYBRID_PREFIX} {payload.display_name} :: Billing"
-            return self.azure.create_billing_owner(payload)
+        payload.display_name = f"{HYBRID_PREFIX} {payload.display_name} :: Billing"
+        return self.azure.create_billing_owner(payload, graph_token=token)
 
     def create_tenant_admin_credential_reset(
         self, payload: TenantAdminCredentialResetCSPPayload
@@ -246,19 +238,6 @@ class HybridCloudProvider(object):
         return self.azure.create_environment(payload)
 
     def create_user(self, payload: UserCSPPayload) -> UserCSPResult:
-        """Create a user in an Azure Active Directory instance.
-        Unlike most of the methods on this interface, this requires
-        two API calls: one POST to create the user and one PATCH to
-        set the alternate email address. The email address cannot
-        be set on the first API call. The email address is
-        necessary so that users can do Self-Service Password
-        Recovery.
-        Arguments:
-            payload {UserCSPPayload} -- a payload object with the
-            data necessary for both calls
-        Returns:
-            UserCSPResult -- a result object containing the AAD ID.
-        """
         return self.azure.create_user(payload)
 
     def create_user_role(self, payload: UserRoleCSPPayload) -> UserRoleCSPResult:

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -311,6 +311,7 @@ class TenantPrincipalOwnershipCSPResult(AliasModel):
 
 class TenantPrincipalAppCSPPayload(BaseCSPPayload):
     display_name: str
+    tenant_principal_app_display_name = "ATAT Remote Admin"
 
 
 class TenantPrincipalAppCSPResult(AliasModel):

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -280,6 +280,7 @@ class TenantAdminCredentialResetCSPResult(AliasModel):
 
 
 class TenantPrincipalOwnershipCSPPayload(BaseCSPPayload):
+    user_object_id: str
     principal_id: str
 
 
@@ -417,6 +418,8 @@ class InitialMgmtGroupCSPResult(AliasModel):
 
 
 class InitialMgmtGroupVerificationCSPPayload(ManagementGroupGetCSPPayload):
+    user_object_id: str
+
     class Config:
         fields = {"management_group_name": "root_management_group_name"}
 

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -259,7 +259,24 @@ class BillingInstructionCSPResult(AliasModel):
         }
 
 
+class RoleAssignmentPayload(BaseModel):
+    role_definition_scope: str
+    role_definition_name: str
+    role_assignment_scope: str
+    role_assignment_name = str(uuid4())
+    principal_id: str
+
+    @property
+    def role_definition_id(self):
+        return (
+            self.role_definition_scope
+            + "/providers/Microsoft.Authorization/roleDefinitions/"
+            + self.role_definition_name
+        )
+
+
 class TenantAdminOwnershipCSPPayload(BaseCSPPayload):
+    root_management_group_name: str
     user_object_id: str
 
 
@@ -280,6 +297,7 @@ class TenantAdminCredentialResetCSPResult(AliasModel):
 
 
 class TenantPrincipalOwnershipCSPPayload(BaseCSPPayload):
+    root_management_group_name: str
     user_object_id: str
     principal_id: str
 

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -873,6 +873,7 @@ def test_create_tenant_admin_ownership(
     payload = TenantAdminOwnershipCSPPayload(
         **{
             "tenant_id": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
+            "root_management_group_name": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
             "user_object_id": "971efe4d-1e80-4e39-b3b9-4e5c63ad446d",
             "root_management_group_name": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
         }

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1905,3 +1905,32 @@ class Test_remove_role_assignment:
         assert {"some": "data"} == mock_azure._remove_role_assignment(
             "token", "role-assignment-id"
         )
+
+
+class Test_get_role_definition_id:
+    def test_interpolates_definition_name(self, mock_azure, monkeypatch):
+        monkeypatch.setattr(
+            mock_azure,
+            "_list_role_definitions",
+            Mock(return_value=[{"name": "definition_UUID"}]),
+        )
+        mock_azure._get_role_definition_id("token", "A definition")
+        mock_azure._list_role_definitions.assert_called_with(
+            "token", params={"$filter": "roleName eq 'A definition'"}
+        )
+
+    def test_returns_name(self, mock_azure, monkeypatch):
+        monkeypatch.setattr(
+            mock_azure,
+            "_list_role_definitions",
+            Mock(return_value=[{"name": "definition_UUID"}]),
+        )
+        assert (
+            mock_azure._get_role_definition_id("token", "A definition")
+            == "definition_UUID"
+        )
+
+    def test_returns_none_for_empty_list(self, mock_azure, monkeypatch):
+        monkeypatch.setattr(mock_azure, "_list_role_definitions", Mock(return_value=[]))
+
+        assert mock_azure._get_role_definition_id("token", "A definition") is None

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -874,6 +874,7 @@ def test_create_tenant_admin_ownership(
         **{
             "tenant_id": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
             "user_object_id": "971efe4d-1e80-4e39-b3b9-4e5c63ad446d",
+            "root_management_group_name": "6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
         }
     )
     with pytest.raises(ConnectionException):
@@ -903,6 +904,7 @@ def test_create_tenant_principal_ownership(
     ]
     payload = TenantPrincipalOwnershipCSPPayload(
         tenant_id="6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
+        root_management_group_name="6d2d2d6c-a6d6-41e1-8bb1-73d11475f8f4",
         principal_id="971efe4d-1e80-4e39-b3b9-4e5c63ad446d",
         user_object_id="test_user_object_id",
     )

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1894,3 +1894,22 @@ def test_list_role_assignments(mock_azure, mock_http_error_response):
         mock_azure._list_role_assignments("token")
 
     assert [] == mock_azure._list_role_assignments("token")
+
+
+def test_list_role_definitions(mock_azure, mock_http_error_response):
+    mock_result = mock_requests_response(json_data={"value": []})
+    mock_azure.sdk.requests.get.side_effect = [
+        mock_azure.sdk.requests.exceptions.ConnectionError,
+        mock_azure.sdk.requests.exceptions.Timeout,
+        mock_http_error_response,
+        mock_result,
+    ]
+    with pytest.raises(ConnectionException):
+        mock_azure._list_role_definitions("token")
+    with pytest.raises(ConnectionException):
+        mock_azure._list_role_definitions("token")
+    with pytest.raises(UnknownServerException, match=r".*500 Server Error.*"):
+        mock_azure._list_role_definitions("token")
+
+
+    assert [] == mock_azure._list_role_definitions("token")

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1934,3 +1934,25 @@ class Test_get_role_definition_id:
         monkeypatch.setattr(mock_azure, "_list_role_definitions", Mock(return_value=[]))
 
         assert mock_azure._get_role_definition_id("token", "A definition") is None
+
+
+def test_filter_role_assignments(mock_azure):
+    target_role_assignment = {
+        "properties": {"roleDefinitionId": "fully/pathed/role_definition_id"}
+    }
+    wrong_role_assignment = {
+        "properties": {"roleDefinitionId": "full/path/wrong_definition_id"}
+    }
+    assert (
+        mock_azure._filter_role_assignments(
+            [target_role_assignment], "role_definition_id"
+        )
+        == target_role_assignment
+    )
+    assert (
+        mock_azure._filter_role_assignments(
+            [wrong_role_assignment], "role_definition_id"
+        )
+        is None
+    )
+    assert mock_azure._filter_role_assignments([], "role_definition_id") is None

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -1876,3 +1876,21 @@ def test_get_graph_sp_and_user_invite_app_role_ids(
         "service_principal_object_id",
         "app_role_id",
     ) == mock_azure._get_graph_sp_and_user_invite_app_role_ids("token")
+
+
+def test_list_role_assignments(mock_azure, mock_http_error_response):
+    mock_result = mock_requests_response(json_data={"value": []})
+    mock_azure.sdk.requests.get.side_effect = [
+        mock_azure.sdk.requests.exceptions.ConnectionError,
+        mock_azure.sdk.requests.exceptions.Timeout,
+        mock_http_error_response,
+        mock_result,
+    ]
+    with pytest.raises(ConnectionException):
+        mock_azure._list_role_assignments("token")
+    with pytest.raises(ConnectionException):
+        mock_azure._list_role_assignments("token")
+    with pytest.raises(UnknownServerException, match=r".*500 Server Error.*"):
+        mock_azure._list_role_assignments("token")
+
+    assert [] == mock_azure._list_role_assignments("token")

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -61,15 +61,15 @@ class MockAzureSDK(object):
 @pytest.fixture(scope="function")
 def mock_azure(monkeypatch):
     monkeypatch.setattr(
-        AzureCloudProvider,
-        "_get_elevated_management_token",
-        Mock(return_value=MOCK_ACCESS_TOKEN),
-    )
-    monkeypatch.setattr(
         AzureCloudProvider, "validate_domain_name", Mock(return_value=True),
     )
     azure_cloud_provider = AzureCloudProvider(
         AZURE_CONFIG, azure_sdk_provider=MockAzureSDK()
+    )
+    monkeypatch.setattr(
+        azure_cloud_provider,
+        "_elevate_tenant_admin_access",
+        Mock(return_value=MOCK_ACCESS_TOKEN),
     )
     monkeypatch.setattr(
         azure_cloud_provider,


### PR DESCRIPTION
Closes: https://ccpo.atlassian.net/browse/AT-5316

We need an elevated access token for a few parts of the portfolio provisioning process. When we don't need access anymore, we should remove the role assignment that's created.

To manage this flow of the Azure Cloud provider class, we use a context manager to execute the process outlined in the [Azure documentation](https://docs.microsoft.com/en-us/azure/role-based-access-control/elevate-access-global-admin#rest-api)

This PR will close the ticket linked above, but in a follow on PR, we will [limit the lifetime of a token](https://docs.microsoft.com/en-us/azure/active-directory/develop/active-directory-configurable-token-lifetimes) from the default limit of one hour to 10 minutes. 

We also may want to retry removing the elevated access role assignment. Right now, if the call to remove the role assignment in the exit block of the context manager fails, the portfolio state machine will enter a failed state. This could be caused by something like a connection issue though, so we may want to retry this call a few times. I had planned to include this retry mechanism initially, but gave up for this PR. See my comments [here](https://github.com/dod-ccpo/atst/pull/1699#discussion_r462595369) and [here](https://github.com/dod-ccpo/atst/pull/1699#discussion_r463595535).

Finally, `remove_tenant_admin_elevated_access` and the `get_elevated_access_token` context manager are looking pretty gnarly. Any recommendations on how we might make those methods simpler would be appreciated 🙌 
