### PR TITLE
[AT-5653] Add Dockerhub authentication to Docker image pulls in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -445,47 +445,47 @@ jobs:
           command: docker push << pipeline.parameters.container_registry >>.azurecr.io/ops:latest
 
   deploy-atat:
-     docker:
-       - image: docker:19
-         auth:
+    docker:
+      - image: docker:19
+        auth:
           username: $DOCKERHUB_USERNAME
           password: $DOCKERHUB_PASSWORD
-     environment:
-       DOCKER_BUILDKIT: 1
-     steps:
-       - checkout
-       - setup_remote_docker:
-           docker_layer_caching: false
-           version: 19.03.13
-       - install_azure_cli
-       - log_into_ops_registry
-       - run:
-           name: Build ops deployment image and deploy to container instances
-           command: |
-             docker build \
-             --cache-from <<pipeline.parameters.ops_registry >>.azurecr.io/ops-cache:latest \
-             -t ops:latest \
-             --build-arg operator_sp_client_id=${AZURE_SP} \
-             --build-arg operator_sp_object_id=${OPERATOR_SP_OBJECT_ID} \
-             --build-arg operator_sp_secret=${AZURE_SP_PASSWORD} \
-             --build-arg azure_tenant=${AZURE_SP_TENANT} \
-             --build-arg azure_subscription_id=${AZURE_SUBSCRIPTION} \
-             --build-arg operator_sp_url=${OPERATOR_SP_URL} \
-             --build-arg circle_api_token=${CIRCLE_API_TOKEN} \
-             --build-arg build_branch=<< pipeline.parameters.build_branch >> \
-             --build-arg az_environment=<< pipeline.parameters.az_environment >> \
-              -f Dockerfile.ops .
-       - run:
-           name: Tag ops image
-           command: docker tag ops:latest <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}
-       - run:
-           name: Push ops image
-           command: docker push  <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}
-       - run:
-           name: run container image
-           command: |
-             az account set -s ${AZURE_SUBSCRIPTION}
-             az container create -g cloudzero-ops --name deploy-build-${CIRCLE_BUILD_NUM} --ip-address Private --vnet cloudzero-ops-network --subnet deployment-subnet --image  <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}  --registry-password ${AZURE_SP_PASSWORD} --registry-username ${AZURE_SP} --command-line "ansible-playbook site.yml --extra-vars deploy_tag=v0.1.0" --cpu 4 --memory 4 --restart-policy Never
+    environment:
+      DOCKER_BUILDKIT: 1
+    steps:
+      - checkout
+      - setup_remote_docker:
+          docker_layer_caching: false
+          version: 19.03.13
+      - install_azure_cli
+      - log_into_ops_registry
+      - run:
+          name: Build ops deployment image and deploy to container instances
+          command: |
+            docker build \
+            --cache-from <<pipeline.parameters.ops_registry >>.azurecr.io/ops-cache:latest \
+            -t ops:latest \
+            --build-arg operator_sp_client_id=${AZURE_SP} \
+            --build-arg operator_sp_object_id=${OPERATOR_SP_OBJECT_ID} \
+            --build-arg operator_sp_secret=${AZURE_SP_PASSWORD} \
+            --build-arg azure_tenant=${AZURE_SP_TENANT} \
+            --build-arg azure_subscription_id=${AZURE_SUBSCRIPTION} \
+            --build-arg operator_sp_url=${OPERATOR_SP_URL} \
+            --build-arg circle_api_token=${CIRCLE_API_TOKEN} \
+            --build-arg build_branch=<< pipeline.parameters.build_branch >> \
+            --build-arg az_environment=<< pipeline.parameters.az_environment >> \
+             -f Dockerfile.ops .
+      - run:
+          name: Tag ops image
+          command: docker tag ops:latest <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}
+      - run:
+          name: Push ops image
+          command: docker push  <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}
+      - run:
+          name: run container image
+          command: |
+            az account set -s ${AZURE_SUBSCRIPTION}
+            az container create -g cloudzero-ops --name deploy-build-${CIRCLE_BUILD_NUM} --ip-address Private --vnet cloudzero-ops-network --subnet deployment-subnet --image  <<pipeline.parameters.ops_registry >>.azurecr.io/ops:${CIRCLE_BUILD_NUM}  --registry-password ${AZURE_SP_PASSWORD} --registry-username ${AZURE_SP} --command-line "ansible-playbook site.yml --extra-vars deploy_tag=v0.1.0" --cpu 4 --memory 4 --restart-policy Never
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -301,6 +301,9 @@ jobs:
       - setup_datastores:
           pgdatabase: atat
       - run:
+          name: Log into Dockerhub
+          command: echo "$DOCKERHUB_PASSWORD" | docker login --username $DOCKERHUB_USERNAME --password-stdin
+      - run:
           name: Start application container
           command: |
             docker run -d \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -238,6 +238,9 @@ jobs:
   docker-build:
     docker:
       - image: docker:19
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - setup_remote_docker:
@@ -257,6 +260,9 @@ jobs:
       - image: docker:19
       - image: circleci/postgres:10-alpine-ram
       - image: circleci/redis:4-alpine3.8
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     environment:
       TF_VERSION: "0.12.24"
     steps:
@@ -284,6 +290,9 @@ jobs:
       - image: docker:19
       - image: circleci/postgres:10-alpine-ram
       - image: circleci/redis:4-alpine3.8
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - setup_remote_docker:
           docker_layer_caching: true
@@ -341,6 +350,9 @@ jobs:
   deploy-staging:
     docker:
       - image: docker:19
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - deploy:
           namespace: staging
@@ -354,6 +366,9 @@ jobs:
         default: ${AZURE_REGISTRY}
     docker:
       - image: docker:19
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - deploy:
           namespace: master
@@ -363,6 +378,9 @@ jobs:
   push-app-images:
     docker:
       - image: docker:19
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - setup_remote_docker:
@@ -393,6 +411,9 @@ jobs:
   push-ops-image:
     docker:
       - image: docker:19
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     environment:
       DOCKER_BUILDKIT: 1
     steps:
@@ -426,6 +447,9 @@ jobs:
   deploy-atat:
      docker:
        - image: docker:19
+         auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
      environment:
        DOCKER_BUILDKIT: 1
      steps:


### PR DESCRIPTION
Docker recently announced that [on November 1st, they will start rate limiting anonymous container pulls as well as authenticated pulls on the free plan](https://www.docker.com/blog/scaling-docker-to-serve-millions-more-developers-network-egress/).

CircleCI responded to this news with [the following](https://circleci.com/docs/2.0/private-images/):
> CircleCI has partnered with Docker to ensure that our users can continue to access Docker Hub without rate limits. As of November 1st 2020, with few exceptions, you should not be impacted by any rate limits when pulling images from Docker Hub through CircleCI.

We can see this in action in a workflow that was run before this PR. In [this step](https://app.circleci.com/pipelines/github/dod-ccpo/atst/5932/workflows/194cbc89-409b-4e5c-85ab-755e2e12a873/jobs/26024/parallel-runs/0/steps/0-0), we see the following message:
```
Warning: No authentication provided, using CircleCI credentials for pulls from Docker Hub.
```

Nevertheless, CircleCI's announcement continues:
> However, these rate limits may go into effect for CircleCI users in the future. That’s why we’re encouraging you and your team to add Docker Hub authentication to your CircleCI configuration and consider upgrading your Docker Hub plan, as appropriate, to prevent any impact from rate limits in the future.

With this in mind, this PR adds DockerHub authentication to our CircleCI workflow so that we can mitigate rate limiting if/when it goes into effect.

Now, [ steps](https://app.circleci.com/pipelines/github/dod-ccpo/atst/5934/workflows/21f75836-282a-486e-845e-c4fcc70b1a5a/jobs/26029/parallel-runs/0/steps/0-0) in workflows that pull docker image no longer contain the warning message.

The credentials we use to authenticate against DockerHub in CircleCI are on a free tier at the time of this PR. This means that instead of being rate limited to 100 pulls every 6 hours, our limit is bumped to 200 pulls every 6 hours. We should be able to survive on this limit, but we should pay attention to our consumption rates and upgrade our plan if needed so that we don't encounter rate limiting.