### PR TITLE
Build ops container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ parameters:
       This is where we pull the rhelubi and rhel-py images from.
       It does not include the "azurecr.io" suffix.
     type: string
-    default: "cloudzeroopsregistry"
+    default: ${AZURE_REGISTRY_OPS}
   tenant_id:
     type: string
     default: ${AZURE_SP_TENANT}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,6 +58,13 @@ parameters:
 
 commands:
   azlogin:
+    parameters:
+      registry:
+        description: The name of the registry (not including the azureacr suffix).
+        type: string
+      suscription_id:
+        description: Target subscription the registry exists under.
+        type: string
     steps:
       - run:
           name: Install Azure CLI
@@ -79,9 +86,9 @@ commands:
               --tenant << pipeline.parameters.tenant_id >> \
               --password << pipeline.parameters.sp_password >> \
               --username << pipeline.parameters.sp >>
-            az account set -s << pipeline.parameters.subscription_id >>
+            az account set -s << parameters.subscription_id >>
             echo "Successfully logged in to Azure CLI."
-            az acr login --name << pipeline.parameters.container_registry >> | grep "Succeeded"
+            az acr login --name << parameters.registry >> | grep "Succeeded"
   cache_docker_images:
     steps:
       - run:
@@ -151,7 +158,9 @@ commands:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin
+      - azlogin:
+          subscription_id: << pipeline.parameters.subscription_id >>
+          registry: << pipeline.parameters.container_registry >>
       - restore_docker_image
       - run:
           name: Build nginx image
@@ -174,7 +183,9 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin
+      - azlogin:
+          subscription_id: << pipeline.parameters.subscription_id >>
+          registry: << pipeline.parameters.container_registry >>
       - run:
           name: Build images
           command: |
@@ -298,34 +309,14 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - run:
-          name: Install Azure CLI
-          command: |
-            apk update
-            apk add bash py3-pip
-            apk add --virtual=build \
-              linux-headers gcc libffi-dev musl-dev openssl-dev python3-dev make curl
-            pip3 --no-cache-dir install -U pip
-            pip3 --no-cache-dir install azure-cli
-            curl -L https://aka.ms/acr/installaad/bash | /bin/bash
-            apk del --purge build
-      - run:
-          name: Login to Azure CLI
-          shell: /bin/sh
-          command: |
-            az login \
-              --service-principal \
-              --tenant << pipeline.parameters.tenant_id >> \
-              --password << pipeline.parameters.sp_password >> \
-              --username << pipeline.parameters.sp >>
-            az account set -s << pipeline.parameters.subscription_id >>
-            echo "Successfully logged in to Azure CLI."
-            az acr login --name << pipeline.parameters.ops_registry >> | grep "Succeeded"
+      - azlogin:
+          subscription_id: << pipeline.parameters.ops_registry >>
+          registry: << pipeline.parameters.ops_registry >>
       - run:
           name: Build images
           command: |
             docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
       - run:
           name: Build nginx image
           command: docker build -t nginx:latest --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
@@ -351,29 +342,9 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - run:
-          name: Install Azure CLI
-          command: |
-            apk update
-            apk add bash py3-pip
-            apk add --virtual=build \
-              linux-headers gcc libffi-dev musl-dev openssl-dev python3-dev make curl
-            pip3 --no-cache-dir install -U pip
-            pip3 --no-cache-dir install azure-cli
-            curl -L https://aka.ms/acr/installaad/bash | /bin/bash
-            apk del --purge build
-      - run:
-          name: Login to Azure CLI
-          shell: /bin/sh
-          command: |
-            az login \
-              --service-principal \
-              --tenant << pipeline.parameters.tenant_id >> \
-              --password << pipeline.parameters.sp_password >> \
-              --username << pipeline.parameters.sp >>
-            az account set -s << pipeline.parameters.subscription_id >>
-            echo "Successfully logged in to Azure CLI."
-            az acr login --name << pipeline.parameters.ops_registry >> | grep "Succeeded"
+      - azlogin:
+          subscription_id: << pipeline.parameters.subscription_id >>
+          registry: << pipeline.parameters.ops_registry >>
       - run:
           name: Build ops deployment image image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,27 @@ version: 2.1
 
 parameters:
   subscription_id:
+    description: Subscription ID for the registry containing the application docker images.
     type: string
     default: ${AZURE_SUBSCRIPTION}
