### PR TITLE
Update the bugbounty overlay.

### DIFF
--- a/deploy/overlays/cloudzero-dryrun-bugbounty/autoscaling.yml
+++ b/deploy/overlays/cloudzero-dryrun-bugbounty/autoscaling.yml
@@ -4,8 +4,8 @@ kind: HorizontalPodAutoscaler
 metadata:
   name: atst
 spec:
-  minReplicas: 1
-  maxReplicas: 1
+  minReplicas: 3
+  maxReplicas: 6
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -13,4 +13,4 @@ metadata:
   name: atst-worker
 spec:
   minReplicas: 1
-  maxReplicas: 1
+  maxReplicas: 3

--- a/deploy/overlays/cloudzero-dryrun-bugbounty/envvars.yml
+++ b/deploy/overlays/cloudzero-dryrun-bugbounty/envvars.yml
@@ -4,10 +4,18 @@ kind: ConfigMap
 metadata:
   name: atst-worker-envvars
 data:
+  AZURE_STORAGE_ACCOUNT_NAME: dryruntasks
+  AZURE_POWERSHELL_CLIENT_ID: 1950a258-227b-4e31-a9cf-717495945fc2
+  AZURE_TENANT_ADMIN_USERNAME: hybrid.admin@atathybrid.onmicrosoft.com
+  AZURE_VAULT_URL: "https://tenants-dryrun-keyvault.vault.azure.net/"
   CAC_URL: https://auth-bugbounty.atat.dev/login-redirect
   CELERY_DEFAULT_QUEUE: celery-bugbounty
+  CSP: hybrid
   FLASK_ENV: bugbounty
   PGDATABASE: cloudzero_dryrun_bugbounty
+  PGHOST: cloudzero-dryrun-sql.postgres.database.azure.com
+  PGUSER: atat@cloudzero-dryrun-sql
+  REDIS_HOST: cloudzero-dryrun-redis.redis.cache.windows.net:6380
   SERVER_NAME: bugbounty.atat.dev
 ---
 apiVersion: v1
@@ -15,16 +23,28 @@ kind: ConfigMap
 metadata:
   name: atst-envvars
 data:
+  ASSETS_URL: ""
+  AZURE_STORAGE_ACCOUNT_NAME: dryruntasks
+  AZURE_POWERSHELL_CLIENT_ID: 1950a258-227b-4e31-a9cf-717495945fc2
+  AZURE_TENANT_ADMIN_USERNAME: hybrid.admin@atathybrid.onmicrosoft.com
+  AZURE_VAULT_URL: "https://tenants-dryrun-keyvault.vault.azure.net/"
+  BLOB_STORAGE_URL: https://dryruntasks.blob.core.windows.net/
   CAC_URL: https://auth-bugbounty.atat.dev/login-redirect
   CDN_ORIGIN: https://bugbounty.atat.dev
   CELERY_DEFAULT_QUEUE: celery-bugbounty
+  CSP: hybrid
   FLASK_ENV: bugbounty
   PGDATABASE: cloudzero_dryrun_bugbounty
+  PGHOST: cloudzero-dryrun-sql.postgres.database.azure.com
+  PGUSER: atat@cloudzero-dryrun-sql
+  REDIS_HOST: cloudzero-dryrun-redis.redis.cache.windows.net:6380
+  SESSION_COOKIE_DOMAIN: atat.dev
   STATIC_URL: "https://bugbounty.atat.dev/static/"
-  SAML_ENTITY_ID: https://bugbounty.atat.dev/login-dev
-  SAML_ACS: https://bugbounty.atat.dev/login-dev?acs
-  SAML_SLS: https://bugbounty.atat.dev/login-dev?sls
-  SAML_IDP_ENTITY_ID: https://sts.windows.net/ab154c46-3d57-4386-9b87-8002123f3858/
-  SAML_IDP_SSOS: https://login.microsoftonline.com/ab154c46-3d57-4386-9b87-8002123f3858/saml2
-  SAML_IDP_SLS: https://login.microsoftonline.com/ab154c46-3d57-4386-9b87-8002123f3858/saml2
-  SAML_LOGIN_DEV: "true"
+  SAML_ENTITY_ID: https://bugbounty.atat.dev
+  SAML_ACS: https://bugbounty.atat.dev/login?acs
+  SAML_SLS: https://bugbounty.atat.dev/login?sls
+  SAML_IDP_URI: https://fs.disa.mil/federationmetadata/2007-06/federationmetadata.xml
+  SAML_DEV_ENTITY_ID: https://bugbounty.atat.dev/login-dev
+  SAML_DEV_ACS: https://bugbounty.atat.dev/login-dev?acs
+  SAML_DEV_SLS: https://bugbounty.atat.dev/login-dev?sls
+  SAML_DEV_IDP_URI: https://login.microsoftonline.com/ab154c46-3d57-4386-9b87-8002123f3858/federationmetadata/2007-06/federationmetadata.xml?appid=69459a6b-da7b-4c84-bb3d-53118fd4ae48

