### PR TITLE
Tidy up the Azure Cloud Provider 

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -538,7 +538,7 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def validate_domain_name(self, name):
         response = self.sdk.requests.get(
-            f"{self.sdk.cloud.endpoints.active_directory}/{name}.onmicrosoft.com/.well-known/openid-configuration",
+            f"{self.sdk.cloud.endpoints.active_directory}{name}.onmicrosoft.com/.well-known/openid-configuration",
             timeout=30,
         )
         response.raise_for_status()
@@ -608,7 +608,7 @@ class AzureCloudProvider(CloudProviderInterface):
         sp_token = self._get_root_provisioning_token()
 
         create_billing_account_body = payload.dict(by_alias=True)
-        billing_account_create_url = f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles"
+        billing_account_create_url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles"
         result = self.sdk.requests.post(
             billing_account_create_url,
             params={"api-version": "2019-10-01-preview"},
@@ -666,7 +666,7 @@ class AzureCloudProvider(CloudProviderInterface):
             }
         }
 
-        url = f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/createBillingRoleAssignment"
+        url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/createBillingRoleAssignment"
         result = self.sdk.requests.post(
             url,
             headers=make_auth_header(sp_token),
@@ -691,7 +691,7 @@ class AzureCloudProvider(CloudProviderInterface):
             }
         ]
 
-        url = f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}"
+        url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}"
 
         result = self.sdk.requests.patch(
             url,
@@ -739,7 +739,7 @@ class AzureCloudProvider(CloudProviderInterface):
             }
         }
 
