### PR TITLE
fixes bad reference to bootstrap state file

### DIFF
--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -7,6 +7,7 @@
 - name: fetch bootstrap vars
   import_tasks: pull_tfvars.yml
 
+
 - name: fetch bootstrap state
   import_tasks: pull_remote_state.yml
   when: fetch_bootstrap_state == true

--- a/ansible/roles/bootstrap/tasks/main.yml
+++ b/ansible/roles/bootstrap/tasks/main.yml
@@ -7,7 +7,6 @@
 - name: fetch bootstrap vars
   import_tasks: pull_tfvars.yml
 
-
 - name: fetch bootstrap state
   import_tasks: pull_remote_state.yml
   when: fetch_bootstrap_state == true

--- a/ansible/roles/bootstrap/tasks/pull_remote_state.yml
+++ b/ansible/roles/bootstrap/tasks/pull_remote_state.yml
@@ -1,4 +1,6 @@
 ---
+
+
 - name: Download bootstrap state
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
@@ -8,5 +10,5 @@
     resource_group: "{{ bootstrap_resource_group_name }}"
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name }}"
-    blob: terraform.bootstrap.tfstate
+    blob: "{{az_environment}}.bootstrap.terraform.tfstate"
     dest: /src/terraform/providers/bootstrap/terraform.tfstate

--- a/ansible/roles/bootstrap/tasks/pull_remote_state.yml
+++ b/ansible/roles/bootstrap/tasks/pull_remote_state.yml
@@ -1,14 +1,12 @@
 ---
-
-
 - name: Download bootstrap state
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
     secret: "{{ bs_secret }}"
-    client_id: "{{  bs_client_id  }}"
+    client_id: "{{ bs_client_id }}"
     tenant: "{{ bs_tenant }}"
     resource_group: "{{ bootstrap_resource_group_name }}"
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name }}"
-    blob: "{{az_environment}}.bootstrap.terraform.tfstate"
+    blob: "{{ az_environment }}.bootstrap.terraform.tfstate"
     dest: /src/terraform/providers/bootstrap/terraform.tfstate

--- a/ansible/roles/bootstrap/tasks/pull_tfvars.yml
+++ b/ansible/roles/bootstrap/tasks/pull_tfvars.yml
@@ -1,13 +1,12 @@
 ---
-
 - name: Download tfvars
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
     secret: "{{ bs_secret }}"
-    client_id: "{{  bs_client_id  }}"
+    client_id: "{{ bs_client_id }}"
     tenant: "{{ bs_tenant }}"
     resource_group: "{{ bootstrap_resource_group_name }}"
     storage_account_name: "{{ bootstrap_storage_account_name }}"
-    container: "{{ bootstrap_container_name}}"
+    container: "{{ bootstrap_container_name }}"
     blob: bootstrap.tfvars
-    dest:  /src/terraform/providers/bootstrap/bootstrap.tfvars
+    dest: /src/terraform/providers/bootstrap/bootstrap.tfvars

--- a/ansible/roles/bootstrap/tasks/pull_tfvars.yml
+++ b/ansible/roles/bootstrap/tasks/pull_tfvars.yml
@@ -1,5 +1,6 @@
 ---
-- name: Download bootstrap state
+
+- name: Download tfvars
   azure_rm_storageblob:
     subscription_id: "{{ bootstrap_subscription_id }}"
     secret: "{{ bs_secret }}"
@@ -9,4 +10,4 @@
     storage_account_name: "{{ bootstrap_storage_account_name }}"
     container: "{{ bootstrap_container_name}}"
     blob: bootstrap.tfvars
-    dest: /src/terraform/providers/bootstrap/bootstrap.tfvars
+    dest:  /src/terraform/providers/bootstrap/bootstrap.tfvars


### PR DESCRIPTION
This fixes a bad reference to terraform bootstrap state residing in a storage account.  

Prior to fix, we could not reliably re-run the deployment image because the environment specific bootstrap state file needs to get pulled into the deploy image so it knows which resources to target.