### PR TITLE
[AT-5554] Update CirleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -190,7 +190,7 @@ commands:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 18.06.0-ce
+          version: 19.03.13
       - install_azure_cli
       - log_into_ops_registry
       - restore_docker_image
@@ -237,12 +237,12 @@ commands:
 jobs:
   docker-build:
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 18.06.0-ce
+          version: 19.03.13
       - install_azure_cli
       - log_into_ops_registry
       - run:
@@ -254,7 +254,7 @@ jobs:
 
   test:
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
       - image: circleci/postgres:10-alpine-ram
       - image: circleci/redis:4-alpine3.8
     environment:
@@ -262,7 +262,7 @@ jobs:
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 18.06.0-ce
+          version: 19.03.13
       - restore_docker_image
       - setup_datastores:
           pgdatabase: atat_test
@@ -281,13 +281,13 @@ jobs:
 
   integration-tests:
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
       - image: circleci/postgres:10-alpine-ram
       - image: circleci/redis:4-alpine3.8
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 18.06.0-ce
+          version: 19.03.13
       - restore_docker_image
       - setup_datastores:
           pgdatabase: atat
@@ -340,7 +340,7 @@ jobs:
 
   deploy-staging:
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
     steps:
       - deploy:
           namespace: staging
@@ -353,7 +353,7 @@ jobs:
         type: string
         default: ${AZURE_REGISTRY}
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
     steps:
       - deploy:
           namespace: master
@@ -362,12 +362,12 @@ jobs:
 
   push-app-images:
     docker:
-      - image: docker:18.06.0-ce-git
+      - image: docker:19
     steps:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: true
-          version: 18.06.0-ce
+          version: 19.03.13
       - install_azure_cli
       - log_into_ops_registry
       - run:
@@ -399,7 +399,7 @@ jobs:
       - checkout
       - setup_remote_docker:
           docker_layer_caching: false
-          version: 19.03.12
+          version: 19.03.13
       - install_azure_cli
       - log_into_ops_registry
       - run:
@@ -432,7 +432,7 @@ jobs:
        - checkout
        - setup_remote_docker:
            docker_layer_caching: false
-           version: 19.03.12
+           version: 19.03.13
        - install_azure_cli
        - log_into_ops_registry
        - run:


### PR DESCRIPTION
This PR will update all docker images used by CircleCI to the supported "docker:19" with version `19.03.13`.  Additionally, anywhere it was using version `19.03.12` has been updated to the above version.  

[Jira](https://ccpo.atlassian.net/browse/AT-5554)