### PR TITLE
[AT-5708] Terraform for deployment VM

### DIFF
--- a/ops/vm/cloud_config.yml
+++ b/ops/vm/cloud_config.yml
@@ -1,0 +1,50 @@
+#cloud-config
+package_update: true
+packages:
+  - software-properties-common
+  - apt-transport-https
+  - wget
+  - firefox
+  - xmlsec1
+  - curl
+  - vim
+  - gettext
+  - unzip
+  - libbz2-dev
+  - libssl-dev
+  - libpq-dev
+  - jq
+  - gnupg2
+  - xrdp
+  - xfce4
+  - libxml2-dev
+  - libxmlsec1-dev
+  - libxmlsec1-openssl
+apt_sources:
+  - source: "ppa:ansible/ansible"
+  - source: "ppa:deadsnakes/ppa"
+runcmd:
+  # enable rdp
+  - echo xfce4-session > /home/${username}/.xsession
+  - [systemctl, enable, xrdp]
+  - [service, xrdp, restart]
+  # install az
+  - curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+  # install terraform repo
+  - sudo apt-add-repository --yes --update "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+  - curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+  # install docker
+  - wget -P /tmp https://download.docker.com/linux/ubuntu/dists/bionic/pool/stable/amd64/docker-ce-cli_19.03.13~3-0~ubuntu-bionic_amd64.deb
+  - dpkg -i /tmp/docker-ce-cli_19.03.13~3-0~ubuntu-bionic_amd64.deb
+  # install kubectl repo
+  - curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+  - echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list
+  # Run second round of installs
+  - sudo apt-get update
+  - sudo apt-get install -y python3.7 python3.7-dev ansible terraform kubectl
+  - sudo apt-get install -y python3-pip
+  - [update-alternatives, --install, /usr/bin/python, python, /usr/bin/python3.7, "1"]
+  - git clone https://github.com/dod-ccpo/atst.git /home/${username}/atst
+  - python -m pip install -r /home/${username}/atst/ops/requirements.txt
+  - [snap, install, code, "--classic"]
+

