### PR TITLE
Add Login Method Aware Saml Signout

### DIFF
--- a/atat/routes/dev.py
+++ b/atat/routes/dev.py
@@ -9,7 +9,6 @@ from atat.domain.permission_sets import PermissionSets
 from atat.domain.users import Users
 from atat.forms.data import SERVICE_BRANCHES
 from atat.jobs import send_mail
-from atat.routes import flash
 from atat.routes.saml_helpers import init_saml_auth, saml_get, saml_post
 from atat.utils import pick
 

--- a/atat/routes/dev.py
+++ b/atat/routes/dev.py
@@ -9,6 +9,7 @@ from atat.domain.permission_sets import PermissionSets
 from atat.domain.users import Users
 from atat.forms.data import SERVICE_BRANCHES
 from atat.jobs import send_mail
+from atat.routes import flash
 from atat.routes.saml_helpers import init_saml_auth, saml_get, saml_post
 from atat.utils import pick
 
@@ -134,6 +135,9 @@ def login_dev():
     query_string_parameters = session.get("query_string_parameters", {})
     user = None
 
+    if "sls" in request.args and request.method == "GET":
+        return redirect(url_for("atat.root"))
+
     if request.method == "GET":
         saml_auth = init_saml_auth(request)
         return redirect(saml_get(saml_auth, request))
@@ -141,6 +145,7 @@ def login_dev():
     if "acs" in request.args and request.method == "POST":
         saml_auth = init_saml_auth(request)
         user = saml_post(saml_auth)
+        session["login_method"] = "dev"
 
     if not user:
         dod_id = query_string_parameters.get("dod_id_param", None) or request.args.get(


### PR DESCRIPTION
To prepare for our bug bounty users possibly using multiple identities, add in the ability to do proper SAML logout by storing login method on session.