### PR TITLE
Update Script/format to run on Ansible yml

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,4 @@
 # run isort on project
 4da73ac463615f1c0696b7ca0482317bace2c7e0
+# Run prettier on ansible yml
+8f32c7701be0c03b2ad78cb6220b0242202d1e24 

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+ansible/roles/k8s/tasks/templates/envvars.yml

--- a/ansible/databases.yml
+++ b/ansible/databases.yml
@@ -4,4 +4,4 @@
       vars:
         db_init_details: "{{ tf_app_env_outputs.outputs }}"
         db_name: "{{ tf_bootstrap_backend_outputs.environment.value }}"
-        postgresql:  "true"
+        postgresql: "true"

--- a/ansible/k8s.yml
+++ b/ansible/k8s.yml
@@ -1,4 +1,3 @@
-
 - hosts: localhost
   roles:
     - role: bootstrap

--- a/ansible/roles/azure_keyvault/tasks/secret.yml
+++ b/ansible/roles/azure_keyvault/tasks/secret.yml
@@ -1,11 +1,3 @@
-
-
-
-
-
-
-
-
 - name: "Create secret"
   azure_rm_keyvaultsecret:
     subscription_id: "{{ vault_subscription_id }}"

--- a/ansible/roles/azure_keyvault/tasks/source_secrets.yml
+++ b/ansible/roles/azure_keyvault/tasks/source_secrets.yml
@@ -1,25 +1,17 @@
-
-
 - name: pickup application_env variables
   set_fact:
     app_vars_vals: "{{ lookup('to_hcl', tf_base_dir ~ '/application_env' ~ '/app.tfvars.json' ) | safe | string }}"
 
-
-
 - include: ../../bootstrap/tasks/show_outputs.yml
-
 
 - name: get app _output
   include: ../../terraform/tasks/get_backend.yml
 
 - include: ../../terraform/tasks/show_outputs.yml
 
-
-
-
 - name: "show outputs of app_config_values"
   debug:
-    msg:  " outputs are .. {{ tf_app_env_outputs.app_config_values.value }}"
+    msg: " outputs are .. {{ tf_app_env_outputs.app_config_values.value }}"
 
 - name: set var values fact
   set_fact:

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -1,20 +1,15 @@
 ---
-
-
 # could move this out to top level or own role
 
 - name: fetch atat.pem
   import_tasks: pull_atat_pem.yml
 
-  
 - name: fetch bootstrap vars
   import_tasks: pull_tfvars.yml
-
 
 - name: fetch bootstrap state
   import_tasks: pull_remote_state.yml
   when: fetch_bootstrap_state == true
-
 
 - name: get vars
   import_tasks: get_variables.yml

--- a/ansible/roles/bootstrap/tasks/pull_atat_pem.yml
+++ b/ansible/roles/bootstrap/tasks/pull_atat_pem.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Download atat pem
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
@@ -10,4 +9,4 @@
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: certs
     blob: atatdev.pem
-    dest:  /src/atatdev.pem
+    dest: /src/atatdev.pem

--- a/ansible/roles/bootstrap/tasks/pull_remote_state.yml
+++ b/ansible/roles/bootstrap/tasks/pull_remote_state.yml
@@ -1,8 +1,4 @@
 ---
-
-
-
-
 - name: Download bootstrap state
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
@@ -13,4 +9,4 @@
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name }}"
     blob: terraform.bootstrap.tfstate
-    dest:  /src/terraform/providers/bootstrap/terraform.tfstate
+    dest: /src/terraform/providers/bootstrap/terraform.tfstate

--- a/ansible/roles/bootstrap/tasks/pull_tfvars.yml
+++ b/ansible/roles/bootstrap/tasks/pull_tfvars.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Download bootstrap state
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
@@ -10,4 +9,4 @@
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name}}"
     blob: bootstrap.tfvars
-    dest:  /src/terraform/providers/bootstrap/bootstrap.tfvars
+    dest: /src/terraform/providers/bootstrap/bootstrap.tfvars

