### PR TITLE
[AT-5333] Removed click after entering CLIN end date

### DIFF
--- a/uitests/Add_expired_TO_to_Portfolio.html
+++ b/uitests/Add_expired_TO_to_Portfolio.html
@@ -299,21 +299,6 @@
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Add_future_TO_to_Portfolio.html
+++ b/uitests/Add_future_TO_to_Portfolio.html
@@ -299,21 +299,6 @@
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Create_New_TO.html
+++ b/uitests/Create_New_TO.html
@@ -463,21 +463,6 @@ return pdfUrl;</script></td>
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Create_New_TO_(Base).html
+++ b/uitests/Create_New_TO_(Base).html
@@ -449,21 +449,6 @@ Imported from: AT-AT CI - login
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Create_TO_after_other_steps.html
+++ b/uitests/Create_TO_after_other_steps.html
@@ -299,21 +299,6 @@
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Create_draft_TO.html
+++ b/uitests/Create_draft_TO.html
@@ -449,21 +449,6 @@ Imported from: AT-AT CI - login
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>

--- a/uitests/Create_expired_TO.html
+++ b/uitests/Create_expired_TO.html
@@ -299,21 +299,6 @@
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Create_future_TO.html
+++ b/uitests/Create_future_TO.html
@@ -299,21 +299,6 @@
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_Basics.html
+++ b/uitests/Reports_-_Basics.html
@@ -510,23 +510,6 @@ return pdfUrl;</script></td>
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - Create New TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_Follow_TO_link.html
+++ b/uitests/Reports_-_Follow_TO_link.html
@@ -539,24 +539,6 @@ Imported from: AT-AT CI - Create New TO
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - Reports - Basics
-Imported from: AT-AT CI - Create New TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_with_TO,_App,_and_Environments.html
+++ b/uitests/Reports_-_with_TO,_App,_and_Environments.html
@@ -885,23 +885,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create TO after other steps
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
+++ b/uitests/Reports_-_with_active,_expired,_and_upcoming_TOs.html
@@ -495,23 +495,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create New TO (Base)
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>
@@ -915,23 +898,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Add expired TO to Portfolio
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>
@@ -1325,23 +1291,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
 <td>2021</td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Add future TO to Portfolio
--->
-<tr>
-<td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_active_and_expired_TOs.html
+++ b/uitests/Reports_-_with_active_and_expired_TOs.html
@@ -495,23 +495,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create New TO (Base)
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>
@@ -905,23 +888,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 <td>type</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
 <td>2019</td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Add expired TO to Portfolio
--->
-<tr>
-<td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/Reports_-_with_draft_TO.html
+++ b/uitests/Reports_-_with_draft_TO.html
@@ -645,23 +645,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create draft TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=a.action-group__action</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_with_expired_TO.html
+++ b/uitests/Reports_-_with_expired_TO.html
@@ -486,23 +486,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create expired TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/Reports_-_with_future_TO.html
+++ b/uitests/Reports_-_with_future_TO.html
@@ -486,23 +486,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create future TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Index_with_Draft_TO.html
+++ b/uitests/TO_Index_with_Draft_TO.html
@@ -510,23 +510,6 @@ return pdfUrl;</script></td>
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - Create New TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Index_with_TO.html
+++ b/uitests/TO_Index_with_TO.html
@@ -510,23 +510,6 @@ return pdfUrl;</script></td>
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - Create New TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Index_with_Unconfirmed_TO.html
+++ b/uitests/TO_Index_with_Unconfirmed_TO.html
@@ -510,23 +510,6 @@ return pdfUrl;</script></td>
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - Create New TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Index_with_expired_TO.html
+++ b/uitests/TO_Index_with_expired_TO.html
@@ -486,23 +486,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create expired TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Index_with_future_TO.html
+++ b/uitests/TO_Index_with_future_TO.html
@@ -486,23 +486,6 @@ Ghost Inspector flow control because button tends to take a little while to beco
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT Holding - Create future TO
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=input[type="submit"]</td>
 <td></td>
 </tr>

--- a/uitests/TO_Step_3.html
+++ b/uitests/TO_Step_3.html
@@ -649,21 +649,6 @@ return pdfUrl;</script></td>
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>

--- a/uitests/TO_Step_3_-_Add_CLIN.html
+++ b/uitests/TO_Step_3_-_Add_CLIN.html
@@ -703,23 +703,6 @@ Imported from: AT-AT CI - TO Step 2
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 3
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>
@@ -907,21 +890,6 @@ Imported from: AT-AT CI - TO Step 2
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
 <td>2020</td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
 </tr>
 </tbody>
 </table>

--- a/uitests/TO_Step_3_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_3_-_with_Option_CLIN.html
@@ -664,21 +664,6 @@ return pdfUrl;</script></td>
 </tr>
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>

--- a/uitests/TO_Step_4.html
+++ b/uitests/TO_Step_4.html
@@ -703,23 +703,6 @@ Imported from: AT-AT CI - TO Step 2
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 3
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>

--- a/uitests/TO_Step_4_-_with_2_CLINs.html
+++ b/uitests/TO_Step_4_-_with_2_CLINs.html
@@ -741,24 +741,6 @@ Imported from: AT-AT CI - TO Step 3
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 3 - Add CLIN
-Imported from: AT-AT CI - TO Step 3
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>
@@ -970,23 +952,6 @@ Imported from: AT-AT CI - TO Step 3
 <td>type</td>
 <td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-year > input[name="date-year"]</td>
 <td>2020</td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 3 - Add CLIN
--->
-<tr>
-<td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-1-end_date"] > .date-picker-component > .usa-form-group.usa-form-group-day > input[name="date-day"]</td>
-<td></td>
 </tr>
 <tr>
 <td>waitForPageToLoad</td>

--- a/uitests/TO_Step_4_-_with_Option_CLIN.html
+++ b/uitests/TO_Step_4_-_with_Option_CLIN.html
@@ -720,23 +720,6 @@ Imported from: AT-AT CI - TO Step 2
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 3 - with Option CLIN
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>

--- a/uitests/TO_Step_5.html
+++ b/uitests/TO_Step_5.html
@@ -741,24 +741,6 @@ Imported from: AT-AT CI - TO Step 3
 -->
 <tr>
 <td>waitForElementPresent</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>click</td>
-<td>css=fieldset[name="clins-0-start_date"] > .date-picker-component > .usa-form-group.usa-form-group-month > input[name="date-month"]</td>
-<td></td>
-</tr>
-<tr>
-<td>waitForPageToLoad</td>
-<td></td>
-<td></td>
-</tr>
-<!--Imported from: AT-AT CI - TO Step 4
-Imported from: AT-AT CI - TO Step 3
--->
-<tr>
-<td>waitForElementPresent</td>
 <td>css=fieldset[name="clins-0-end_date"] > .date-picker-component > div:nth-of-type(4) > .usa-form-group-date-ok > .icon.icon--ok.icon--green > svg.svg-inline--fa.fa-check-circle.fa-w-16</td>
 <td></td>
 </tr>


### PR DESCRIPTION
Prior to the fix introduced on [AT-5333](https://ccpo.atlassian.net/browse/AT-5333), the Step 3 screen of TO creation would not enable the CTA button until the user had shifted focus out of the "Year" field of the PoP End Date. This meant that I needed to have a test step that clicked into another field after completing the Step 3 screen, prior to clicking the CTA.

The bug ticket fixed the issue. This PR is to remove that (now-)extraneous click from all tests that interact with TO Creation Step 3.