--- a/ops/vm/main.tf
+++ b/ops/vm/main.tf
@@ -1,0 +1,124 @@
+provider "azurerm" {
+  version = "~>2.0"
+  features {}
+}
+
+resource "azurerm_resource_group" "vm_resource_group" {
+  name     = var.resource_group
+  location = var.region
+
+}
+
+resource "azurerm_virtual_network" "vm_vnet" {
+  name                = var.vnet
+  address_space       = ["10.2.0.0/24"]
+  location            = var.region
+  resource_group_name = azurerm_resource_group.vm_resource_group.name
+}
+
+resource "azurerm_subnet" "vm_subnet" {
+  name                 = var.subnet
+  resource_group_name  = azurerm_resource_group.vm_resource_group.name
+  virtual_network_name = azurerm_virtual_network.vm_vnet.name
+  address_prefixes     = ["10.2.0.0/24"]
+}
+
+resource "azurerm_public_ip" "vm_publicip" {
+  name                = "${var.vm_name}-ip"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.vm_resource_group.name
+  allocation_method   = "Static"
+}
+
+resource "azurerm_network_security_group" "vm_nsg" {
+  name                = "${var.vm_name}-nsg"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.vm_resource_group.name
+
+  security_rule {
+    name                       = "SSH"
+    priority                   = 300
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "TCP"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+  security_rule {
+    name                       = "RDP"
+    priority                   = 320
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "TCP"
+    source_port_range          = "*"
+    destination_port_range     = "3389"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_network_interface" "vm_nic" {
+  name                = "${var.vm_name}-nic"
+  location            = var.region
+  resource_group_name = azurerm_resource_group.vm_resource_group.name
+
+  ip_configuration {
+    name                          = "ipconfig1"
+    subnet_id                     = azurerm_subnet.vm_subnet.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.vm_publicip.id
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "nic_nsg_assoc" {
+  network_interface_id      = azurerm_network_interface.vm_nic.id
+  network_security_group_id = azurerm_network_security_group.vm_nsg.id
+}
+
+resource "random_password" "vm_user_password" {
+  length           = 16
+  min_numeric      = 1
+  special          = false
+  override_special = "!"
+}
+
+data "template_cloudinit_config" "config" {
+  gzip          = true
+  base64_encode = true
+  part {
+    content_type = "text/cloud-config"
+    content      = templatefile("${path.module}/cloud_config.yml", { username = var.username })
+
+  }
+}
+
+resource "azurerm_linux_virtual_machine" "vm" {
+  name                  = var.vm_name
+  location              = var.region
+  resource_group_name   = azurerm_resource_group.vm_resource_group.name
+  network_interface_ids = [azurerm_network_interface.vm_nic.id]
+  size                  = "Standard_DS1_v2"
+  custom_data           = data.template_cloudinit_config.config.rendered
+
+  os_disk {
+    name                 = "${var.vm_name}-disk"
+    caching              = "ReadWrite"
+    storage_account_type = "Premium_LRS"
+    disk_size_gb         = 30
+  }
+
+  source_image_reference {
+    publisher = "Canonical"
+    offer     = "UbuntuServer"
+    sku       = "18.04-LTS"
+    version   = "latest"
+  }
+
+  computer_name                   = var.vm_name
+  admin_username                  = var.username
+  admin_password                  = random_password.vm_user_password.result
+  disable_password_authentication = false
+
+}

--- a/ops/vm/outputs.tf
+++ b/ops/vm/outputs.tf
@@ -1,0 +1,16 @@
+output "vm_username" {
+  value = var.username
+}
+
+output "vm_user_password" {
+  value = random_password.vm_user_password.result
+}
+
+output "public_ip_address" {
+  value = azurerm_public_ip.vm_publicip.ip_address
+}
+
+output "cloud-init_message" {
+  value = "cloud-init script will take a few minutes to finish. Check /var/log/cloud-init-output.log for progress"
+}
+

--- a/ops/vm/variables.tf
+++ b/ops/vm/variables.tf
@@ -1,0 +1,35 @@
+variable "vm_name" {
+  description = "The base name of virtual machine"
+  default     = "dry-run-ops-vm"
+  type        = string
+}
+
+variable "region" {
+  description = "Azure region"
+  default     = "eastus"
+  type        = string
+}
+
+variable "username" {
+  description = "username to be created on the vm"
+  default     = "atat"
+  type        = string
+}
+
+variable "vnet" {
+  description = "vnet vm will use"
+  default     = "dry-run-ops-vm-vnet"
+  type        = string
+}
+
+variable "subnet" {
+  description = "subnet vm will use"
+  default     = "dry-run-ops-vm-subnet"
+  type        = string
+}
+
+variable "resource_group" {
+  description = "resource_group vm will use"
+  default     = "dry-run-ops-vm-resource-group"
+  type        = string
+}


### PR DESCRIPTION
This Terraform will spin up a Ubuntu/XFCE4 virtual machine in its own vnet/subnet that should have all the necessary installations and configurations (az, kubectl, Ansible, etc)  to drive a dry run deployment. You can test yourself by setting your `az` to one of the `pwsandbox` subscriptions and doing the usual `terraform plan/apply` routine. You should be able to SSH and RDP into the machine with the credentials supplied in the TF output and find all the tools good to go. (Microsoft Remote Desktop is a good RDP app if you need one)

In order to do most of the installs and configurations we utilize the [cloud-init](https://cloudinit.readthedocs.io/en/latest/) formatted `cloud_config.yml` file, which can take up to 10 minutes after the Terraform has completed to also complete. You know it's complete when the `/var/log/cloud-init-output.log` file on the VM displays a message the looks like the following:
```
cloud-init v. 20.3-2-g371b392c-0ubuntu1~18.04.1 finished at Mon, 09 Nov 2020 15:50:01 +0000. Datasource DataSourceAzure [seed=/dev/sr0].  Up 4052.43 seconds
```
This message will be logged even if the cloud-init encountered problems, so you may need to check earlier in the log for any error messages.

I placed these files in the `/ops` directory but it may need to be moved and have the exact vnet setting changed to work best with the dry run deployment