### PR TITLE
Replace `rhelubi` with `rhel-py` for ops base image build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -392,7 +392,7 @@ jobs:
           name: Build ops deployment image image
           command: |
             docker build -t ops:latest \
-            --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhelubi:8.2 \
+            --build-arg IMAGE=<< pipeline.parameters.ops_registry >>.azurecr.io/rhel-py \
             --build-arg operator_sp_client_id=<< pipeline.parameters.sp >> \
             --build-arg operator_sp_object_id=<< pipeline.parameters.sp_object_id >> \
             --build-arg operator_sp_secret=<< pipeline.parameters.sp_password >> \


### PR DESCRIPTION
Ops image cannot build because it depends on rhel-py.