### PR TITLE
Perform GPG check when adding RHEL repositories in Dockerfiles

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -27,3 +27,96 @@ LICENSE
 node_modules
 
 !/node_modules/uswds/dist/fonts/
+
+# sass and webassets output artifacts
+scss/assets
+scss/variables.scss
+scss/variables.scss.map
+.sass-cache/
+.webassets-cache
+
+# Python virtual env
+.venv/
+
+.pytest_cache/
+__pycache__
+
+# Compiled python bytecode files
+*.pyc
+.cache/
+
+# static/fonts for now, since it is just symlink
+static/fonts
+# font files originate from a node module
+static/fonts/*
+
+static/assets
+static/assets/*
+
+# buildinfo files
+static/buildinfo.*
+
+# local log files
+log/*
+*.log
+
+config/dev.ini
+.env*
+
+# CRLs
+/crl
+/crls
+/crl-tmp
+*.bk
+crl_locations.json
+
+# test CA config
+ssl/client-certs/*.srl
+
+# local cert
+ssl/local.crt
+ssl/local.key
+
+# uploads
+/uploads
+
+# python coverage output
+.coverage
+
+# je coverage output
+coverage
+
+# BrowserStack
+browserstacklocal
+
+# decompiled CircleCI yaml
+local-ci.yml
+
+# python config
+.python-version
+
+# configuration files
+override.ini
+atst-overrides.ini
+
+# binary file created by celery beat
+celerybeat-schedule
+
+# templates created for JS tests
+js/test_templates
+
+.mypy_cache/
+
+# terraform
+*.tfstate
+*.backup
+*.tfplan
+
+# vscode config files
+.vscode/
+
+# mac indexing
+**/*.DS_Store
+
+# sonar cube files
+.scannerwork

--- a/.dockerignore
+++ b/.dockerignore
@@ -120,3 +120,5 @@ js/test_templates
 
 # sonar cube files
 .scannerwork
+
+*.secret

--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ js/test_templates
 
 # sonar cube files
 .scannerwork
+
+*.secret

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,6 @@
 #
 # https://docs.docker.com/engine/reference/commandline/build/#options
 ARG IMAGE
-ARG REDHAT_USERNAME
-ARG REDHAT_PASSWORD
 
 FROM $IMAGE as builder
 
@@ -33,27 +31,6 @@ RUN yum updateinfo && \
 
 # Install the `Python.h` file for compiling certain libraries.
 RUN dnf install python3-devel -y
-
-# Install dependencies for python3-saml
-RUN yum install -y \
-      libxml2-devel \
-      xmlsec1 \
-      xmlsec1-openssl
-
-# Install dev dependencies required to build the xmlsec dependency of python3-saml
-# TODO(tomdds): Find proper gpg secured sources for both of these
-
-#
-#
-# https://developers.redhat.com/articles/renew-your-red-hat-developer-program-subscription
-RUN subscription-manager remove --all
-RUN subscription-manager clean
-RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD
-RUN subscription-manager refresh
-RUN subscription-manager attach --auto
-
-# https://access.redhat.com/articles/4348511#enable
-RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 
 # https://man7.org/linux/man-pages/man1/yum-utils.1.html
 RUN yum repolist
@@ -114,47 +91,8 @@ RUN groupadd --system -g 101 atat
 # https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html/deployment_guide/s2-users-cl-tools
 RUN useradd --system atst -g atat
 
-# TODO(heyzoos): Make this all work as part of the first stage.
-# Get the latest GPG key for enterprise linux 8.
-# https://yum.theforeman.org/
-# RUN wget "https://yum.theforeman.org/releases/2.1/RPM-GPG-KEY-foreman"
-# Import it into the rpm db
-# RUN rpm --import RPM-GPG-KEY-foreman
-
-RUN subscription-manager remove --all
-RUN subscription-manager clean
-RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD
-RUN subscription-manager refresh
-RUN subscription-manager attach --auto
-
-# https://access.redhat.com/articles/4348511#enable
-RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
-
-RUN yum install yum-utils -y
-RUN yum install libtool-ltdl-devel -y
-RUN yum install xmlsec1-devel -y
-
 # Install postgresql client.
-# https://www.postgresql.org/download/linux/redhat/
-# TODO(heyzoos): WE NEED TO CHECK THE GPG KEY ASAP
-# TODO(heyzoos): Copy the out of these from the first stage to the final image.
-# RUN dnf install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
 RUN dnf install @postgresql -y
