### PR TITLE
Add login postback view to csrf exemption

### DIFF
--- a/atat/app.py
+++ b/atat/app.py
@@ -57,6 +57,7 @@ def make_app(config):
     csrf = CSRFProtect()
     csrf.exempt("atat.routes.dev.login_dev")
     csrf.exempt("atat.routes.login")
+    csrf.exempt("atat.routes.handle_login_response")
 
     app.config.update(config)
     app.config.update({"SESSION_REDIS": app.redis})


### PR DESCRIPTION
The login view was split into get and post functions and the post function wasn't exempted from CSRF, meaning it would reject all SAML responses as violating CSRF.