### PR TITLE
[AT-5510] Fix Option Input Validation

### DIFF
--- a/atat/forms/edit_user.py
+++ b/atat/forms/edit_user.py
@@ -41,7 +41,8 @@ USER_FIELDS = {
             ("United States", "United States"),
             ("Foreign National", "Foreign National"),
             ("Other", "Other"),
-        ]
+        ],
+        default="",
     ),
     "designation": RadioField(
         translate("forms.edit_user.designation_label"),
@@ -50,6 +51,7 @@ USER_FIELDS = {
             ("civilian", "Civilian"),
             ("contractor", "Contractor"),
         ],
+        default="",
     ),
 }
 

--- a/js/components/__tests__/options_input.test.js
+++ b/js/components/__tests__/options_input.test.js
@@ -41,6 +41,42 @@ describe('SelectInput Renders Correctly', () => {
     })
     expect(wrapper.find('.usa-input select').element.value).toBe('')
   })
+
+  it('Should be considered invalid if default is re-selected', async () => {
+    const wrapper = mount(SelectWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+
+    await wrapper.find('select#selectfield').trigger('change')
+
+    expect(wrapper.contains('.usa-input--error')).toBe(true)
+    expect(wrapper.contains('.usa-input--success')).toBe(false)
+  })
+
+  it('Should be considered valid if value is selected', async () => {
+    const wrapper = mount(SelectWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+
+    const selectField = wrapper.find('select#selectfield')
+    await wrapper.find('option[value="a"]').setSelected()
+    await selectField.trigger('change')
+
+    expect(wrapper.contains('.usa-input--error')).toBe(false)
+    expect(wrapper.contains('.usa-input--success')).toBe(true)
+  })
 })
 
 const RadioWrapperComponent = makeTestWrapper({
@@ -84,5 +120,36 @@ describe('RadioInput Renders Correctly', () => {
       },
     })
     expect(wrapper.find('.usa-input input').element.checked).toBe(false)
+  })
+
+  it('Should be considered invalid if default is re-selected', async () => {
+    const wrapper = mount(RadioWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+
+    expect(wrapper.vm.$children[0].valid).toBe(false)
+  })
+
+  it('Should be considered valid if value is selected', async () => {
+    const wrapper = mount(RadioWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+
+    await wrapper.findAll('input[type="radio"]').at(0).setChecked()
+
+    expect(wrapper.contains('.usa-input--error')).toBe(false)
+    expect(wrapper.contains('.usa-input--success')).toBe(true)
   })
 })

--- a/js/components/__tests__/options_input.test.js
+++ b/js/components/__tests__/options_input.test.js
@@ -1,0 +1,88 @@
+import { mount } from '@vue/test-utils'
+
+import optionsinput from '../options_input'
+
+import { makeTestWrapper } from '../../test_utils/component_test_helpers'
+
+const SelectWrapperComponent = makeTestWrapper({
+  components: {
+    optionsinput,
+  },
+  templatePath: 'select_input_template.html',
+  data: function () {
+    const { initialvalue, optional } = this.initialData
+    return { initialvalue, optional }
+  },
+})
+
+describe('SelectInput Renders Correctly', () => {
+  it('Should initialize checked', () => {
+    const wrapper = mount(SelectWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: 'b',
+          optional: true,
+        },
+      },
+    })
+    expect(wrapper.find('.usa-input select').element.value).toBe('b')
+  })
+
+  it('Should initialize unchecked', () => {
+    const wrapper = mount(SelectWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+    expect(wrapper.find('.usa-input select').element.value).toBe('')
+  })
+})
+
+const RadioWrapperComponent = makeTestWrapper({
+  components: {
+    optionsinput,
+  },
+  templatePath: 'radio_input_template.html',
+  data: function () {
+    const { initialvalue, optional } = this.initialData
+    return { initialvalue, optional }
+  },
+})
+
+describe('RadioInput Renders Correctly', () => {
+  it('Should initialize checked', () => {
+    const wrapper = mount(RadioWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: 'b',
+          optional: true,
+        },
+      },
+    })
+    expect(wrapper.find('.usa-input input[value="a"]').element.checked).toBe(
+      false
+    )
+    expect(wrapper.find('.usa-input input[value="b"]').element.checked).toBe(
+      true
+    )
+  })
+
+  it('Should initialize unchecked', () => {
+    const wrapper = mount(RadioWrapperComponent, {
+      propsData: {
+        name: 'testCheck',
+        initialData: {
+          initialvalue: '',
+          optional: false,
+        },
+      },
+    })
+    expect(wrapper.find('.usa-input input').element.checked).toBe(false)
+  })
+})

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -28,6 +28,21 @@ export default {
     }
   },
 
