### PR TITLE
Add ability to provide first/last name when making AAD user.

### DIFF
--- a/atat/domain/csp/cloud/models.py
+++ b/atat/domain/csp/cloud/models.py
@@ -657,6 +657,8 @@ class UserCSPPayload(BaseCSPPayload, UserMixin):
     display_name: str
     tenant_host_name: str
     email: str
+    first_name: Optional[str]
+    last_name: Optional[str]
 
 
 class UserCSPResult(AliasModel):

--- a/atat/domain/csp/cloud/utils.py
+++ b/atat/domain/csp/cloud/utils.py
@@ -56,6 +56,8 @@ def create_active_directory_user(
             "forceChangePasswordNextSignIn": password_reset,
             "password": payload.password,
         },
+        "givenName": payload.first_name,
+        "surname": payload.last_name,
     }
 
     url = f"{graph_resource}/v1.0/users"

--- a/script/add_users_to_aad_tenant.py
+++ b/script/add_users_to_aad_tenant.py
@@ -43,6 +43,8 @@ def create_user(token, tenant_id, tenant_host_name):
         tenant_host_name=tenant_host_name,
         email=email,
         password=password,
+        first_name=first_name,
+        last_name=last_name,
     )
     response = create_active_directory_user(
         token, GRAPH_RESOURCE, payload, password_reset=False


### PR DESCRIPTION
The autogenerated users created by script/add_users_to_aad_tenant.py
need to have first name and last name provided in order for them to use
federated authentication to access an instance of ATAT for which their
tenant is acting as the identity provider. Effectively, this means that
we have to provide the givenName and surname properties on the request
to create the user. I've added those as nullable fields and updated the
script.