### PR TITLE
Ghost Inspector updates August 7, 2020

### DIFF
--- a/uitests/Application_Index_with_App.html
+++ b/uitests/Application_Index_with_App.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
@@ -630,7 +630,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Environments (4)")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Environments (4)&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>
@@ -705,7 +705,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Environments (4)")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Environments (4)&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>
@@ -720,7 +720,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Environments (4)")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Environments (4)&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>
@@ -735,7 +735,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.accordion-list__collapse</td>
 <td></td>
 </tr>
-<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), "Collapse All")]">
+<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), &quot;Collapse All&quot;)]">
 <td>click</td>
 <td>css=a.accordion-list__collapse</td>
 <td></td>
@@ -750,7 +750,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Environments (4)")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Environments (4)&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Create_New_Application.html
+++ b/uitests/Create_New_Application.html
@@ -132,7 +132,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -200,7 +200,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -249,7 +249,7 @@ Imported from: AT-AT CI - login
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -279,7 +279,7 @@ Imported from: AT-AT CI - login
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -294,7 +294,7 @@ Imported from: AT-AT CI - login
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -309,7 +309,7 @@ Imported from: AT-AT CI - login
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -399,7 +399,7 @@ Imported from: AT-AT CI - login
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -414,7 +414,7 @@ Imported from: AT-AT CI - login
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -474,7 +474,7 @@ Imported from: AT-AT CI - login
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>

--- a/uitests/Create_New_TO.html
+++ b/uitests/Create_New_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -216,7 +216,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -482,7 +482,7 @@ Imported from: AT-AT CI - login
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -497,7 +497,7 @@ Imported from: AT-AT CI - login
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -512,7 +512,7 @@ Imported from: AT-AT CI - login
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Edit_App_Member.html
+++ b/uitests/Edit_App_Member.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>

--- a/uitests/Edit_Portfolio_Member.html
+++ b/uitests/Edit_Portfolio_Member.html
@@ -142,7 +142,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -218,7 +218,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -645,7 +645,7 @@ Brandon Buchannan's access to this Portfolio is pending until they sign in for t
 <td>css=.portfolio-perms > div:nth-of-type(2) > .usa-input.input__inline-fields.checked > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".portfolio-perms > div:nth-of-type(2) > .usa-input.input__inline-fields.checked > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Funding")]">
+<tr original-target=".portfolio-perms > div:nth-of-type(2) > .usa-input.input__inline-fields.checked > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Funding&quot;)]">
 <td>click</td>
 <td>css=.portfolio-perms > div:nth-of-type(2) > .usa-input.input__inline-fields.checked > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -660,7 +660,7 @@ Brandon Buchannan's access to this Portfolio is pending until they sign in for t
 <td>css=.portfolio-perms > div:nth-of-type(4) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".portfolio-perms > div:nth-of-type(4) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Portfolio")]">
+<tr original-target=".portfolio-perms > div:nth-of-type(4) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Portfolio&quot;)]">
 <td>click</td>
 <td>css=.portfolio-perms > div:nth-of-type(4) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/New_App_Step_1.html
+++ b/uitests/New_App_Step_1.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/New_App_Step_2.html
+++ b/uitests/New_App_Step_2.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/New_App_Step_2_-_Add_Env.html
+++ b/uitests/New_App_Step_2_-_Add_Env.html
@@ -75,7 +75,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -151,7 +151,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/New_App_Step_3.html
+++ b/uitests/New_App_Step_3.html
@@ -138,7 +138,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -214,7 +214,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/New_Portfolio.html
+++ b/uitests/New_Portfolio.html
@@ -65,7 +65,7 @@
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -125,7 +125,7 @@
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/New_Portfolio_Member.html
+++ b/uitests/New_Portfolio_Member.html
@@ -135,7 +135,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -207,7 +207,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/Portfolio_Settings.html
+++ b/uitests/Portfolio_Settings.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/Reports_-_Basics.html
+++ b/uitests/Reports_-_Basics.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -800,7 +800,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_Empty_State.html
+++ b/uitests/Reports_-_Empty_State.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -216,7 +216,7 @@ Imported from: AT-AT CI - login
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_Follow_TO_link.html
+++ b/uitests/Reports_-_Follow_TO_link.html
@@ -75,7 +75,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -151,7 +151,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -243,7 +243,7 @@ Imported from: AT-AT CI - Create New TO
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -562,7 +562,7 @@ Imported from: AT-AT CI - Create New TO
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -580,7 +580,7 @@ Imported from: AT-AT CI - Create New TO
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -598,7 +598,7 @@ Imported from: AT-AT CI - Create New TO
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -855,7 +855,7 @@ Remaining funds-->
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_TO,_App,_and_Environments.html
+++ b/uitests/Reports_-_with_TO,_App,_and_Environments.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
@@ -621,7 +621,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -922,7 +922,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -939,7 +939,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -956,7 +956,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1020,7 +1020,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
+++ b/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -214,7 +214,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -634,7 +634,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
@@ -651,7 +651,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -952,7 +952,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -969,7 +969,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -986,7 +986,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1054,7 +1054,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.sticky-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".sticky-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".sticky-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.sticky-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
@@ -1071,7 +1071,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -1372,7 +1372,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -1389,7 +1389,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1406,7 +1406,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1470,7 +1470,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_active_and_expired_TOs.html
+++ b/uitests/Reports_-_with_active_and_expired_TOs.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -214,7 +214,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -634,7 +634,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
@@ -651,7 +651,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -952,7 +952,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -969,7 +969,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -986,7 +986,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1050,7 +1050,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_draft_TO.html
+++ b/uitests/Reports_-_with_draft_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -222,7 +222,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -294,7 +294,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -364,7 +364,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -381,7 +381,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -665,7 +665,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>
-<tr original-target="a.action-group__action,xpath=//a[contains(text(), "Cancel")]">
+<tr original-target="a.action-group__action,xpath=//a[contains(text(), &quot;Cancel&quot;)]">
 <td>click</td>
 <td>css=a.action-group__action</td>
 <td></td>