-        url = f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/instructions/{payload.initial_task_order_id}:CLIN00{payload.initial_clin_type}"
+        url = f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Billing/billingAccounts/{payload.billing_account_name}/billingProfiles/{payload.billing_profile_name}/instructions/{payload.initial_task_order_id}:CLIN00{payload.initial_clin_type}"
 
         result = self.sdk.requests.put(
             url,
@@ -1455,7 +1455,7 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def _elevate_tenant_admin_access(self, token):
         result = self.sdk.requests.post(
-            f"{self.sdk.cloud.endpoints.resource_manager}/providers/Microsoft.Authorization/elevateAccess",
+            f"{self.sdk.cloud.endpoints.resource_manager}providers/Microsoft.Authorization/elevateAccess",
             headers=make_auth_header(token),
             params={"api-version": "2016-07-01"},
             timeout=30,

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -59,6 +59,22 @@ class TenantCSPPayload(AliasModel):
     password_recovery_email_address: str
 
 
+class PrincipalTokenPayload(BaseModel):
+    scope: str
+    client_id: str
+
+
+class UserPrincipalTokenPayload(PrincipalTokenPayload):
+    grant_type = "password"
+    username: str
+    password: str
+
+
+class ServicePrincipalTokenPayload(PrincipalTokenPayload):
+    grant_type = "client_credentials"
+    client_secret: str
+
+
 class TenantCSPResult(AliasModel):
     user_id: str
     tenant_id: str

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -1,11 +1,9 @@
-import os
-import string
 import re
-import requests
-from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
+import string
 
+import requests
 from flask import current_app as app
-from atat.domain.csp.cloud.exceptions import AuthenticationException
+from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD as cloud
 
 
 def generate_user_principal_name(name, domain_name):
@@ -20,23 +18,20 @@ def generate_mail_nickname(name):
     return re.sub(f"[{ESCAPED_PUNCTUATION} ]+", ".", name).lower()
 
 
-def get_user_principal_token_for_scope(username, password, tenant_id, scope):
-    cloud = AZURE_PUBLIC_CLOUD
+def get_principal_auth_token(tenant_id, payload):
+    """Returns an OAuth Access token for a User or Service Principal
+    
+    args:
+        tenant_id (str)
+        payload (UserPrincipalTokenPayload or ServicePrincipalTokenPayload)
+    returns:
+        str: token 
+        or
+        None
+    """
+
     url = f"{cloud.endpoints.active_directory}/{tenant_id}/oauth2/v2.0/token"
-    payload = {
-        # TODO: client_id should be parameterized
-        "client_id": os.environ["AZURE_POWERSHELL_CLIENT_ID"],
-        "grant_type": "password",
-        "username": username,
-        "password": password,
-        "scope": scope,
-    }
-    token_response = requests.post(url, data=payload, timeout=30)
-    token_response.raise_for_status()
-    token = token_response.json().get("access_token")
-    if token is None:
-        message = f"Failed to get user principal token for scope '{scope}' in tenant '{tenant_id}'"
-        app.logger.error(message, exc_info=1)
-        raise AuthenticationException(message)
-    else:
-        return token
+    response = requests.post(url, data=payload.dict(), timeout=30)
+    response.raise_for_status()
+    token = response.json().get("access_token")
+    return token

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -6,6 +6,12 @@ from flask import current_app as app
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD as cloud
 
 
+def make_auth_header(token):
+    return {
+        "Authorization": f"Bearer {token}",
+    }
+
+
 def generate_user_principal_name(name, domain_name):
     mail_name = generate_mail_nickname(name)
     return f"{mail_name}@{domain_name}.{app.config.get('OFFICE_365_DOMAIN')}"

--- a/script/teardown_hybrid.py
+++ b/script/teardown_hybrid.py
@@ -7,7 +7,8 @@ sys.path.append(parent_dir)
 
 from atat.app import make_config
 from atat.domain.csp.cloud.hybrid_cloud_provider import HYBRID_PREFIX
-from atat.domain.csp.cloud.utils import get_user_principal_token_for_scope
+from atat.domain.csp.cloud.utils import get_principal_auth_token
+from atat.domain.csp.cloud.models import UserPrincipalTokenPayload
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
 
@@ -118,16 +119,21 @@ if __name__ == "__main__":
     tenant_id, username, password, ps_client_id = [config[s] for s in required_config]
 
     # Delete App registations (which also deletes connected service principals)
-    graph_token = get_user_principal_token_for_scope(
-        username, password, tenant_id, GRAPH_API + "/.default"
+    payload = UserPrincipalTokenPayload(
+        client_id=ps_client_id,
+        username=username,
+        password=password,
+        scope=GRAPH_API + "/.default",
     )
+    graph_token = get_principal_auth_token(tenant_id, payload)
     delete_app_registrations(graph_token)
 
     # Delete management_groups
-    resource_token = get_user_principal_token_for_scope(
-        username,
-        password,
-        tenant_id,
-        AZURE_PUBLIC_CLOUD.endpoints.resource_manager + "/.default",
+    payload = UserPrincipalTokenPayload(
+        client_id=ps_client_id,
+        username=username,
+        password=password,
+        scope=AZURE_PUBLIC_CLOUD.endpoints.resource_manager + "/.default",
     )
+    resource_token = get_principal_auth_token(tenant_id, payload)
     delete_management_groups(resource_token)

--- a/script/teardown_hybrid.py
+++ b/script/teardown_hybrid.py
@@ -7,7 +7,7 @@ sys.path.append(parent_dir)
 
 from atat.app import make_config
 from atat.domain.csp.cloud.hybrid_cloud_provider import HYBRID_PREFIX
-from atat.domain.csp.cloud.utils import get_principal_auth_token
+from atat.domain.csp.cloud.utils import get_principal_auth_token, make_auth_header
 from atat.domain.csp.cloud.models import UserPrincipalTokenPayload
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
 
@@ -16,23 +16,16 @@ GRAPH_API = "https://graph.microsoft.com"
 
 
 def delete_tenant_principal_app(token, app_id):
-    auth_header = {
-        "Authorization": f"Bearer {token}",
-    }
-
     url = f"{GRAPH_API}/v1.0/applications/{app_id}"
 
-    response = requests.delete(url, headers=auth_header)
+    response = requests.delete(url, headers=make_auth_header(token))
     response.raise_for_status()
 
 
 def list_app_registrations(token):
-    auth_header = {
-        "Authorization": f"Bearer {token}",
-    }
 
     url = f"{GRAPH_API}/v1.0/applications"
-    response = requests.get(url, headers=auth_header)
+    response = requests.get(url, headers=make_auth_header(token))
     response.raise_for_status()
 
     apps = response.json()["value"]
@@ -56,12 +49,9 @@ def delete_app_registrations(token):
 
 
 def list_management_groups(token):
-    auth_header = {
-        "Authorization": f"Bearer {token}",
-    }
     response = requests.get(
         "https://management.azure.com/providers/Microsoft.Management/managementGroups?api-version=2020-02-01",
-        headers=auth_header,
+        headers=make_auth_header(token),
     )
     response.raise_for_status()
     mgmt_groups = response.json()["value"]
@@ -74,12 +64,9 @@ def list_management_groups(token):
 
 
 def delete_management_group(token, mgmt_group_id):
-    auth_header = {
-        "Authorization": f"Bearer {token}",
-    }
     response = requests.delete(
         f"https://management.azure.com/providers/Microsoft.Management/managementGroups/{mgmt_group_id}?api-version=2020-02-01",
-        headers=auth_header,
+        headers=make_auth_header(token),
     )
     response.raise_for_status()
 

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -12,6 +12,7 @@ from atat.domain.csp.cloud.models import (
     CostManagementQueryCSPPayload,
     SubscriptionCreationCSPPayload,
 )
+from atat.domain.csp.cloud.utils import make_auth_header
 from atat.jobs import (
     do_create_application,
     do_create_environment,
@@ -144,12 +145,9 @@ class TestIntegration:
 
     def _get_management_group(self, csp, tenant_id, management_group_id):
         sp_token = csp.azure._get_tenant_principal_token(tenant_id)
-        headers = {
-            "Authorization": f"Bearer {sp_token}",
-        }
         response = csp.azure.sdk.requests.get(
             f"{csp.azure.sdk.cloud.endpoints.resource_manager}{management_group_id}?api-version=2020-02-01",
-            headers=headers,
+            headers=make_auth_header(sp_token),
         )
         response.raise_for_status()
         return response.json()

--- a/tests/domain/cloud/test_utils.py
+++ b/tests/domain/cloud/test_utils.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+import requests
+
+from atat.domain.csp.cloud.utils import get_principal_auth_token
+from tests.domain.cloud.test_azure_csp import mock_requests_response
+from tests.mock_azure import mock_requests
+
+
+@patch("atat.domain.csp.cloud.utils.requests", new_callable=mock_requests)
+def test_get_principal_auth_token(mock_requests):
+    mock_requests.post.side_effect = [
+        mock_requests_response(
+            status=500,
+            raise_for_status=requests.exceptions.HTTPError("500 Server Error"),
+        ),
+        mock_requests_response(json_data={"access_token": "token"}),
+        mock_requests_response(json_data={}),
+    ]
+    payload = MagicMock(return_value={})
+
+    with pytest.raises(requests.HTTPError):
+        get_principal_auth_token("a_tenant_id", payload)
+
+    assert get_principal_auth_token("a_tenant_id", payload) == "token"
+    assert get_principal_auth_token("a_tenant_id", payload) is None

--- a/tests/domain/cloud/test_utils.py
+++ b/tests/domain/cloud/test_utils.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 import requests
 
-from atat.domain.csp.cloud.utils import get_principal_auth_token
+from atat.domain.csp.cloud.utils import get_principal_auth_token, make_auth_header
 from tests.domain.cloud.test_azure_csp import mock_requests_response
 from tests.mock_azure import mock_requests
 
@@ -25,3 +25,8 @@ def test_get_principal_auth_token(mock_requests):
 
     assert get_principal_auth_token("a_tenant_id", payload) == "token"
     assert get_principal_auth_token("a_tenant_id", payload) is None
+
+
+def test_make_auth_header():
+    header = make_auth_header("foo")
+    assert header["Authorization"] == "Bearer foo"

--- a/tests/mock_azure.py
+++ b/tests/mock_azure.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import pytest
 
 from atat.domain.csp.cloud import AzureCloudProvider
+import atat.domain.csp.cloud.azure_cloud_provider
 
 AZURE_CONFIG = {
     "AZURE_CALC_CLIENT_ID": "MOCK",
@@ -22,17 +23,15 @@ AZURE_CONFIG = {
     "AZURE_AADP_QTY": 5,
 }
 
-AUTH_CREDENTIALS = {
-    "client_id": AZURE_CONFIG["AZURE_CLIENT_ID"],
-    "secret_key": AZURE_CONFIG["AZURE_SECRET_KEY"],
-    "tenant_id": AZURE_CONFIG["AZURE_TENANT_ID"],
-}
-
 KEYVAULT_SECRET = {
-    **AUTH_CREDENTIALS,
+    "root_sp_client_id": AZURE_CONFIG["AZURE_CLIENT_ID"],
+    "root_sp_key": AZURE_CONFIG["AZURE_SECRET_KEY"],
+    "root_tenant_id": AZURE_CONFIG["AZURE_TENANT_ID"],
     "tenant_id": "mock_tenant_id",
     "tenant_admin_username": "mock_tenant_admin_username",
     "tenant_admin_password": "mock_tenant_admin_password",  # pragma: allowlist secret
+    "tenant_sp_client_id": AZURE_CONFIG["AZURE_CLIENT_ID"],
+    "tenant_sp_key": AZURE_CONFIG["AZURE_SECRET_KEY"],
 }
 
 MOCK_ACCESS_TOKEN = "TOKEN"
@@ -61,6 +60,11 @@ class MockAzureSDK(object):
 @pytest.fixture(scope="function")
 def mock_azure(monkeypatch):
     monkeypatch.setattr(
+        atat.domain.csp.cloud.azure_cloud_provider,
+        "get_principal_auth_token",
+        Mock(return_value=MOCK_ACCESS_TOKEN),
+    )
+    monkeypatch.setattr(
         AzureCloudProvider, "validate_domain_name", Mock(return_value=True),
     )
     azure_cloud_provider = AzureCloudProvider(
@@ -80,11 +84,6 @@ def mock_azure(monkeypatch):
     monkeypatch.setattr(
         azure_cloud_provider,
         "_get_keyvault_token",
-        Mock(return_value=MOCK_ACCESS_TOKEN),
-    )
-    monkeypatch.setattr(
-        azure_cloud_provider,
-        "_get_service_principal_token",
         Mock(return_value=MOCK_ACCESS_TOKEN),
     )
     return azure_cloud_provider


### PR DESCRIPTION
When I was writing a [proof of concept script](https://gist.github.com/graham-dds/a9302dbe78d24865006f3346d78348af) for #1699, I used a few patterns that I thought would be good to incorporate into the project:
- use the `params` kwarg to add URL parameters for `requests` functions. This mostly amounted to moving the `api-version` from the url string to the prams dictionary
- use [`urljoin`](https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin) to join `AZURE_PUBLIC_CLOUD` base urls and various API endpoints to construct absolute URLs. This will properly account for trailing slashes in the base url and/or beginning slashes in the endpoint we create with string concatenation. 
- make a helper function to build an authorization header instead of having to write: 
```{"Authorization": f"Bearer {token}"}``` over and over
- make a util function to handle getting tokens for both user and service principals. See the commit message of 496b2ff  for more details

In addition to passing unit tests, I confirmed that these changes passed the hybrid integration suite ✅ 

With the last two bullet points in mind, we may look into using `requests` to build a [custom auth class](https://2.python-requests.org/en/master/user/authentication/#new-forms-of-authentication) for our needs to streamline some of our authentication even more.