+  ops_subscription_id:
+    description: Subscription ID for the registry containing the operator docker images.
+    type: string
+    default: ${AZURE_SUBSCRIPTION_OPS}
   container_registry:
+    description: |
+      Container registry for built application images.
+      This is where we push the built atat and nginx image to.
+      It does not include the "azurecr.io" suffix.
     type: string
     default: ${AZURE_REGISTRY}
+  ops_registry:
+    description: |
+      Container registry for base operations images.
+      This is where we pull the rhelubi and rhel-py images from.
+      It does not include the "azurecr.io" suffix.
+    type: string
+    default: "cloudzeroopsregistry"
   tenant_id:
     type: string
     default: ${AZURE_SP_TENANT}
@@ -51,20 +67,9 @@ parameters:
     description: Causes a build with a single stage that creates and pushes the ops deployment image to a container registry only.
     type: boolean
     default: false
-  ops_registry:
-    description: The name of the registry (not including the azureacr suffix).
-    type: string
-    default: "cloudzeroopsregistry"
 
 commands:
-  azlogin:
-    parameters:
-      registry:
-        description: The name of the registry (not including the azureacr suffix).
-        type: string
-      subscription_id:
-        description: Target subscription the registry exists under.
-        type: string
+  install_azure_cli:
     steps:
       - run:
           name: Install Azure CLI
@@ -77,6 +82,8 @@ commands:
             pip3 --no-cache-dir install azure-cli
             curl -L https://aka.ms/acr/installaad/bash | /bin/bash
             apk del --purge build
+  log_into_app_registry:
+    steps:
       - run:
           name: Login to Azure CLI
           shell: /bin/sh
@@ -86,9 +93,23 @@ commands:
               --tenant << pipeline.parameters.tenant_id >> \
               --password << pipeline.parameters.sp_password >> \
               --username << pipeline.parameters.sp >>
-            az account set -s << parameters.subscription_id >>
+            az account set -s << pipeline.parameters.subscription_id >>
             echo "Successfully logged in to Azure CLI."
-            az acr login --name << parameters.registry >> | grep "Succeeded"
+            az acr login --name << pipeline.parameters.container_registry >> | grep "Succeeded"
+  log_into_ops_registry:
+    steps:
+      - run:
+          name: Login to Azure CLI
+          shell: /bin/sh
+          command: |
+            az login \
+              --service-principal \
+              --tenant << pipeline.parameters.tenant_id >> \
+              --password << pipeline.parameters.sp_password >> \
+              --username << pipeline.parameters.sp >>
+            az account set -s << pipeline.parameters.ops_subscription_id >>
+            echo "Successfully logged in to Azure CLI."
+            az acr login --name << pipeline.parameters.ops_registry >> | grep "Succeeded"
   cache_docker_images:
     steps:
       - run:
@@ -158,9 +179,8 @@ commands:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin:
-          subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.ops_registry >>
+      - install_azure_cli
+      - log_into_ops_registry
       - restore_docker_image
       - run:
           name: Build nginx image
@@ -169,9 +189,7 @@ commands:
           name: Tag images
           command: |
             docker tag atat:latest << pipeline.parameters.atat_image_tag >>
-      - azlogin:
-          subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.container_registry >>
+      - log_into_app_registry
       - run:
           name: Push image
           command: |
@@ -186,9 +204,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin:
-          subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.container_registry >>
+      - install_azure_cli
+      - log_into_ops_registry
       - run:
           name: Build images
           command: |
@@ -312,9 +329,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin:
-          subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.ops_registry >>
+      - install_azure_cli
+      - log_into_ops_registry
       - run:
           name: Build images
           command: |
@@ -328,9 +344,7 @@ jobs:
           command: |
             docker tag atat:latest << pipeline.parameters.atat_image_tag >>
             docker tag nginx:latest << pipeline.parameters.nginx_image_tag >>
-      - run:
-          name: Log into the target registry
-          command: az acr login --name << pipeline.parameters.container_registry >>.azurecr.io | grep "Succeeded"
+      - log_into_app_registry
       - run:
           name: Push image
           command: |
@@ -345,9 +359,8 @@ jobs:
       - setup_remote_docker:
           docker_layer_caching: true
           version: 18.06.0-ce
