### PR TITLE
Bump ansible to 2.9.2 to address security issue

### DIFF
--- a/ops/requirements.txt
+++ b/ops/requirements.txt
@@ -1,7 +1,7 @@
 adal~=1.2.4
 alembic~=1.4.2
 amqp~=2.6.1
-ansible[azure]==2.9
+ansible[azure]==2.9.2
 applicationinsights~=0.11.9
 argcomplete~=1.12.1
 azure-cli-core~=2.0.35


### PR DESCRIPTION
This is to address the following security issue: https://github.com/advisories/GHSA-3m93-m4q6-mc6v