-# Install postgresql client library
-# RUN yum install libpq.i686
-
-# Install dependencies for python3-saml
-RUN yum install -y \
-      libxml2-devel \
-      xmlsec1 \
-      xmlsec1-openssl
-
-# Install dev dependencies required to build the xmlsec dependency of python3-saml
-# TODO(tomdds): Find proper gpg secured sources for both of these
-# RUN yum install -y ftp://ftp.redhat.com/pub/redhat/rhel/rhel-8-beta/appstream/x86_64/Packages/libtool-ltdl-devel-2.4.6-25.el8.x86_64.rpm
-# RUN yum install -y http://mirror.centos.org/centos/8/PowerTools/x86_64/os/Packages/xmlsec1-devel-1.2.25-4.el8.x86_64.rps
-RUN yum install libtool-ltdl-devel -y
-RUN yum install xmlsec1-devel -y
 
 # Install dumb-init.
 # dumb-init is a simple process supervisor and init system designed to run as PID 1 inside minimal container environments.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 ARG IMAGE
 
 # FROM $IMAGE as builder
-FROM atst:rhel-py as builder
+FROM $IMAGE as builder
 
 ARG CDN_URL=/static/assets/
 ENV TZ UTC
@@ -52,9 +52,7 @@ RUN rm -rf ./static/fonts \
       && cp -rf ./node_modules/uswds/dist/fonts ./static/fonts \
       && yarn build-prod
 
-## NEW IMAGE
-# FROM $IMAGE
-FROM atst:rhel-py
+FROM $IMAGE
 
 ### Very low chance of changing
 ###############################

--- a/Dockerfile
+++ b/Dockerfile
@@ -100,8 +100,6 @@ RUN dnf install python3-devel -y
 # https://uwsgi-docs.readthedocs.io/en/latest/Logging.html#logging-to-files
 RUN pip3 install uwsgi pendulum
 
-COPY . .
-
 COPY --from=builder /install/.venv/ ./.venv/
 COPY --from=builder /install/alembic/ ./alembic/
 COPY --from=builder /install/alembic.ini .

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,12 +32,6 @@ RUN yum updateinfo && \
 # Install the `Python.h` file for compiling certain libraries.
 RUN dnf install python3-devel -y
 
-# https://man7.org/linux/man-pages/man1/yum-utils.1.html
-RUN yum repolist
-RUN yum install yum-utils -y
-RUN yum install libtool-ltdl-devel -y
-RUN yum install xmlsec1-devel -y
-
 COPY . .
 RUN pip3 install uwsgi poetry
 RUN poetry install --no-root --no-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@
 # https://docs.docker.com/engine/reference/commandline/build/#options
 ARG IMAGE
 
-FROM $IMAGE as builder
+# FROM $IMAGE as builder
+FROM atst:rhel-py as builder
 
 ARG CDN_URL=/static/assets/
 ENV TZ UTC
@@ -52,7 +53,8 @@ RUN rm -rf ./static/fonts \
       && yarn build-prod
 
 ## NEW IMAGE
-FROM $IMAGE
+# FROM $IMAGE
+FROM atst:rhel-py
 
 ### Very low chance of changing
 ###############################
@@ -86,7 +88,7 @@ RUN groupadd --system -g 101 atat
 RUN useradd --system atst -g atat
 
 # Install postgresql client.
-RUN dnf install @postgresql -y
+RUN dnf install postgresql-10.6-1.module+el8+2469+5ecd5aae -y
 
 # Install dumb-init.
 # dumb-init is a simple process supervisor and init system designed to run as PID 1 inside minimal container environments.

--- a/README.md
+++ b/README.md
@@ -482,3 +482,19 @@ fi
 ```
 
 Also note that if the line number of a previously whitelisted secret changes, the whitelist file, `.secrets.baseline`, will be updated and needs to be committed.
+
+## How to build the RHEL Python base image
+
+First create two files, containing a RedHat username and password respectively.
+
+- redhat_username.secret
+- redhat_password.secret
+
+Then run the build script.
+
+```
+./script/build-docker-image-python-base.sh
+```
+
+Then publish the image.
+

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ First create two files, containing a RedHat username and password respectively.
 Then run the build script.
 
 ```
-./script/build-docker-image-python-base.sh
+env CONTAINER_REGISTRY=cloudzerodryrunregistry.azurecr.io ./script/build-docker-image-python-base.sh
 ```
 
 Then publish the image. Start by tagging it with the appropriate registry. In

--- a/README.md
+++ b/README.md
@@ -496,5 +496,21 @@ Then run the build script.
 ./script/build-docker-image-python-base.sh
 ```
 
-Then publish the image.
+Then publish the image. Start by tagging it with the appropriate registry. In
+this example we use the dry run registry.
 
