### PR TITLE
[AT-5425] Use the Azure ACR credential helper

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,9 +9,10 @@ commands:
             apk update
             apk add bash py3-pip
             apk add --virtual=build \
-              linux-headers gcc libffi-dev musl-dev openssl-dev python3-dev make
+              linux-headers gcc libffi-dev musl-dev openssl-dev python3-dev make curl
             pip3 --no-cache-dir install -U pip
             pip3 --no-cache-dir install azure-cli
+            curl -L https://aka.ms/acr/installaad/bash | /bin/bash
             apk del --purge build
       - run:
           name: Login to Azure CLI


### PR DESCRIPTION
Install the [offical Azure CLI credential helper](https://github.com/Azure/acr-docker-credential-helper) for docker to prevent credentials from being stored in plaintext.

# Before
![Screen Shot 2020-08-14 at 9 51 55 AM](https://user-images.githubusercontent.com/52750307/90256512-dce59600-de13-11ea-93c1-8cc99aace34b.png)

# After
![Screen Shot 2020-08-14 at 9 51 26 AM](https://user-images.githubusercontent.com/52750307/90256550-e66efe00-de13-11ea-990c-0b633f3eb738.png)
