### PR TITLE
Build and publish nginx images along with the app image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,6 +61,7 @@ commands:
           command: |
             docker load < docker-cache/atat.tar
             docker load < docker-cache/builder.tar
+            docker load < docker-cache/nginx.tar
   setup_datastores:
     parameters:
       pgdatabase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ commands:
               --username << parameters.sp >>  
             echo "Successfully logged in to Azure CLI."
             az acr login --name << parameters.container_registry >> | grep "Succeeded"
-  cache_docker_image:
+  cache_docker_images:
     steps:
       - run:
           name: Save the docker images to a cache
@@ -46,6 +46,7 @@ commands:
             mkdir -p docker-cache
             docker save -o docker-cache/atat.tar atat:latest
             docker save -o docker-cache/builder.tar atat:builder
+            docker save -o docker-cache/nginx.tar nginx:latest
       - save_cache:
           key: docker-cache-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -102,9 +103,12 @@ commands:
       namespace:
         type: string
         default: atat
-      tag:
+      atat-image-tag:
         type: string
         default: << parameters.azure_server_name>>/atat:latest
+      nginx-image-tag:
+        type: string
+        default: << parameters.azure_server_name>>/nginx:latest
       cluster_name:
         type: string
         default: ${CLUSTER_NAME}
@@ -134,24 +138,26 @@ commands:
       - run:
           name: Tag images
           command: |
-            docker tag atat:latest << parameters.tag >>
+            docker tag atat:latest << parameters.atat-image-tag >>
+            docker tag nginx:latest << parameters.nginx-image-tag >>
       - run:
           name: Push image
           command: |
-            docker push << parameters.tag >>
+            docker push << parameters.atat-image-tag >>
+            docker push << parameters.nginx-image-tag >>
       - run:
           name: Add gettext package
           command: apk add gettext
       - run:
-          command: K8S_NAMESPACE=<< parameters.namespace >> CONTAINER_IMAGE=<< parameters.tag >> /bin/sh ./script/cluster_migration
+          command: K8S_NAMESPACE=<< parameters.namespace >> CONTAINER_IMAGE=<< parameters.atat-image-tag >> /bin/sh ./script/cluster_migration
           name: Apply Migrations and Seed Roles
       - run:
           name: Update Kubernetes cluster
           command: |
-            kubectl set image deployment.apps/atst atst=<< parameters.tag >> --namespace=<< parameters.namespace >>
-            kubectl set image deployment.apps/atst-worker atst-worker=<< parameters.tag >> --namespace=<< parameters.namespace >>
-            kubectl set image deployment.apps/atst-beat atst-beat=<< parameters.tag >> --namespace=<< parameters.namespace >>
-            kubectl set image cronjobs.batch/crls crls=<< parameters.tag >> --namespace=<< parameters.namespace >>
+            kubectl set image deployment.apps/atst atst=<< parameters.atat-image-tag >> --namespace=<< parameters.namespace >>
+            kubectl set image deployment.apps/atst-worker atst-worker=<< parameters.atat-image-tag >> --namespace=<< parameters.namespace >>
+            kubectl set image deployment.apps/atst-beat atst-beat=<< parameters.atat-image-tag >> --namespace=<< parameters.namespace >>
+            kubectl set image cronjobs.batch/crls crls=<< parameters.atat-image-tag >> --namespace=<< parameters.namespace >>
 
 jobs:
   docker-build:
@@ -168,11 +174,12 @@ jobs:
           version: 18.06.0-ce
       - azlogin
       - run:
-          name: Build image
+          name: Build images
           command: |
             docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
             docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
-      - cache_docker_image
+            docker build --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
+      - cache_docker_images
 
   test:
     docker:
@@ -288,7 +295,8 @@ jobs:
     steps:
       - deploy:
           namespace: staging
-          tag: ${AZURE_SERVER_NAME}/atat:staging-${CIRCLE_SHA1}
+          atat-image-tag: ${AZURE_SERVER_NAME}/atat:staging-${CIRCLE_SHA1}
+          nginx-image-tag: ${AZURE_SERVER_NAME}/nginx:staging-${CIRCLE_SHA1}
 
   deploy-master:
     docker:
