### PR TITLE
Add a prefix to keep psql server names unique

### DIFF
--- a/terraform/providers/application_env/pg.tf
+++ b/terraform/providers/application_env/pg.tf
@@ -12,7 +12,7 @@ resource "random_password" "pg_root_password" {
 }
 
 resource "azurerm_postgresql_server" "sql" {
-  name                = "${var.deployment_namespace}-sql"
+  name                = "cz-${var.deployment_namespace}-sql"
   location            = azurerm_resource_group.sql.location
   resource_group_name = azurerm_resource_group.sql.name
   sku_name            = "GP_Gen5_2"


### PR DESCRIPTION
Hunter hit an issue where the server name was not unique because their env name was 'test'. This adds cz-