### PR TITLE
[AT-5341] Use async handler in remaining _VERIFICATION steps

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -688,12 +688,11 @@ class AzureCloudProvider(CloudProviderInterface):
             timeout=30,
         )
         result.raise_for_status()
-
-        if result.status_code == 202:
-            # 202 has location/retry after headers
-            return BillingProfileCreationCSPResult(**result.headers)
-        elif result.status_code == 200:
-            return BillingProfileVerificationCSPResult(**result.json())
+        return self._handle_async_operation_response(
+            result,
+            BillingProfileCreationCSPResult,
+            BillingProfileVerificationCSPResult,
+        )
 
     @log_and_raise_exceptions
     def create_billing_profile_tenant_access(
@@ -908,15 +907,9 @@ class AzureCloudProvider(CloudProviderInterface):
             timeout=30,
         )
         result.raise_for_status()
-
-        if result.status_code == 202:
-            # 202 has location/retry after headers
-            return ProductPurchaseCSPResult(**result.headers)
-        elif result.status_code == 200:
-            premium_purchase_date = result.json()["properties"]["purchaseDate"]
-            return ProductPurchaseVerificationCSPResult(
-                premium_purchase_date=premium_purchase_date
-            )
+        return self._handle_async_operation_response(
+            result, ProductPurchaseCSPResult, ProductPurchaseVerificationCSPResult,
+        )
 
     def create_tenant_admin_credential_reset(
         self, payload: TenantAdminCredentialResetCSPPayload

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -622,7 +622,7 @@ class ProductPurchaseVerificationCSPResult(AliasModel):
     premium_purchase_date: str
 
     @root_validator(pre=True)
-    def extract_premium_purchase_date(cls, values):
+    def populate_premium_purchase_date(cls, values):
         if "premium_purchase_date" in values:
             return values
         try:
@@ -698,7 +698,9 @@ class CostManagementQueryCSPPayload(BaseCSPPayload):
     to_date: str
 
     @root_validator(pre=True)
-    def extract_invoice_section(cls, values):
+    def populate_invoice_section_id(cls, values):
+        if "invoice_section_id" in values:
+            return values
         try:
             values["invoice_section_id"] = values["billing_profile_properties"][
                 "invoice_sections"

--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -621,6 +621,16 @@ class ProductPurchaseVerificationCSPPayload(BaseCSPPayload):
 class ProductPurchaseVerificationCSPResult(AliasModel):
     premium_purchase_date: str
 
+    @root_validator(pre=True)
+    def extract_premium_purchase_date(cls, values):
+        if "premium_purchase_date" in values:
+            return values
+        try:
+            values["premium_purchase_date"] = values["properties"]["purchaseDate"]
+            return values
+        except KeyError:
+            raise ValueError("Premium purchasedate not present in payload")
+
 
 class UserMixin(BaseModel):
     password: Optional[str]

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -357,6 +357,7 @@ def test_validate_billing_profile_creation(
         json_data={
             "id": "/providers/Microsoft.Billing/billingAccounts/7c89b735-b22b-55c0-ab5a-c624843e8bf6:de4416ce-acc6-44b1-8122-c87c4e903c91_2019-05-31/billingProfiles/KQWI-W2SU-BG7-TGB",
             "name": "KQWI-W2SU-BG7-TGB",
+            "status": "Succeeded",
             "properties": {
                 "address": {
                     "addressLine1": "123 S Broad Street, Suite 2400",
@@ -706,6 +707,7 @@ def test_create_product_purchase_verification(mock_azure, mock_http_error_respon
         json_data={
             "id": "/providers/Microsoft.Billing/billingAccounts/BILLINGACCOUNTNAME/billingProfiles/BILLINGPROFILENAME/invoiceSections/INVOICESECTION/products/29386e29-a025-faae-f70b-b1cbbc266600",
             "name": "29386e29-a025-faae-f70b-b1cbbc266600",
+            "status": "Succeeded",
             "properties": {
                 "availabilityId": "C07TTFC7Q9XK",
                 "billingProfileId": "/providers/Microsoft.Billing/billingAccounts/BILLINGACCOUNTNAME/billingProfiles/BILLINGPROFILENAME",

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -9,6 +9,7 @@ from atat.domain.csp.cloud.models import (
     KeyVaultCredentials,
     ManagementGroupCSPPayload,
     ManagementGroupCSPResponse,
+    ProductPurchaseVerificationCSPResult,
     TenantCSPResult,
     UserCSPPayload,
     UserRoleCSPPayload,
@@ -124,6 +125,18 @@ def test_KeyVaultCredentials_enforce_root_creds():
     assert KeyVaultCredentials(
         root_tenant_id="an id", root_sp_client_id="C3PO", root_sp_key="beep boop"
     )
+
+
+class Test_ProductPurchaseVerificationCSPResult:
+    def test_azure_payload(self):
+        model = ProductPurchaseVerificationCSPResult(
+            **{"properties": {"purchaseDate": "2020/01/01"}}
+        )
+        assert model.premium_purchase_date == "2020/01/01"
+
+    def test_keywords(self):
+        model = ProductPurchaseVerificationCSPResult(premium_purchase_date="2020/01/01")
+        assert model.premium_purchase_date == "2020/01/01"
 
 
 def test_KeyVaultCredentials_merge_credentials():


### PR DESCRIPTION
PR 2/2 for [AT-5341](https://ccpo.atlassian.net/browse/AT-5341) (Initial PR: #1738 )


In 225e3f2a8 we created a handler for async operations to be used in `_VERIFICATION` state machine steps, and in 18c12cf22 we used this new method for task order billing. In this PR, we ensure that all remaining `_VERIFICATION` steps use the async handler.