### PR TITLE
Set HttpOnly flag when deleting sidenav cookie.

### DIFF
--- a/atat/routes/__init__.py
+++ b/atat/routes/__init__.py
@@ -119,7 +119,7 @@ def login_redirect():
 def logout():
     _logout()
     response = make_response(redirect(url_for(".root")))
-    response.set_cookie("expandSidenav", "", expires=0)
+    response.set_cookie("expandSidenav", "", expires=0, httponly=True)
     flash("logged_out")
     return response
 


### PR DESCRIPTION
We use a cookie, expandSidenav, to track a user's preference for an expanded or minimized side navigation pane. When the user expands or minimizes the pane, client-side JS sets or update the cookie value. When the user logs out, the Flask application reset the expiration time for the cookie so that it expires immediately, effectively deleting it.

This commit adds the HttpOnly flag to the cookie. This is not strictly necessary for security--it's not a session cookie or security-sensitive cookie--but it doesn't hurt anything to make it HttpOnly when it's unset by Flask and it will prevent an automated or human security auditor from flagging that line of code.