### PR TITLE
[AT-5358] Add polling to manual provisioning

### DIFF
--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -11,34 +11,21 @@ from atat.domain.csp.cloud.models import (
 from script.provision.provision_base import handle, verify_async
 
 
-def poll_billing(csp, inputs, csp_response):
-    """Polls billing endpoint for async response three times.  If verify url is not 
-    available, the csp_response payload will be returned. 
-
-    Args:
-        csp: CSP Class object
-        inputs: Json string
-        csp_response: Result from billing profile creation
-
-    Returns:
-        Response from billing profile verification or csp_response payload
-    """
-    verify_url = csp_response.get("billing_profile_verify_url")
-    csp_method = csp.create_billing_profile_verification
-    payload = BillingProfileVerificationCSPPayload(
-        **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response,}
-    )
-    return verify_async(verify_url, csp_method, payload, csp_response)
-
-
 def setup_billing(csp, inputs):
     create_billing_profile = BillingProfileCreationCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
+    result = csp.create_billing_profile_creation(create_billing_profile).dict()
 
-    result = csp.create_billing_profile_creation(create_billing_profile)
-    polling_result = poll_billing(csp, inputs, result.dict())
-    return polling_result.dict()
+    # If there is a verify URL, then we need to poll for the result.
+    if result.get("billing_profile_verify_url"):
+        csp_method = csp.create_billing_profile_verification
+        payload = BillingProfileVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
+        )
+        result = verify_async(csp_method, payload)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -13,6 +13,17 @@ import time
 
 
 def poll_billing(csp, inputs, csp_response):
+    """Polls billing endpoint for async response three times.  If verify url is not 
+    available, the csp_response payload will be returned. 
+
+    Args:
+        csp: CSP Class object
+        inputs: Json string
+        csp_response: Result from billing profile creation
+
+    Returns:
+        Response from billing profile verification or csp_response payload
+    """
     if csp_response.get("billing_profile_verify_url") is not None:
         retries = 3
         for _ in range(retries):

--- a/script/provision/b_setup_billing.py
+++ b/script/provision/b_setup_billing.py
@@ -23,7 +23,8 @@ def setup_billing(csp, inputs):
         payload = BillingProfileVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
         )
-        result = verify_async(csp_method, payload)
+        retry_after = result.get("billing_profile_retry_after")
+        result = verify_async(csp_method, payload, retry_after)
 
     return result
 

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -13,6 +13,17 @@ import time
 
 
 def poll_billing(csp, inputs, csp_response):
+    """Polls billing endpoint for async response three times.  If verify url is not 
+    available, the csp_response payload will be returned. 
+
+    Args:
+        csp: CSP Class object
+        inputs: Json string
+        csp_response: Result from billing profile creation
+
+    Returns:
+        Response from billing verification or csp_response payload
+    """
     if csp_response.get("task_order_billing_verify_url") is not None:
         retries = 3
         for _ in range(retries):

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -23,7 +23,8 @@ def setup_to_billing(csp, inputs):
         payload = TaskOrderBillingVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
         )