--- a/ansible/roles/bootstrap/tasks/push_state_remote.yml
+++ b/ansible/roles/bootstrap/tasks/push_state_remote.yml
@@ -1,6 +1,3 @@
-
-
-
 - name: push bootstrap tf state to storage account
   azure_rm_storageblob:
     resource_group: "{{ bootstrap_resource_group_name }}"
@@ -8,4 +5,4 @@
     container: "{{bootstrap_container_name}}"
     blob: "{{tf_bootstrap_backend_outputs.environment.value}}.bootstrap.terraform.tfstate"
     src: "{{tf_dir}}/terraform.tfstate"
-    content_type: 'application/json'
+    content_type: "application/json"

--- a/ansible/roles/bootstrap/tasks/setup.yml
+++ b/ansible/roles/bootstrap/tasks/setup.yml
@@ -17,7 +17,6 @@
     - target_modules is not defined
     - az_environment is defined
 
-
 - name: plan  (modules)
   terraform:
     force_init: "{{ bootstrap_init_tf }}"
@@ -32,8 +31,6 @@
   when:
     - target_modules is defined
     - az_environment is not defined
-
-
 
 - name: tf apply (no modules)
   terraform:

--- a/ansible/roles/circle_ci/tasks/main.yml
+++ b/ansible/roles/circle_ci/tasks/main.yml
@@ -1,6 +1,3 @@
-
-
-
 - name: get the circle ci api token
   import_tasks: source_api_token.yml
 
@@ -9,7 +6,6 @@
     name: terraform
   vars:
     deploy_app_env: false
-
 
 - name: run circle ci ops build
   import_tasks: run_ops_build.yml

--- a/ansible/roles/circle_ci/tasks/run_app_build.yml
+++ b/ansible/roles/circle_ci/tasks/run_app_build.yml
@@ -16,10 +16,10 @@
         sp_object_id: "{{ lookup('env','TF_VAR_OPS_OID') }}"
         sp_password: "{{ lookup('env', 'ARM_CLIENT_SECRET_BUILD' ) }}"
         operator_sp_url: "{{ lookup('env','AZ_CLI_SP') }}"
-        ops_registry:  "{{ ops_registy }}"
+        ops_registry: "{{ ops_registy }}"
         ops_subscription_id: "{{ lookup('env','SUBSCRIPTION_ID') }}"
         build_and_push_app_images: "{{ build_and_push_app_images }}"
-        tenant_id:  "{{ lookup('env','SUBSCRIPTION_TENANT') }}"
+        tenant_id: "{{ lookup('env','SUBSCRIPTION_TENANT') }}"
     body_format: json
     status_code:
       - 201

--- a/ansible/roles/circle_ci/tasks/run_ops_build.yml
+++ b/ansible/roles/circle_ci/tasks/run_ops_build.yml
@@ -13,16 +13,15 @@
         sp_object_id: "{{ lookup('env','TF_VAR_OPS_OID') }}"
         sp_password: "{{ lookup('env', 'ARM_CLIENT_SECRET_BUILD' ) }}"
         operator_sp_url: "{{ lookup('env','AZ_CLI_SP') }}"
-        ops_registry:  "{{ ops_registy }}"
+        ops_registry: "{{ ops_registy }}"
         ops_subscription_id: "{{ lookup('env','SUBSCRIPTION_ID') }}"
         build_and_push_ops_image: "{{ build_and_push_ops_image }}"
         build_and_push_app_images: "{{ build_and_push_app_images }}"
-        tenant_id:  "{{ lookup('env','SUBSCRIPTION_TENANT') }}"
+        tenant_id: "{{ lookup('env','SUBSCRIPTION_TENANT') }}"
     body_format: json
     status_code:
       - 201
   register: _result
-
 
 - name: Fetch latest `ops` image from {{ tf_bootstrap_backend_outputs.ops_container_registry_name.value }}
   shell: az acr repository show-tags --top 1 --orderby time_desc --repository ops --name {{ tf_bootstrap_backend_outputs.ops_container_registry_name.value }}

--- a/ansible/roles/circle_ci/tasks/source_api_token.yml
+++ b/ansible/roles/circle_ci/tasks/source_api_token.yml
@@ -1,6 +1,5 @@
 # just get it from the tfvars json instead of running an expensive terraform output cmd
 ---