@@ -682,7 +682,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
 </tr>
-<tr original-target=".action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), "Yes, save for later")]">
+<tr original-target=".action-group > button[type=&quot;submit&quot;].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), &quot;Yes, save for later&quot;)]">
 <td>click</td>
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
@@ -728,7 +728,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_expired_TO.html
+++ b/uitests/Reports_-_with_expired_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -205,7 +205,7 @@ Imported from: AT-AT CI - login
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -222,7 +222,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -523,7 +523,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -540,7 +540,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -557,7 +557,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -621,7 +621,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Reports_-_with_future_TO.html
+++ b/uitests/Reports_-_with_future_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -205,7 +205,7 @@ Imported from: AT-AT CI - login
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -222,7 +222,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -523,7 +523,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -540,7 +540,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -557,7 +557,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -637,7 +637,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), "Expired funding")]">
+<tr original-target="button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired funding&quot;)]">
 <td>click</td>
 <td>css=button.usa-accordion-button</td>
 <td></td>

--- a/uitests/Resend_App_Member_Invite.html
+++ b/uitests/Resend_App_Member_Invite.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>

--- a/uitests/Resend_Portfolio_Member_Invite.html
+++ b/uitests/Resend_Portfolio_Member_Invite.html
@@ -142,7 +142,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -218,7 +218,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -615,7 +615,7 @@ Brandon Buchannan's access to this Portfolio is pending until they sign in for t
 <td>css=table.atat-table > tbody > tr:nth-of-type(2) > td.toggle-menu__container > .toggle-menu > .accordion-table__item-toggle-content.toggle-menu__toggle > a:nth-of-type(2)</td>
 <td></td>
 </tr>
-<tr original-target="table.atat-table > tbody > tr:nth-of-type(2) > td.toggle-menu__container > .toggle-menu > .accordion-table__item-toggle-content.toggle-menu__toggle > a:nth-of-type(2),xpath=//a[contains(text(), "Resend Invite")]">
+<tr original-target="table.atat-table > tbody > tr:nth-of-type(2) > td.toggle-menu__container > .toggle-menu > .accordion-table__item-toggle-content.toggle-menu__toggle > a:nth-of-type(2),xpath=//a[contains(text(), &quot;Resend Invite&quot;)]">
 <td>click</td>
 <td>css=table.atat-table > tbody > tr:nth-of-type(2) > td.toggle-menu__container > .toggle-menu > .accordion-table__item-toggle-content.toggle-menu__toggle > a:nth-of-type(2)</td>
 <td></td>

--- a/uitests/Revoke_App_Member_Invite.html
+++ b/uitests/Revoke_App_Member_Invite.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>

--- a/uitests/Revoke_Environment_Access.html
+++ b/uitests/Revoke_Environment_Access.html
@@ -139,7 +139,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -211,7 +211,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -264,7 +264,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Create Your First Application")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Create Your First Application&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -298,7 +298,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Environments")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Environments&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -315,7 +315,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=button[type="submit"]</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"],xpath=//button[contains(text(), "Next: Add Members")]">
+<tr original-target="button[type=&quot;submit&quot;],xpath=//button[contains(text(), &quot;Next: Add Members&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"]</td>
 <td></td>