--- a/deploy/overlays/cloudzero-dryrun-bugbounty/flex_vol.yml
+++ b/deploy/overlays/cloudzero-dryrun-bugbounty/flex_vol.yml
@@ -6,7 +6,59 @@ spec:
   template:
     spec:
       volumes:
+        - name: nginx-secret
+          flexVolume:
+            options:
+              usepodidentity: "false"
+              usevmmanagedidentity: "true"
+              vmmanagedidentityclientid: $VMSS_CLIENT_ID
+              keyvaultname: "cz-dryrun-keyvault"
+              keyvaultobjectnames: "dhparam4096;atatdev;atatdev"
         - name: flask-secret
           flexVolume:
             options:
+              usepodidentity: "false"
+              usevmmanagedidentity: "true"
+              vmmanagedidentityclientid: $VMSS_CLIENT_ID
+              keyvaultname: "cz-dryrun-keyvault"
               keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID;AZURE-BILLING-ACCOUNT-NAME;AZURE-BILLING-PROFILE-ID;AZURE-INVOICE-SECTION-ID;AZURE-HYBRID-REPORTING-CLIENT-ID;AZURE-HYBRID-REPORTING-SECRET"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID;AZURE_BILLING_ACCOUNT_NAME;AZURE_BILLING_PROFILE_ID;AZURE_INVOICE_SECTION_ID;AZURE_HYBRID_REPORTING_CLIENT_ID;AZURE_HYBRID_REPORTING_SECRET"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret;secret;secret;secret;secret;secret"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atst-worker
+spec:
+  template:
+    spec:
+      volumes:
+        - name: flask-secret
+          flexVolume:
+            options:
+              usepodidentity: "false"
+              usevmmanagedidentity: "true"
+              vmmanagedidentityclientid: $VMSS_CLIENT_ID
+              keyvaultname: "cz-dryrun-keyvault"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: atst-beat
+spec:
+  template:
+    spec:
+      volumes:
+        - name: flask-secret
+          flexVolume:
+            options:
+              usepodidentity: "false"
+              usevmmanagedidentity: "true"
+              vmmanagedidentityclientid: $VMSS_CLIENT_ID
+              keyvaultname: "cz-dryrun-keyvault"
+              keyvaultobjectnames: "AZURE-STORAGE-KEY;MAIL-PASSWORD;PGPASSWORD;REDIS-PASSWORD;SECRET-KEY;AZURE-TENANT-ID;AZURE-CLIENT-ID;AZURE-USER-OBJECT-ID;AZURE-TENANT-ADMIN-PASSWORD;AZURE-SECRET-KEY;AZURE-HYBRID-TENANT-ID"
+              keyvaultobjectaliases: "AZURE_STORAGE_KEY;MAIL_PASSWORD;PGPASSWORD;REDIS_PASSWORD;SECRET_KEY;AZURE_TENANT_ID;AZURE_CLIENT_ID;AZURE_USER_OBJECT_ID;AZURE_TENANT_ADMIN_PASSWORD;AZURE_SECRET_KEY;AZURE_HYBRID_TENANT_ID"
+              keyvaultobjecttypes: "secret;secret;secret;secret;key;secret;secret;secret;secret;secret;secret"

--- a/deploy/overlays/cloudzero-dryrun-bugbounty/kustomization.yaml
+++ b/deploy/overlays/cloudzero-dryrun-bugbounty/kustomization.yaml
@@ -1,9 +1,10 @@
 namespace: bugbounty
 bases:
-  - ../cloudzero-dryrun-staging
+  - ../../azure/
 resources:
   - namespace.yml
 patchesStrategicMerge:
   - envvars.yml
-  - autoscaling.yml
+  - ports.yml
   - flex_vol.yml
+  - autoscaling.yml

--- a/deploy/overlays/cloudzero-dryrun-bugbounty/ports.yml
+++ b/deploy/overlays/cloudzero-dryrun-bugbounty/ports.yml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: atst-main
+  annotations:
+    service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "cloudzero-dryrun-public"


### PR DESCRIPTION
This updates the bugbounty overlay in the following ways:

1. It was previously referencing the cloudzero-dryrun-staging overlay as its base. That overlay no longer exists since we transitioned the staging site to new infrastructure. I've updated it to reference the base config in the deploy/azure directory.
2. Because of 1, the bugbounty overlay has to explicitly define all of the configuration it was previously inheriting from the staging overlay (Postgres server URL, etc.).
3. It now has the updated configuration for fed auth against both the development and prod IdPs.
4. I've updated the scaling values for the Horizontal Pod Autoscaler since we have more room in that cluster.

Deploying these changes will also remove CAC auth from the bugbounty instance of the site.