-
 - name: get from tfvars file
   set_fact:
     circle_ci_api_key: "{{ (lookup('file','/src/terraform/providers/application_env/app.tfvars.json') | from_json).get('circle_ci_api_key') }}"

--- a/ansible/roles/crypto/tasks/main.yml
+++ b/ansible/roles/crypto/tasks/main.yml
@@ -1,10 +1,8 @@
-
-
 - name: Create the dh directory if it does not exist
   file:
     path: /src/ansible/dh
     state: directory
-    mode: '0755'
+    mode: "0755"
 
 - name: Generate Diffie-Hellman parameters with the default size (4096 bits)
   openssl_dhparam:

--- a/ansible/roles/db/defaults/main.yml
+++ b/ansible/roles/db/defaults/main.yml
@@ -1,4 +1,3 @@
-
 postgres_root_cert: /src/deploy/azure/pgsslrootcert.yml
 bootstrap_resource_group_name: cloudzero-ops
 bootstrap_storage_account_name: czopsstorageaccount

--- a/ansible/roles/db/tasks/main.yml
+++ b/ansible/roles/db/tasks/main.yml
@@ -1,6 +1,4 @@
 ---
-
-
 - name: source ccpo users file
   import_tasks: source_ccpo_user_file.yml
   when: postgresql is defined

--- a/ansible/roles/db/tasks/postgres.yml
+++ b/ansible/roles/db/tasks/postgres.yml
@@ -1,7 +1,6 @@
--  name: lets see outputs
-   debug:
-     msg: "{{tf_app_env_outputs}}"
-
+- name: lets see outputs
+  debug:
+    msg: "{{tf_app_env_outputs}}"
 
 - name: grab the root cert from yaml
   shell: cat "{{ postgres_root_cert }}"
@@ -24,7 +23,6 @@
     subscription_id: "{{ lookup('env','SUBSCRIPTION_ID') }}"
     tenant: "{{ lookup('env','SUBSCRIPTION_TENANT') }}"
 
-
 - name: Adds uuid-ossp extension to the database
   postgresql_ext:
     name: uuid-ossp
@@ -37,12 +35,6 @@
   environment:
     PGSSLROOTCERT: /tmp/pgcaroot/pgcaroot.cert
     PGSSLMODE: verify-full
-
-
-
-
-
-
 
 - name: Create database user
   shell:

--- a/ansible/roles/db/tasks/source_ccpo_user_file.yml
+++ b/ansible/roles/db/tasks/source_ccpo_user_file.yml
@@ -1,6 +1,4 @@
 ---
-
-
 - name: Download CCPO Users file from storage account
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
@@ -11,4 +9,4 @@
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name}}"
     blob: ccpo_users.yml
-    dest:  /src/script/ccpo_users.yml
+    dest: /src/script/ccpo_users.yml

--- a/ansible/roles/destroy_bootstrap/defaults/main.yml
+++ b/ansible/roles/destroy_bootstrap/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 bootstrap_init_tf: yes
 tf_base_dir: /src/terraform/providers/
 tfvars_file_path: /src/terraform/providers/bootstrap/dryrun.tfvars

--- a/ansible/roles/destroy_bootstrap/tasks/get_variables.yml
+++ b/ansible/roles/destroy_bootstrap/tasks/get_variables.yml
@@ -8,5 +8,5 @@
 
 - name: make k/v
   set_fact:
-    kv_tf: "{{ kv_tf|default({}) | combine({ item : (vars_vals[item] | regex_replace(\"'\",'\"'))  }) }}"
+    kv_tf: '{{ kv_tf|default({}) | combine({ item : (vars_vals[item] | regex_replace("''",''"''))  }) }}'
   with_items: "{{ vars_vals }}"

--- a/ansible/roles/destroy_bootstrap/tasks/main.yml
+++ b/ansible/roles/destroy_bootstrap/tasks/main.yml
@@ -1,10 +1,6 @@
 ---
-
-
 - name: get vars
   import_tasks: get_variables.yml
