### PR TITLE
Poll for latest nginx image tag

### DIFF
--- a/ansible/roles/k8s/tasks/configure_private_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_private_cluster.yml
@@ -100,6 +100,17 @@
   set_fact:
     latest_tag: "{{ (atat_images.stdout | from_json)[0] }}"
 
+- name: Fetch latest `nginx` image from {{ tf_app_env_outputs.container_registry_name.value }}
+  shell: az acr repository show-tags --top 1 --orderby time_desc --repository nginx --name {{ tf_app_env_outputs.container_registry_name.value }}
+  register: nginx_images
+  retries: 100
+  delay: 10
+  until: nginx_images is not failed
+
+- name: Extract latest nginx tag
+  set_fact:
+    latest_nginx_tag: "{{ (nginx_images.stdout | from_json)[0] }}"
+
 - name: Show variable "atat_images"
   debug:
     msg: "{{ atat_images }}"
@@ -108,7 +119,13 @@
   debug:
     msg: "{{ latest_tag }}"
 
+- name: Show variable "nginx_images"
+  debug:
+    msg: "{{ atat_images }}"
 
+- name: Show variable "latest_nginx_tag"
+  debug:
+    msg: "{{ latest_nginx_tag }}"
 
 - name: Show output directory
   debug:
@@ -118,7 +135,7 @@
   shell: /src/script/k8s_config {{ playbook_dir + '/.out' }} | kubectl apply -f -
   environment:
     CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/atat:{{ latest_tag }}"
-    NGINX_CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/nginx:latest"
+    NGINX_CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/nginx:{{ latest_nginx_tag }}"
     MAIN_DOMAIN: "{{ namespace }}.atat.dev"
     AUTH_DOMAIN: "auth-{{ namespace }}.atat.dev"
     VMSS_CLIENT_ID: "{{ tf_app_env_outputs.keyvault_reader_client_id.value }}"

--- a/ansible/roles/k8s/tasks/configure_private_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_private_cluster.yml
@@ -121,7 +121,7 @@
 
 - name: Show variable "nginx_images"
   debug:
-    msg: "{{ atat_images }}"
+    msg: "{{ nginx_images }}"
 
 - name: Show variable "latest_nginx_tag"
   debug:

--- a/ansible/roles/k8s/tasks/configure_public_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_public_cluster.yml
@@ -90,7 +90,7 @@
 
 - name: Show variable "nginx_images"
   debug:
-    msg: "{{ atat_images }}"
+    msg: "{{ nginx_images }}"
 
 - name: Show variable "latest_nginx_tag"
   debug:

--- a/ansible/roles/k8s/tasks/configure_public_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_public_cluster.yml
@@ -69,6 +69,17 @@
   set_fact:
     latest_tag: "{{ (atat_images.stdout | from_json)[0] }}"
 
+- name: Fetch latest `nginx` image from {{ tf_app_env_outputs.container_registry_name.value }}
+  shell: az acr repository show-tags --top 1 --orderby time_desc --repository nginx --name {{ tf_app_env_outputs.container_registry_name.value }}
+  register: nginx_images
+  retries: 100
+  delay: 10
+  until: nginx_images is not failed
+
+- name: Extract latest nginx tag
+  set_fact:
+    latest_nginx_tag: "{{ (nginx_images.stdout | from_json)[0] }}"
+
 - name: Show variable "atat_images"
   debug:
     msg: "{{ atat_images }}"
@@ -77,7 +88,13 @@
   debug:
     msg: "{{ latest_tag }}"
 
+- name: Show variable "nginx_images"
+  debug:
+    msg: "{{ atat_images }}"
 
+- name: Show variable "latest_nginx_tag"
+  debug:
+    msg: "{{ latest_nginx_tag }}"
 
 - name: Show output directory
   debug:
@@ -87,7 +104,7 @@
   shell: /src/script/k8s_config {{ playbook_dir + '/.out' }} | kubectl apply -f -
   environment:
     CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/atat:{{ latest_tag }}"
-    NGINX_CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/nginx:latest"
+    NGINX_CONTAINER_IMAGE: "{{ tf_app_env_outputs.container_registry_name.value }}.azurecr.io/nginx:{{ latest_nginx_tag }}"
     MAIN_DOMAIN: "{{ namespace }}.atat.dev"
     AUTH_DOMAIN: "auth-{{ namespace }}.atat.dev"
     VMSS_CLIENT_ID: "{{ tf_app_env_outputs.keyvault_reader_client_id.value }}"


### PR DESCRIPTION
- Adds a polling task that checks the repository for the latest built NGINX image
- Gets the single latest built NGINX image and stores it in fact called `latest_nginx_tag`
- This tag is then used to specify the image in the `NGINX_CONTAINER_IMAGE` environment variable