@@ -332,7 +332,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), "Add Team Member")]">
+<tr original-target="a.usa-button.usa-button-secondary.add-new-button,xpath=//a[contains(text(), &quot;Add Team Member&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-secondary.add-new-button</td>
 <td></td>
@@ -434,7 +434,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Edit Application Team")]">
+<tr original-target=".application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Edit Application Team&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(1) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -451,7 +451,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "Manage Application Environments")]">
+<tr original-target=".application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;Manage Application Environments&quot;)]">
 <td>click</td>
 <td>css=.application-perms > div:nth-of-type(2) > .usa-input.input__inline-fields > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -519,7 +519,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
 </tr>
-<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), "Save Application")]">
+<tr original-target=".action-group-footer > .action-group-footer--container > a.usa-button,xpath=//a[contains(text(), &quot;Save Application&quot;)]">
 <td>click</td>
 <td>css=.action-group-footer > .action-group-footer--container > a.usa-button</td>
 <td></td>
@@ -662,7 +662,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=label.link</td>
 <td></td>
 </tr>
-<tr original-target="label.link,xpath=//label[contains(text(), "Undo")]">
+<tr original-target="label.link,xpath=//label[contains(text(), &quot;Undo&quot;)]">
 <td>click</td>
 <td>css=label.link</td>
 <td></td>

--- a/uitests/Revoke_Portfolio_Member_Invite.html
+++ b/uitests/Revoke_Portfolio_Member_Invite.html
@@ -142,7 +142,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -218,7 +218,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -615,7 +615,7 @@ Brandon Buchannan's access to this Portfolio is pending until they sign in for t
 <td>css=.accordion-table__item-toggle-content > a:nth-of-type(3)</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-table__item-toggle-content > a:nth-of-type(3),xpath=//a[contains(text(), "Revoke Invite")]">
+<tr original-target=".accordion-table__item-toggle-content > a:nth-of-type(3),xpath=//a[contains(text(), &quot;Revoke Invite&quot;)]">
 <td>click</td>
 <td>css=.accordion-table__item-toggle-content > a:nth-of-type(3)</td>
 <td></td>
@@ -645,7 +645,7 @@ Brandon Buchannan's access to this Portfolio is pending until they sign in for t
 <td>css=button[type="submit"].action-group__action</td>
 <td></td>
 </tr>
-<tr original-target="button[type="submit"].action-group__action,xpath=//button[contains(text(), "Revoke Invite")]">
+<tr original-target="button[type=&quot;submit&quot;].action-group__action,xpath=//button[contains(text(), &quot;Revoke Invite&quot;)]">
 <td>click</td>
 <td>css=button[type="submit"].action-group__action</td>
 <td></td>

--- a/uitests/TO_Index_(Landing)_Page_-_Empty_State.html
+++ b/uitests/TO_Index_(Landing)_Page_-_Empty_State.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Index_with_Draft_TO.html
+++ b/uitests/TO_Index_with_Draft_TO.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -615,7 +615,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -630,7 +630,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -716,7 +716,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>
-<tr original-target="a.action-group__action,xpath=//a[contains(text(), "Cancel")]">
+<tr original-target="a.action-group__action,xpath=//a[contains(text(), &quot;Cancel&quot;)]">
 <td>click</td>
 <td>css=a.action-group__action</td>
 <td></td>
@@ -731,7 +731,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
 </tr>
-<tr original-target=".action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), "Yes, save for later")]">
+<tr original-target=".action-group > button[type=&quot;submit&quot;].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), &quot;Yes, save for later&quot;)]">
 <td>click</td>
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
@@ -746,7 +746,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Active Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Active Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>

--- a/uitests/TO_Index_with_TO.html
+++ b/uitests/TO_Index_with_TO.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -660,7 +660,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Draft Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Draft Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -690,7 +690,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Upcoming Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Upcoming Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -720,7 +720,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Expired Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -750,7 +750,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Expired Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -765,7 +765,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Upcoming Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Upcoming Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -780,7 +780,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Draft Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Draft Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -795,7 +795,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Active Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Active Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -810,7 +810,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Active Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Active Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -825,7 +825,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Expired Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -840,7 +840,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.accordion-list__collapse</td>
 <td></td>
 </tr>
-<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), "Collapse All")]">
+<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), &quot;Collapse All&quot;)]">
 <td>click</td>
 <td>css=a.accordion-list__collapse</td>
 <td></td>

