### PR TITLE
Update Ghost Inspector tests with bad dates (especially CLINs)

### DIFF
--- a/uitests/Add_future_TO_to_Portfolio.html
+++ b/uitests/Add_future_TO_to_Portfolio.html
@@ -215,7 +215,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -245,7 +245,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -290,7 +290,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_New_TO.html
+++ b/uitests/Create_New_TO.html
@@ -379,7 +379,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -409,7 +409,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -424,7 +424,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -439,7 +439,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_New_TO_(Base).html
+++ b/uitests/Create_New_TO_(Base).html
@@ -365,7 +365,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -395,7 +395,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -410,7 +410,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -425,7 +425,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_TO_after_other_steps.html
+++ b/uitests/Create_TO_after_other_steps.html
@@ -215,7 +215,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -245,7 +245,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -260,7 +260,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -275,7 +275,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_draft_TO.html
+++ b/uitests/Create_draft_TO.html
@@ -365,7 +365,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -395,7 +395,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -410,7 +410,7 @@ Imported from: AT-AT CI - login
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Create_future_TO.html
+++ b/uitests/Create_future_TO.html
@@ -215,7 +215,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -245,7 +245,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -290,7 +290,7 @@
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_Basics.html
+++ b/uitests/Reports_-_Basics.html
@@ -414,7 +414,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -448,7 +448,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -465,7 +465,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -482,7 +482,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -680,7 +680,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - September 30, 2020*</td>
+<td>*June 01, 2020 - December 31, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_Follow_TO_link.html
+++ b/uitests/Reports_-_Follow_TO_link.html
@@ -437,7 +437,7 @@ Imported from: AT-AT CI - Create New TO
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -473,7 +473,7 @@ Imported from: AT-AT CI - Create New TO
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -491,7 +491,7 @@ Imported from: AT-AT CI - Create New TO
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -509,7 +509,7 @@ Imported from: AT-AT CI - Create New TO
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -721,7 +721,7 @@ Funding Duration-->
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - September 30, 2020*</td>
+<td>*June 01, 2020 - December 31, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_TO,_App,_and_Environments.html
+++ b/uitests/Reports_-_with_TO,_App,_and_Environments.html
@@ -789,7 +789,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -823,7 +823,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -840,7 +840,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -857,7 +857,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
+++ b/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
@@ -399,7 +399,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -433,7 +433,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -467,7 +467,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1239,7 +1239,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1273,7 +1273,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1324,7 +1324,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1520,7 +1520,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - September 30, 2020*</td>
+<td>*June 01, 2020 - December 31, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_active_and_expired_TOs.html
+++ b/uitests/Reports_-_with_active_and_expired_TOs.html
@@ -399,7 +399,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -433,7 +433,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -450,7 +450,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -467,7 +467,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1098,7 +1098,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=.row > .col.col--grow.summary-item:nth-of-type(2) > .summary-item__value</td>
-<td>*October 01, 2019 - September 30, 2020*</td>
+<td>*June 01, 2020 - December 31, 2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_draft_TO.html
+++ b/uitests/Reports_-_with_draft_TO.html
@@ -549,7 +549,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -583,7 +583,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -600,7 +600,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_future_TO.html
+++ b/uitests/Reports_-_with_future_TO.html
@@ -390,7 +390,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -424,7 +424,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -475,7 +475,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_Draft_TO.html
+++ b/uitests/TO_Index_with_Draft_TO.html
@@ -414,7 +414,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -448,7 +448,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -465,7 +465,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -482,7 +482,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_TO.html
+++ b/uitests/TO_Index_with_TO.html
@@ -414,7 +414,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -448,7 +448,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -465,7 +465,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -482,7 +482,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_Unconfirmed_TO.html
+++ b/uitests/TO_Index_with_Unconfirmed_TO.html
@@ -414,7 +414,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -448,7 +448,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -465,7 +465,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>9</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -482,7 +482,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Index_with_future_TO.html
+++ b/uitests/TO_Index_with_future_TO.html
@@ -390,7 +390,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -424,7 +424,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -475,7 +475,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -789,7 +789,7 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <tr>
 <td>assertText</td>
 <td>css=#Upcoming > .accordion__content--list-item > .usa-grid > .usa-width-one-fourth:nth-of-type(1) > p</td>