-      - azlogin:
-          subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.ops_registry >>
+      - install_azure_cli
+      - log_into_ops_registry
       - run:
           name: Build ops deployment image image
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -410,4 +410,4 @@ workflows:
   push-ops-image:
     when: << pipeline.parameters.build_and_push_ops_image >>
     jobs:
-      - push-app-images
+      - push-ops-image

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,6 +51,10 @@ parameters:
     description: Causes a build with a single stage that creates and pushes the ops deployment image to a container registry only.
     type: boolean
     default: false
+  ops_registry:
+    description: The name of the registry (not including the azureacr suffix).
+    type: string
+    default: "cloudzeroopsregistry"
 
 commands:
   azlogin:
@@ -316,15 +320,15 @@ jobs:
               --username << pipeline.parameters.sp >>
             az account set -s << pipeline.parameters.subscription_id >>
             echo "Successfully logged in to Azure CLI."
-            az acr login --name cloudzeroopsregistry | grep "Succeeded"
+            az acr login --name << pipeline.parameters.ops_registry >> | grep "Succeeded"
       - run:
           name: Build images
           command: |
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
       - run:
           name: Build nginx image
-          command: docker build -t nginx:latest --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
+          command: docker build -t nginx:latest --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
       - run:
           name: Tag images
           command: |
@@ -369,12 +373,12 @@ jobs:
               --username << pipeline.parameters.sp >>
             az account set -s << pipeline.parameters.subscription_id >>
             echo "Successfully logged in to Azure CLI."
-            az acr login --name cloudzeroopsregistry | grep "Succeeded"
+            az acr login --name << pipeline.parameters.ops_registry >> | grep "Succeeded"
       - run:
           name: Build ops deployment image image
           command: |
             docker build -t ops:latest \
-            --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhelubi:8.2 \
+            --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 \
             --build-arg operator_sp_client_id=<< pipeline.parameters.sp >> \
             --build-arg operator_sp_object_id=<< pipeline.parameters.sp_object_id >> \
             --build-arg operator_sp_secret=<< pipeline.parameters.sp_password >> \
@@ -384,10 +388,10 @@ jobs:
             . < Dockerfile.ops
       - run:
           name: Tag ops image
-          command: docker tag ops:latest cloudzeroopsregistry.azurecr.io/ops:latest
+          command: docker tag ops:latest << pipeline.parameters.ops_registry >>.azurecr.io/ops:latest
       - run:
           name: Push ops image
-          command: docker push cloudzeroopsregistry.azurecr.io/ops:latest
+          command: docker push << pipeline.parameters.ops_registry >>.azurecr.io/ops:latest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -160,15 +160,18 @@ commands:
           version: 18.06.0-ce
       - azlogin:
           subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.container_registry >>
+          registry: << pipeline.parameters.ops_registry >>
       - restore_docker_image
       - run:
           name: Build nginx image
-          command: docker build -t nginx:latest --build-arg IMAGE=<< pipeline.parameters.container_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
+          command: docker build -t nginx:latest --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
       - run:
           name: Tag images
           command: |
             docker tag atat:latest << pipeline.parameters.atat_image_tag >>
+      - azlogin:
+          subscription_id: << pipeline.parameters.subscription_id >>
+          registry: << pipeline.parameters.container_registry >>
       - run:
           name: Push image
           command: |
@@ -185,12 +188,12 @@ jobs:
           version: 18.06.0-ce
       - azlogin:
           subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.container_registry >>
+          registry: << pipeline.parameters.ops_registry >>
       - run:
           name: Build images
           command: |
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.container_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.container_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
       - cache_docker_images
 
   test:
@@ -300,7 +303,7 @@ jobs:
           namespace: master
           atat_image_tag: << pipeline.parameters.container_registry >>.azurecr.io/atat:master-${CIRCLE_SHA1}
           nginx_image_tag: << pipeline.parameters.container_registry >>.azurecr.io/nginx:master-${CIRCLE_SHA1}
-  
+
   push-app-images:
     docker:
       - image: docker:18.06.0-ce-git
@@ -327,7 +330,7 @@ jobs:
             docker tag nginx:latest << pipeline.parameters.nginx_image_tag >>
       - run:
           name: Log into the target registry