+```
+docker tag atst:rhel-py cloudzerodryrunregistry.azurecr.io/rhel-py
+```
+
+Make sure you're logged into said registry.
+
+```
+az acr login -n cloudzerodryrunregistry
+```
+
+Then push!
+
+```
+docker push cloudzerodryrunregistry.azurecr.io/rhel-py
+```

--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -29,13 +29,25 @@ RUN yum install -y gcc libffi-devel make wget zlib-devel
 # Causes python to be built with SSL capabilitiy, allowing pip to function.
 RUN yum install -y openssl-devel
 
+RUN subscription-manager remove --all
+RUN subscription-manager clean
+RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD
+RUN subscription-manager refresh
+RUN subscription-manager attach --auto
+
+# https://access.redhat.com/articles/4348511#enable
+RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
+
 # Need EPEL to install SQLLite
 # https://fedoraproject.org/wiki/EPEL
 # TODO(heyzoos): Do the GPG check.
-RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm --nogpgcheck
 
 # Allows python to use SQLLite modules.
-RUN yum install -y sqlite sqlite-devel libsqlite3x.x86_64
+RUN yum repolist
+RUN yum install yum-utils -y
+RUN yum install libtool-ltdl-devel -y
+RUN yum install xmlsec1-devel -y
+RUN yum install -y sqlite sqlite-devel 
 
 # Install python!
 # https://github.com/python/cpython#build-instructions

--- a/python.Dockerfile
+++ b/python.Dockerfile
@@ -29,24 +29,23 @@ RUN yum install -y gcc libffi-devel make wget zlib-devel
 # Causes python to be built with SSL capabilitiy, allowing pip to function.
 RUN yum install -y openssl-devel
 
+# Register this machine with a RedHat subscription.
+# Enables us to add the CodeReady repository.
 RUN subscription-manager remove --all
 RUN subscription-manager clean
 RUN subscription-manager register --username $REDHAT_USERNAME --password $REDHAT_PASSWORD
 RUN subscription-manager refresh
 RUN subscription-manager attach --auto
 
+# Enable the CodeReady repository.
+# Allows us to install the xmlsec1-devel package.
 # https://access.redhat.com/articles/4348511#enable
 RUN subscription-manager repos --enable codeready-builder-for-rhel-8-x86_64-rpms
 
-# Need EPEL to install SQLLite
-# https://fedoraproject.org/wiki/EPEL
-# TODO(heyzoos): Do the GPG check.
+# Install dependencies of python3-saml.
+RUN yum install -y libxml2-devel xmlsec1 xmlsec1-openssl libtool-ltdl-devel xmlsec1-devel
 
-# Allows python to use SQLLite modules.
-RUN yum repolist
-RUN yum install yum-utils -y
-RUN yum install libtool-ltdl-devel -y
-RUN yum install xmlsec1-devel -y
+# Enable python3 to be built with sqlite extensions.
 RUN yum install -y sqlite sqlite-devel 
 
 # Install python!

--- a/script/build-docker-image-python-base.sh
+++ b/script/build-docker-image-python-base.sh
@@ -1,0 +1,9 @@
+#! /bin/bash
+
+env DOCKER_BUILDKIT=1 docker build \
+    -t atst:rhel-py \
+    -f python.Dockerfile \
+    --build-arg IMAGE=cloudzerodryrunregistry.azurecr.io/rhelubi:8.2 \
+    --secret id=redhat_username,src=redhat_username.secret \
+    --secret id=redhat_password,src=redhat_password.secret \
+    .

--- a/script/build-docker-image-python-base.sh
+++ b/script/build-docker-image-python-base.sh
@@ -3,7 +3,7 @@
 env DOCKER_BUILDKIT=1 docker build \
     -t atst:rhel-py \
     -f python.Dockerfile \
-    --build-arg IMAGE=cloudzerodryrunregistry.azurecr.io/rhelubi:8.2 \
+    --build-arg IMAGE=$CONTAINER_REGISTRY/rhelubi:8.2 \
     --secret id=redhat_username,src=redhat_username.secret \
     --secret id=redhat_password,src=redhat_password.secret \
     .


### PR DESCRIPTION
https://ccpo.atlassian.net/browse/AT-5381

Gets rid of `--nogpgcheck` options in our base docker files.

Requires us to use a developer subscription and provide credentials as part of the build.

### Other

 - Introduces Build Kit for the base python file for secret passing and faster build file
 - Adds a build script for the base python file
 - Update readme to show how to build the base python file
 - Copy over .gitignore contents to .dockerignore