### PR TITLE
[AT-4902] Full verification of SSL/TLS connections to Postgres.

### DIFF
--- a/deploy/overlays/cloudzero-dryrun-staging/envvars.yml
+++ b/deploy/overlays/cloudzero-dryrun-staging/envvars.yml
@@ -12,9 +12,8 @@ data:
   CSP: hybrid
   FLASK_ENV: staging
   PGDATABASE: cloudzero_dryrun
-  PGHOST: 191.238.6.43
+  PGHOST: cloudzero-dryrun-sql.postgres.database.azure.com
   PGUSER: atat@cloudzero-dryrun-sql
-  PGSSLMODE: require
   REDIS_HOST: cloudzero-dryrun-redis.redis.cache.windows.net:6380
   SERVER_NAME: staging.atat.dev
 ---
@@ -35,9 +34,8 @@ data:
   CSP: hybrid
   FLASK_ENV: staging
   PGDATABASE: cloudzero_dryrun
-  PGHOST: 191.238.6.43
+  PGHOST: cloudzero-dryrun-sql.postgres.database.azure.com
   PGUSER: atat@cloudzero-dryrun-sql
-  PGSSLMODE: require
   REDIS_HOST: cloudzero-dryrun-redis.redis.cache.windows.net:6380
   SESSION_COOKIE_DOMAIN: atat.dev
   STATIC_URL: "https://staging.atat.dev/static/"


### PR DESCRIPTION
The strictest PostgreSQL connection option (PGSSLMODE) available is
"verify-full".  This forces the client to verify the certificate the
server presents against a known certificate authority. The CA is
specified with PGSSLROOTCERT.

https://www.postgresql.org/docs/10/libpq-connect.html#LIBPQ-CONNECT-SSLMODE

Because of DNS issues we were experiencing within the
cluster at one point, the client could not resolve the full hostname of
the Postgres server every time. We resorted to using the IP address of
the server and not using PGSSLMODE=verify-full. That DNS issues is
resolved. This commit reverts us to using the default value set in the
Kubernetes config, PGSSLMODE=verify-full.

I tested this change on staging and the app was still able to connect to the database.