### PR TITLE
[AT-5703] Fix CLIN dropdown edit bug

### DIFF
--- a/templates/components/options_input.html
+++ b/templates/components/options_input.html
@@ -8,12 +8,19 @@
   label=True,
   show_validation=True,
   disabled=False,
-  optional=True) -%}
+  optional=True,
+  data_literal=False) -%}
   <optionsinput
     name='{{ field.name }}'
     inline-template
     {% if field.errors %}v-bind:initial-errors='{{ field.errors | list }}'{% endif %}
-    {% if field.data and field.data != "None" %}v-bind:initial-value="{{ field.data }}"{% endif %}
+    {% if field.data and field.data != "None" %}
+      {% if data_literal %}
+        v-bind:initial-value="{{ field.data }}"
+      {% else %}
+        v-bind:initial-value="'{{ field.data }}'"
+      {% endif %}
+    {% endif %}
     key='{{ field.name }}'
     v-bind:optional={{ optional|lower }}
     {% if field.default and field.default != "None" %}v-bind:null-option="{{ field.default }}"{% endif %}

--- a/tests/render_vue_component.py
+++ b/tests/render_vue_component.py
@@ -132,10 +132,10 @@ def test_make_select_input_template(options_input_macro, options_form):
     options_form.radiofield.choices = [("a", "A"), ("b", "B")]
 
     rendered_select_input_macro = options_input_macro(
-        options_form.selectfield, optional=Markup("'optional'")
+        options_form.selectfield, optional=Markup("'optional'"), data_literal=True
     )
     rendered_radio_input_macro = options_input_macro(
-        options_form.radiofield, optional=Markup("'optional'")
+        options_form.radiofield, optional=Markup("'optional'"), data_literal=True
     )
     write_template(rendered_select_input_macro, "select_input_template.html")
     write_template(rendered_radio_input_macro, "radio_input_template.html")


### PR DESCRIPTION
This adds a new option to the OptionsInput macro to change how the data is fed into the vue template. Because we need data literals for doing automated testing, we need a way to also provide string literals to the options input.