### PR TITLE
[AT-5341] Handle _VERIFICATION state machine steps

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -430,11 +430,14 @@ class AzureCloudProvider(CloudProviderInterface):
             response.raise_for_status()
             response_json = response.json()
             status = response_json["status"]
-            if status == "Succeeded":
+            if status == AsyncOperationStatus.SUCCEEDED.value:
                 resp = session.get(result_url)
                 resp.raise_for_status()
                 return resp.json()
-            elif status in ("Failed", "Canceled"):
+            elif status in (
+                AsyncOperationStatus.FAILED.value,
+                AsyncOperationStatus.CANCELED.value,
+            ):
                 error_message = f"{response_json['error']['message']}\nError code: {response_json['error']['code']}"
                 raise ResourceProvisioningError("management group", f"{error_message}")
             else:

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1,5 +1,6 @@
 import json
 import time
+from enum import Enum
 from contextlib import contextmanager
 from functools import wraps
 from secrets import token_hex, token_urlsafe
@@ -21,6 +22,7 @@ from .exceptions import (
     UserProvisioningException,
 )
 from .models import (
+    class_to_stage,
     AdminRoleDefinitionCSPPayload,
     AdminRoleDefinitionCSPResult,
     ApplicationCSPPayload,
@@ -163,6 +165,15 @@ class AzureSDKProvider(object):
 
         self.cloud = AZURE_PUBLIC_CLOUD
         self.requests = requests
+
+
+class AsyncOperationStatus(Enum):
+    """https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations"""
+
+    SUCCEEDED = "Succeeded"
+    FAILED = "Failed"
+    CANCELED = "Canceled"
+    IN_PROGRESS = "InProgress"
 
 
 class AzureCloudProvider(CloudProviderInterface):
@@ -741,6 +752,42 @@ class AzureCloudProvider(CloudProviderInterface):
             return TaskOrderBillingCreationCSPResult(**result.headers)
         elif result.status_code == 200:
             return TaskOrderBillingVerificationCSPResult(**result.json())
+
+    def _handle_async_operation_response(
+        self, response, creation_response_model, verification_response_model
+    ):
+        """Handle the response of an Async operation
+        https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations
+
+        Args:
+            response (requests.Response): a requests response object
+            creation_response_model (pydantic.BaseModel): the model to create and
+                return if the operation is still in progress
+            verification_response_model (pydantic.BaseModel): the model to 
+                create and return if the operation succeeds
+
+        Raises:
+            ResourceProvisioningError: The operation didn't complete successfully
+
+        Returns:
+            pydantic.BaseModel: the creation_response_mode or verification_response_model
+        """
+        response_json = response.json()
+        if response.status_code == 202:
+            return creation_response_model(**response.headers, reset_stage=True)
+        elif response.status_code == 200:
+            status = response_json["status"]
+            if status == AsyncOperationStatus.SUCCEEDED.value:
+                return verification_response_model(**response_json)
+            elif status in (
+                AsyncOperationStatus.FAILED.value,
+                AsyncOperationStatus.CANCELED.value,
+            ):
+                provisioning_stage = class_to_stage(verification_response_model)
+                error_message = f"{response_json['error']['message']}\nError code: {response_json['error']['code']}"
+                raise ResourceProvisioningError(provisioning_stage, f"{error_message}")
+            else:
+                return creation_response_model(**response.headers, reset_stage=True)
 
     @log_and_raise_exceptions
     def create_task_order_billing_verification(

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -801,12 +801,11 @@ class AzureCloudProvider(CloudProviderInterface):
             timeout=30,
         )
         result.raise_for_status()
-
-        if result.status_code == 202:
-            # 202 has location/retry after headers
-            return TaskOrderBillingCreationCSPResult(**result.headers)
-        elif result.status_code == 200:
-            return TaskOrderBillingVerificationCSPResult(**result.json())
+        return self._handle_async_operation_response(
+            result,
+            TaskOrderBillingCreationCSPResult,
+            TaskOrderBillingVerificationCSPResult,
+        )
 
     @log_and_raise_exceptions
     def create_billing_instruction(self, payload: BillingInstructionCSPPayload):

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -10,7 +10,7 @@ from .utils import (
     generate_mail_nickname,
     generate_user_principal_name,
 )
-from atat.utils import snake_to_camel
+from atat.utils import snake_to_camel, camel_to_snake
 
 
 AZURE_MGMNT_PATH = "/providers/Microsoft.Management/managementGroups/"
@@ -21,6 +21,25 @@ SUBSCRIPTION_ID_REGEX = re.compile(
     "\/?subscriptions\/([0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})",
     re.I,
 )
+PAYLOAD_CLASS_SUFFIX_REGEX = re.compile(r"(Creation|Verification)?CSP.*")
+
+
+def stage_to_classname(stage):
+    return "".join(map(lambda word: word.capitalize(), stage.split("_")))
+
+
+def class_to_stage(klass):
+    """Given a CSP model class, derive the stage name
+
+    Args:
+        klass (pydantic.BaseModel): a pydantic CSP data model class
+
+    Returns:
+        str: the stage name
+    """
+    class_name = klass.__name__
+    stage_camel_case = PAYLOAD_CLASS_SUFFIX_REGEX.split(class_name)[0]
+    return camel_to_snake(stage_camel_case)
 
 
 def normalize_management_group_id(cls, id_):

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -59,9 +59,18 @@ class AliasModel(BaseModel):
     * user_object_id:objectId
     """
 
+    reset_stage: bool = False
+
     class Config:
         alias_generator = snake_to_camel
         allow_population_by_field_name = True
+
+    def dict(self, *args, **kwargs):
+        kwargs.setdefault("exclude")
+        if kwargs["exclude"] is None:
+            kwargs["exclude"] = set()
+        kwargs["exclude"].update({"reset_stage"})
+        return super().dict(*args, **kwargs)
 
 
 class BaseCSPPayload(AliasModel):

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -101,8 +101,6 @@ def _build_transitions(csp_stages):
     
     - from the last stage's `_CREATED` state to the system `COMPLETED` state
         - triggered with a `finish_<CSP stage>` trigger
-
-    TODO: Turn the nested for loop into a generator
     """
     transitions = []
     states = []

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -192,9 +192,10 @@ class FSMMixin:
         a trigger prefix of `create`, find the `create_tenant` trigger and call it.
         """
         trigger = next(
-            filter(
-                lambda trigger: trigger.startswith(trigger_prefix),
-                self.machine.get_triggers(self.state_str),
+            (
+                trigger
+                for trigger in self.machine.get_triggers(self.state_str)
+                if trigger.startswith(trigger_prefix)
             ),
             None,
         )

--- a/atat/models/mixins/state_machines.py
+++ b/atat/models/mixins/state_machines.py
@@ -85,27 +85,39 @@ def _build_transitions(csp_stages):
     For each CSP state (a combination of CSP stages and StateStages) We need 
     transitions: 
     
-    - from the system `UNSTARTED` state or the previous stage's `_CREATED` state to
-     `<CSP stage>_IN_PROGRESS` to try the provisioning step
+    - from the system `UNSTARTED` state or the previous stage's `_CREATED` state
+      to `<CSP stage>_IN_PROGRESS` to try the provisioning step
         - triggered with a `create_<CSP stage>` trigger
     
-    - from `<CSP stage>_IN_PROGRESS` to `<CSP stage>_FAILED`, when the provisioning step fails
+    - from `<CSP stage>_IN_PROGRESS` to `<CSP stage>_FAILED`, when the 
+      provisioning step fails
         - triggered with a `fail_<CSP stage>` trigger
     
-    - from `<CSP stage>_FAILED` to `<CSP stage>_IN_PROGRESS`, to retry the provisioning step
+    - from `<CSP stage>_IN_PROGRESS` to the previous `<CSP stage>_CREATED` state
+      (or UNSTARTED), when we need to retry the provisioning step
+        - triggered with a `reset_<CSP stage>` trigger
+    
+    - from `<CSP stage>_FAILED` to `<CSP stage>_IN_PROGRESS`, to retry the
+      provisioning step
         - triggered with a `resume_progress_<CSP stage>` trigger
     
-    - from `<CSP stage>_IN_PROGRESS` to `<CSP stage>_CREATED` state, 
-      when the provisioning step is successful
+    - from `<CSP stage>_IN_PROGRESS` to `<CSP stage>_CREATED` state, when the 
+      provisioning step is successful
         - triggered with a `finish_<CSP stage>` trigger
     
     - from the last stage's `_CREATED` state to the system `COMPLETED` state
-        - triggered with a `finish_<CSP stage>` trigger
+        - triggered with a `complete` trigger
     """
     transitions = []
     states = []
     for stage_index, csp_stage in enumerate(csp_stages):
         for state in StageStates:
+            if stage_index > 0:
+                previous_state = compose_state(
+                    list(csp_stages)[stage_index - 1], StageStates.CREATED
+                )
+            else:
+                previous_state = PortfolioStates.UNSTARTED
             states.append(
                 dict(
                     name=compose_state(csp_stage, state),
@@ -113,16 +125,10 @@ def _build_transitions(csp_stages):
                 )
             )
             if state == StageStates.CREATED:
-                if stage_index > 0:
-                    source = compose_state(
-                        list(csp_stages)[stage_index - 1], StageStates.CREATED
-                    )
-                else:
-                    source = PortfolioStates.UNSTARTED
                 transitions.append(
                     dict(
                         trigger="create_" + csp_stage.name.lower(),
-                        source=source,
+                        source=previous_state,
                         dest=compose_state(csp_stage, StageStates.IN_PROGRESS),
                         after="after_in_progress_callback",
                     )
@@ -134,6 +140,13 @@ def _build_transitions(csp_stages):
                         source=compose_state(csp_stage, state),
                         dest=compose_state(csp_stage, StageStates.CREATED),
                         conditions=["is_csp_data_valid"],
+                    )
+                )
+                transitions.append(
+                    dict(
+                        trigger="reset_" + csp_stage.name.lower(),
+                        dest=previous_state,
+                        source=compose_state(csp_stage, state),
                     )
                 )
             if state == StageStates.FAILED:
