### PR TITLE
Update secrets baseline file.

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,9 +1,10 @@
 {
+  "custom_plugin_paths": [],
   "exclude": {
     "files": "^.secrets.baseline$|^.*pgsslrootcert.yml$",
     "lines": null
   },
-  "generated_at": "2020-05-13T16:34:32Z",
+  "generated_at": "2020-07-31T11:13:35Z",
   "plugins_used": [
     {
       "base64_limit": 4.5,
@@ -150,7 +151,7 @@
       }
     ]
   },
-  "version": "0.13.1",
+  "version": "0.14.2",
   "word_list": {
     "file": null,
     "hash": null


### PR DESCRIPTION
The secrets baseline file needs to be updated to record the current version of the detect-secrets library, 0.14.2.