### PR TITLE
[AT-5504] Add a blank option for service branch on user edit form

### DIFF
--- a/atat/forms/edit_user.py
+++ b/atat/forms/edit_user.py
@@ -13,6 +13,10 @@ from .fields import SelectField
 from .forms import BaseForm
 from .validators import Name, PhoneNumber
 
+SERVICE_BRANCH_CHOICES = [
+    ("", translate("fragments.edit_user_form.service_choice"))
+] + SERVICE_BRANCHES
+
 USER_FIELDS = {
     "first_name": StringField(
         translate("forms.edit_user.first_name_label"),
@@ -28,7 +32,8 @@ USER_FIELDS = {
     ),
     "phone_ext": StringField("Extension", validators=[Number(), Length(max=10)]),
     "service_branch": SelectField(
-        translate("forms.edit_user.service_branch_label"), choices=SERVICE_BRANCHES
+        translate("forms.edit_user.service_branch_label"),
+        choices=SERVICE_BRANCH_CHOICES,
     ),
     "citizenship": RadioField(
         choices=[

--- a/atat/forms/edit_user.py
+++ b/atat/forms/edit_user.py
@@ -34,6 +34,7 @@ USER_FIELDS = {
     "service_branch": SelectField(
         translate("forms.edit_user.service_branch_label"),
         choices=SERVICE_BRANCH_CHOICES,
+        default="",
     ),
     "citizenship": RadioField(
         choices=[

--- a/translations.yaml
+++ b/translations.yaml
@@ -340,6 +340,7 @@ fragments:
     explain: AT-AT allows you to create multiple applications within a portfolio. Each application can then be broken down into its own customizable environments.
   edit_user_form:
     save_details_button: Save
+    service_choice: Please choose a service branch or agency
   portfolio_admin:
     none: Not Selected
   ppoc:


### PR DESCRIPTION
The service dropdown on both the user onboarding form and the user edit form would default to Air Force if no other option was selected. This inserts a placeholder at the front of the list to ensure the user selects a branch themselves.