### PR TITLE
Delete all jobs prior to attempting to run a migration

### DIFF
--- a/ops/deploy/justdeploy.py
+++ b/ops/deploy/justdeploy.py
@@ -129,6 +129,7 @@ def deploy(
         template_variables=template_variables,
     )
 
+    subprocess.run(f"kubectl -n {namespace} delete jobs --all".split())
     subprocess.run(["kubectl", "apply", "-f", f".migration.out/migration.yml"])
     result = subprocess.run(
         f"kubectl -n {namespace} wait --for=condition=complete --timeout=120s job/migration-{image_tag}".split(),


### PR DESCRIPTION
As a way of mitigating migration job failures, delete other competing jobs. This is a pretty jank way of fixing this issue, hopefully a more robust CD solution for deploying to the private cluster gets rid of this.