--- a/uitests/TO_Index_with_Unconfirmed_TO.html
+++ b/uitests/TO_Index_with_Unconfirmed_TO.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -231,7 +231,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -532,7 +532,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -566,7 +566,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -615,7 +615,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -630,7 +630,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -870,7 +870,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>
-<tr original-target="a.action-group__action,xpath=//a[contains(text(), "Cancel")]">
+<tr original-target="a.action-group__action,xpath=//a[contains(text(), &quot;Cancel&quot;)]">
 <td>click</td>
 <td>css=a.action-group__action</td>
 <td></td>
@@ -885,7 +885,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
 </tr>
-<tr original-target=".action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), "Yes, save for later")]">
+<tr original-target=".action-group > button[type=&quot;submit&quot;].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), &quot;Yes, save for later&quot;)]">
 <td>click</td>
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
@@ -900,7 +900,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Active Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Active Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>

--- a/uitests/TO_Index_with_expired_TO.html
+++ b/uitests/TO_Index_with_expired_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -205,7 +205,7 @@ Imported from: AT-AT CI - login
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -222,7 +222,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -523,7 +523,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -540,7 +540,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -557,7 +557,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -606,7 +606,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), "Active Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), &quot;Active Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(2) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -636,7 +636,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), "Draft Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), &quot;Draft Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -666,7 +666,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), "Upcoming Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), &quot;Upcoming Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -711,7 +711,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.accordion-list__collapse</td>
 <td></td>
 </tr>
-<tr original-target="a.accordion-list__collapse,//a[contains(text(), "Collapse All")]">
+<tr original-target="a.accordion-list__collapse,//a[contains(text(), &quot;Collapse All&quot;)]">
 <td>click</td>
 <td>css=a.accordion-list__collapse</td>
 <td></td>
@@ -726,7 +726,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), "Expired Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,//button[contains(text(), &quot;Expired Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>

--- a/uitests/TO_Index_with_future_TO.html
+++ b/uitests/TO_Index_with_future_TO.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -205,7 +205,7 @@ Imported from: AT-AT CI - login
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -222,7 +222,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -523,7 +523,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -540,7 +540,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -557,7 +557,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -651,7 +651,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Draft Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Draft Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(3) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -681,7 +681,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Expired Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Expired Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(5) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
@@ -711,7 +711,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=a.accordion-list__collapse</td>
 <td></td>
 </tr>
-<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), "Collapse All")]">
+<tr original-target="a.accordion-list__collapse,xpath=//a[contains(text(), &quot;Collapse All&quot;)]">
 <td>click</td>
 <td>css=a.accordion-list__collapse</td>
 <td></td>
@@ -741,7 +741,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>
 </tr>
-<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), "Upcoming Task Orders")]">
+<tr original-target=".accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button,xpath=//button[contains(text(), &quot;Upcoming Task Orders&quot;)]">
 <td>click</td>
 <td>css=.accordion-list > .accordion:nth-of-type(4) > div > h4.accordion__button > button.usa-accordion-button</td>
 <td></td>

--- a/uitests/TO_Step_1.html
+++ b/uitests/TO_Step_1.html
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_2.html
+++ b/uitests/TO_Step_2.html
@@ -72,7 +72,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -144,7 +144,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_3.html
+++ b/uitests/TO_Step_3.html
@@ -75,7 +75,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -151,7 +151,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_3_-_Add_CLIN.html
+++ b/uitests/TO_Step_3_-_Add_CLIN.html
@@ -78,7 +78,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -158,7 +158,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_3_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_3_-_with_Option_CLIN.html
@@ -75,7 +75,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -151,7 +151,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_4.html
+++ b/uitests/TO_Step_4.html
@@ -78,7 +78,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -158,7 +158,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_4_-_with_2_CLINs.html
+++ b/uitests/TO_Step_4_-_with_2_CLINs.html
@@ -81,7 +81,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -165,7 +165,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_4_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_4_-_with_Option_CLIN.html
@@ -78,7 +78,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -158,7 +158,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>

--- a/uitests/TO_Step_5.html
+++ b/uitests/TO_Step_5.html
@@ -81,7 +81,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -165,7 +165,7 @@ Imported from: AT-AT CI - New Portfolio
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -977,7 +977,7 @@ Imported from: AT-AT CI - TO Step 3
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1007,7 +1007,7 @@ Imported from: AT-AT CI - TO Step 3
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1022,7 +1022,7 @@ Imported from: AT-AT CI - TO Step 3
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -1052,7 +1052,7 @@ Imported from: AT-AT CI - TO Step 3
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>


### PR DESCRIPTION
It looks like the folks at Ghost Inspector made some changes to their own HTML extracts, mostly to how they handle quotes and double-quotes. Changing them to escaped characters actually fixes a bug that I had encountered and reported for BDT.