-<td>*Oct 01, 2020 - Dec 31, 2020*</td>
+<td>*Jan 01, 2021 - Dec 31, 2021*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_3.html
+++ b/uitests/TO_Step_3.html
@@ -565,7 +565,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -580,7 +580,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -595,7 +595,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -610,7 +610,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>06</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -625,7 +625,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_3_-_Add_CLIN.html
+++ b/uitests/TO_Step_3_-_Add_CLIN.html
@@ -607,7 +607,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -624,7 +624,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -641,7 +641,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -658,7 +658,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>06</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -675,7 +675,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -831,7 +831,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -861,7 +861,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -876,7 +876,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -891,7 +891,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_3_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_3_-_with_Option_CLIN.html
@@ -580,7 +580,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -595,7 +595,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -610,7 +610,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -655,7 +655,7 @@ return pdfUrl;</script></td>
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_4.html
+++ b/uitests/TO_Step_4.html
@@ -607,7 +607,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -624,7 +624,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -641,7 +641,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -658,7 +658,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>06</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -675,7 +675,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -860,7 +860,7 @@ return downloadUrl == expectedPdfUrl;</script></td>
 <tr>
 <td>assertText</td>
 <td>css=table.fixed-table-wrapper > tbody > tr > td:nth-of-type(4)</td>
-<td>*10/01/2019 -  06/30/2020*</td>
+<td>*06/01/2020 - 12/31/2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_4_-_with_2_CLINs.html
+++ b/uitests/TO_Step_4_-_with_2_CLINs.html
@@ -639,7 +639,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -657,7 +657,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -675,7 +675,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -693,7 +693,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>06</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -711,7 +711,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -884,7 +884,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -918,7 +918,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -935,7 +935,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>6</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -952,7 +952,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1106,7 +1106,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>assertText</td>
 <td>css=table.fixed-table-wrapper > tbody > tr:nth-of-type(1) > td:nth-of-type(4)</td>
-<td>*10/01/2019 -  06/30/2020*</td>
+<td>*06/01/2020 -  12/31/2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -1181,7 +1181,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>assertText</td>
 <td>css=table.fixed-table-wrapper > tbody > tr:nth-of-type(2) > td:nth-of-type(4)</td>
-<td>*10/01/2019 -  06/30/2020*</td>
+<td>*06/01/2020 -  12/31/2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_4_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_4_-_with_Option_CLIN.html
@@ -624,7 +624,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -641,7 +641,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -658,7 +658,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -709,7 +709,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2020</td>
+<td>2021</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -848,7 +848,7 @@ Imported from: AT-AT CI - TO Step 2
 <tr>
 <td>assertText</td>
 <td>css=table.fixed-table-wrapper > tbody > tr > td:nth-of-type(4)</td>
-<td>*10/01/2019 -  06/30/2020*</td>
+<td>*01/01/2021 - 06/30/2021*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_5.html
+++ b/uitests/TO_Step_5.html
@@ -639,7 +639,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>10</td>
+<td>6</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -657,7 +657,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>01</td>
+<td>1</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -675,7 +675,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
-<td>2019</td>
+<td>2020</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -693,7 +693,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td>06</td>
+<td>12</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -711,7 +711,7 @@ Imported from: AT-AT CI - TO Step 3
 <tr>
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td>30</td>
+<td>31</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>
@@ -916,7 +916,7 @@ return downloadUrl == expectedPdfUrl;</script></td>
 <tr>
 <td>assertText</td>
 <td>css=table.fixed-table-wrapper > tbody > tr > td:nth-of-type(4)</td>
-<td>*10/01/2019 -  06/30/2020*</td>
+<td>*06/01/2020 - 12/31/2020*</td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>


### PR DESCRIPTION
Several Ghost Inspector tests/steps involve dates (especially those for active, expired, and upcoming Periods of Performance). Tests failed today because several tests included steps with dates ending September 30, 2020. This branch updates those steps, several subsequent steps, and other tests/steps with dates that were no longer accurate for the type of PoP they are supposed to test.