-
-
 
 - name: get bootstrap env outputs before destroy
   import_tasks: show_outputs.yml

--- a/ansible/roles/k8s/tasks/configure_private_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_private_cluster.yml
@@ -5,7 +5,7 @@
     storage_account_name: "{{ b_end.storage_account_name }}"
     container: "{{ b_end.container_name }}"
     blob: k8s.overlays
-    dest:  /tmp/private_k8s_overlays.tgz
+    dest: /tmp/private_k8s_overlays.tgz
 
 - name: Extract private cluster configs
   unarchive:
@@ -28,7 +28,6 @@
 - name: Assign Network Contributor role to the AKS Service Principal for the Virtual Network
   shell:
     cmd: az role assignment create --role "Network Contributor" --assignee {{ tf_app_env_outputs.aks_sp_id.value }} --scope {{tf_app_env_outputs.vnet_id.value }}
-
 
 - name: Get vmss
   shell:

--- a/ansible/roles/k8s/tasks/configure_public_cluster.yml
+++ b/ansible/roles/k8s/tasks/configure_public_cluster.yml
@@ -2,14 +2,11 @@
 - name: Connect to the {{ namespace }} kubernetes cluster
   shell: "az aks get-credentials -g cloudzero-vpc-{{ namespace }} -n cloudzero-k8s-{{ namespace }}"
 
-
-
 - name: Create {{ namespace }} namespace
   k8s:
     kind: Namespace
     state: present
     name: "{{ namespace }}"
-
 
 - name: "Attach the ACR to the K8s cluster"
   shell:
@@ -18,7 +15,6 @@
 - name: Assign Network Contributor role to the AKS Service Principal for the Virtual Network
   shell:
     cmd: az role assignment create --role "Network Contributor" --assignee {{ tf_app_env_outputs.aks_sp_id.value }} --scope {{tf_app_env_outputs.vnet_id.value }}
-
 
 - name: Get vmss
   shell:

--- a/ansible/roles/k8s/tasks/push_overlays.yml
+++ b/ansible/roles/k8s/tasks/push_overlays.yml
@@ -1,16 +1,12 @@
 ---
-
-
 - name: Compress overlays
   archive:
     path: "{{ playbook_dir }}/.out"
     dest: "{{ playbook_dir }}/k8s_overlays.tgz"
 
-
 - name: show outputs
   debug:
     msg: "{{ b_end }}"
-
 
 - name: push overlays to a storage account
   azure_rm_storageblob:
@@ -19,4 +15,4 @@
     container: "{{ b_end.container_name }}"
     blob: k8s.overlays
     src: "{{ playbook_dir }}/k8s_overlays.tgz"
-    content_type: 'gzip'
+    content_type: "gzip"

--- a/ansible/roles/terraform/defaults/main.yml
+++ b/ansible/roles/terraform/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
-
 init_tf: yes
 deploy_app_env: true
 show_app_env_outputs: true
@@ -10,8 +9,8 @@ application_subscription_id: "{{ lookup('env','SUBSCRIPTION_ID') }}"
 terraform_dir: "{{ tf_dir }}"
 terraform_deploy_version: "{{ deploy_tag }}"
 keyvault_list_service_principle_client_id: "{{ vault_client_id }}"
-keyvault_list_service_principle_secret:    "{{ vault_secret }}"
-keyvault_list_service_principle_tenant:  "{{ vault_tenant }}"
+keyvault_list_service_principle_secret: "{{ vault_secret }}"
+keyvault_list_service_principle_tenant: "{{ vault_tenant }}"
 bs_client_id: "{{ lookup('env','TF_VAR_OPS_CID') }}"
 bs_tenant: "{{ lookup('env','AZURE_TENANT_ID') }}"
 bs_secret: "{{ lookup('env','TF_VAR_OPS_SEC') }}"

--- a/ansible/roles/terraform/tasks/setup.yml
+++ b/ansible/roles/terraform/tasks/setup.yml
@@ -4,7 +4,6 @@
   debug:
     msg: "{{ app_kv_tf | to_nice_json }}"
 
