### PR TITLE
fix(TO creation step 3): onchange -> oninput

### DIFF
--- a/js/components/__tests__/pop_date_range.test.js
+++ b/js/components/__tests__/pop_date_range.test.js
@@ -144,13 +144,13 @@ describe('PopDateRange Test', () => {
     var endDateField = wrapper.find('fieldset[name="end_date"]')
 
     // set valid date range
-    await startDateField.find('input[name="date-month"]').setValue('01')
-    await startDateField.find('input[name="date-day"]').setValue('01')
-    await startDateField.find('input[name="date-year"]').setValue('2020')
-
     await endDateField.find('input[name="date-month"]').setValue('01')
     await endDateField.find('input[name="date-day"]').setValue('01')
     await endDateField.find('input[name="date-year"]').setValue('2020')
+
+    await startDateField.find('input[name="date-month"]').setValue('01')
+    await startDateField.find('input[name="date-day"]').setValue('01')
+    await startDateField.find('input[name="date-year"]').setValue('2020')
 
     // manually trigger the change event in the hidden fields
     await endDateField.find('input[name="end_date"]').trigger('change')

--- a/templates/components/pop_date_range.html
+++ b/templates/components/pop_date_range.html
@@ -73,7 +73,7 @@
                     type="number"
                     v-bind:class="{ 'usa-input-error': (month && !isMonthValid) }"
                     v-model="month"
-                    v-on:change="onInput"
+                    v-on:input="onInput"
                   />
                 </div>
 
@@ -87,7 +87,7 @@
                     v-bind:class="{ 'usa-input-error': (day && !isDayValid) }"
                     v-bind:max="daysMaxCalculation"
                     v-model="day"
-                    v-on:change="onInput"
+                    v-on:input="onInput"
                   />
                 </div>
 
@@ -100,7 +100,7 @@
                     v-model="year"
                     {% if maxdate %}max="{{ maxdate.year }}"{% endif %}
                     {% if mindate %}min="{{ mindate.year }}"{% endif %}
-                    v-on:change="onInput"
+                    v-on:input="onInput"
                   />
 
                 </div>
@@ -172,7 +172,7 @@
                       type="number"
                       v-bind:class="{ 'usa-input-error': (month && !isMonthValid) }"
                       v-model="month"
-                      v-on:change="onInput"
+                      v-on:input="onInput"
                       />
                   </div>
 
@@ -186,7 +186,7 @@
                       v-bind:class="{ 'usa-input-error': (day && !isDayValid) }"
                       v-bind:max="daysMaxCalculation"
                       v-model="day"
-                      v-on:change="onInput"
+                      v-on:input="onInput"
                       />
                   </div>
 
@@ -197,7 +197,7 @@
                       maxlength="4"
                       type="number"
                       v-model="year"
-                      v-on:change="onInput"
+                      v-on:input="onInput"
                       />
                   </div>
 


### PR DESCRIPTION
[Jira](https://ccpo.atlassian.net/browse/AT-5333?atlOrigin=eyJpIjoiMGM5NmFlMTliZGM2NDUwNzg0M2Q1NjA0ODk4NmViMmQiLCJwIjoiaiJ9)

## Why

> The difference is that the oninput event occurs immediately after the value of an element has changed, while onchange occurs when the element loses focus, after the content has been changed

From [w3Schools](https://www.w3schools.com/jsref/event_oninput.asp#:~:text=The%20difference%20is%20that%20the,works%20on%20elements.)