### PR TITLE
Fix `ar` not defined

### DIFF
--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -117,7 +117,7 @@ def do_create_user(csp: CloudProviderInterface, application_role_ids=None):
                 app.logger.warning(
                     "Application role cloud ID %s already present.", ar.cloud_id
                 )
-            return
+                return
 
         csp_details = app_roles[0].application.portfolio.csp_data
         user = app_roles[0].user

--- a/atat/jobs.py
+++ b/atat/jobs.py
@@ -112,10 +112,11 @@ def do_create_user(csp: CloudProviderInterface, application_role_ids=None):
 
     with claim_many_for_update(app_roles) as app_roles:
 
-        if any([ar.cloud_id for ar in app_roles]):
-            app.logger.warning(
-                "Application role cloud ID %s already present.", ar.cloud_id
-            )
+        for ar in app_roles:
+            if ar.cloud_id:
+                app.logger.warning(
+                    "Application role cloud ID %s already present.", ar.cloud_id
+                )
             return
 
         csp_details = app_roles[0].application.portfolio.csp_data


### PR DESCRIPTION
`ar` was not defined in this block of code, which would have led to property access exceptions when attempting to issue warnings.

```
       if any([ar.cloud_id for ar in app_roles]):
            app.logger.warning(
                "Application role cloud ID %s already present.", ar.cloud_id
            )
            return
```