@@ -296,7 +304,8 @@ jobs:
     steps:
       - deploy:
           namespace: master
-          tag: ${AZURE_SERVER_NAME}/atat:master-${CIRCLE_SHA1}
+          atat-image-tag: ${AZURE_SERVER_NAME}/atat:master-${CIRCLE_SHA1}
+          nginx-image-tag: ${AZURE_SERVER_NAME}/nginx:master-${CIRCLE_SHA1}
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,6 @@ commands:
             mkdir -p docker-cache
             docker save -o docker-cache/atat.tar atat:latest
             docker save -o docker-cache/builder.tar atat:builder
-            docker save -o docker-cache/nginx.tar nginx:latest
       - save_cache:
           key: docker-cache-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -61,7 +60,6 @@ commands:
           command: |
             docker load < docker-cache/atat.tar
             docker load < docker-cache/builder.tar
-            docker load < docker-cache/nginx.tar
   setup_datastores:
     parameters:
       pgdatabase:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,15 +99,18 @@ commands:
       azure_server_name:
         type: string 
         default: ${AZURE_SERVER_NAME}
+      container_registry:
+        type: string
+        default: ${AZURE_REGISTRY}
       namespace:
         type: string
         default: atat
       atat-image-tag:
         type: string
-        default: << parameters.azure_server_name>>/atat:latest
+        default: << parameters.azure_server_name >>/atat:latest
       nginx-image-tag:
         type: string
-        default: << parameters.azure_server_name>>/nginx:latest
+        default: << parameters.azure_server_name >>/nginx:latest
       cluster_name:
         type: string
         default: ${CLUSTER_NAME}
@@ -134,6 +137,9 @@ commands:
           command: |
             apk add libssl1.0
             az aks get-credentials --name << parameters.cluster_name >>  --resource-group << parameters.resource_group >> 
+      - run:
+          name: Build nginx image
+          command: docker build --build-arg IMAGE=<< parameters.container_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
       - run:
           name: Tag images
           command: |
@@ -175,9 +181,8 @@ jobs:
       - run:
           name: Build images
           command: |
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
-            docker build --build-arg IMAGE=<<parameters.container_registry>>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< parameters.container_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< parameters.container_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
       - cache_docker_images
 
   test:
@@ -289,22 +294,30 @@ jobs:
               /bin/sh -c "poetry install --no-root && /bin/sh script/sync-crls && poetry run pytest --no-cov tests/check_crl_parse.py"
 
   deploy-staging:
+    parameters:
+      container_registry:
+        type: string
+        default: ${AZURE_REGISTRY}
     docker:
       - image: docker:18.06.0-ce-git
     steps:
       - deploy:
           namespace: staging
-          atat-image-tag: ${AZURE_SERVER_NAME}/atat:staging-${CIRCLE_SHA1}
-          nginx-image-tag: ${AZURE_SERVER_NAME}/nginx:staging-${CIRCLE_SHA1}
+          atat-image-tag: << parameters.container_registry >>.azurecr.io/atat:staging-${CIRCLE_SHA1}
+          nginx-image-tag: << parameters.container_registry >>.azurecr.io/nginx:staging-${CIRCLE_SHA1}
 
   deploy-master:
+    parameters:
+      container_registry:
+        type: string
+        default: ${AZURE_REGISTRY}
     docker:
       - image: docker:18.06.0-ce-git
     steps:
       - deploy:
           namespace: master
-          atat-image-tag: ${AZURE_SERVER_NAME}/atat:master-${CIRCLE_SHA1}
-          nginx-image-tag: ${AZURE_SERVER_NAME}/nginx:master-${CIRCLE_SHA1}
+          atat-image-tag: << parameters.container_registry >>.azurecr.io/atat:master-${CIRCLE_SHA1}
+          nginx-image-tag: << parameters.container_registry >>.azurecr.io/nginx:master-${CIRCLE_SHA1}
 
 workflows:
   version: 2


### PR DESCRIPTION
Builds and publishes Nginx images as part of the build pipeline. This is necessary for ops to automate the deployment of the Nginx container.

- Renames `tag` parameter to `atat-image-tag` for disambiguation
- Adds tagging, building and publishing step for the `nginx.Dockerfile` (doesn't use context)