### PR TITLE
Update Ghost Inspector to recognize the new login route

### DIFF
--- a/uitests/Add_CCPO_User.html
+++ b/uitests/Add_CCPO_User.html
@@ -35,7 +35,7 @@
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -96,7 +96,7 @@
 </tr>
 <tr>
 <td>open</td>
-<td>/login-dev?username=sam</td>
+<td>/login-local?username=sam</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Application_Index_with_App.html
+++ b/uitests/Application_Index_with_App.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Create_New_Application.html
+++ b/uitests/Create_New_Application.html
@@ -35,7 +35,7 @@
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -99,7 +99,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Create_New_TO.html
+++ b/uitests/Create_New_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Create_New_TO_(Base).html
+++ b/uitests/Create_New_TO_(Base).html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -201,7 +201,7 @@ Imported from: AT-AT CI - login
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.usa-button.usa-button-primary</td>
 <td></td>
@@ -216,7 +216,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -482,7 +482,7 @@ Imported from: AT-AT CI - login
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -497,7 +497,7 @@ Imported from: AT-AT CI - login
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -512,7 +512,7 @@ Imported from: AT-AT CI - login
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Create_draft_TO.html
+++ b/uitests/Create_draft_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>
@@ -69,7 +69,7 @@ Imported from: AT-AT CI - login
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
 </tr>
-<tr original-target="a[href="/portfolios/new"],xpath=//a[contains(text(), "Add New Portfolio")]">
+<tr original-target="a[href=&quot;/portfolios/new&quot;],xpath=//a[contains(text(), &quot;Add New Portfolio&quot;)]">
 <td>click</td>
 <td>css=a[href="/portfolios/new"]</td>
 <td></td>
@@ -137,7 +137,7 @@ Imported from: AT-AT CI - login
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
 </tr>
-<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), "Other")]">
+<tr original-target="fieldset.usa-input__choices > ul > li:nth-of-type(5) > label,xpath=//label[contains(text(), &quot;Other&quot;)]">
 <td>click</td>
 <td>css=fieldset.usa-input__choices > ul > li:nth-of-type(5) > label</td>
 <td></td>
@@ -201,7 +201,7 @@ Imported from: AT-AT CI - login
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -216,7 +216,7 @@ Imported from: AT-AT CI - login
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -467,7 +467,7 @@ Imported from: AT-AT CI - login
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>
-<tr original-target="a.action-group__action,xpath=//a[contains(text(), "Cancel")]">
+<tr original-target="a.action-group__action,xpath=//a[contains(text(), &quot;Cancel&quot;)]">
 <td>click</td>
 <td>css=a.action-group__action</td>
 <td></td>
@@ -482,7 +482,7 @@ Imported from: AT-AT CI - login
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>
 </tr>
-<tr original-target=".action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), "Yes, save for later")]">
+<tr original-target=".action-group > button[type=&quot;submit&quot;].usa-button.usa-button-primary:nth-of-type(2),xpath=//button[contains(text(), &quot;Yes, save for later&quot;)]">
 <td>click</td>
 <td>css=.action-group > button[type="submit"].usa-button.usa-button-primary:nth-of-type(2)</td>
 <td></td>