-          command: az acr login --name << pipeline.parameters.container_registry >> | grep "Succeeded"
+          command: az acr login --name << pipeline.parameters.container_registry >>.azurecr.io | grep "Succeeded"
       - run:
           name: Push image
           command: |
@@ -368,8 +371,8 @@ workflows:
   version: 2
   run-tests:
     when:
-      not: 
-        and: 
+      not:
+        and:
           - << pipeline.parameters.build_and_push_app_images >>
           - << pipeline.parameters.build_and_push_ops_image >>
     jobs:
@@ -401,7 +404,7 @@ workflows:
             branches:
               only:
                 - master
-  
+
   push-app-images:
     when: << pipeline.parameters.build_and_push_app_images >>
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,12 +10,18 @@ parameters:
   tenant_id:
     type: string
     default: ${AZURE_SP_TENANT}
-  sp_password:
-    type: string
-    default: ${AZURE_SP_PASSWORD}
   sp:
     type: string
     default: ${AZURE_SP}
+  sp_password:
+    type: string
+    default: ${AZURE_SP_PASSWORD}
+  sp_object_id:
+    type: string
+    default: "__NONE__"
+  operator_sp_url:
+    type: string
+    default: "__NONE__"
   container_env:
     type: string
     default: -e PGHOST=postgres -e REDIS_HOST=redis:6379
@@ -366,20 +372,22 @@ jobs:
             az acr login --name cloudzeroopsregistry | grep "Succeeded"
       - run:
           name: Build ops deployment image image
-          command: docker build -t nginx:latest --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
-      - run:
-          name: Tag images
           command: |
-            docker tag atat:latest << pipeline.parameters.atat_image_tag >>
-            docker tag nginx:latest << pipeline.parameters.nginx_image_tag >>
+            docker build -t ops:latest \
+            --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhelubi:8.2 \
+            --build-arg operator_sp_client_id=<< pipeline.parameters.sp >> \
+            --build-arg operator_sp_object_id=<< pipeline.parameters.sp_object_id >> \
+            --build-arg operator_sp_secret=<< pipeline.parameters.sp_password >> \
+            --build-arg azure_tenant=<< pipeline.parameters.tenant_id >> \
+            --build-arg azure_subscription_id=<< pipeline.parameters.subscription_id >> \
+            --build-arg operator_sp_url=<< pipeline.parameters.operator_sp_url >> \
+            . < Dockerfile.ops
       - run:
-          name: Log into the target registry
-          command: az acr login --name << pipeline.parameters.container_registry >> | grep "Succeeded"
+          name: Tag ops image
+          command: docker tag ops:latest cloudzeroopsregistry.azurecr.io/ops:latest
       - run:
-          name: Push image
-          command: |
-            docker push << pipeline.parameters.atat_image_tag >>
-            docker push << pipeline.parameters.nginx_image_tag >>
+          name: Push ops image
+          command: docker push cloudzeroopsregistry.azurecr.io/ops:latest
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
       registry:
         description: The name of the registry (not including the azureacr suffix).
         type: string
-      suscription_id:
+      subscription_id:
         description: Target subscription the registry exists under.
         type: string
     steps:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,8 +37,12 @@ parameters:
   resource_group:
     type: string
     default: ${RESOURCE_GROUP}
-  build_and_push_images_only:
-    description: Causes a build with a single stage that creates and pushes docker images to a container registry only.
+  build_and_push_app_images:
+    description: Causes a build with a single stage that creates and pushes atat and docker images docker images to a container registry only.
+    type: boolean
+    default: false
+  build_and_push_ops_image:
+    description: Causes a build with a single stage that creates and pushes the ops deployment image to a container registry only.
     type: boolean
     default: false
 
@@ -275,8 +279,8 @@ jobs:
           namespace: master
           atat_image_tag: << pipeline.parameters.container_registry >>.azurecr.io/atat:master-${CIRCLE_SHA1}
           nginx_image_tag: << pipeline.parameters.container_registry >>.azurecr.io/nginx:master-${CIRCLE_SHA1}
-
-  push-images:
+  
+  push-app-images:
     docker:
       - image: docker:18.06.0-ce-git
     steps:
@@ -329,11 +333,62 @@ jobs:
             docker push << pipeline.parameters.atat_image_tag >>
             docker push << pipeline.parameters.nginx_image_tag >>
 
