### PR TITLE
[AT-5453] Validate elevated access context manager

### DIFF
--- a/atat/domain/csp/cloud/azure_cloud_provider.py
+++ b/atat/domain/csp/cloud/azure_cloud_provider.py
@@ -1771,6 +1771,11 @@ class AzureCloudProvider(CloudProviderInterface):
             tenant_id, self.sdk.cloud.endpoints.resource_manager + "/.default"
         )
         self._elevate_tenant_admin_access(tenant_admin_token)
+        app.logger.info(
+            "Assigned User Access Administrator to user %s in tenant %s",
+            user_object_id,
+            tenant_id,
+        )
         elevated_token = None
         try:
             elevated_token = self._get_tenant_admin_token(
@@ -1782,6 +1787,11 @@ class AzureCloudProvider(CloudProviderInterface):
                 remove_access_token = elevated_token or tenant_admin_token
                 self._remove_tenant_admin_elevated_access(
                     tenant_id, user_object_id, token=remove_access_token
+                )
+                app.logger.info(
+                    "Succssfully removed User Access Administrator assignment from user %s in tenant %s",
+                    user_object_id,
+                    tenant_id,
                 )
             except self.sdk.requests.exceptions.RequestException:
                 app.logger.error(

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -2101,9 +2101,7 @@ class Test_remove_tenant_admin_elevated_access:
 
         def test_remove_elevated_access_fails(self, mock_azure, mock_logger):
             mock_azure._remove_tenant_admin_elevated_access.side_effect = [
-                mock_azure.sdk.requests.exceptions.ConnectionError,
-                mock_azure.sdk.requests.exceptions.ConnectionError,
-                mock_azure.sdk.requests.exceptions.ConnectionError,
+                mock_azure.sdk.requests.exceptions.ConnectionError
             ]
             with pytest.raises(Exception):
                 with mock_azure._get_elevated_access_token(
@@ -2125,3 +2123,15 @@ class Test_remove_tenant_admin_elevated_access:
                     mock_azure._remove_tenant_admin_elevated_access.assert_called_with(
                         "tenant_id", "user_object_id", token="MOCK_TOKEN"
                     )
+
+        def test_remove_elevated_access_called_after_exception(
+            self, mock_azure, mock_logger
+        ):
+            with pytest.raises(Exception):
+                with mock_azure._get_elevated_access_token(
+                    "tenant_id", "user_object_id"
+                ) as elevated_token:
+                    raise Exception
+            mock_azure._remove_tenant_admin_elevated_access.assert_called_once_with(
+                "tenant_id", "user_object_id", token=elevated_token
+            )

--- a/tests/domain/cloud/test_azure_csp.py
+++ b/tests/domain/cloud/test_azure_csp.py
@@ -2092,12 +2092,13 @@ class Test_remove_tenant_admin_elevated_access:
                 ) as _:
                     pass
 
-        def test_get_token(self, mock_azure):
+        def test_get_token(self, mock_azure, mock_logger):
             with mock_azure._get_elevated_access_token(
                 "tenant_id", "user_object_id"
             ) as elevated_token:
                 pass
             assert elevated_token == "MOCK_ELEVATED_TOKEN"
+            assert len(mock_logger.messages) == 2
 
         def test_remove_elevated_access_fails(self, mock_azure, mock_logger):
             mock_azure._remove_tenant_admin_elevated_access.side_effect = [
@@ -2108,7 +2109,7 @@ class Test_remove_tenant_admin_elevated_access:
                     "tenant_id", "user_object_id"
                 ) as _:
                     pass
-            assert len(mock_logger.messages) == 1
+            assert len(mock_logger.messages) == 2
 
         def test_second_token_request_fails(self, mock_azure, monkeypatch):
             monkeypatch.setattr(

--- a/tests/domain/cloud/test_hybrid_csp.py
+++ b/tests/domain/cloud/test_hybrid_csp.py
@@ -6,6 +6,7 @@ import pendulum
 import pytest
 
 from atat.domain.csp import CSP
+from atat.domain.csp.cloud.exceptions import UnknownServerException
 from atat.domain.csp.cloud.hybrid_cloud_provider import HYBRID_PREFIX
 from atat.domain.csp.cloud.models import (
     CostManagementQueryCSPPayload,
@@ -80,6 +81,10 @@ class TestIntegration:
     def tenant_id(self, portfolio):
         return portfolio.csp_data["tenant_id"]
 
+    @pytest.fixture(scope="function")
+    def user_object_id(self, portfolio):
+        return portfolio.csp_data["user_object_id"]
+
     @pytest.fixture(scope="session")
     def user(self):
         first_name = f"test-user-{uuid4()}"
@@ -114,6 +119,15 @@ class TestIntegration:
     def state_machine(self, app, csp, portfolio):
         return PortfolioStateMachineFactory.create(portfolio=portfolio, cloud=csp)
 
+    def _get_management_group(self, csp, tenant_id, management_group_id):
+        sp_token = csp.azure._get_tenant_principal_token(tenant_id)
+        response = csp.azure.sdk.requests.get(
+            f"{csp.azure.sdk.cloud.endpoints.resource_manager}{management_group_id}?api-version=2020-02-01",
+            headers=make_auth_header(sp_token),
+        )
+        response.raise_for_status()
+        return response.json()
+
     @pytest.mark.depends(name="portfolio")
     def test_hybrid_provision_portfolio(self, state_machine: PortfolioStateMachine):
         csp_data = {}
@@ -142,14 +156,39 @@ class TestIntegration:
 
             csp_data = state_machine.portfolio.csp_data
 
-    def _get_management_group(self, csp, tenant_id, management_group_id):
-        sp_token = csp.azure._get_tenant_principal_token(tenant_id)
-        response = csp.azure.sdk.requests.get(
-            f"{csp.azure.sdk.cloud.endpoints.resource_manager}{management_group_id}?api-version=2020-02-01",
-            headers=make_auth_header(sp_token),
+    @pytest.mark.depends(on=["portfolio"])
+    def test_hybrid_access_not_elevated(self, csp, tenant_id, env_role):
+        """By the end of portfolio provisioning, access should not be elevated"""
+
+        token = csp.azure._get_tenant_admin_token(
+            tenant_id, csp.azure.sdk.cloud.endpoints.resource_manager + "/.default"
         )
-        response.raise_for_status()
-        return response.json()
+        with pytest.raises(UnknownServerException):
+            # "Asserts" that the tenant admin no longer has elevated access
+            # since "_list_role_assignments" requires elevated acces
+            csp.azure._list_role_assignments(token)
+
+    @pytest.mark.depends(on=["portfolio"])
+    def test_context_manager_removes_access(self, csp, tenant_id, user_object_id):
+        """Specifically test the behavior of the access manager. Elevating
+        access allows a call to an API function that requires it, and trying the
+        same function again without the context manager raises an exception """
+
+        with csp.azure._get_elevated_access_token(
+            tenant_id, user_object_id
+        ) as elevated_token:
+            assert csp.azure._list_role_assignments(
+                elevated_token,
+                params={"$filter": f"principalId eq '{user_object_id}'"},
+            )
+
+        token = csp.azure._get_tenant_admin_token(
+            tenant_id, csp.azure.sdk.cloud.endpoints.resource_manager + "/.default"
+        )
+        with pytest.raises(UnknownServerException):
+            csp.azure._list_role_assignments(
+                token, params={"$filter": f"principalId eq '{user_object_id}'"}
+            )
 
     @pytest.mark.depends(name="application", on=["portfolio"])
     def test_hybrid_create_application_job(self, csp, application, tenant_id, session):
@@ -206,7 +245,7 @@ class TestIntegration:
     @pytest.mark.depends(on=["environment_role"])
     def test_hybrid_disable_user(self, csp, user, tenant_id, env_role):
         env_role_cloud_id = env_role.cloud_id
-        disable_user_result = csp.azure.disable_user(tenant_id, env_role_cloud_id)
+        disable_user_result = csp.disable_user(tenant_id, env_role_cloud_id)
         assert disable_user_result["id"] == env_role_cloud_id
 
 


### PR DESCRIPTION
This PR contains additional tests and logging that make assertions about the behavior of the elevate access context manager. 

In #1714, we initially observed some flakiness in portfolio provisioning functions that relied on the elevated access token context manager. The goal with this PR is to provide full test coverage for this context manager so that we prevent such flakiness in the future and are sure that it works as expected.