-        result = verify_async(csp_method, payload)
+        retry_after = result.get("task_order_retry_after")
+        result = verify_async(csp_method, payload, retry_after)
 
     return result
 

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -9,7 +9,6 @@ from atat.domain.csp.cloud.models import (
     TaskOrderBillingVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-import time
 
 
 def poll_billing(csp, inputs, csp_response):
@@ -24,23 +23,12 @@ def poll_billing(csp, inputs, csp_response):
     Returns:
         Response from billing verification or csp_response payload
     """
-    if csp_response.get("task_order_billing_verify_url") is not None:
-        retries = 3
-        for _ in range(retries):
-            enable_to_billing = TaskOrderBillingVerificationCSPPayload(
-                **{
-                    **inputs.get("initial_inputs"),
-                    **inputs.get("csp_data"),
-                    **csp_response,
-                }
-            )
-            response = csp.create_task_order_billing_verification(enable_to_billing)
-            if response.reset_stage:
-                time.sleep(10)
-            else:
-                return response
-    else:
-        return csp_response
+    verify_url = csp_response.get("task_order_billing_verify_url")
+    csp_method = csp.create_task_order_billing_verification
+    payload = TaskOrderBillingVerificationCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response,}
+    )
+    return verify_async(verify_url, csp_method, payload, csp_response)
 
 
 def setup_to_billing(csp, inputs):

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -9,20 +9,25 @@ from atat.domain.csp.cloud.models import (
     TaskOrderBillingVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-from atat.domain.csp.cloud.exceptions import GeneralCSPException
 import time
 
 
 def poll_billing(csp, inputs, csp_response):
     if csp_response.get("task_order_billing_verify_url") is not None:
-        enable_to_billing = TaskOrderBillingVerificationCSPPayload(
-            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response}
-        )
-        try:
-            return csp.create_task_order_billing_verification(enable_to_billing)
-        except GeneralCSPException:
-            time.sleep(10)
-            return poll_billing(csp, inputs, csp_response)
+        retries = 3
+        for _ in range(retries):
+            enable_to_billing = TaskOrderBillingVerificationCSPPayload(
+                **{
+                    **inputs.get("initial_inputs"),
+                    **inputs.get("csp_data"),
+                    **csp_response,
+                }
+            )
+            response = csp.create_task_order_billing_verification(enable_to_billing)
+            if response.reset_stage:
+                time.sleep(10)
+            else:
+                return response
     else:
         return csp_response
 

--- a/script/provision/d_setup_to_billing.py
+++ b/script/provision/d_setup_to_billing.py
@@ -8,36 +8,24 @@ from atat.domain.csp.cloud.models import (
     TaskOrderBillingCreationCSPPayload,
     TaskOrderBillingVerificationCSPPayload,
 )
-from script.provision.provision_base import handle
-
-
-def poll_billing(csp, inputs, csp_response):
-    """Polls billing endpoint for async response three times.  If verify url is not 
-    available, the csp_response payload will be returned. 
-
-    Args:
-        csp: CSP Class object
-        inputs: Json string
-        csp_response: Result from billing profile creation
-
-    Returns:
-        Response from billing verification or csp_response payload
-    """
-    verify_url = csp_response.get("task_order_billing_verify_url")
-    csp_method = csp.create_task_order_billing_verification
-    payload = TaskOrderBillingVerificationCSPPayload(
-        **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response,}
-    )
-    return verify_async(verify_url, csp_method, payload, csp_response)
+from script.provision.provision_base import handle, verify_async
 
 
 def setup_to_billing(csp, inputs):
     enable_to_billing = TaskOrderBillingCreationCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
-    result = csp.create_task_order_billing_creation(enable_to_billing)
-    poll_result = poll_billing(csp, inputs, result.dict())
-    return poll_result.dict()
+    result = csp.create_task_order_billing_creation(enable_to_billing).dict()
+
+    # If there is a verify URL, then we need to poll for the result.
+    if result.get("task_order_billing_verify_url"):
+        csp_method = csp.create_task_order_billing_verification
+        payload = TaskOrderBillingVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
+        )
+        result = verify_async(csp_method, payload)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -9,7 +9,6 @@ from atat.domain.csp.cloud.models import (
     ProductPurchaseVerificationCSPPayload,
 )
 from script.provision.provision_base import handle
-import time
 
 
 def poll_purchase(csp, inputs, csp_response):
@@ -24,23 +23,12 @@ def poll_purchase(csp, inputs, csp_response):
     Returns:
         Response from billing profile verification or csp_response payload
     """
-    if csp_response.get("product_purchase_verify_url") is not None:
-        retries = 3
-        for _ in range(retries):
-            purchase_premium = ProductPurchaseVerificationCSPPayload(
-                **{
-                    **inputs.get("initial_inputs"),
-                    **inputs.get("csp_data"),
-                    **csp_response,
-                }
-            )
-            response = csp.create_product_purchase_verification(purchase_premium)
-            if response.reset_stage:
-                time.sleep(10)
-            else:
-                return response
-    else:
-        return csp_response
+    verify_url = csp_response.get("product_purchase_verify_url")
+    csp_method = csp.create_product_purchase_verification
+    payload = ProductPurchaseVerificationCSPPayload(
+        **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response,}
+    )
+    return verify_async(verify_url, csp_method, payload, csp_response)
 
 
 def purchase_aadp(csp, inputs):

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -13,6 +13,17 @@ import time
 
 
 def poll_purchase(csp, inputs, csp_response):
