### PR TITLE
Remove yum updateinfo from application Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@ ENV TZ UTC
 
 WORKDIR /install
 
-RUN yum updateinfo && \
-      yum install -y \
+RUN yum install -y \
       curl \
       ca-certificates \
       git \


### PR DESCRIPTION
By removing `yum updateinfo` from the application Dockerfile, we avoid reaching out to the CodeReady repository. This way, the state of our session with Redhat doesn't matter for the purposes of building the application. The base `rhel-py` image should be the one that is soley responsible for ensuring package repositories are up to date.