### PR TITLE
Bump libssl in the deploy-staging workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ commands:
       - run:
           name: Configure kubectl
           command: |
-            apk add libssl1.0
+            apk add libssl1.1
             az aks get-credentials --name << pipeline.parameters.cluster_name >>  --resource-group << pipeline.parameters.resource_group >>
       - run:
           name: Add gettext package


### PR DESCRIPTION
Our `deploy-staging` workflow [began to fail](https://app.circleci.com/pipelines/github/dod-ccpo/atst/5736/workflows/e4e9047d-6b35-4365-a9fd-1be883e03e74/jobs/25584) after we upgraded the Circle CI docker image used in our CI pipeline. It was due to the version of `libssl` that we install in the [`Configure kubectl`](https://app.circleci.com/pipelines/github/dod-ccpo/atst/5736/workflows/e4e9047d-6b35-4365-a9fd-1be883e03e74/jobs/25584/parallel-runs/0/steps/0-112) step. This PR bumps that package version from 1.0 -> 1.1 .

In [this workflow](https://app.circleci.com/pipelines/github/dod-ccpo/atst/5742/workflows/811259d6-ca64-4a76-9228-c1538a2100a4/jobs/25594), in addition to the version bump commit in this PR, we commented out some Circle CI config so that the `deploy-staging` workflow would be triggered as a dry run. The version bump appears to have successfully solved the issue since the `Configure kubectl` step passed.