### PR TITLE
[AT-5505][AT-5506] Fixes tests where we'd assert that two objects were identical

### DIFF
--- a/tests/domain/test_portfolio_roles.py
+++ b/tests/domain/test_portfolio_roles.py
@@ -1,14 +1,9 @@
 from atat.domain.permission_sets import PermissionSets
 from atat.domain.portfolio_roles import PortfolioRoles
-from atat.domain.users import Users
 from atat.models.permissions import Permissions
 from atat.models.portfolio_role import Status as PortfolioRoleStatus
-from tests.factories import (
-    PortfolioFactory,
-    PortfolioInvitationFactory,
-    PortfolioRoleFactory,
-    UserFactory,
-)
+from tests.factories import PortfolioFactory, PortfolioRoleFactory, UserFactory
+from tests.utils import lists_contain_same_members
 
 
 def test_add_portfolio_role_with_permission_sets():
@@ -28,7 +23,7 @@ def test_add_portfolio_role_with_permission_sets():
         PermissionSets.VIEW_PORTFOLIO,
     ]
     actual_names = [prms.name for prms in port_role.permission_sets]
-    assert expected_names == expected_names
+    assert lists_contain_same_members(actual_names, expected_names)
 
 
 def test_disable_portfolio_role():

--- a/tests/models/test_portfolio_role.py
+++ b/tests/models/test_portfolio_role.py
@@ -1,13 +1,7 @@
-import pendulum
 import pytest
 
-from atat.domain.applications import Applications
-from atat.domain.environments import Environments
-from atat.domain.permission_sets import PermissionSets
-from atat.domain.portfolio_roles import PortfolioRoles
-from atat.domain.portfolios import Portfolios
-from atat.models import AuditEvent, CSPRole, InvitationStatus, PortfolioRoleStatus
 from tests.factories import *
+from tests.utils import lists_contain_same_members
 
 
 @pytest.mark.audit_log
@@ -269,7 +263,14 @@ def test_can_list_all_permissions():
     role_two = PermissionSets.get(PermissionSets.VIEW_PORTFOLIO_REPORTS)
     port_role = PortfolioRoleFactory.create(permission_sets=[role_one, role_two])
     expected_perms = role_one.permissions + role_two.permissions
-    assert expected_perms == expected_perms
+    assert lists_contain_same_members(
+        expected_perms,
+        [
+            perm
+            for perm_set in port_role.permission_sets
+            for perm in perm_set.permissions
+        ],
+    )
 
 
 def test_has_permission_set():


### PR DESCRIPTION
In both of these tests, we'd assert that a list was equal to itself. This was more akin to a typo than anything -- instead of `assert expected_list == actual_list`, we'd `assert expected_list == expected_list`. 

This PR fixes these tests so that they assert the correct behavior. It also removes unneeded imports in the modules where the tests reside.