+  mounted: function () {
+    const selectEl = this.$el.querySelector('select')
+    if (selectEl) {
+      selectEl.value = this.value
+    }
+
+    const radios = this.$el.querySelectorAll('input[type="radio"]')
+    if (radios && radios.length) {
+      const initialValue = this.value
+      radios.forEach(function (radio) {
+        radio.checked = radio.value == initialValue
+      })
+    }
+  },
+
   methods: {
     onInput: function (changeEvent) {
       this.value = changeEvent.srcElement.value

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -45,8 +45,7 @@ export default {
       return this._isValid(this.value)
     },
     showError: function () {
-      const showError =
-        (this.initialErrors && this.initialErrors.length) || false
+      const showError = this.initialErrors && this.initialErrors.length
       return showError || (this.modified && !this.valid)
     },
     showValid: function () {

--- a/js/components/options_input.js
+++ b/js/components/options_input.js
@@ -9,7 +9,10 @@ export default {
       type: Array,
       default: () => [],
     },
-    initialValue: String,
+    initialValue: {
+      type: String,
+      default: '',
+    },
     optional: Boolean,
     nullOption: {
       type: String,
@@ -18,17 +21,17 @@ export default {
   },
 
   data: function () {
-    const showError = (this.initialErrors && this.initialErrors.length) || false
     return {
-      showError: showError,
-      showValid: false,
       validationError: this.initialErrors.join(' '),
       value: this.initialValue,
+      modified: false,
     }
   },
 
   methods: {
-    onInput: function () {
+    onInput: function (changeEvent) {
+      this.value = changeEvent.srcElement.value
+      this.modified = true
       emitFieldChange(this)
     },
 
@@ -40,6 +43,14 @@ export default {
   computed: {
     valid: function () {
       return this._isValid(this.value)
+    },
+    showError: function () {
+      const showError =
+        (this.initialErrors && this.initialErrors.length) || false
+      return showError || (this.modified && !this.valid)
+    },
+    showValid: function () {
+      return this.modified && this.valid
     },
   },
 }

--- a/templates/components/clin_fields.html
+++ b/templates/components/clin_fields.html
@@ -83,7 +83,7 @@
             {% if fields %}
               {{ OptionsInput(fields.jedi_clin_type, show_validation=False, optional=False) }}
             {% else %}
-              <optionsinput :name="'clins-' + clinIndex + '-jedi_clin_type'" :optional='false' inline-template>
+              <optionsinput :name="'clins-' + clinIndex + '-jedi_clin_type'" :optional='false' :initial-value="'JEDI_CLIN_1'" inline-template>
                 <div v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">
                   <fieldset data-ally-disabled="true" class="usa-input__choices" v-on:change="onInput">
                       <legend>

--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -13,10 +13,10 @@
     name='{{ field.name }}'
     inline-template
     {% if field.errors %}v-bind:initial-errors='{{ field.errors | list }}'{% endif %}
-    {% if field.data and field.data != "None" %}v-bind:initial-value="'{{ field.data }}'"{% endif %}
+    {% if field.data and field.data != "None" %}v-bind:initial-value="{{ field.data }}"{% endif %}
     key='{{ field.name }}'
     v-bind:optional={{ optional|lower }}
-    v-bind:null-option="'{{ field.default }}'"
+    {% if field.default and field.default != "None" %}v-bind:null-option="{{ field.default }}"{% endif %}
     >
     <div
       v-bind:class="['usa-input', { 'usa-input--error': showError, 'usa-input--success': showValid }]">


### PR DESCRIPTION
Option input fields (select dropdowns and radio buttons) were not correctly reporting their validity to their parent form, causing them to be ignored for the purposes of allowing form submission.