@@ -218,3 +231,6 @@ class FSMMixin:
 
     def finish_stage(self, **kwargs):
         self._find_and_call_stage_trigger("finish_", **kwargs)
+
+    def reset_stage(self, **kwargs):
+        self._find_and_call_stage_trigger("reset_", **kwargs)

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -20,10 +20,7 @@ from atat.models.mixins.state_machines import (
     StateMachineMisconfiguredError,
 )
 from atat.models.types import Id
-
-
-def _stage_to_classname(stage):
-    return "".join(map(lambda word: word.capitalize(), stage.split("_")))
+from atat.domain.csp.cloud.models import stage_to_classname
 
 
 def get_stage_csp_class(stage, class_type):
@@ -32,7 +29,7 @@ def get_stage_csp_class(stage, class_type):
     class_type is either 'payload' or 'result'
 
     """
-    cls_name = f"{_stage_to_classname(stage)}CSP{class_type.capitalize()}"
+    cls_name = f"{stage_to_classname(stage)}CSP{class_type.capitalize()}"
     try:
         return getattr(
             importlib.import_module("atat.domain.csp.cloud.models"), cls_name

--- a/atat/models/portfolio_state_machine.py
+++ b/atat/models/portfolio_state_machine.py
@@ -158,8 +158,11 @@ class PortfolioStateMachine(
         try:
             payload = event.kwargs.get("csp_data")
             response = self._do_provisioning_stage(payload)
-            self._update_csp_data(response.dict())
-            self.finish_stage()
+            if response.reset_stage:
+                self.reset_stage()
+            else:
+                self._update_csp_data(response.dict())
+                self.finish_stage()
         except:
             self.fail_stage()
             raise

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -1,16 +1,40 @@
 import pytest
-
 from pydantic import ValidationError
 
 from atat.domain.csp.cloud.models import (
     AZURE_MGMNT_PATH,
+    BillingOwnerCSPPayload,
+    BillingProfileCreationCSPResult,
+    BillingProfileVerificationCSPResult,
     KeyVaultCredentials,
     ManagementGroupCSPPayload,
     ManagementGroupCSPResponse,
+    TenantCSPResult,
     UserCSPPayload,
     UserRoleCSPPayload,
-    BillingOwnerCSPPayload,
+    class_to_stage,
+    stage_to_classname,
 )
+from atat.models.mixins.state_machines import AzureStages
+
+
+def test_stage_to_classname():
+    assert (
+        stage_to_classname(AzureStages.BILLING_PROFILE_CREATION.name)
+        == "BillingProfileCreation"
+    )
+
+
+@pytest.mark.parametrize(
+    "klass, stage",
+    [
+        (TenantCSPResult, "tenant"),
+        (BillingProfileCreationCSPResult, "billing_profile"),
+        (BillingProfileVerificationCSPResult, "billing_profile"),
+    ],
+)
+def test_class_to_stage(klass, stage):
+    assert class_to_stage(klass) == stage
 
 
 def test_ManagementGroupCSPPayload_management_group_name():

--- a/tests/models/mixins/test_state_machines.py
+++ b/tests/models/mixins/test_state_machines.py
@@ -13,6 +13,7 @@ from atat.models.mixins.state_machines import (
     compose_state,
 )
 from tests.factories import PortfolioFactory
+from tests.utils import lists_contain_same_members
 
 
 class AzureStagesTest(Enum):
@@ -36,43 +37,69 @@ def test_find_and_call_stage_trigger_fails():
 
 
 @pytest.mark.state_machine
-def test_build_transitions():
-    states, transitions = _build_transitions(AzureStagesTest)
-    assert [s.get("name").name for s in states] == [
-        "TENANT_CREATED",
-        "TENANT_IN_PROGRESS",
-        "TENANT_FAILED",
-        "POLICIES_CREATED",
-        "POLICIES_IN_PROGRESS",
-        "POLICIES_FAILED",
-    ]
-    assert [s.get("tags") for s in states] == [
-        ["TENANT", "CREATED"],
-        ["TENANT", "IN_PROGRESS"],
-        ["TENANT", "FAILED"],
-        ["POLICIES", "CREATED"],
-        ["POLICIES", "IN_PROGRESS"],
-        ["POLICIES", "FAILED"],
-    ]
-    assert [t.get("trigger") for t in transitions] == [
-        "create_tenant",
-        "finish_tenant",
-        "fail_tenant",
-        "resume_progress_tenant",
-        "create_policies",
-        "finish_policies",
-        "fail_policies",
-        "resume_progress_policies",
-        "complete",
-    ]
+class Test_build_transitions:
+    @pytest.fixture(scope="class")
+    def states(self):
+        states, _ = _build_transitions(AzureStagesTest)
+        return states
 
-    created_to_in_progress_trigger = next(
-        (t for t in transitions if t.get("trigger") == "create_policies")
-    )
-    assert created_to_in_progress_trigger["source"] == PortfolioStates.TENANT_CREATED
-    assert (
-        created_to_in_progress_trigger["dest"] == PortfolioStates.POLICIES_IN_PROGRESS
-    )
+    @pytest.fixture(scope="class")
+    def transitions(self):
+        _, transitions = _build_transitions(AzureStagesTest)
+        return transitions
+
+    def test_states(self, states):
+        state_names = [s.get("name").name for s in states]
+        expected_state_names = [
+            "TENANT_CREATED",
+            "TENANT_IN_PROGRESS",
+            "TENANT_FAILED",
+            "POLICIES_CREATED",
+            "POLICIES_IN_PROGRESS",
+            "POLICIES_FAILED",
+        ]
+        assert lists_contain_same_members(state_names, expected_state_names)
+
+    def test_tags(self, states):
+        tags = [s.get("tags") for s in states]
+        expected_tags = [
+            ["TENANT", "CREATED"],
+            ["TENANT", "IN_PROGRESS"],
+            ["TENANT", "FAILED"],
+            ["POLICIES", "CREATED"],
+            ["POLICIES", "IN_PROGRESS"],
+            ["POLICIES", "FAILED"],
+        ]
+        assert lists_contain_same_members(tags, expected_tags)
+
+    def test_triggers(self, transitions):
+        triggers = [t.get("trigger") for t in transitions]
+        expecte_triggers = [
+            "create_tenant",
+            "finish_tenant",
+            "reset_tenant",
+            "fail_tenant",
+            "resume_progress_tenant",
+            "create_policies",
+            "finish_policies",
+            "reset_policies",
+            "fail_policies",
+            "resume_progress_policies",
+            "complete",
+        ]
+        assert lists_contain_same_members(triggers, expecte_triggers)
+
+    def test_correct_states_for_trigger(self, transitions):
+        created_to_in_progress_trigger = next(
+            (t for t in transitions if t.get("trigger") == "create_policies")
+        )
+        assert (
+            created_to_in_progress_trigger["source"] == PortfolioStates.TENANT_CREATED
+        )
+        assert (
+            created_to_in_progress_trigger["dest"]
+            == PortfolioStates.POLICIES_IN_PROGRESS
+        )
 
 
 @pytest.mark.state_machine

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -4,6 +4,7 @@ import pendulum
 import pydantic
 import pytest
 from pytest import raises
+from tests.utils import lists_contain_same_members
 from tests.factories import (
     ApplicationFactory,
     CLINFactory,
@@ -22,6 +23,7 @@ from atat.models.portfolio_state_machine import (
     PortfolioStateMachine,
     get_stage_csp_class,
 )
+from atat.domain.csp.cloud.models import AliasModel
 
 # TODO: Write failure case tests
 
@@ -86,10 +88,10 @@ def test_get_stage_csp_class_import_fail():
 
 
 @pytest.mark.state_machine
-def test_state_machine_valid_data_classes_for_stages():
-    for stage in AzureStages:
-        assert get_stage_csp_class(stage.name.lower(), "payload") is not None
-        assert get_stage_csp_class(stage.name.lower(), "result") is not None
+@pytest.mark.parametrize("stage", [stage for stage in AzureStages])
+def test_state_machine_valid_data_classes_for_stages(stage):
+    assert get_stage_csp_class(stage.name.lower(), "payload") is not None
+    assert get_stage_csp_class(stage.name.lower(), "result") is not None
 
 
 @pytest.mark.state_machine
@@ -98,28 +100,51 @@ def test_attach_machine(state_machine):
         "reset",
         "configuration_error",
         "create_tenant",
+        "reset_tenant",
         "finish_tenant",
         "fail_tenant",
         "resume_progress_tenant",
     ]
     state_machine.attach_machine()
-    assert list(state_machine.machine.events)[: len(initial_stages)] == initial_stages
+    assert lists_contain_same_members(
+        list(state_machine.machine.events)[: len(initial_stages)], initial_stages
+    )
 
 
 @pytest.mark.state_machine
-@patch("atat.models.PortfolioStateMachine._do_provisioning_stage")
-def test_after_in_progress_callback(_do_provisioning_stage):
-    # Given: a portfolio state machine is attempting a provisioning stage
-    portfolio = PortfolioFactory.create(state="TENANT_IN_PROGRESS")
-    # Given: The provisioning stage throws an exception
-    _do_provisioning_stage.side_effect = Exception()
+class Test_after_in_progress_callback:
+    @patch("atat.models.PortfolioStateMachine._do_provisioning_stage")
+    def test_failure(self, _do_provisioning_stage):
+        # Given: a portfolio state machine is attempting a provisioning stage
+        portfolio = PortfolioFactory.create(state="TENANT_IN_PROGRESS")
+        # Given: The provisioning stage throws an exception
+        _do_provisioning_stage.side_effect = [Exception]
 
-    # When I run the task, then:
-    # The exception is re-raised
-    with raises(Exception):
+        # When I run the task, then:
+        # The exception is re-raised
+        with raises(Exception):
+            portfolio.state_machine.after_in_progress_callback(Mock())
+        # Then the state machine fails the stage
+        assert portfolio.state_machine.state == PortfolioStates.TENANT_FAILED
+
+    @patch("atat.models.PortfolioStateMachine._do_provisioning_stage")
+    def test_reset_stage(self, _do_provisioning_stage):
+        # Given: a portfolio state machine is attempting a provisioning stage
+        portfolio = PortfolioFactory.create(
+            state="TASK_ORDER_BILLING_VERIFICATION_IN_PROGRESS"
+        )
+        # Given: The provisioning stage returns a model where the reset_stage
+        # property is set to True
+        _do_provisioning_stage.side_effect = [AliasModel(reset_stage=True)]
+
+        # When after_in_progress_callback is called
         portfolio.state_machine.after_in_progress_callback(Mock())
-    # Then the state machine fails the stage
-    assert portfolio.state_machine.state == PortfolioStates.TENANT_FAILED
+
+        # Then the state machine resets the stage to the previous "CREATED" state
+        assert (
+            portfolio.state_machine.state
+            == PortfolioStates.TASK_ORDER_BILLING_CREATION_CREATED
+        )
 
 
 @pytest.mark.state_machine
@@ -157,6 +182,13 @@ def test_fail_stage(state_machine):
 
 
 @pytest.mark.state_machine
+def test_reset_stage(state_machine):
+    state_machine.state = PortfolioStates.BILLING_PROFILE_CREATION_IN_PROGRESS
+    state_machine.reset_stage()
+    assert state_machine.state == PortfolioStates.TENANT_CREATED
+
+
+@pytest.mark.state_machine
 def test_finish_stage(state_machine):
     state_machine.portfolio.csp_data = {}
     state_machine.state = PortfolioStates.TENANT_IN_PROGRESS
@@ -179,25 +211,36 @@ def test_current_stage(state_machine_state, state_machine):
 
 
 @pytest.mark.state_machine
-def test_state_machine_initialization(state_machine):
-    for stage in AzureStages:
-
-        # check that all stages have a 'create' and 'fail' triggers
+class Test_state_machine_initialization:
+    @pytest.mark.parametrize("stage", [stage for stage in AzureStages])
+    def test_stages_have_triggers(self, stage, state_machine):
+        # check that all stages have the common trigger prefixes
         stage_name = stage.name.lower()
-        for trigger_prefix in ["create", "fail"]:
+        for trigger_prefix in [
+            "create",
+            "resume_progress",
+            "fail",
+            "finish",
+            "reset",
+        ]:
             assert hasattr(state_machine, trigger_prefix + "_" + stage_name)
 
-        # check that machine
-        in_progress_triggers = state_machine.machine.get_triggers(
-            stage.name + "_IN_PROGRESS"
-        )
-        assert [
-            "reset",
-            "configuration_error",
-            "finish_" + stage_name,
-            "fail_" + stage_name,
-        ] == in_progress_triggers
+    def test_in_progress_triggers(self, state_machine):
+        for stage in AzureStages:
+            in_progress_triggers = state_machine.machine.get_triggers(
+                stage.name + "_IN_PROGRESS"
+            )
+            stage_name = stage.name.lower()
+            expected_triggers = [
+                "reset",
+                "configuration_error",
+                "finish_" + stage_name,
+                "fail_" + stage_name,
+                "reset_" + stage_name,
+            ]
+            assert lists_contain_same_members(expected_triggers, in_progress_triggers)
 
+    def test_created_triggers(self, state_machine):
         started_triggers = state_machine.machine.get_triggers("UNSTARTED")
         create_trigger = next(
             filter(

--- a/tests/models/test_portfolio_state_machine.py
+++ b/tests/models/test_portfolio_state_machine.py
@@ -20,7 +20,6 @@ from atat.models.mixins.state_machines import (
 )
 from atat.models.portfolio_state_machine import (
     PortfolioStateMachine,
-    _stage_to_classname,
     get_stage_csp_class,
 )
 
@@ -72,14 +71,6 @@ class TestTriggerNextTransition:
             csp_data=state_machine.portfolio.to_dictionary()
         )
         assert state_machine.current_state == PortfolioStates.TENANT_CREATED
-
-
-@pytest.mark.state_machine
-def test_stage_to_classname():
-    assert (
-        _stage_to_classname(AzureStages.BILLING_PROFILE_CREATION.name)
-        == "BillingProfileCreation"
-    )
 
 
 @pytest.mark.state_machine

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -58,6 +58,10 @@ class FakeLogger:
 FakeNotificationSender = lambda: Mock(spec=NotificationSender)
 
 
+def lists_contain_same_members(list_1, list_2):
+    return sorted(list_1) == sorted(list_2)
+
+
 def parse_for_issuer_and_next_update(crl):
     with open(crl, "rb") as crl_file:
         parsed = crypto.load_crl(crypto.FILETYPE_ASN1, crl_file.read())


### PR DESCRIPTION
PR 1/2 for [AT-5341](https://ccpo.atlassian.net/browse/AT-5341)

Some API calls in Azure kick off ["async operations"](https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations). In the initial call to and endpoint, we receive a response with headers that contain a URL to check on the status of the ongoing operation.  

We handle portfolio provisioning stages that encounter async operations by using `_CREATION` and `_VERIFICATION` steps in the state machine. The `_CREATION` step handles the initial call to the endpoint and saves the URL to check, and the `_VERIFICATION` step hits the this URL for the payload of the operation.

It appears we made an assumption that by the time we got to the `_VERIFICATION` step, the async operation would be complete and we'd be able to return the desired payload. But, there's a chance that we could try a verification URL and the job isn't completed yet. This would mean that we'd either falsely report that the job was successful before it completed, or possibly that the payload would not have all the expected values and a Pydantic validation error would be raised.

In this PR, we add infrastructure to the state machine to account for this case of incomplete operations. If we try a URL in the verification step and the operation is still "In Progress", we reset the state machine from the current stage's _IN_PROGRESS state to the previous stage's _CREATED state. This effectively allows for the verification URL to be tried again after the next query for portfolios pending provisioning.

For this PR, we've only applied this new pattern to the `create_task_order_billing_verification` method. If this pattern looks sound for the state machine and Azure Cloud Provider, the next PR will continue the pattern to other stages that use the `_CREATION` & `_VERIFICATION` method for handling async operations.

