### PR TITLE
Restore `deploy-staging`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -347,6 +347,14 @@ workflows:
               only:
                 - staging
                 - master
+      - deploy-staging:
+          requires:
+            - test
+            - integration-tests
+          filters:
+            branches:
+              only:
+                - staging
       - deploy-master:
           requires:
             - test


### PR DESCRIPTION
I accidentally deleted the step responsible for pushing built images on the staging branch. This PR restores that step.