### PR TITLE
Map SAML_LOGIN_DEV config value as a boolean

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -196,6 +196,7 @@ def map_config(config):
             config.get("default", "CONTRACT_END_DATE"), "YYYY-MM-DD"
         ).date(),
         "SESSION_COOKIE_SECURE": config.getboolean("default", "SESSION_COOKIE_SECURE"),
+        "SAML_LOGIN_DEV": config.getboolean("default", "SAML_LOGIN_DEV"),
     }
 
 


### PR DESCRIPTION
The `SAML_LOGIN_DEV` flag was not being correctly interpreted as a boolean configuration value, meaning it was always evaluating as a string, which evaluated to `True`. This caused all uses of the `login-dev` endpoint to force SAML, breaking integration tests.