### PR TITLE
Update Celery loglevel argument.

### DIFF
--- a/deploy/azure/azure.yml
+++ b/deploy/azure/azure.yml
@@ -170,7 +170,7 @@ spec:
               "-A",
               "celery_worker.celery",
               "worker",
-              "--loglevel=info",
+              "--loglevel=INFO",
             ]
           envFrom:
             - configMapRef:
@@ -244,7 +244,7 @@ spec:
               "-A",
               "celery_worker.celery",
               "beat",
-              "--loglevel=info",
+              "--loglevel=INFO",
             ]
           envFrom:
             - configMapRef:

--- a/script/dev_queue
+++ b/script/dev_queue
@@ -4,7 +4,7 @@
 
 set -e
 
-WORKER="poetry run celery -A celery_worker.celery worker --loglevel=info -B -c 1"
+WORKER="poetry run celery -A celery_worker.celery worker --loglevel=INFO -B -c 1"
 
 if [[ `command -v entr` ]]; then
   find atat | entr -r $WORKER


### PR DESCRIPTION
Celery no longer accepts lowercase values for the command line
`--loglevel` flag. This commit update the K8s config and local script to
supply the uppercase value.

Note that the Celery command exits with an error if you supply the wrong
value, so Celery was not running in the K8s cluster.