### PR TITLE
Updates to Ghost Inspector "helper" tests

### DIFF
--- a/uitests/Add_expired_TO_to_Portfolio.html
+++ b/uitests/Add_expired_TO_to_Portfolio.html
@@ -51,7 +51,7 @@
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".stick-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.stick-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
@@ -66,7 +66,7 @@
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -332,7 +332,7 @@
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -347,7 +347,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -362,7 +362,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Add_future_TO_to_Portfolio.html
+++ b/uitests/Add_future_TO_to_Portfolio.html
@@ -51,7 +51,7 @@
 <td>css=.sticky-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".sticky-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add New Task Order")]">
+<tr original-target=".sticky-cta-buttons > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add New Task Order&quot;)]">
 <td>click</td>
 <td>css=.sticky-cta-buttons > .usa-button.usa-button-primary</td>
 <td></td>
@@ -66,7 +66,7 @@
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -332,7 +332,7 @@
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -347,7 +347,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -362,7 +362,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Create_TO_after_other_steps.html
+++ b/uitests/Create_TO_after_other_steps.html
@@ -66,7 +66,7 @@
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -332,7 +332,7 @@
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -347,7 +347,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -362,7 +362,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Create_expired_TO.html
+++ b/uitests/Create_expired_TO.html
@@ -51,7 +51,7 @@
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -66,7 +66,7 @@
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -332,7 +332,7 @@
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -347,7 +347,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -362,7 +362,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>

--- a/uitests/Create_future_TO.html
+++ b/uitests/Create_future_TO.html
@@ -51,7 +51,7 @@
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), "Add Task Order")]">
+<tr original-target=".empty-state__footer > .usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Add Task Order&quot;)]">
 <td>click</td>
 <td>css=.empty-state__footer > .usa-button.usa-button-primary</td>
 <td></td>
@@ -66,7 +66,7 @@
 <td>css=.upload-button</td>
 <td></td>
 </tr>
-<tr original-target=".upload-button,xpath=//span[contains(text(), "Browse")]">
+<tr original-target=".upload-button,xpath=//span[contains(text(), &quot;Browse&quot;)]">
 <td>click</td>
 <td>css=.upload-button</td>
 <td></td>
@@ -332,7 +332,7 @@
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
 </tr>
-<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), "Next: Submit Task Order")]">
+<tr original-target="a.usa-button.usa-button-primary,xpath=//a[contains(text(), &quot;Next: Submit Task Order&quot;)]">
 <td>click</td>
 <td>css=a.usa-button.usa-button-primary</td>
 <td></td>
@@ -347,7 +347,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm the uploaded Task Order is signed by the appropriate")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm the uploaded Task Order is signed by the appropriate&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(1) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
@@ -362,7 +362,7 @@
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>
 </tr>
-<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), "I confirm that the information entered here in matches that of the submitted Task Order.")]">
+<tr original-target=".task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label,xpath=//label[contains(text(), &quot;I confirm that the information entered here in matches that of the submitted Task Order.&quot;)]">
 <td>click</td>
 <td>css=.task-order__confirmation > div:nth-of-type(2) > .usa-input > fieldset.usa-input__choices > legend > label</td>
 <td></td>


### PR DESCRIPTION
A few weeks ago, Ghost Inspector updated the way that they escape double-quotes when tests are exported to HTML files. Soon thereafter, I updated all our main tests in Github. This PR is the same updates, applied to "helper" tests (not directly executed but imported into other tests). This does not represent any functional/logical changes to these tests.