### PR TITLE
[AT-5501] Remove HTTP basic auth from NGINX.

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -34,22 +34,6 @@ If you are satisfied with the output from the diff, you can apply the new config
 
 **Note:** Depending on how your `kubectl` config is set up, these commands may need to be adjusted. If you have configuration for multiple clusters, you may need to specify the `kubectl` context for each command with the `--context` flag (something like `kubectl --context=my-cluster [etc.]` or `kubectl --context=azure [etc.]`).
 
-## Secrets and Configuration
-
-### nginx-htpasswd
-
-If the site is running in dev mode, the `/login-dev` endpoint is available. This endpoint is protected by basic HTTP auth. To create a new password file, run:
-
-```
-htpasswd -c ./htpasswd atat
-```
-
-Enter a new password string when prompted. Then create the secret:
-
-```
-kubectl -n atat create secret generic nginx-htpasswd --from-file=./htpasswd
-```
-
 ## SSL/TLS
 
 ### Renewing TLS certs

--- a/deploy/azure/atst-nginx-configmap.yml
+++ b/deploy/azure/atst-nginx-configmap.yml
@@ -47,22 +47,12 @@ data:
         location /login-redirect {
             return 301 https://${AUTH_DOMAIN}$request_uri;
         }
-        location /login-dev {
-            try_files $uri @appbasicauth;
-        }
         location / {
             try_files $uri @app;
         }
         location @app {
             include uwsgi_params;
             uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
-            uwsgi_param HTTP_X_REQUEST_ID $request_id;
-        }
-        location @appbasicauth {
-            include uwsgi_params;
-            uwsgi_pass unix:///var/run/uwsgi/uwsgi.socket;
-            auth_basic "Developer Access";
-            auth_basic_user_file /etc/nginx/.htpasswd;
             uwsgi_param HTTP_X_REQUEST_ID $request_id;
         }
     }

--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -82,9 +82,6 @@ spec:
               mountPath: "/etc/nginx/conf.d/"
             - name: uwsgi-socket-dir
               mountPath: "/var/run/uwsgi"
-            - name: nginx-htpasswd
-              mountPath: "/etc/nginx/.htpasswd"
-              subPath: .htpasswd
             - name: nginx-client-ca-bundle
               mountPath: "/etc/ssl/client-ca-bundle.pem"
               subPath: "client-ca-bundle.pem"
@@ -115,13 +112,6 @@ spec:
         - name: uwsgi-socket-dir
           emptyDir:
             medium: Memory
-        - name: nginx-htpasswd
-          secret:
-            secretName: atst-nginx-htpasswd
-            items:
-              - key: htpasswd
-                path: .htpasswd
-                mode: 0640
         - name: crls-vol
           persistentVolumeClaim:
             claimName: crls-vol-claim


### PR DESCRIPTION
Folowing up on the recent addition of configurable HTTP basic auth to
ATAT's uWSGI config, this commit removes configuration for basic auth
from NGINX. Specifically, it removes:

- the NGINX configuration
- the reference to the K8s secret we had used to store the
  htpassword file
- the documentation regarding the k8s secret