### PR TITLE
[AT-5396] add users to tenant

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -188,7 +188,6 @@ def map_config(config):
         # with a Beat job once a day)
         "CELERY_RESULT_EXPIRES": 0,
         "CELERY_RESULT_EXTENDED": True,
-        "OFFICE_365_DOMAIN": "onmicrosoft.com",
         "CONTRACT_START_DATE": pendulum.from_format(
             config.get("default", "CONTRACT_START_DATE"), "YYYY-MM-DD"
         ).date(),

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -85,7 +85,11 @@ from .models import (
     UserRoleCSPResult,
 )
 from .policy import AzurePolicyManager
-from .utils import get_principal_auth_token, make_auth_header
+from .utils import (
+    get_principal_auth_token,
+    make_auth_header,
+    create_active_directory_user,
+)
 
 # This needs to be a fully pathed role definition identifier, not just a UUID
 # TODO: Extract these from sdk msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD
@@ -765,7 +769,7 @@ class AzureCloudProvider(CloudProviderInterface):
             response (requests.Response): a requests response object
             creation_response_model (pydantic.BaseModel): the model to create and
                 return if the operation is still in progress
-            verification_response_model (pydantic.BaseModel): the model to 
+            verification_response_model (pydantic.BaseModel): the model to
                 create and return if the operation succeeds
 
         Raises:
@@ -930,7 +934,7 @@ class AzureCloudProvider(CloudProviderInterface):
     def _create_role_assignment(self, payload: RoleAssignmentPayload, token):
         """
         https://docs.microsoft.com/en-us/rest/api/authorization/roleassignments/create
-        
+
         Role assignment definition IDs are assigned at a particular scope
         https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-rest#add-a-role-assignment
 
@@ -962,7 +966,7 @@ class AzureCloudProvider(CloudProviderInterface):
         return response
 
     def create_tenant_admin_ownership(self, payload: TenantAdminOwnershipCSPPayload):
-        """Assigns the tenant admin (human user) the Owner role on the root 
+        """Assigns the tenant admin (human user) the Owner role on the root
         management group."""
 
         role_assignment_payload = RoleAssignmentPayload(
@@ -987,7 +991,7 @@ class AzureCloudProvider(CloudProviderInterface):
         """Assigns the the owner role for the service principal over the root management group.
 
         https://docs.microsoft.com/en-us/rest/api/authorization/roleassignments/create
-        
+
         Role assignment definition IDs are assigned at a particular scope
         https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-rest#add-a-role-assignment
         """
@@ -1083,7 +1087,7 @@ class AzureCloudProvider(CloudProviderInterface):
     def create_principal_app_graph_api_permissions(
         self, payload: PrincipalAppGraphApiPermissionsCSPPayload
     ) -> PrincipalAppGraphApiPermissionsCSPResult:
-        """Grant the Directory.ReadWrite.All app role assignment to the tenant 
+        """Grant the Directory.ReadWrite.All app role assignment to the tenant
         service principal
 
         https://docs.microsoft.com/en-us/graph/api/serviceprincipal-post-approleassignments?view=graph-rest-1.0&tabs=http
@@ -1112,14 +1116,14 @@ class AzureCloudProvider(CloudProviderInterface):
 
     def _extract_service_principal_from_query(self, response):
         """Extract a service principal object from a response
-        
-        In `_get_graph_sp_and_user_invite_app_role_ids`, the query parameters 
-        should make it so that a single service principal object is returned in 
+
+        In `_get_graph_sp_and_user_invite_app_role_ids`, the query parameters
+        should make it so that a single service principal object is returned in
         a list. This method returns that single service principal.
 
         Returns:
             servicePrincipal: https://docs.microsoft.com/en-us/graph/api/resources/serviceprincipal?view=graph-rest-1.0
-        
+
         Raises:
             ResourceProvisioningError: No service principal present
 
@@ -1143,7 +1147,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
         Returns:
             appRole: https://docs.microsoft.com/en-us/graph/api/resources/approle?view=graph-rest-1.0
-        
+
         Raises:
             ResourceProvisioningError: No app role found in service principal's appRoles list with the given value
         """
@@ -1172,7 +1176,7 @@ class AzureCloudProvider(CloudProviderInterface):
         https://docs.microsoft.com/en-us/graph/api/serviceprincipal-list?view=graph-rest-1.0&tabs=http
 
         Returns:
-            Tuple of the service principal object ID of the Graph API app 
+            Tuple of the service principal object ID of the Graph API app
             registration and the app role id for "Directory.ReadWrite.All"
         """
         response = self.sdk.requests.get(
@@ -1394,22 +1398,7 @@ class AzureCloudProvider(CloudProviderInterface):
 
     @log_and_raise_exceptions
     def _create_active_directory_user(self, graph_token, payload) -> UserCSPResult:
-        request_body = {
-            "accountEnabled": True,
-            "displayName": payload.display_name,
-            "mailNickname": payload.mail_nickname,
-            "userPrincipalName": payload.user_principal_name,
-            "passwordProfile": {
-                "forceChangePasswordNextSignIn": True,
-                "password": payload.password,
-            },
-        }
-
-        url = f"{self.graph_resource}/v1.0/users"
-
-        result = self.sdk.requests.post(
-            url, headers=make_auth_header(graph_token), json=request_body, timeout=30,
-        )
+        result = create_active_directory_user(graph_token, self.graph_resource, payload)
         result.raise_for_status()
 
         return UserCSPResult(**result.json())
@@ -1667,7 +1656,7 @@ class AzureCloudProvider(CloudProviderInterface):
     @log_and_raise_exceptions
     def _remove_role_assignment(self, token, role_assignment_id):
         """Removes role assignment in a given tenant
-        
+
         https://docs.microsoft.com/en-us/rest/api/authorization/roleassignments/delete
         """
         response = self.sdk.requests.delete(

--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -89,6 +89,7 @@ from .utils import (
     get_principal_auth_token,
     make_auth_header,
     create_active_directory_user,
+    OFFICE_365_DOMAIN,
 )
 
 # This needs to be a fully pathed role definition identifier, not just a UUID
@@ -618,8 +619,9 @@ class AzureCloudProvider(CloudProviderInterface):
 
         result_dict = result.json()
         tenant_id = result_dict.get("tenantId")
-        tenant_admin_username = f"{payload.user_id}@{payload.domain_name}.{self.config.get('OFFICE_365_DOMAIN')}"
-
+        tenant_admin_username = (
+            f"{payload.user_id}@{payload.domain_name}.{OFFICE_365_DOMAIN}"
+        )
         self.create_tenant_creds(
             tenant_id,
             KeyVaultCredentials(

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -2,8 +2,10 @@ import re
 import string
 
 import requests
-from flask import current_app as app
 from msrestazure.azure_cloud import AZURE_PUBLIC_CLOUD as cloud
+
+
+OFFICE_365_DOMAIN = "onmicrosoft.com"
 
 
 def make_auth_header(token):
@@ -14,7 +16,7 @@ def make_auth_header(token):
 
 def generate_user_principal_name(name, domain_name):
     mail_name = generate_mail_nickname(name)
-    return f"{mail_name}@{domain_name}.{app.config.get('OFFICE_365_DOMAIN')}"
+    return f"{mail_name}@{domain_name}.{OFFICE_365_DOMAIN}"
 
 
 ESCAPED_PUNCTUATION = re.escape(string.punctuation)

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -45,14 +45,16 @@ def get_principal_auth_token(tenant_id, payload):
     return token
 
 
-def create_active_directory_user(graph_token, graph_resource, payload):
+def create_active_directory_user(
+    graph_token, graph_resource, payload, password_reset=True
+):
     request_body = {
         "accountEnabled": True,
         "displayName": payload.display_name,
         "mailNickname": payload.mail_nickname,
         "userPrincipalName": payload.user_principal_name,
         "passwordProfile": {
-            "forceChangePasswordNextSignIn": True,
+            "forceChangePasswordNextSignIn": password_reset,
             "password": payload.password,
         },
     }

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -26,12 +26,12 @@ def generate_mail_nickname(name):
 
 def get_principal_auth_token(tenant_id, payload):
     """Returns an OAuth Access token for a User or Service Principal
-    
+
     args:
         tenant_id (str)
         payload (UserPrincipalTokenPayload or ServicePrincipalTokenPayload)
     returns:
-        str: token 
+        str: token
         or
         None
     """
@@ -41,3 +41,22 @@ def get_principal_auth_token(tenant_id, payload):
     response.raise_for_status()
     token = response.json().get("access_token")
     return token
+
+
+def create_active_directory_user(graph_token, graph_resource, payload):
+    request_body = {
+        "accountEnabled": True,
+        "displayName": payload.display_name,
+        "mailNickname": payload.mail_nickname,
+        "userPrincipalName": payload.user_principal_name,
+        "passwordProfile": {
+            "forceChangePasswordNextSignIn": True,
+            "password": payload.password,
+        },
+    }
+
+    url = f"{graph_resource}/v1.0/users"
+
+    return requests.post(
+        url, headers=make_auth_header(graph_token), json=request_body, timeout=30,
+    )

--- a/script/add_ccpo_users.py
+++ b/script/add_ccpo_users.py
@@ -17,7 +17,14 @@ from atat.models import User
 def add_ccpo_users(ccpo_users):
     print("Creating initial set of CCPO users.")
     for user_data in ccpo_users:
-        user = User(**user_data)
+        user = User(
+            first_name=user_data["first_name"],
+            last_name=user_data["last_name"],
+            dod_id=user_data["dod_id"],
+            email=user_data.get("email"),
+            phone_number=user_data.get("phone_number"),
+            phone_ext=user_data.get("phone_ext"),
+        )
         Users.give_ccpo_perms(user, commit=False)
         db.session.add(user)
 

--- a/script/add_users_to_aad_tenant.py
+++ b/script/add_users_to_aad_tenant.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python
+# Add root application dir to the python path
+import os
+import sys
+
+parent_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.append(parent_dir)
+
+import argparse
+import random
+from secrets import token_urlsafe
+import string
+
+import factory
+import yaml
+
+from atat.domain.csp.cloud.utils import (
+    get_principal_auth_token,
+    create_active_directory_user,
+)
+from atat.domain.csp.cloud.models import ServicePrincipalTokenPayload, UserCSPPayload
+
+
+GRAPH_RESOURCE = "https://graph.microsoft.com"
+TOKEN_SCOPE = GRAPH_RESOURCE + "/.default"
+
+
+def get_token(scope, client_id, client_secret, tenant_id):
+    payload = ServicePrincipalTokenPayload(
+        scope=scope, client_id=client_id, client_secret=client_secret,
+    )
+    return get_principal_auth_token(tenant_id, payload)
+
+
+def create_user(token, tenant_id, tenant_host_name):
+    first_name = factory.Faker("first_name").generate()
+    last_name = factory.Faker("last_name").generate()
+    email = f"{first_name}.{last_name}@example.com".lower()
+    password = token_urlsafe(32)
+    payload = UserCSPPayload(
+        tenant_id=tenant_id,
+        display_name=f"{first_name} {last_name}",
+        tenant_host_name=tenant_host_name,
+        email=email,
+        password=password,
+    )
+    response = create_active_directory_user(token, GRAPH_RESOURCE, payload)
+    response.raise_for_status()
+    result = payload.dict()
+    result.update(
+        {
+            "first_name": first_name,
+            "last_name": last_name,
+            "login_name": payload.user_principal_name,
+            "dod_id": "".join(random.choices(string.digits, k=10)),
+        }
+    )
+    return result
+
+
+def run(cli_args):
+    users = []
+    token = get_token(
+        TOKEN_SCOPE, cli_args.client_id, cli_args.client_secret, cli_args.tenant_id
+    )
+    for i in range(cli_args.user_count):
+        user = create_user(token, cli_args.tenant_id, cli_args.tenant_name)
+        users.append(user)
+
+    with open(cli_args.out, "w") as output:
+        yaml.dump(users, output)
+
+
+def parser():
+    parser = argparse.ArgumentParser(
+        description="""
+This script will add a specified number of random sample users to an Azure
+Active Directory tenant.
+
+It requires a service principal with a minimum of User.ReadWrite.All Graph API
+permissions to the AAD tenant:
+https://docs.microsoft.com/en-us/graph/api/user-post-users?view=graph-rest-1.0&tabs=http
+
+The YAML output includes the details created for each user as well as a fake
+DoD ID/EDIPI in case the information needs to be loaded into the database
+separately.
+"""
+    )
+    parser.add_argument("tenant_id", type=str, help="GUID of the AAD tenant")
+    parser.add_argument(
+        "client_id", type=str, help="Application (client) GUID of the App Registration"
+    )
+    parser.add_argument(
+        "client_secret", type=str, help="Client secret for the App Registration"
+    )
+    parser.add_argument(
+        "tenant_name",
+        type=str,
+        help="The subdomain of the tenant hostname, i.e., 'contoso' if the tenant hostname is 'contoso.onmicrosoft.com'",
+    )
+    parser.add_argument("user_count", type=int, help="The number of users to create")
+    parser.add_argument(
+        "-o",
+        "--out",
+        default="users.yml",
+        type=str,
+        help="The location of the YAML output file",
+    )
+    return parser
+
+
+if __name__ == "__main__":
+    cli_args = parser().parse_args()
+    run(cli_args)

--- a/script/add_users_to_aad_tenant.py
+++ b/script/add_users_to_aad_tenant.py
@@ -44,7 +44,9 @@ def create_user(token, tenant_id, tenant_host_name):
         email=email,
         password=password,
     )
-    response = create_active_directory_user(token, GRAPH_RESOURCE, payload)
+    response = create_active_directory_user(
+        token, GRAPH_RESOURCE, payload, password_reset=False
+    )
     response.raise_for_status()
     result = payload.dict()
     result.update(

--- a/tests/domain/cloud/test_models.py
+++ b/tests/domain/cloud/test_models.py
@@ -16,6 +16,7 @@ from atat.domain.csp.cloud.models import (
     class_to_stage,
     stage_to_classname,
 )
+from atat.domain.csp.cloud.utils import OFFICE_365_DOMAIN
 from atat.models.mixins.state_machines import AzureStages
 
 
@@ -174,10 +175,7 @@ def test_UserCSPPayload_mail_nickname():
 
 def test_UserCSPPayload_user_principal_name(app):
     payload = UserCSPPayload(**user_payload)
-    assert (
-        payload.user_principal_name
-        == f"han.solo@rebelalliance.{app.config.get('OFFICE_365_DOMAIN')}"
-    )
+    assert payload.user_principal_name == f"han.solo@rebelalliance.{OFFICE_365_DOMAIN}"
 
 
 def test_UserCSPPayload_password():
@@ -212,7 +210,7 @@ class TestBillingOwnerCSPPayload:
         payload = BillingOwnerCSPPayload(**self.user_payload)
         assert (
             payload.user_principal_name
-            == f"billing.admin@rebelalliance.{app.config.get('OFFICE_365_DOMAIN')}"
+            == f"billing.admin@rebelalliance.{OFFICE_365_DOMAIN}"
         )
 
     def test_email(self):

--- a/tests/domain/cloud/test_utils.py
+++ b/tests/domain/cloud/test_utils.py
@@ -1,9 +1,16 @@
 from unittest.mock import MagicMock, patch
+from uuid import uuid4
 
 import pytest
 import requests
 
-from atat.domain.csp.cloud.utils import get_principal_auth_token, make_auth_header
+from atat.domain.csp.cloud.utils import (
+    get_principal_auth_token,
+    make_auth_header,
+    create_active_directory_user,
+)
+from atat.domain.csp.cloud.models import UserCSPPayload
+
 from tests.domain.cloud.test_azure_csp import mock_requests_response
 from tests.mock_azure import mock_requests
 
@@ -30,3 +37,33 @@ def test_get_principal_auth_token(mock_requests):
 def test_make_auth_header():
     header = make_auth_header("foo")
     assert header["Authorization"] == "Bearer foo"
+
+
+@patch("atat.domain.csp.cloud.utils.requests", new_callable=mock_requests)
+def test_create_active_directory_user(mock_requests):
+    mock_result = mock_requests_response(json_data={"id": "id"})
+
+    mock_requests.post.side_effect = [
+        requests.exceptions.ConnectionError,
+        requests.exceptions.Timeout,
+        requests.exceptions.HTTPError,
+        mock_result,
+    ]
+
+    payload = UserCSPPayload(
+        tenant_id=uuid4().hex,
+        display_name="Test Testerson",
+        tenant_host_name="testtenant",
+        email="test@testerson.test",
+        password="asdfghjkl",  # pragma: allowlist secret
+    )
+    with pytest.raises(requests.exceptions.ConnectionError):
+        create_active_directory_user("token", "azure.com", payload)
+    with pytest.raises(requests.exceptions.Timeout):
+        create_active_directory_user("token", "azure.com", payload)
+    with pytest.raises(requests.exceptions.HTTPError):
+        create_active_directory_user("token", "azure.com", payload)
+
+    result = create_active_directory_user("token", "azure.com", payload)
+
+    assert result == mock_result

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -23,6 +23,7 @@ from atat.domain.csp.cloud.models import (
     UserRoleCSPResult,
     SubscriptionCreationCSPPayload,
 )
+from atat.domain.csp.cloud.utils import OFFICE_365_DOMAIN
 from atat.jobs import (
     RecordFailure,
     build_subscription_payload,
@@ -163,7 +164,7 @@ class TestCreateUserJob:
         return PortfolioFactory.create(
             csp_data={
                 "tenant_id": str(uuid4()),
-                "domain_name": f"rebelalliance.{app.config.get('OFFICE_365_DOMAIN')}",
+                "domain_name": f"rebelalliance.{OFFICE_365_DOMAIN}",
             }
         )
 
@@ -383,7 +384,7 @@ def test_send_ppoc_email(monkeypatch, app):
             "email.portfolio_ready.body",
             {
                 "password_reset_address": app.config.get("AZURE_LOGIN_URL"),
-                "username": f"{user_id}@{domain_name}.{app.config.get('OFFICE_365_DOMAIN')}",
+                "username": f"{user_id}@{domain_name}.{OFFICE_365_DOMAIN}",
             },
         ),
     )


### PR DESCRIPTION
This adds a utility script for adding sample users to a specified AAD tenant. It uses the Python faker library to generate user details and outputs a YAML file with details for every user it generated. The script uses [argparse](https://docs.python.org/3/library/argparse.html) for CLI arguments, so you can see the documentation for the script by running `poetry run python script/add_users_to_aad_tenant.py -h`. 

I ran it against one of our new sample tenants an generated five new sample users, shown in the screenshot below (some identifying details are removed):

<img width="1530" alt="Screen Shot 2020-08-24 at 11 20 04 AM" src="https://user-images.githubusercontent.com/38955503/91067226-a3c1d880-e600-11ea-986b-8d320ffeca00.png">


## notes

I moved the Azure interface code for creating an AAD user into a utility function so that it could be used by the script. This resulted in some small updates to other modules:
- I moved `OFFICE_365_DOMAIN` into a constant rather than config. Partly I don't think this needs to be configurable (that we know of, yet) and partly I don't want the new script to require a Flask application context in order to work. The latter is an anti-pattern I think we should avoid repeating in new code.
- In the request body POSTED to the Graph API `/users` endpoint, we can specify whether the user should have to reset their password on initial login. Typically we do, but in the case of these sample users we don't. I've made that a kwarg with a default so that it can be set as-needed by the caller.

I also updated script/add_ccpo_users.py to specify what keys from the dictionary it receives it should use to make an instance of the `User` model, rather than assuming everything in the dictionary is a valid attribute for a `User` instance. This way we can take the output from script/add_users_to_aad_tenant.py and use it to seed the database if needed.