-
 - debug:
     msg: "{{ lookup('env','TF_VAR_OPS_OID') }} {{ lookup('env','TF_VAR_OPS_SEC') }}"
 

--- a/ansible/roles/terraform/tasks/source_vars_from_storage_account.yml
+++ b/ansible/roles/terraform/tasks/source_vars_from_storage_account.yml
@@ -1,6 +1,4 @@
 ---
-
-
 - name: Download tfvars file
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"

--- a/ansible/roles/terraform/tasks/teardown.yml
+++ b/ansible/roles/terraform/tasks/teardown.yml
@@ -6,8 +6,6 @@
   set_fact:
     tf_dir: "{{ tf_base_dir }}/{{tf_subdir}}"
 
-
-
 - name: build backend
   set_fact:
     b_end: "{{ b_end|default({}) | combine( { item : tf_bootstrap_backend_outputs.outputs[item].value } ) }}"
@@ -51,8 +49,6 @@
 - name: sdhow tf_vars
   debug:
     msg: "{{ app_kv_tf | to_nice_json }}"
-
-
 
 - name: tf plan (no modules)
   terraform:

--- a/prettier.config.json
+++ b/prettier.config.json
@@ -2,5 +2,16 @@
   "semi": false,
   "singleQuote": true,
   "tabWidth": 2,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "overrides": [
+    {
+      "files": [
+        "**/*.scss",
+        "**/*.yml"
+      ],
+      "options": {
+        "singleQuote": false
+      }
+    }
+  ]
 }

--- a/script/format
+++ b/script/format
@@ -8,6 +8,7 @@ if [ "$1" == "check" ]; then
   poetry run isort --check ${FILES_TO_SORT}
   yarn run prettier --list-different "js/**/*.js" --config ./prettier.config.json
   yarn run prettier --list-different "styles/**/*.scss"
+  yarn run prettier --list-different "ansible/**/*.yml"
   if [ -x "$(command -v terraform)" ]; then
     terraform fmt -recursive -check terraform/
   fi
@@ -16,6 +17,7 @@ else
   poetry run isort ${FILES_TO_SORT}
   yarn run prettier --list-different --write "js/**/*.js" --config ./prettier.config.json
   yarn run prettier --list-different --write "styles/**/*.scss"
+  yarn run prettier --list-different --write "ansible/**/*.yml"
   if [ -x "$(command -v terraform)" ]; then
     terraform fmt -recursive terraform/
   fi

--- a/script/format
+++ b/script/format
@@ -6,18 +6,14 @@ FILES_TO_SORT="atat tests"
 if [ "$1" == "check" ]; then
   poetry run black --check ${FILES_TO_FORMAT}
   poetry run isort --check ${FILES_TO_SORT}
-  yarn run prettier --list-different "js/**/*.js" --config ./prettier.config.json
-  yarn run prettier --list-different "styles/**/*.scss"
-  yarn run prettier --list-different "ansible/**/*.yml"
+  yarn run prettier --list-different --config ./prettier.config.json "js/**/*.js" "styles/**/*.scss" "ansible/**/*.yml" 
   if [ -x "$(command -v terraform)" ]; then
     terraform fmt -recursive -check terraform/
   fi
 else
   poetry run black ${FILES_TO_FORMAT}
   poetry run isort ${FILES_TO_SORT}
-  yarn run prettier --list-different --write "js/**/*.js" --config ./prettier.config.json
-  yarn run prettier --list-different --write "styles/**/*.scss"
-  yarn run prettier --list-different --write "ansible/**/*.yml"
+  yarn run prettier --list-different --write --config ./prettier.config.json "js/**/*.js" "styles/**/*.scss" "ansible/**/*.yml" 
   if [ -x "$(command -v terraform)" ]; then
     terraform fmt -recursive terraform/
   fi


### PR DESCRIPTION
`script/format` now runs prettier on the yaml files in `./ansible`, which should make for a more consistent experience. I had to add config to ignore the `ansible/roles/k8s/tasks/templates/envvars.yml` file because prettier really doesn't like how we nest the collections in there, but I believe its a requirement of ConfigMap