+    """Polls purchase endpoint for async response three times.  If verify url is not 
+    available, the csp_response payload will be returned. 
+
+    Args:
+        csp: CSP Class object
+        inputs: Json string
+        csp_response: Result from billing profile creation
+
+    Returns:
+        Response from billing profile verification or csp_response payload
+    """
     if csp_response.get("product_purchase_verify_url") is not None:
         retries = 3
         for _ in range(retries):

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -8,37 +8,24 @@ from atat.domain.csp.cloud.models import (
     ProductPurchaseCSPPayload,
     ProductPurchaseVerificationCSPPayload,
 )
-from script.provision.provision_base import handle
-
-
-def poll_purchase(csp, inputs, csp_response):
-    """Polls purchase endpoint for async response three times.  If verify url is not 
-    available, the csp_response payload will be returned. 
-
-    Args:
-        csp: CSP Class object
-        inputs: Json string
-        csp_response: Result from billing profile creation
-
-    Returns:
-        Response from billing profile verification or csp_response payload
-    """
-    verify_url = csp_response.get("product_purchase_verify_url")
-    csp_method = csp.create_product_purchase_verification
-    payload = ProductPurchaseVerificationCSPPayload(
-        **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **csp_response,}
-    )
-    return verify_async(verify_url, csp_method, payload, csp_response)
+from script.provision.provision_base import handle, verify_async
 
 
 def purchase_aadp(csp, inputs):
     purchase_premium = ProductPurchaseCSPPayload(
         **{**inputs.get("initial_inputs"), **inputs.get("csp_data")}
     )
+    result = csp.create_product_purchase(purchase_premium).dict()
 
-    result = csp.create_product_purchase(purchase_premium)
-    poll_result = poll_purchase(csp, inputs, result.dict())
-    return poll_result.dict()
+    # If there is a verify URL, then we need to poll for the result.
+    if result.get("product_purchase_verify_url"):
+        csp_method = csp.create_product_purchase_verification
+        payload = ProductPurchaseVerificationCSPPayload(
+            **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
+        )
+        result = verify_async(csp_method, payload)
+
+    return result
 
 
 if __name__ == "__main__":

--- a/script/provision/f_purchase_aadp.py
+++ b/script/provision/f_purchase_aadp.py
@@ -23,7 +23,8 @@ def purchase_aadp(csp, inputs):
         payload = ProductPurchaseVerificationCSPPayload(
             **{**inputs.get("initial_inputs"), **inputs.get("csp_data"), **result,}
         )
-        result = verify_async(csp_method, payload)
+        retry_after = result.get("product_purchase_retry_after")
+        result = verify_async(csp_method, payload, retry_after)
 
     return result
 

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -3,6 +3,7 @@ import os
 import pprint
 import sys
 import argparse
+import time
 
 from atat.domain.csp.cloud.models import KeyVaultCredentials
 from atat.app import make_config
@@ -76,10 +77,10 @@ def handle(f):
         traceback.print_exc()
 
 
-def verify_async(csp_method, payload):
+def verify_async(csp_method, payload, retry_after):
     while True:
         response = csp_method(payload)
         if response.reset_stage:
-            time.sleep(10)
+            time.sleep(retry_after)
         else:
             return response.dict()

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -76,13 +76,10 @@ def handle(f):
         traceback.print_exc()
 
 
-def verify_async(verify_url, csp_method, payload, csp_response):
-    if verify_url is not None:
-        while True:
-            response = csp_method(payload)
-            if response.reset_stage:
-                time.sleep(10)
-            else:
-                return response
-    else:
-        return csp_response
+def verify_async(csp_method, payload):
+    while True:
+        response = csp_method(payload)
+        if response.reset_stage:
+            time.sleep(10)
+        else:
+            return response.dict()

--- a/script/provision/provision_base.py
+++ b/script/provision/provision_base.py
@@ -74,3 +74,15 @@ def handle(f):
         import traceback
 
         traceback.print_exc()
+
+
+def verify_async(verify_url, csp_method, payload, csp_response):
+    if verify_url is not None:
+        while True:
+            response = csp_method(payload)
+            if response.reset_stage:
+                time.sleep(10)
+            else:
+                return response
+    else:
+        return csp_response


### PR DESCRIPTION
This PR is to actually poll for async results within the manual provisioning scripts.  

Open questions:
- Should we check if the "URL" is in the payload before starting the polling?
- Is three retries enough? 