### PR TITLE
Handle missing user correctly in name lookup

### DIFF
--- a/atat/domain/users.py
+++ b/atat/domain/users.py
@@ -123,13 +123,13 @@ class Users(object):
 
     @classmethod
     def get_by_first_and_last_name(cls, first_name, last_name):
-        try:
-            user = (
-                db.session.query(User)
-                .filter_by(first_name=first_name, last_name=last_name)
-                .first()
-            )
-        except NoResultFound:
+        user = (
+            db.session.query(User)
+            .filter_by(first_name=first_name, last_name=last_name)
+            .first()
+        )
+
+        if user is None:
             raise NotFoundError("user")
 
         return user


### PR DESCRIPTION
We switched from .one() to .first() to make sure there weren't extra issues around duplicate names, but first() doesn't throw exceptions, it'll return None if nothing is found.