### PR TITLE
Disable interpolation for config parsing

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -225,7 +225,7 @@ def make_config(direct_config=None):
     Finally, the final ConfigParser object is passed to `map_config()`
     """
 
-    config = ConfigParser(allow_no_value=True)
+    config = ConfigParser(allow_no_value=True, interpolation=None)
     config.optionxform = str
 
     # Read configuration values from base and environment configuration files

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -33,7 +33,7 @@ def test_make_crl_validator_creates_crl_dir(app, tmpdir, replace_crl_dir_config)
 
 @pytest.fixture
 def config_object(request):
-    config = ConfigParser()
+    config = ConfigParser(interpolation=None)
     config.optionxform = str
     config.read_dict(request.param)
     return config


### PR DESCRIPTION
By default, Python's `ConfigParser` will try to resolve `%` as a token that proceeds a reference in the config file. Since many of our config values are generated (.e.g passwords) they may contain `%` and can cause issues deploying the code. This disables the interpolation entirely so we don't have to try to conform our values to the default parser implementation.