### PR TITLE
[AT-5577] Escape query params in /task_orders/<portfolio_id>/download_link

### DIFF
--- a/atat/routes/task_orders/new.py
+++ b/atat/routes/task_orders/new.py
@@ -1,5 +1,5 @@
 from flask import current_app as app
-from flask import g, jsonify, redirect, render_template
+from flask import escape, g, jsonify, redirect, render_template
 from flask import request as http_request
 from flask import url_for
 
@@ -131,8 +131,8 @@ def upload_token(portfolio_id):
 @task_orders_bp.route("/task_orders/<portfolio_id>/download_link")
 @user_can(Permissions.VIEW_TASK_ORDER_DETAILS, message="view task order download link")
 def download_link(portfolio_id):
-    filename = http_request.args.get("filename")
-    object_name = http_request.args.get("objectName")
+    filename = str(escape(http_request.args.get("filename")))
+    object_name = str(escape(http_request.args.get("objectName")))
     render_args = {
         "downloadLink": app.csp.files.generate_download_link(object_name, filename)
     }


### PR DESCRIPTION
Closes [AT-5577](https://ccpo.atlassian.net/browse/AT-5577)

In this route, user input was interpolated directly into text that was rendered back to the screen. We now escape that input so that no potentially malicious payloads are rendered to the screen.

Thankfully, the use of this endpoint is very limited -- it is only used in our [`UploadInput`](https://github.com/dod-ccpo/atst/blob/staging/templates/components/upload_input.html) component, which itself is only used in [Step 1](https://github.com/dod-ccpo/atst/blob/staging/templates/task_orders/step_1.html) of the "new task order" flow. In other cases, we generate a download link on the back end and render it with Jinja, as opposed to generating the link from user input on the front end with Vue. The data coming from the back end is considered safe because it passes back end validation when the [Step 1 form data](https://github.com/dod-ccpo/atst/blob/de5d44285911796979ddda459fc369a52a4e277c/atat/forms/task_order.py#L129-L151) is submitted.