--- a/uitests/Edit_App_Member.html
+++ b/uitests/Edit_App_Member.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Edit_Portfolio_Member.html
+++ b/uitests/Edit_Portfolio_Member.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -105,7 +105,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Login_Brandon.html
+++ b/uitests/Login_Brandon.html
@@ -33,7 +33,7 @@
 </tr>
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_App_Step_1.html
+++ b/uitests/New_App_Step_1.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_App_Step_2.html
+++ b/uitests/New_App_Step_2.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_App_Step_2_-_Add_Env.html
+++ b/uitests/New_App_Step_2_-_Add_Env.html
@@ -38,7 +38,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_App_Step_3.html
+++ b/uitests/New_App_Step_3.html
@@ -35,7 +35,7 @@
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -101,7 +101,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_Portfolio.html
+++ b/uitests/New_Portfolio.html
@@ -35,7 +35,7 @@
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/New_Portfolio_Member.html
+++ b/uitests/New_Portfolio_Member.html
@@ -35,7 +35,7 @@
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -100,7 +100,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Portfolio_Settings.html
+++ b/uitests/Portfolio_Settings.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_Basics.html
+++ b/uitests/Reports_-_Basics.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_Empty_State.html
+++ b/uitests/Reports_-_Empty_State.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_Follow_TO_link.html
+++ b/uitests/Reports_-_Follow_TO_link.html
@@ -38,7 +38,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_TO,_App,_and_Environments.html
+++ b/uitests/Reports_-_with_TO,_App,_and_Environments.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
+++ b/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_active_and_expired_TOs.html
+++ b/uitests/Reports_-_with_active_and_expired_TOs.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_draft_TO.html
+++ b/uitests/Reports_-_with_draft_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>
@@ -187,7 +187,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_expired_TO.html
+++ b/uitests/Reports_-_with_expired_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Reports_-_with_future_TO.html
+++ b/uitests/Reports_-_with_future_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Resend_App_Member_Invite.html
+++ b/uitests/Resend_App_Member_Invite.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Resend_Portfolio_Member_Invite.html
+++ b/uitests/Resend_Portfolio_Member_Invite.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -105,7 +105,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Revoke_App_Member_Invite.html
+++ b/uitests/Revoke_App_Member_Invite.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Revoke_Environment_Access.html
+++ b/uitests/Revoke_Environment_Access.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -104,7 +104,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/Revoke_Portfolio_Member_Invite.html
+++ b/uitests/Revoke_Portfolio_Member_Invite.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - Login Brandon
 -->
 <tr>
 <td>open</td>
-<td>/login-dev?username=brandon</td>
+<td>/login-local?username=brandon</td>
 <td></td>
 </tr>
 <tr>
@@ -105,7 +105,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_(Landing)_Page_-_Empty_State.html
+++ b/uitests/TO_Index_(Landing)_Page_-_Empty_State.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_with_Draft_TO.html
+++ b/uitests/TO_Index_with_Draft_TO.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_with_TO.html
+++ b/uitests/TO_Index_with_TO.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_with_Unconfirmed_TO.html
+++ b/uitests/TO_Index_with_Unconfirmed_TO.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_with_expired_TO.html
+++ b/uitests/TO_Index_with_expired_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Index_with_future_TO.html
+++ b/uitests/TO_Index_with_future_TO.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_1.html
+++ b/uitests/TO_Step_1.html
@@ -36,7 +36,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_2.html
+++ b/uitests/TO_Step_2.html
@@ -37,7 +37,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_3.html
+++ b/uitests/TO_Step_3.html
@@ -38,7 +38,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_3_-_Add_CLIN.html
+++ b/uitests/TO_Step_3_-_Add_CLIN.html
@@ -39,7 +39,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_3_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_3_-_with_Option_CLIN.html
@@ -38,7 +38,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_4.html
+++ b/uitests/TO_Step_4.html
@@ -39,7 +39,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_4_-_with_2_CLINs.html
+++ b/uitests/TO_Step_4_-_with_2_CLINs.html
@@ -40,7 +40,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_4_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_4_-_with_Option_CLIN.html
@@ -39,7 +39,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/TO_Step_5.html
+++ b/uitests/TO_Step_5.html
@@ -40,7 +40,7 @@ Imported from: AT-AT CI - login
 -->
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>

--- a/uitests/login.html
+++ b/uitests/login.html
@@ -33,7 +33,7 @@
 </tr>
 <tr>
 <td>open</td>
-<td>/login-dev</td>
+<td>/login-local</td>
 <td></td>
 </tr>
 <tr>


### PR DESCRIPTION
With all the changes to logins recently (FedAuth, EIFS, etc.), a new route was created for automated tests to login: `/login-local`. All Ghost Inspector tests that login (or import the login step) needed to be updated to account for this new route. This branch captures those changes into our repo.