### PR TITLE
Update kubernetes API versions

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -4,7 +4,7 @@ kind: Namespace
 metadata:
   name: atat
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -168,7 +168,7 @@ spec:
               keyvaultobjecttypes: "secret;secret;secret;secret;key"
               tenantid: $TENANT_ID
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
@@ -241,7 +241,7 @@ spec:
               keyvaultobjecttypes: "secret;secret;secret;secret;key"
               tenantid: $TENANT_ID
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:

--- a/deploy/azure/keyvault/kv-flex-vol-installer.yml
+++ b/deploy/azure/keyvault/kv-flex-vol-installer.yml
@@ -3,7 +3,7 @@ kind: Namespace
 metadata:
   name: kv
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:

--- a/deploy/overlays/cloudzero-dryrun-staging/flex_vol.yml
+++ b/deploy/overlays/cloudzero-dryrun-staging/flex_vol.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: atst
@@ -25,7 +25,7 @@ spec:
               keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID;AZURE_BILLING_ACCOUNT_NAME;AZURE_BILLING_PROFILE_ID;AZURE_INVOICE_SECTION_ID;AZURE_HYBRID_REPORTING_CLIENT_ID;AZURE_HYBRID_REPORTING_SECRET;SAML_IDP_CERT"
               keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret;secret;secret;secret;secret;secret;secret"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: atst-worker
@@ -44,7 +44,7 @@ spec:
               keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
               keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: atst-beat


### PR DESCRIPTION
`extensions/v1beta1` deprecated as of 1.16 - Most of us use > 1.16 so we should update this.

https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/