### PR TITLE
set 'pool_pre_ping' flag on db engine creation

### DIFF
--- a/script/create_database.py
+++ b/script/create_database.py
@@ -23,7 +23,7 @@ def _create_connection(config, db):
         config.get("PGPORT"),
         db,
     )
-    engine = sqlalchemy.create_engine(database_uri)
+    engine = sqlalchemy.create_engine(database_uri, pool_pre_ping=True)
     return engine.connect()
 
 


### PR DESCRIPTION
[Jira](https://ccpo.atlassian.net/browse/AT-5567?atlOrigin=eyJpIjoiMTEwODkxZDVjNGQ2NDkyN2JkOGJhZDdmZmJmZjc2YmUiLCJwIjoiaiJ9)

The 502 error that the above ticket references is caused by an unhandled [generic DBAPI exception](https://docs.sqlalchemy.org/en/13/errors.html#operationalerror) in our app.

From [Dealing with Disconnects](https://docs.sqlalchemy.org/en/13/core/pooling.html#disconnect-handling-pessimistic), includes a small change to send a ping before using a connection in the DB pool.