+  push-ops-image:
+    docker:
+      - image: docker:18.06.0-ce-git
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: true
+          version: 18.06.0-ce
+      - run:
+          name: Install Azure CLI
+          command: |
+            apk update
+            apk add bash py3-pip
+            apk add --virtual=build \
+              linux-headers gcc libffi-dev musl-dev openssl-dev python3-dev make curl
+            pip3 --no-cache-dir install -U pip
+            pip3 --no-cache-dir install azure-cli
+            curl -L https://aka.ms/acr/installaad/bash | /bin/bash
+            apk del --purge build
+      - run:
+          name: Login to Azure CLI
+          shell: /bin/sh
+          command: |
+            az login \
+              --service-principal \
+              --tenant << pipeline.parameters.tenant_id >> \
+              --password << pipeline.parameters.sp_password >> \
+              --username << pipeline.parameters.sp >>
+            az account set -s << pipeline.parameters.subscription_id >>
+            echo "Successfully logged in to Azure CLI."
+            az acr login --name cloudzeroopsregistry | grep "Succeeded"
+      - run:
+          name: Build ops deployment image image
+          command: docker build -t nginx:latest --build-arg IMAGE=cloudzeroopsregistry.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile
+      - run:
+          name: Tag images
+          command: |
+            docker tag atat:latest << pipeline.parameters.atat_image_tag >>
+            docker tag nginx:latest << pipeline.parameters.nginx_image_tag >>
+      - run:
+          name: Log into the target registry
+          command: az acr login --name << pipeline.parameters.container_registry >> | grep "Succeeded"
+      - run:
+          name: Push image
+          command: |
+            docker push << pipeline.parameters.atat_image_tag >>
+            docker push << pipeline.parameters.nginx_image_tag >>
+
 workflows:
   version: 2
   run-tests:
     when:
-      not: << pipeline.parameters.build_and_push_images_only >>
+      not: 
+        and: 
+          - << pipeline.parameters.build_and_push_app_images >>
+          - << pipeline.parameters.build_and_push_ops_image >>
     jobs:
       - docker-build
       - test:
@@ -363,8 +418,13 @@ workflows:
             branches:
               only:
                 - master
-
-  push-images:
-    when: << pipeline.parameters.build_and_push_images_only >>
+  
+  push-app-images:
+    when: << pipeline.parameters.build_and_push_app_images >>
     jobs:
-      - push-images
+      - push-app-images
+
+  push-ops-image:
+    when: << pipeline.parameters.build_and_push_ops_image >>
+    jobs:
+      - push-app-images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -310,7 +310,7 @@ jobs:
           docker_layer_caching: true
           version: 18.06.0-ce
       - azlogin:
-          subscription_id: << pipeline.parameters.ops_registry >>
+          subscription_id: << pipeline.parameters.subscription_id >>
           registry: << pipeline.parameters.ops_registry >>
       - run:
           name: Build images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -316,7 +316,7 @@ jobs:
           name: Build images
           command: |
             docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:builder --target builder
-            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
+            docker build . --build-arg GIT_SHA=${CIRCLE_SHA1} --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py -f ./Dockerfile -t atat:latest
       - run:
           name: Build nginx image
           command: docker build -t nginx:latest --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 - < nginx.Dockerfile

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,7 +85,7 @@ commands:
   log_into_app_registry:
     steps:
       - run:
-          name: Login to Azure CLI
+          name: Login to application registry
           shell: /bin/sh
           command: |
             az login \
@@ -99,7 +99,7 @@ commands:
   log_into_ops_registry:
     steps:
       - run:
-          name: Login to Azure CLI
+          name: Login to operations registry
           shell: /bin/sh
           command: |
             az login \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -188,7 +188,7 @@ jobs:
           version: 18.06.0-ce
       - azlogin:
           subscription_id: << pipeline.parameters.subscription_id >>
-          registry: << pipeline.parameters.ops_registry >>
+          registry: << pipeline.parameters.container_registry >>
       - run:
           name: Build images
           command: |


### PR DESCRIPTION
- Adds a flag `build_and_push_ops_image` to trigger building and storing ops image in the registry
- Adds environment variables `AZURE_SUBSCRIPTION_OPS` and `AZURE_REGISTRY_OPS`
- Breaks `azlogin` into `install_azure_cli` and `log_into_ops_registry` and `log_into_app_registry`